### PR TITLE
feat: expand evaluation metrics

### DIFF
--- a/graine/target/tests/test_evaluate.py
+++ b/graine/target/tests/test_evaluate.py
@@ -15,25 +15,32 @@ def _fast_benchmark(
     return {"median": 0.0, "iqr": 0.0, "ic95": (0.0, 0.0)}
 
 
+def _stub_diff_test(baseline, variant, cases=100):
+    return {"equivalent": True, "mismatches": []}
+
+
 # Unit and integration tests for evaluate()
 
 def test_evaluate_success(monkeypatch):
     monkeypatch.setattr(evaluate, "benchmark", _fast_benchmark)
+    monkeypatch.setattr(evaluate, "diff_test", _stub_diff_test)
     result = evaluate.evaluate(reduce_sum)
-    assert result["functional"]
-    assert result["robustness"]
+    assert result["functional_pass"]
+    assert result["security_pass"]
+    assert result["robustness"]["pass_rate"] == 1.0
     assert "performance" in result
 
 
 def test_evaluate_robustness_failure(monkeypatch):
     monkeypatch.setattr(evaluate, "benchmark", _fast_benchmark)
+    monkeypatch.setattr(evaluate, "diff_test", _stub_diff_test)
 
     def bad_candidate(values):
         return sum(values) + 1
 
     result = evaluate.evaluate(bad_candidate)
-    assert not result["functional"]
-    assert not result["robustness"]
+    assert not result["functional_pass"]
+    assert result["robustness"]["pass_rate"] < 1.0
 
 
 # Tests for diff-testing


### PR DESCRIPTION
## Summary
- broaden evaluation to return functional and security pass results plus performance, robustness, quality, and stability metrics
- adjust tests to new API

## Testing
- `python3 -m pytest graine/target/tests/test_evaluate.py` *(fails: No module named pytest)*
- `python3 -m pytest graine/tests/test_runs.py` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ae901a6944832ab7f95d0f3768c05f