### PR TITLE
feat: add deterministic run replay and reports

### DIFF
--- a/graine/runs/report.py
+++ b/graine/runs/report.py
@@ -35,10 +35,15 @@ def generate_report(snapshot_paths: Iterable[Path] | None = None, out_path: Path
     """Create a simple HTML report summarising Pareto fronts and Δperf curves."""
 
     if snapshot_paths is None:
-        snapshot_paths = SNAPSHOT_DIR.glob("*.json")
-    snapshots = [json.loads(p.read_text(encoding="utf-8")) for p in snapshot_paths]
-    named_snaps = [(p.stem, s) for p, s in zip(snapshot_paths, snapshots)]
-    points = [{"name": n, "err": s["history"][-1]["err"], "cost": s["history"][-1]["cost"]} for n, s in named_snaps]
+        snapshot_paths = SNAPSHOT_DIR.glob("*/snapshot.json")
+
+    paths = list(snapshot_paths)
+    snaps = [(p, json.loads(p.read_text(encoding="utf-8"))) for p in paths]
+    named_snaps = [(p.parent.name if p.name == "snapshot.json" else p.stem, s) for p, s in snaps]
+    points = [
+        {"name": name, "err": snap["history"][-1]["err"], "cost": snap["history"][-1]["cost"]}
+        for name, snap in named_snaps
+    ]
     front = _pareto_front(points)
 
     html: List[str] = ["<html><body>", "<h1>Run Report</h1>", "<h2>Pareto Front</h2>", "<ul>"]

--- a/graine/tests/test_runs.py
+++ b/graine/tests/test_runs.py
@@ -4,12 +4,16 @@ import pytest
 from graine.runs import capture_run, replay
 
 
-def test_replay_is_deterministic():
+def test_replay_is_deterministic(tmp_path):
     name = "demo"
     path = capture_run(seed=123, name=name, steps=3)
+
     snap_data = json.loads(path.read_text(encoding="utf-8"))
-    reproduced = replay(path, seed=123)
+    reproduced = replay(path)
     assert reproduced == snap_data
 
+    # Tamper with the stored seed to ensure mismatch is detected
+    seeds_file = path.parent / "seeds.json"
+    seeds_file.write_text(json.dumps({"seed": 321}), encoding="utf-8")
     with pytest.raises(RuntimeError):
-        replay(path, seed=321)
+        replay(path)


### PR DESCRIPTION
## Summary
- replay runs from stored seeds and configs and log event
- build HTML reports with Pareto front and performance deltas
- test deterministic replay using tampered seeds

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'graine/configs/zones.yaml')*
- `pytest tests/test_runs.py`


------
https://chatgpt.com/codex/tasks/task_e_68af4112cd00832abb06f4a41aa20e8f