### PR TITLE
Add meta spec JSON schema and constraints

### DIFF
--- a/graine/tests/test_meta.py
+++ b/graine/tests/test_meta.py
@@ -2,6 +2,7 @@ import pytest
 
 from graine.meta.dsl import MetaSpec, MetaValidationError, MAX_POPULATION_CAP
 from graine.meta.phantom import replay
+from graine.kernel.verifier import DIFF_LIMIT
 
 
 def build_spec(**overrides):
@@ -9,6 +10,7 @@ def build_spec(**overrides):
         "weights": {"perf": 0.5, "robust": 0.5},
         "operator_mix": {"CONST_TUNE": 0.5, "EQ_REWRITE": 0.5},
         "population_cap": 10,
+        "selection_strategy": "elitism",
     }
     data.update(overrides)
     return MetaSpec.from_dict(data)
@@ -28,6 +30,24 @@ def test_meta_rejects_unknown_operator():
 
 def test_meta_rejects_excess_population():
     spec = build_spec(population_cap=MAX_POPULATION_CAP + 1)
+    with pytest.raises(MetaValidationError):
+        spec.validate()
+
+
+def test_meta_rejects_bad_selection_strategy():
+    spec = build_spec(selection_strategy="bad")
+    with pytest.raises(MetaValidationError):
+        spec.validate()
+
+
+def test_meta_rejects_excess_diff_max():
+    spec = build_spec(diff_max=DIFF_LIMIT + 1)
+    with pytest.raises(MetaValidationError):
+        spec.validate()
+
+
+def test_meta_rejects_forbidden_relaxation():
+    spec = build_spec(forbidden=["net"]) 
     with pytest.raises(MetaValidationError):
         spec.validate()
 


### PR DESCRIPTION
## Summary
- define JSON schema for meta-level settings, including selection strategy
- enforce selection strategies, diff limits and forbiddens in MetaSpec validation
- add negative tests for bad strategies, excessive diff, and forbidden relaxation

## Testing
- `pytest tests/test_meta.py -q`
- `pytest tests/test_kernel.py::test_verify_accepts_valid_patch -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'graine/configs/zones.yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68ae787a7ea0832a92ac99f057d8fcf4