### PR TITLE
Add evaluation and benchmarking for reduce_sum

### DIFF
--- a/graine/target/__init__.py
+++ b/graine/target/__init__.py
@@ -1,0 +1,1 @@
+"""Target package containing algorithms, benchmarks and evaluation utilities."""

--- a/graine/target/benchmarks/__init__.py
+++ b/graine/target/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark scripts for target algorithms."""

--- a/graine/target/benchmarks/benchmark_reduce_sum.py
+++ b/graine/target/benchmarks/benchmark_reduce_sum.py
@@ -1,0 +1,18 @@
+"""Benchmark reduce_sum implementation."""
+
+from __future__ import annotations
+
+from graine.target.src.algorithms.reduce_sum import reduce_sum
+from graine.target.src.evaluate import benchmark
+
+
+def main() -> None:
+    data = range(1000)
+    results = benchmark(reduce_sum, data)
+    median = results["median"]
+    low, high = results["ic95"]
+    print(f"median: {median:.6f}s\nic95: {low:.6f}s - {high:.6f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/graine/target/src/__init__.py
+++ b/graine/target/src/__init__.py
@@ -1,0 +1,1 @@
+"""Source code for target algorithms and evaluation helpers."""

--- a/graine/target/src/algorithms/__init__.py
+++ b/graine/target/src/algorithms/__init__.py
@@ -1,0 +1,1 @@
+"""Collection of reference algorithm implementations."""

--- a/graine/target/src/evaluate.py
+++ b/graine/target/src/evaluate.py
@@ -1,0 +1,74 @@
+"""Utilities for evaluating target algorithms."""
+
+from __future__ import annotations
+
+import random
+import statistics
+import time
+from typing import Callable, Dict, Iterable, Tuple
+
+
+def benchmark(
+    func: Callable[[Iterable[int]], int],
+    data: Iterable[int],
+    runs: int = 21,
+    bootstrap_samples: int = 1000,
+) -> Dict[str, Tuple[float, float]]:
+    """Return median runtime and 95% confidence interval.
+
+    Args:
+        func: Function to benchmark.
+        data: Input iterable passed to ``func`` each run.
+        runs: Number of timing runs to execute.
+        bootstrap_samples: Number of bootstrap resamples for the CI.
+    """
+    timings = []
+    payload = list(data)
+    for _ in range(runs):
+        start = time.perf_counter()
+        func(payload)
+        timings.append(time.perf_counter() - start)
+
+    median = statistics.median(timings)
+    boot = []
+    for _ in range(bootstrap_samples):
+        sample = random.choices(timings, k=len(timings))
+        boot.append(statistics.median(sample))
+    boot.sort()
+    lower = boot[int(0.025 * len(boot))]
+    upper = boot[int(0.975 * len(boot))]
+    return {"median": median, "ic95": (lower, upper)}
+
+
+def evaluate(candidate: Callable[[Iterable[int]], int]) -> Dict[str, object]:
+    """Evaluate a candidate implementation of ``reduce_sum``.
+
+    Returns functional correctness, performance metrics, and robustness.
+    """
+    # Functional correctness on a simple example
+    sample = [1, 2, 3, 4, 5]
+    functional = candidate(sample) == sum(sample)
+
+    # Performance metrics
+    performance = benchmark(candidate, range(1000))
+
+    # Robustness checks
+    robustness = True
+    # Property: agreement with built-in sum for random lists
+    for _ in range(10):
+        arr = [random.randint(-1000, 1000) for _ in range(random.randint(0, 100))]
+        if candidate(arr) != sum(arr):
+            robustness = False
+            break
+    # Metamorphic: permutation invariance
+    if robustness:
+        arr = [random.randint(-1000, 1000) for _ in range(50)]
+        shuffled = arr.copy()
+        random.shuffle(shuffled)
+        robustness = candidate(arr) == candidate(shuffled)
+
+    return {
+        "functional": functional,
+        "performance": performance,
+        "robustness": robustness,
+    }

--- a/graine/target/tests/__init__.py
+++ b/graine/target/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for target algorithms."""

--- a/graine/target/tests/test_reduce_sum.py
+++ b/graine/target/tests/test_reduce_sum.py
@@ -1,0 +1,54 @@
+import random
+
+from graine.target.src.algorithms.reduce_sum import reduce_sum
+
+
+# Unit tests
+
+def test_unit_basic_sum():
+    assert reduce_sum([1, 2, 3]) == 6
+
+
+def test_unit_negative_numbers():
+    assert reduce_sum([-1, -2, -3]) == -6
+
+
+def test_unit_empty_iterable():
+    assert reduce_sum([]) == 0
+
+
+# Integration tests
+
+def test_integration_with_generator():
+    data = (i for i in range(5))
+    assert reduce_sum(data) == 10
+
+
+def test_integration_with_map():
+    data = map(int, ["1", "2", "3"])
+    assert reduce_sum(data) == 6
+
+
+# Property-based tests using randomised examples
+
+def test_property_equivalent_to_builtin_sum_random_cases():
+    for _ in range(100):
+        length = random.randint(0, 50)
+        xs = [random.randint(-1000, 1000) for _ in range(length)]
+        assert reduce_sum(xs) == sum(xs)
+
+
+# Metamorphic tests
+
+def test_metamorphic_permutation_invariance_random():
+    xs = [random.randint(-10, 10) for _ in range(20)]
+    shuffled = xs[:]
+    random.shuffle(shuffled)
+    assert reduce_sum(xs) == reduce_sum(shuffled)
+
+
+def test_metamorphic_add_constant_random():
+    xs = [random.randint(-10, 10) for _ in range(20)]
+    k = random.randint(-10, 10)
+    shifted = [x + k for x in xs]
+    assert reduce_sum(shifted) == reduce_sum(xs) + k * len(xs)


### PR DESCRIPTION
## Summary
- Add unit, integration, property, and metamorphic tests for `reduce_sum`
- Implement benchmarking harness with median and 95% confidence interval
- Provide `evaluate` API returning functional, performance, and robustness metrics

## Testing
- `pytest`
- `python -m graine.target.benchmarks.benchmark_reduce_sum`
- `python - <<'PY'
from graine.target.src.algorithms.reduce_sum import reduce_sum
from graine.target.src.evaluate import evaluate
print(evaluate(reduce_sum))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ae686ab730832aaf6f1eae166997c5