### PR TITLE
Implement scoring with runtime median and AST complexity

### DIFF
--- a/life/score.py
+++ b/life/score.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import ast
+import statistics
+import time
+from typing import Tuple
+
+from . import sandbox
+
+
+def score(code: str, runs: int = 5, alpha: float = 0.05) -> Tuple[float, float]:
+    """Return performance score and variance for *code*.
+
+    The code is executed ``runs`` times inside :mod:`life.sandbox`. For each
+    execution the runtime in milliseconds is recorded. The median of these
+    timings is combined with the AST node count as a simple complexity measure
+    to produce the final score::
+
+        score = median_ms + alpha * complexity
+
+    The function returns a tuple ``(score, variance)`` where ``variance`` is the
+    population variance of the collected timings. ``alpha`` controls the weight
+    of the complexity penalty and defaults to ``0.05``.
+    """
+
+    timings = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        sandbox.run(code)
+        timings.append((time.perf_counter() - start) * 1000)
+
+    median_ms = statistics.median(timings)
+    variance = statistics.pvariance(timings) if len(timings) > 1 else 0.0
+
+    tree = ast.parse(code)
+    complexity = sum(1 for _ in ast.walk(tree))
+
+    score_value = median_ms + alpha * complexity
+    return score_value, variance

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,0 +1,16 @@
+import math
+from life.score import score
+
+
+def test_score_single_run_variance_zero():
+    value, var = score("result = 1", runs=1)
+    assert isinstance(value, float)
+    assert var == 0.0
+
+
+def test_complexity_penalty_increases_score():
+    simple = "result = 1"
+    complex_code = "result = 0\nfor i in range(1000):\n    result += i\n"
+    simple_score, _ = score(simple, runs=1, alpha=100.0)
+    complex_score, _ = score(complex_code, runs=1, alpha=100.0)
+    assert complex_score > simple_score


### PR DESCRIPTION
## Summary
- Add `life.score` module computing median runtime across repeated sandbox runs and AST node count complexity
- Expose weighted score with configurable alpha and return variance
- Add tests for scoring metrics and complexity penalty

## Testing
- `PYTHONPATH=src:. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af99cbfb08832aa66c3c49924293d9