### PR TITLE
Add CLI subcommands and seed option

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -1,0 +1,42 @@
+"""Command line interface for singular."""
+
+from __future__ import annotations
+
+import argparse
+import random
+from typing import Callable, Any
+
+from .organisms.birth import birth
+from .organisms.talk import talk
+from .runs.run import run as run_run
+from .runs.synthesize import synthesize
+
+Command = Callable[[int | None], Any]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the singular command line interface."""
+
+    parser = argparse.ArgumentParser(prog="singular")
+    parser.add_argument(
+        "--seed", type=int, default=None, help="Random seed for reproducibility"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("birth", help="Birth a new organism").set_defaults(func=birth)
+    subparsers.add_parser("run", help="Execute a run").set_defaults(func=run_run)
+    subparsers.add_parser("talk", help="Talk with the system").set_defaults(func=talk)
+    subparsers.add_parser("synthesize", help="Synthesize results").set_defaults(func=synthesize)
+
+    args = parser.parse_args(argv)
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    func: Command = args.func
+    func(seed=args.seed)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -1,0 +1,13 @@
+"""Birth command implementation."""
+
+from __future__ import annotations
+
+
+def birth(seed: int | None = None) -> None:
+    """Handle the ``birth`` subcommand.
+
+    Parameters
+    ----------
+    seed:
+        Optional random seed for reproducibility.
+    """

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -1,0 +1,13 @@
+"""Talk command implementation."""
+
+from __future__ import annotations
+
+
+def talk(seed: int | None = None) -> None:
+    """Handle the ``talk`` subcommand.
+
+    Parameters
+    ----------
+    seed:
+        Optional random seed for reproducibility.
+    """

--- a/src/singular/runs/run.py
+++ b/src/singular/runs/run.py
@@ -1,0 +1,13 @@
+"""Run command implementation."""
+
+from __future__ import annotations
+
+
+def run(seed: int | None = None) -> None:
+    """Handle the ``run`` subcommand.
+
+    Parameters
+    ----------
+    seed:
+        Optional random seed for reproducibility.
+    """

--- a/src/singular/runs/synthesize.py
+++ b/src/singular/runs/synthesize.py
@@ -1,0 +1,13 @@
+"""Synthesize command implementation."""
+
+from __future__ import annotations
+
+
+def synthesize(seed: int | None = None) -> None:
+    """Handle the ``synthesize`` subcommand.
+
+    Parameters
+    ----------
+    seed:
+        Optional random seed for reproducibility.
+    """


### PR DESCRIPTION
## Summary
- add `birth`, `run`, `talk`, and `synthesize` subcommands
- wire subcommands to internal modules
- support `--seed` for reproducible runs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af94aff7c4832aa0331db900b998bb