### PR TITLE
Enhance benchmarking with warm-up and variance metrics

### DIFF
--- a/graine/target/benchmarks/benchmark_reduce_sum.py
+++ b/graine/target/benchmarks/benchmark_reduce_sum.py
@@ -8,10 +8,17 @@ from graine.target.src.evaluate import benchmark
 
 def main() -> None:
     data = range(1000)
-    results = benchmark(reduce_sum, data)
+    # ``benchmark`` performs warm-up runs and pins the process to a single
+    # logical CPU to reduce variance.
+    results = benchmark(reduce_sum, data, cpu=0)
     median = results["median"]
+    iqr = results["iqr"]
     low, high = results["ic95"]
-    print(f"median: {median:.6f}s\nic95: {low:.6f}s - {high:.6f}s")
+    print(
+        f"median: {median:.6f}s\n"
+        f"IQR: {iqr:.6f}s\n"
+        f"IC95: {low:.6f}s - {high:.6f}s"
+    )
 
 
 if __name__ == "__main__":

--- a/graine/target/tests/test_benchmark.py
+++ b/graine/target/tests/test_benchmark.py
@@ -1,0 +1,27 @@
+from graine.target.src.evaluate import benchmark
+
+
+def _noop(xs):
+    for _ in xs:
+        pass
+
+
+def test_benchmark_statistics_keys():
+    res = benchmark(_noop, range(3), runs=5, warmups=1, bootstrap_samples=10, cpu=None)
+    assert "median" in res and "iqr" in res and "ic95" in res
+    low, high = res["ic95"]
+    assert low <= res["median"] <= high
+
+
+class _Counter:
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, xs):
+        self.calls += 1
+
+
+def test_benchmark_honours_warmups():
+    counter = _Counter()
+    benchmark(counter, range(1), runs=3, warmups=2, bootstrap_samples=10, cpu=None)
+    assert counter.calls == 5

--- a/graine/target/tests/test_evaluate.py
+++ b/graine/target/tests/test_evaluate.py
@@ -4,8 +4,15 @@ from graine.target.src.algorithms.reduce_sum import reduce_sum
 
 # Helper benchmark to keep tests fast
 
-def _fast_benchmark(func, data, runs=21, bootstrap_samples=1000):
-    return {"median": 0.0, "ic95": (0.0, 0.0)}
+def _fast_benchmark(
+    func,
+    data,
+    runs=21,
+    warmups=0,
+    bootstrap_samples=1000,
+    cpu=None,
+):
+    return {"median": 0.0, "iqr": 0.0, "ic95": (0.0, 0.0)}
 
 
 # Unit and integration tests for evaluate()


### PR DESCRIPTION
## Summary
- extend benchmarking utility with warm-up runs, CPU affinity pinning and variance metrics (median, IQR and 95% CI)
- update reduce_sum benchmark script to display the new statistics
- add unit tests covering benchmark statistics and warm-up behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8f463e14832a896cb81038d011b1