### PR TITLE
Implement pure kernel operators and DSL coverage

### DIFF
--- a/graine/tests/test_dsl.py
+++ b/graine/tests/test_dsl.py
@@ -24,6 +24,22 @@ def test_dsl_accepts_valid_patch():
     assert patch.validate() is True
 
 
+@pytest.mark.parametrize(
+    "op",
+    [
+        {"op": "CONST_TUNE", "delta": 0.0, "bounds": [-0.1, 0.1]},
+        {"op": "EQ_REWRITE", "rule_id": "algebra.id"},
+        {"op": "INLINE"},
+        {"op": "EXTRACT"},
+        {"op": "DEADCODE_ELIM"},
+        {"op": "MICRO_MEMO"},
+    ],
+)
+def test_dsl_accepts_all_whitelisted_ops(op):
+    patch = build_patch(ops=[op])
+    assert patch.validate() is True
+
+
 def test_dsl_rejects_bad_operator():
     data = {
         "type": "Patch",


### PR DESCRIPTION
## Summary
- implement explicit operator functions in the kernel interpreter with a `@pure` marker
- enforce that only pure operations are executed and expose mapping of allowed ops
- add regression tests validating all whitelisted DSL operators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae7160ef8c832a85d001bfcc8b8a16