### PR TITLE
Add identity JSON creation and verification

### DIFF
--- a/src/singular/identity.py
+++ b/src/singular/identity.py
@@ -1,0 +1,73 @@
+"""Identity file creation and reading utilities."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class Identity:
+    """Data class representing an identity."""
+
+    name: str
+    soulseed: str
+    id: str
+    born_at: str
+
+
+def create_identity(name: str, soulseed: str, path: Path | str = Path("id.json")) -> Identity:
+    """Create an identity JSON file.
+
+    Parameters
+    ----------
+    name:
+        Name of the identity.
+    soulseed:
+        Seed string representing the soul.
+    path:
+        Path where the ``id.json`` file will be written.
+
+    Returns
+    -------
+    Identity
+        The identity information that was written to the file.
+    """
+
+    identity = Identity(
+        name=name,
+        soulseed=soulseed,
+        id=hashlib.sha256(f"{name}:{soulseed}".encode("utf-8")).hexdigest(),
+        born_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+    path = Path(path)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(identity.__dict__, file)
+
+    return identity
+
+
+def read_identity(path: Path | str = Path("id.json")) -> Identity:
+    """Read an identity JSON file.
+
+    Parameters
+    ----------
+    path:
+        Path to the ``id.json`` file.
+
+    Returns
+    -------
+    Identity
+        The identity information loaded from the file.
+    """
+
+    path = Path(path)
+    with path.open(encoding="utf-8") as file:
+        data: dict[str, Any] = json.load(file)
+
+    return Identity(**data)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from datetime import datetime
+import hashlib
+
+from singular.identity import create_identity, read_identity
+
+
+def test_create_and_read_identity(tmp_path: Path) -> None:
+    path = tmp_path / "id.json"
+    data = create_identity("Alice", "42", path)
+
+    assert path.exists()
+    loaded = read_identity(path)
+
+    assert loaded == data
+    assert loaded.name == "Alice"
+    assert loaded.soulseed == "42"
+    expected_id = hashlib.sha256(b"Alice:42").hexdigest()
+    assert loaded.id == expected_id
+    # Ensure born_at is a valid ISO timestamp
+    datetime.fromisoformat(loaded.born_at)


### PR DESCRIPTION
## Summary
- add `identity` module to generate and read `id.json`
- compute identity id via SHA-256 hash of `name:soulseed`
- test identity file generation and reading

## Testing
- `PYTHONPATH=src pytest tests/test_identity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9584da18832a9cbf569994a9c623