### PR TITLE
Implement NSGA-II selection with threshold filtering

### DIFF
--- a/graine/tests/test_selection.py
+++ b/graine/tests/test_selection.py
@@ -18,8 +18,9 @@ def build_patch(**overrides):
 
 def test_select_accepts_only_best_candidate(caplog):
     caplog.set_level(logging.INFO)
-    c1 = Candidate(build_patch(), {"err": 1, "time": 1}, name="A")
-    c2 = Candidate(build_patch(), {"err": 2, "time": 2}, name="B")
+    thresholds = {"tests": True, "perf": True, "quality": True, "stability": True}
+    c1 = Candidate(build_patch(), {"err": 1, "time": 1}, thresholds, name="A")
+    c2 = Candidate(build_patch(), {"err": 2, "time": 2}, thresholds, name="B")
 
     chosen = select([c1, c2])
     assert chosen is c1
@@ -32,8 +33,9 @@ def test_select_accepts_only_best_candidate(caplog):
 
 def test_select_retains_prev_best(caplog):
     caplog.set_level(logging.INFO)
-    prev = Candidate(build_patch(), {"err": 1, "time": 1}, name="Prev")
-    new = Candidate(build_patch(), {"err": 2, "time": 2}, name="New")
+    thresholds = {"tests": True, "perf": True, "quality": True, "stability": True}
+    prev = Candidate(build_patch(), {"err": 1, "time": 1}, thresholds, name="Prev")
+    new = Candidate(build_patch(), {"err": 2, "time": 2}, thresholds, name="New")
 
     chosen = select([new], prev_best=prev)
     assert chosen is prev
@@ -43,10 +45,31 @@ def test_select_retains_prev_best(caplog):
 
 def test_select_replaces_dominated_prev_best(caplog):
     caplog.set_level(logging.INFO)
-    prev = Candidate(build_patch(), {"err": 2, "time": 2}, name="Prev")
-    new = Candidate(build_patch(), {"err": 1, "time": 1}, name="New")
+    thresholds = {"tests": True, "perf": True, "quality": True, "stability": True}
+    prev = Candidate(build_patch(), {"err": 2, "time": 2}, thresholds, name="Prev")
+    new = Candidate(build_patch(), {"err": 1, "time": 1}, thresholds, name="New")
 
     chosen = select([new], prev_best=prev)
     assert chosen is new
     assert any("Accepted patch New" in r.message for r in caplog.records)
     assert any("Rejected patch Prev" in r.message for r in caplog.records)
+
+
+def test_select_filters_on_thresholds(caplog):
+    caplog.set_level(logging.INFO)
+    good = Candidate(
+        build_patch(),
+        {"err": 1, "time": 1},
+        {"tests": True, "perf": True, "quality": True, "stability": True},
+        name="Good",
+    )
+    bad = Candidate(
+        build_patch(),
+        {"err": 0.5, "time": 0.5},
+        {"tests": True, "perf": False, "quality": True, "stability": True},
+        name="Bad",
+    )
+
+    chosen = select([good, bad])
+    assert chosen is good
+    assert any("Rejected patch Bad: failed thresholds" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- enforce candidate thresholds (tests, perf, quality, stability) before selection
- implement conservative elitism and NSGA-II selection
- cover selection logic with new tests including threshold filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae76e380e0832a8dd4e156c4e8e8f5