### PR TITLE
Add memory utilities for birth

### DIFF
--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -1,0 +1,145 @@
+"""Memory management utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import json
+
+# Base memory directory
+MEM_DIR = Path("mem")
+
+# File paths within the memory directory
+PROFILE_FILE = MEM_DIR / "profile.json"
+VALUES_FILE = MEM_DIR / "values.yaml"
+EPISODIC_FILE = MEM_DIR / "episodic.jsonl"
+SKILLS_FILE = MEM_DIR / "skills.json"
+
+
+def _ensure_dir(path: Path) -> None:
+    """Ensure the parent directory of ``path`` exists."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def ensure_memory_structure(mem_dir: Path | str = MEM_DIR) -> None:
+    """Create the memory directory structure if it does not exist."""
+    mem_dir = Path(mem_dir)
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    (mem_dir / "profile.json").touch(exist_ok=True)
+    (mem_dir / "values.yaml").touch(exist_ok=True)
+    (mem_dir / "episodic.jsonl").touch(exist_ok=True)
+    (mem_dir / "skills.json").touch(exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Profile helpers
+# ---------------------------------------------------------------------------
+
+def read_profile(path: Path | str = PROFILE_FILE) -> dict[str, Any]:
+    """Read the profile JSON file."""
+    path = Path(path)
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as file:
+        try:
+            return json.load(file)
+        except json.JSONDecodeError:
+            return {}
+
+
+def write_profile(profile: dict[str, Any], path: Path | str = PROFILE_FILE) -> None:
+    """Write the profile JSON file."""
+    path = Path(path)
+    _ensure_dir(path)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(profile, file)
+
+
+def update_trait(trait: str, value: Any, path: Path | str = PROFILE_FILE) -> dict[str, Any]:
+    """Update or add a trait in the profile file."""
+    profile = read_profile(path)
+    profile[trait] = value
+    write_profile(profile, path)
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# Values helpers
+# ---------------------------------------------------------------------------
+
+def read_values(path: Path | str = VALUES_FILE) -> dict[str, Any]:
+    """Read the values YAML file."""
+    path = Path(path)
+    if not path.exists():
+        return {}
+    import yaml  # type: ignore
+    with path.open(encoding="utf-8") as file:
+        data = yaml.safe_load(file)
+    return data or {}
+
+
+def write_values(values: dict[str, Any], path: Path | str = VALUES_FILE) -> None:
+    """Write the values YAML file."""
+    path = Path(path)
+    _ensure_dir(path)
+    import yaml  # type: ignore
+    with path.open("w", encoding="utf-8") as file:
+        yaml.safe_dump(values, file)
+
+
+# ---------------------------------------------------------------------------
+# Episodic helpers
+# ---------------------------------------------------------------------------
+
+def read_episodes(path: Path | str = EPISODIC_FILE) -> list[dict[str, Any]]:
+    """Read all episodes from the JSONL file."""
+    path = Path(path)
+    if not path.exists():
+        return []
+    episodes = []
+    with path.open(encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if not line:
+                continue
+            episodes.append(json.loads(line))
+    return episodes
+
+
+def add_episode(episode: dict[str, Any], path: Path | str = EPISODIC_FILE) -> None:
+    """Append a new episode to the episodic memory file."""
+    path = Path(path)
+    _ensure_dir(path)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(episode) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Skills helpers
+# ---------------------------------------------------------------------------
+
+def read_skills(path: Path | str = SKILLS_FILE) -> dict[str, Any]:
+    """Read the skills JSON file."""
+    path = Path(path)
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as file:
+        try:
+            return json.load(file)
+        except json.JSONDecodeError:
+            return {}
+
+
+def write_skills(skills: dict[str, Any], path: Path | str = SKILLS_FILE) -> None:
+    """Write the skills JSON file."""
+    path = Path(path)
+    _ensure_dir(path)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(skills, file)
+
+
+def update_score(skill: str, score: float, path: Path | str = SKILLS_FILE) -> dict[str, Any]:
+    """Update a skill score in the skills file."""
+    skills = read_skills(path)
+    skills[skill] = score
+    write_skills(skills, path)
+    return skills

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from ..memory import ensure_memory_structure
+
 
 def birth(seed: int | None = None) -> None:
     """Handle the ``birth`` subcommand.
@@ -11,3 +13,4 @@ def birth(seed: int | None = None) -> None:
     seed:
         Optional random seed for reproducibility.
     """
+    ensure_memory_structure()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import json
+
+import pytest
+
+from singular.memory import add_episode, update_trait, update_score
+from singular.organisms.birth import birth
+
+
+def test_birth_creates_memory_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    birth()
+    mem = tmp_path / "mem"
+    assert mem.is_dir()
+    for name in ["profile.json", "values.yaml", "episodic.jsonl", "skills.json"]:
+        assert (mem / name).exists()
+
+
+def test_add_episode(tmp_path: Path) -> None:
+    episode_path = tmp_path / "mem" / "episodic.jsonl"
+    add_episode({"event": "test"}, path=episode_path)
+    lines = episode_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {"event": "test"}
+
+
+def test_update_trait_and_score(tmp_path: Path) -> None:
+    profile_path = tmp_path / "mem" / "profile.json"
+    skills_path = tmp_path / "mem" / "skills.json"
+
+    update_trait("courage", "high", path=profile_path)
+    assert json.loads(profile_path.read_text(encoding="utf-8")) == {"courage": "high"}
+
+    update_score("archery", 10, path=skills_path)
+    assert json.loads(skills_path.read_text(encoding="utf-8")) == {"archery": 10}


### PR DESCRIPTION
## Summary
- add memory module to manage profile, values, episodic and skills files
- support updating traits, scores and logging episodes
- ensure `birth` creates memory directory structure
- add tests for memory helpers and birth setup

## Testing
- `PYTHONPATH=src pytest tests/test_memory.py tests/test_identity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af964fb12c832abff98fc82c4dc878