### PR TITLE
Implement mutation generation and NSGA-II selection

### DIFF
--- a/graine/evolver/generate.py
+++ b/graine/evolver/generate.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+"""Generate candidate patches based on configuration zones.
+
+This module reads the ``zones.yaml`` configuration and produces minimal
+``Patch`` objects that respect the allowed operators and other constraints
+specified for each zone. The parsing logic mirrors the lightweight approach
+used elsewhere in the project to avoid external dependencies.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .dsl import Patch
+
+
+def load_zones(path: Path | None = None) -> List[Dict[str, Any]]:
+    """Parse ``zones.yaml`` without external YAML parsers.
+
+    Parameters
+    ----------
+    path:
+        Optional path to the configuration file. When omitted, the default
+        project configuration is used.
+
+    Returns
+    -------
+    list of dict
+        Each dict represents a mutation zone with keys ``file``, ``function``,
+        ``purity``, ``max_cyclomatic`` and ``operators``.
+    """
+
+    if path is None:
+        path = Path(__file__).resolve().parents[1] / "configs" / "zones.yaml"
+
+    zones: List[Dict[str, Any]] = []
+    current: Dict[str, Any] | None = None
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        if raw.startswith("targets:"):
+            continue
+        if raw.startswith("  -"):
+            if current:
+                zones.append(current)
+            current = {}
+            continue
+        if current is None:
+            continue
+        line = raw.strip()
+        if line.startswith("file:"):
+            current["file"] = line.split(":", 1)[1].strip()
+        elif line.startswith("function:"):
+            current["function"] = line.split(":", 1)[1].strip()
+        elif line.startswith("purity:"):
+            current["purity"] = line.split(":", 1)[1].strip().lower() == "true"
+        elif line.startswith("max_cyclomatic:"):
+            current["max_cyclomatic"] = int(line.split(":", 1)[1].strip())
+        elif line == "operators:":
+            current["operators"] = []
+        elif line.startswith("-") and "operators" in current:
+            op = line.split("-", 1)[1].strip()
+            current["operators"].append(op)
+    if current:
+        zones.append(current)
+    return zones
+
+
+def propose_mutations(zones: List[Dict[str, Any]] | None = None) -> List[Patch]:
+    """Return simple ``Patch`` objects for each configured zone.
+
+    The first operator listed for a zone is used to build a deterministic
+    patch, ensuring reproducibility for tests.
+    """
+
+    if zones is None:
+        zones = load_zones()
+
+    patches: List[Patch] = []
+    for zone in zones:
+        ops = zone.get("operators", [])
+        if not ops:
+            continue
+        op_name = ops[0]
+        patch = Patch.from_dict(
+            {
+                "target": {"file": zone.get("file", ""), "function": zone.get("function", "")},
+                "ops": [{"op": op_name}],
+                "theta_diff": 0.0,
+                "purity": zone.get("purity", True),
+                "cyclomatic": zone.get("max_cyclomatic", 0),
+            }
+        )
+        patches.append(patch)
+    return patches

--- a/graine/evolver/select.py
+++ b/graine/evolver/select.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+"""Selection utilities implementing a minimal NSGA-II algorithm.
+
+The selection process accepts at most a single patch per cycle. All other
+candidates are rejected and the reasons for acceptance or rejection are
+logged. A conservative elitism strategy ensures that a previous elite patch
+is retained unless dominated by a newcomer.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List
+import logging
+
+from .dsl import Patch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(eq=False)
+class Candidate:
+    """Container for a patch and its objective values."""
+
+    patch: Patch
+    objectives: Dict[str, float]
+    name: str = ""
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.name or repr(self.patch)
+
+
+def dominates(a: Candidate, b: Candidate) -> bool:
+    """Return ``True`` if candidate ``a`` dominates ``b`` (all objectives are
+    less than or equal and at least one is strictly less)."""
+
+    better_or_equal = all(a.objectives[m] <= b.objectives[m] for m in a.objectives)
+    strictly_better = any(a.objectives[m] < b.objectives[m] for m in a.objectives)
+    return better_or_equal and strictly_better
+
+
+def fast_non_dominated_sort(population: List[Candidate]) -> List[List[Candidate]]:
+    """Classical fast non-dominated sort used by NSGA-II."""
+
+    fronts: List[List[Candidate]] = []
+    S: Dict[Candidate, List[Candidate]] = {}
+    n: Dict[Candidate, int] = {}
+    rank: Dict[Candidate, int] = {}
+
+    for p in population:
+        S[p] = []
+        n[p] = 0
+        for q in population:
+            if p is q:
+                continue
+            if dominates(p, q):
+                S[p].append(q)
+            elif dominates(q, p):
+                n[p] += 1
+        if n[p] == 0:
+            rank[p] = 0
+    current_front = [p for p in population if n[p] == 0]
+    fronts.append(current_front)
+    i = 0
+    while fronts[i]:
+        next_front: List[Candidate] = []
+        for p in fronts[i]:
+            for q in S[p]:
+                n[q] -= 1
+                if n[q] == 0:
+                    rank[q] = i + 1
+                    next_front.append(q)
+        i += 1
+        fronts.append(next_front)
+    return fronts[:-1]
+
+
+def crowding_distance(front: List[Candidate]) -> Dict[Candidate, float]:
+    """Compute crowding distance for a single front."""
+
+    distance = {c: 0.0 for c in front}
+    if not front:
+        return distance
+    objectives = list(front[0].objectives.keys())
+    for m in objectives:
+        front.sort(key=lambda c: c.objectives[m])
+        distance[front[0]] = float("inf")
+        distance[front[-1]] = float("inf")
+        min_m = front[0].objectives[m]
+        max_m = front[-1].objectives[m]
+        denom = max_m - min_m or 1.0
+        for i in range(1, len(front) - 1):
+            prev_m = front[i - 1].objectives[m]
+            next_m = front[i + 1].objectives[m]
+            distance[front[i]] += (next_m - prev_m) / denom
+    return distance
+
+
+def select(candidates: List[Candidate], prev_best: Candidate | None = None) -> Candidate | None:
+    """Select at most one candidate using NSGA-II with conservative elitism."""
+
+    population = list(candidates)
+    if prev_best is not None:
+        population.append(prev_best)
+
+    if not population:
+        return None
+
+    fronts = fast_non_dominated_sort(population)
+    first_front = fronts[0]
+    cd = crowding_distance(first_front)
+    first_front.sort(key=lambda c: (cd[c], c is prev_best), reverse=True)
+    chosen = first_front[0]
+
+    # Logging and enforcing single acceptance
+    for cand in candidates:
+        if cand is chosen:
+            logger.info("Accepted patch %s", cand)
+        else:
+            reason = "dominated by accepted patch" if dominates(chosen, cand) else "crowded out"
+            logger.info("Rejected patch %s: %s", cand, reason)
+    if prev_best is not None:
+        if chosen is prev_best:
+            logger.info("Accepted patch %s: retained as elite", prev_best)
+        else:
+            reason = "dominated by accepted patch" if dominates(chosen, prev_best) else "crowded out"
+            logger.info("Rejected patch %s: %s", prev_best, reason)
+    return chosen if chosen is not prev_best else prev_best

--- a/graine/tests/test_selection.py
+++ b/graine/tests/test_selection.py
@@ -1,0 +1,52 @@
+import logging
+from graine.evolver.dsl import Patch
+from graine.evolver.select import Candidate, select
+
+
+def build_patch(**overrides):
+    data = {
+        "type": "Patch",
+        "target": {"file": "dummy.py", "function": "foo"},
+        "ops": [{"op": "CONST_TUNE", "delta": 0.0, "bounds": [-0.1, 0.1]}],
+        "theta_diff": 1,
+        "purity": True,
+        "cyclomatic": 1,
+    }
+    data.update(overrides)
+    return Patch.from_dict(data)
+
+
+def test_select_accepts_only_best_candidate(caplog):
+    caplog.set_level(logging.INFO)
+    c1 = Candidate(build_patch(), {"err": 1, "time": 1}, name="A")
+    c2 = Candidate(build_patch(), {"err": 2, "time": 2}, name="B")
+
+    chosen = select([c1, c2])
+    assert chosen is c1
+    accepted = [r for r in caplog.records if "Accepted patch" in r.message]
+    rejected = [r for r in caplog.records if "Rejected patch" in r.message]
+    assert len(accepted) == 1
+    assert any("A" in r.message for r in accepted)
+    assert any("B" in r.message and "dominated" in r.message for r in rejected)
+
+
+def test_select_retains_prev_best(caplog):
+    caplog.set_level(logging.INFO)
+    prev = Candidate(build_patch(), {"err": 1, "time": 1}, name="Prev")
+    new = Candidate(build_patch(), {"err": 2, "time": 2}, name="New")
+
+    chosen = select([new], prev_best=prev)
+    assert chosen is prev
+    assert any("Accepted patch Prev" in r.message for r in caplog.records)
+    assert any("Rejected patch New" in r.message for r in caplog.records)
+
+
+def test_select_replaces_dominated_prev_best(caplog):
+    caplog.set_level(logging.INFO)
+    prev = Candidate(build_patch(), {"err": 2, "time": 2}, name="Prev")
+    new = Candidate(build_patch(), {"err": 1, "time": 1}, name="New")
+
+    chosen = select([new], prev_best=prev)
+    assert chosen is new
+    assert any("Accepted patch New" in r.message for r in caplog.records)
+    assert any("Rejected patch Prev" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- generate patches from config zones without external YAML dependency
- add NSGA-II selector with conservative elitism and detailed logging
- test selection behaviour ensuring only one patch accepted per cycle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6947adc8832ab22427f76a33c539