### PR TITLE
Add meta evolution validation and regression safeguards

### DIFF
--- a/graine/meta/__init__.py
+++ b/graine/meta/__init__.py
@@ -1,0 +1,3 @@
+"""Meta-evolution package."""
+
+from .dsl import MetaSpec, MetaValidationError, MAX_POPULATION_CAP

--- a/graine/meta/dsl.py
+++ b/graine/meta/dsl.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from graine.evolver.dsl import OPERATOR_NAMES
+
+
+class MetaValidationError(ValueError):
+    """Raised when a meta configuration is invalid."""
+
+
+MAX_POPULATION_CAP = 100
+_WEIGHT_TOLERANCE = 1e-6
+
+
+@dataclass
+class MetaSpec:
+    """Specification for meta-level evolutionary settings."""
+
+    weights: Dict[str, float] = field(default_factory=dict)
+    operator_mix: Dict[str, float] = field(default_factory=dict)
+    population_cap: int = 0
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "MetaSpec":
+        return cls(
+            weights=dict(data.get("weights", {})),
+            operator_mix=dict(data.get("operator_mix", {})),
+            population_cap=int(data.get("population_cap", 0)),
+        )
+
+    def validate(self) -> bool:
+        # Validate weights
+        if not self.weights:
+            raise MetaValidationError("Weights must be provided")
+        total = sum(self.weights.values())
+        if any(w < 0 or w > 1 for w in self.weights.values()) or abs(total - 1.0) > _WEIGHT_TOLERANCE:
+            raise MetaValidationError("Weights must be within [0,1] and sum to 1")
+
+        # Validate operator mix
+        if not self.operator_mix:
+            raise MetaValidationError("Operator mix must be provided")
+        unknown = [op for op in self.operator_mix if op not in OPERATOR_NAMES]
+        if unknown:
+            raise MetaValidationError(f"Unknown operator in mix: {unknown[0]}")
+        op_total = sum(self.operator_mix.values())
+        if any(v < 0 for v in self.operator_mix.values()) or abs(op_total - 1.0) > _WEIGHT_TOLERANCE:
+            raise MetaValidationError("Operator mix must be non-negative and sum to 1")
+
+        # Validate population cap
+        if not (0 < self.population_cap <= MAX_POPULATION_CAP):
+            raise MetaValidationError("Population cap exceeds constitutional limit")
+        return True

--- a/graine/meta/evolve.py
+++ b/graine/meta/evolve.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from .dsl import MetaSpec, MAX_POPULATION_CAP
+
+
+def propose_mutation(spec: MetaSpec, delta: float = 0.1) -> MetaSpec:
+    """Propose a simple meta-mutation while respecting constitutional limits.
+
+    The mutation deterministically adjusts the first two weights and operator
+    mixes while keeping the distributions normalized. The population cap is
+    increased by one but clamped to ``MAX_POPULATION_CAP``. The returned
+    ``MetaSpec`` is validated before being returned.
+    """
+
+    new_spec = MetaSpec(
+        weights=dict(spec.weights),
+        operator_mix=dict(spec.operator_mix),
+        population_cap=spec.population_cap,
+    )
+
+    # Mutate weights
+    weight_keys = list(new_spec.weights.keys())
+    if len(weight_keys) >= 2:
+        a, b = weight_keys[:2]
+        new_a = min(1.0, max(0.0, new_spec.weights[a] + delta))
+        new_spec.weights[a] = new_a
+        new_spec.weights[b] = 1.0 - new_a
+
+    # Mutate operator mix
+    op_keys = list(new_spec.operator_mix.keys())
+    if len(op_keys) >= 2:
+        a, b = op_keys[:2]
+        new_a = min(1.0, max(0.0, new_spec.operator_mix[a] + delta))
+        new_spec.operator_mix[a] = new_a
+        new_spec.operator_mix[b] = 1.0 - new_a
+
+    # Increase population cap within limit
+    if new_spec.population_cap < MAX_POPULATION_CAP:
+        new_spec.population_cap += 1
+
+    new_spec.validate()
+    return new_spec

--- a/graine/meta/phantom.py
+++ b/graine/meta/phantom.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Iterable, Dict
+
+from .dsl import MetaSpec
+
+
+def replay(history: Iterable[Dict[str, object]]) -> bool:
+    """Replay a sequence of historical meta specifications.
+
+    Each historical entry is validated using :func:`MetaSpec.validate`. If any
+    entry fails validation, a ``MetaValidationError`` propagates to the caller.
+    Returns ``True`` when all entries pass validation.
+    """
+
+    for entry in history:
+        spec = MetaSpec.from_dict(entry)
+        spec.validate()
+    return True

--- a/graine/tests/test_meta.py
+++ b/graine/tests/test_meta.py
@@ -1,0 +1,42 @@
+import pytest
+
+from graine.meta.dsl import MetaSpec, MetaValidationError, MAX_POPULATION_CAP
+from graine.meta.phantom import replay
+
+
+def build_spec(**overrides):
+    data = {
+        "weights": {"perf": 0.5, "robust": 0.5},
+        "operator_mix": {"CONST_TUNE": 0.5, "EQ_REWRITE": 0.5},
+        "population_cap": 10,
+    }
+    data.update(overrides)
+    return MetaSpec.from_dict(data)
+
+
+def test_meta_rejects_bad_weights():
+    spec = build_spec(weights={"perf": 0.7, "robust": 0.2})
+    with pytest.raises(MetaValidationError):
+        spec.validate()
+
+
+def test_meta_rejects_unknown_operator():
+    spec = build_spec(operator_mix={"CONST_TUNE": 0.5, "BAD_OP": 0.5})
+    with pytest.raises(MetaValidationError):
+        spec.validate()
+
+
+def test_meta_rejects_excess_population():
+    spec = build_spec(population_cap=MAX_POPULATION_CAP + 1)
+    with pytest.raises(MetaValidationError):
+        spec.validate()
+
+
+def test_phantom_rejects_invalid_history():
+    bad_entry = {
+        "weights": {"perf": 1.0},
+        "operator_mix": {"CONST_TUNE": 1.0},
+        "population_cap": MAX_POPULATION_CAP + 1,
+    }
+    with pytest.raises(MetaValidationError):
+        replay([bad_entry])


### PR DESCRIPTION
## Summary
- introduce MetaSpec DSL validating objective weights, operator mixes, and population caps
- add deterministic meta mutation proposal and history replay
- add negative tests guarding against forbidden meta changes

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae6a5aea44832aa279d1981c6dfaf0