### PR TITLE
Add rejection tests for forbidden operations and spec limits

### DIFF
--- a/graine/tests/test_dsl.py
+++ b/graine/tests/test_dsl.py
@@ -5,6 +5,7 @@ from graine.evolver.dsl import (
     DSLValidationError,
     CYCLOMATIC_LIMIT,
     OPERATOR_NAMES,
+    THETA_DIFF_LIMIT,
 )
 from graine.evolver.generate import propose_mutations, load_zones
 
@@ -44,20 +45,12 @@ def test_dsl_accepts_all_whitelisted_ops(op):
 
 
 def test_dsl_rejects_bad_operator():
-    data = {
-        "type": "Patch",
-        "target": {"file": "dummy.py", "function": "foo"},
-        "ops": [{"op": "BAD_OP"}],
-        "theta_diff": 1,
-        "purity": True,
-        "cyclomatic": 1,
-    }
     with pytest.raises(DSLValidationError):
-        Patch.from_dict(data)
+        build_patch(ops=[{"op": "BAD_OP"}])
 
 
 def test_dsl_rejects_large_theta_diff():
-    patch = build_patch(theta_diff=50)
+    patch = build_patch(theta_diff=THETA_DIFF_LIMIT + 1)
     with pytest.raises(DSLValidationError):
         patch.validate()
 

--- a/graine/tests/test_kernel.py
+++ b/graine/tests/test_kernel.py
@@ -103,8 +103,8 @@ def _inline_patch(code: str) -> dict:
     }
 
 
-def test_verify_rejects_network_import():
-    patch = _inline_patch("import socket")
+def test_verify_rejects_socket_usage():
+    patch = _inline_patch("import socket\nsocket.socket()")
     with pytest.raises(VerificationError):
         run_variant(patch)
 
@@ -115,14 +115,14 @@ def test_verify_rejects_ffi_import():
         run_variant(patch)
 
 
-def test_verify_rejects_subprocess_import():
-    patch = _inline_patch("import subprocess")
+def test_verify_rejects_subprocess_execution():
+    patch = _inline_patch("import subprocess\nsubprocess.run(['echo', 'hi'])")
     with pytest.raises(VerificationError):
         run_variant(patch)
 
 
-def test_verify_rejects_outside_io():
-    patch = _inline_patch("open('evil.txt', 'w')")
+def test_verify_rejects_outside_write():
+    patch = _inline_patch("open('/tmp/evil.txt', 'w')")
     with pytest.raises(VerificationError):
         run_variant(patch)
 

--- a/graine/tests/test_meta.py
+++ b/graine/tests/test_meta.py
@@ -44,7 +44,7 @@ def test_meta_rejects_bad_selection_strategy():
         spec.validate()
 
 
-def test_meta_rejects_excess_diff_max():
+def test_meta_rejects_diff_max_relaxation():
     spec = build_spec(diff_max=DIFF_LIMIT + 1)
     with pytest.raises(MetaValidationError):
         spec.validate()


### PR DESCRIPTION
## Summary
- test kernel sandbox rejects socket use, subprocess execution, and outside writes
- ensure DSL rejects unknown operators and oversized theta_diff
- meta specs cannot relax diff_max beyond allowed limit

## Testing
- `pytest graine/tests/test_kernel.py graine/tests/test_dsl.py graine/tests/test_meta.py`

------
https://chatgpt.com/codex/tasks/task_e_68af628483e4832a92617b4120d6ded6