### PR TITLE
Implement run snapshots with hashed logging

### DIFF
--- a/graine/runs/replay.py
+++ b/graine/runs/replay.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import json
 import random
+import shutil
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List
 
 # Base directories for run artefacts
 BASE_DIR = Path(__file__).resolve().parent
+ROOT_DIR = BASE_DIR.parent
 LOG_DIR = BASE_DIR / "logs"
 SNAPSHOT_DIR = BASE_DIR / "snapshots"
 REPORT_DIR = BASE_DIR / "reports"
@@ -28,24 +31,34 @@ def _generate_history(seed: int, steps: int) -> List[Dict[str, float]]:
 
 
 def capture_run(seed: int, name: str, steps: int = 5) -> Path:
-    """Generate a run and persist its snapshot and log.
+    """Generate a run snapshot including code, tests and configuration."""
 
-    Parameters
-    ----------
-    seed:
-        Random seed controlling the generated objectives.
-    name:
-        Name used for snapshot and log filenames.
-    steps:
-        Number of objective pairs to generate.
-    """
+    run_id = f"{name}-{uuid.uuid4().hex[:8]}"
+    run_dir = SNAPSHOT_DIR / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
 
     data: Dict[str, Any] = {"seed": seed, "history": _generate_history(seed, steps)}
-    snapshot_path = SNAPSHOT_DIR / f"{name}.json"
-    log_path = LOG_DIR / f"{name}.log"
+    snapshot_path = run_dir / "snapshot.json"
     snapshot_path.write_text(json.dumps(data), encoding="utf-8")
-    with open(log_path, "w", encoding="utf-8") as fh:
-        fh.write(json.dumps(data) + "\n")
+
+    # Persist seed and configuration
+    (run_dir / "seeds.json").write_text(json.dumps({"seed": seed}), encoding="utf-8")
+    (run_dir / "config.json").write_text(json.dumps({"steps": steps}), encoding="utf-8")
+
+    # Copy source code and tests for reproducibility
+    code_dir = run_dir / "code"
+    code_dir.mkdir(parents=True, exist_ok=True)
+    for folder in ["kernel", "evolver", "meta", "target"]:
+        shutil.copytree(ROOT_DIR / folder, code_dir / folder)
+    shutil.copytree(ROOT_DIR / "tests", run_dir / "tests")
+    shutil.copytree(ROOT_DIR / "configs", run_dir / "configs")
+
+    # Log capture event with hashed JSONL logger
+    from ..kernel.logger import JsonlLogger
+
+    logger = JsonlLogger(LOG_DIR / f"{run_id}.log")
+    logger.log({"event": "capture", "seed": seed, "steps": steps, "snapshot": snapshot_path.name})
+
     return snapshot_path
 
 


### PR DESCRIPTION
## Summary
- Add hash-chained JSONL logger for kernel events
- Snapshot runs by archiving code, configs, tests and seeds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae912a4248832aa7c4c150086af8e7