### PR TITLE
Add operation counters and hard resource limits

### DIFF
--- a/graine/kernel/__init__.py
+++ b/graine/kernel/__init__.py
@@ -2,15 +2,13 @@
 from __future__ import annotations
 
 import time
-import resource
 from typing import Dict, Any
 
-from .interpreter import ALLOWED_OPS, execute
+from .interpreter import ALLOWED_OPS, execute, limits
 from .logger import JsonlLogger
 from .verifier import VerificationError, verify_patch
 
-
-DEFAULT_LIMITS = {"cpu": 1.0, "ram": None, "ops": 1000}
+DEFAULT_LIMITS = {"cpu": 1.0, "ram": 256 * 1024 * 1024, "ops": 1000}
 
 
 def run_variant(patch: Dict[str, Any]) -> Dict[str, Any]:
@@ -21,31 +19,29 @@ def run_variant(patch: Dict[str, Any]) -> Dict[str, Any]:
     written for each invocation.
     """
     verify_patch(patch)
-    limits = {**DEFAULT_LIMITS, **patch.get("limits", {})}
-    op_limit = limits["ops"]
-    cpu_limit = limits["cpu"]
-    ram_limit = limits["ram"]
+    quota = {**DEFAULT_LIMITS, **patch.get("limits", {})}
+    op_limit = quota["ops"]
+    cpu_limit = quota["cpu"]
+    ram_limit = quota["ram"]
+
+    if cpu_limit <= 0:
+        raise RuntimeError("CPU time limit exceeded")
 
     logger = JsonlLogger()
     ops = patch.get("ops", [])
     start = time.time()
     executed = 0
     logger.log({"event": "start", "ops": len(ops)})
-    for op in ops:
-        if executed >= op_limit:
-            logger.log({"event": "error", "type": "op_limit"})
-            raise RuntimeError("operation count exceeded")
-        execute(op)
-        executed += 1
-        elapsed = time.time() - start
-        if elapsed > cpu_limit:
-            logger.log({"event": "error", "type": "cpu_limit", "elapsed": elapsed})
-            raise RuntimeError("CPU time limit exceeded")
-        if ram_limit is not None:
-            usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
-            if usage > ram_limit:
-                logger.log({"event": "error", "type": "ram_limit", "ram": usage})
-                raise RuntimeError("RAM limit exceeded")
+    limits.start(op_limit, cpu_limit, ram_limit)
+    try:
+        for op in ops:
+            execute(op)
+            executed += 1
+    except RuntimeError as err:
+        logger.log({"event": "error", "type": str(err)})
+        raise
+    finally:
+        limits.stop()
     elapsed = time.time() - start
     logger.log({"event": "success", "ops": executed, "elapsed": elapsed})
     return {"status": "validated", "ops_executed": executed}

--- a/graine/kernel/interpreter.py
+++ b/graine/kernel/interpreter.py
@@ -1,7 +1,58 @@
 """In-process execution of whitelisted patch operations."""
 from __future__ import annotations
 
+import os
+import signal
+import time
 from typing import Any, Dict, Set
+
+try:  # pragma: no cover - psutil is optional
+    import psutil
+except Exception:  # pragma: no cover - fallback if psutil missing
+    psutil = None  # type: ignore[assignment]
+
+
+def _current_rss() -> int:
+    """Return current resident set size in bytes."""
+
+    if psutil is not None:  # pragma: no cover - simple passthrough
+        return psutil.Process().memory_info().rss
+    # Fallback to procfs which is available on Linux systems.
+    with open("/proc/self/statm", "r", encoding="utf8") as fh:
+        pages = int(fh.readline().split()[0])
+    return pages * os.sysconf("SC_PAGE_SIZE")
+
+
+class _LimitManager:
+    """Track execution quotas for operations, time and memory."""
+
+    def __init__(self) -> None:
+        self.max_ops = 0
+        self.mem_limit = 0
+        self.ops = 0
+
+    def start(self, op_limit: int, timeout: float, mem_limit: int) -> None:
+        self.max_ops = op_limit
+        self.mem_limit = mem_limit
+        self.ops = 0
+        signal.signal(signal.SIGALRM, self._on_timeout)
+        signal.setitimer(signal.ITIMER_REAL, timeout)
+
+    def stop(self) -> None:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+
+    def _on_timeout(self, *_: Any) -> None:  # pragma: no cover - signal path
+        raise RuntimeError("CPU time limit exceeded")
+
+    def tick(self) -> None:
+        self.ops += 1
+        if self.ops > self.max_ops:
+            raise RuntimeError("operation count exceeded")
+        if _current_rss() > self.mem_limit:
+            raise RuntimeError("RAM limit exceeded")
+
+
+limits = _LimitManager()
 
 # Whitelisted operations understood by the interpreter.
 ALLOWED_OPS: Set[str] = {
@@ -17,15 +68,25 @@ ALLOWED_OPS: Set[str] = {
 def execute(op: Dict[str, Any]) -> None:
     """Execute a single operation.
 
-    The current implementation is a stub that simply validates the
-    operation name.  Real kernels would modify a program representation.
+    The interpreter validates the operation name and applies a few helper
+    behaviours used in tests such as sleeping or allocating memory.  After
+    each operation the global :data:`limits` are updated.
     """
     name = op.get("op")
     if name not in ALLOWED_OPS:
         raise RuntimeError(f"Forbidden operation: {name}")
-    # Placeholder for operation-specific behavior.  For now we perform no
-    # additional work beyond the whitelist check.
-    return None
+    data = None
+    try:
+        if name == "INLINE":
+            if (size := op.get("size")):
+                data = bytearray(int(size))
+            if (sleep := op.get("sleep")):
+                time.sleep(float(sleep))
+        limits.tick()
+    finally:
+        # Ensure any temporary buffers are released promptly.
+        if data is not None:
+            del data
 
 
-__all__ = ["ALLOWED_OPS", "execute"]
+__all__ = ["ALLOWED_OPS", "execute", "limits"]

--- a/graine/tests/test_kernel.py
+++ b/graine/tests/test_kernel.py
@@ -137,3 +137,29 @@ def test_verify_rejects_ram_quota():
     patch["limits"]["ram"] = 10**10
     with pytest.raises(VerificationError):
         run_variant(patch)
+
+
+def test_run_variant_hard_timeout_signal():
+    patch = {
+        "type": "Patch",
+        "target": {"file": "target/src/algorithms/reduce_sum.py", "function": "reduce_sum"},
+        "ops": [
+            {"op": "INLINE", "sleep": 1.0},
+        ],
+        "limits": {"diff_max": 5, "cpu": 0.1},
+    }
+    with pytest.raises(RuntimeError):
+        run_variant(patch)
+
+
+def test_run_variant_memory_limit_exceeded():
+    patch = {
+        "type": "Patch",
+        "target": {"file": "target/src/algorithms/reduce_sum.py", "function": "reduce_sum"},
+        "ops": [
+            {"op": "INLINE", "size": 300 * 1024 * 1024},
+        ],
+        "limits": {"diff_max": 5},
+    }
+    with pytest.raises(RuntimeError):
+        run_variant(patch)


### PR DESCRIPTION
## Summary
- enforce per-operation counters, memory checks and signal-based timeouts in interpreter
- centralize run limits with default 256MB memory cap in kernel runner
- test hard timeout and memory limit exceedance in kernel tests

## Testing
- `pytest graine/tests/test_kernel.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae702553fc832a9f5c17cb381c230d