### PR TITLE
Add diff testing and broaden target test suite

### DIFF
--- a/graine/target/tests/test_evaluate.py
+++ b/graine/target/tests/test_evaluate.py
@@ -1,0 +1,76 @@
+from graine.target.src import evaluate
+from graine.target.src.algorithms.reduce_sum import reduce_sum
+
+
+# Helper benchmark to keep tests fast
+
+def _fast_benchmark(func, data, runs=21, bootstrap_samples=1000):
+    return {"median": 0.0, "ic95": (0.0, 0.0)}
+
+
+# Unit and integration tests for evaluate()
+
+def test_evaluate_success(monkeypatch):
+    monkeypatch.setattr(evaluate, "benchmark", _fast_benchmark)
+    result = evaluate.evaluate(reduce_sum)
+    assert result["functional"]
+    assert result["robustness"]
+    assert "performance" in result
+
+
+def test_evaluate_robustness_failure(monkeypatch):
+    monkeypatch.setattr(evaluate, "benchmark", _fast_benchmark)
+
+    def bad_candidate(values):
+        return sum(values) + 1
+
+    result = evaluate.evaluate(bad_candidate)
+    assert not result["functional"]
+    assert not result["robustness"]
+
+
+# Tests for diff-testing
+
+def baseline(xs):
+    return sum(xs)
+
+
+def variant_ok(xs):
+    return sum(xs)
+
+
+def variant_bug(xs):
+    return sum(xs) + 1
+
+
+def variant_error(xs):
+    raise ValueError("boom")
+
+
+def baseline_error(xs):
+    raise RuntimeError("oops")
+
+
+def test_diff_test_equivalent():
+    res = evaluate.diff_test(baseline, variant_ok, cases=5)
+    assert res["equivalent"]
+    assert res["mismatches"] == []
+
+
+def test_diff_test_mismatch():
+    res = evaluate.diff_test(baseline, variant_bug, cases=5)
+    assert not res["equivalent"]
+    assert res["mismatches"]
+
+
+def test_diff_test_variant_error():
+    res = evaluate.diff_test(baseline, variant_error, cases=1)
+    assert not res["equivalent"]
+    assert "variant_error" in res["mismatches"][0]
+
+
+def test_diff_test_baseline_error():
+    res = evaluate.diff_test(baseline_error, variant_ok, cases=1)
+    assert not res["equivalent"]
+    assert "baseline_error" in res["mismatches"][0]
+

--- a/graine/target/tests/test_reduce_sum.py
+++ b/graine/target/tests/test_reduce_sum.py
@@ -29,11 +29,11 @@ def test_integration_with_map():
     assert reduce_sum(data) == 6
 
 
-# Property-based tests using randomised examples
+# Property-based tests using randomised examples (≥10 000 cases)
 
-def test_property_equivalent_to_builtin_sum_random_cases():
-    for _ in range(100):
-        length = random.randint(0, 50)
+def test_property_equivalent_to_builtin_sum_random_cases_large():
+    for _ in range(10000):
+        length = random.randint(0, 20)
         xs = [random.randint(-1000, 1000) for _ in range(length)]
         assert reduce_sum(xs) == sum(xs)
 


### PR DESCRIPTION
## Summary
- implement diff-testing helper to compare baseline and variant algorithms
- expand tests for reduce_sum including 10k random cases and metamorphic checks
- add evaluation tests covering success and failure paths and diff-test scenarios

## Testing
- `pytest graine/target/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae8e60094c832aad1e83cb6773eacc