### PR TITLE
Add atomic run logger with crash recovery

### DIFF
--- a/runs/.gitignore
+++ b/runs/.gitignore
@@ -1,0 +1,2 @@
+*.jsonl
+*.jsonl.tmp

--- a/src/singular/runs/__init__.py
+++ b/src/singular/runs/__init__.py
@@ -1,1 +1,5 @@
 """Run management modules."""
+
+from .logger import RUNS_DIR, RunLogger
+
+__all__ = ["RUNS_DIR", "RunLogger"]

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -1,0 +1,102 @@
+"""Utilities for recording execution runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import json
+import os
+from typing import Any
+
+# Directory where run logs are stored
+RUNS_DIR = Path("runs")
+
+
+def _ensure_dir(path: Path) -> None:
+    """Ensure ``path``'s parent directory exists."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+@dataclass
+class RunLogger:
+    """Append JSONL run records with crash recovery.
+
+    Parameters
+    ----------
+    run_id:
+        Identifier for the run.
+    root:
+        Directory in which log files are written. Defaults to :data:`RUNS_DIR`.
+    """
+
+    run_id: str
+    root: Path = RUNS_DIR
+
+    def __post_init__(self) -> None:
+        self.root = Path(self.root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        # Resume from existing temporary file if present
+        tmp_pattern = f"{self.run_id}-*.jsonl.tmp"
+        existing = sorted(self.root.glob(tmp_pattern))
+        if existing:
+            self.tmp_path = existing[-1]
+            # derive final path and timestamp from tmp file name
+            self.path = self.tmp_path.with_suffix("")
+            stem = self.path.name
+            # stem is <id>-<timestamp>
+            self.timestamp = stem.split("-", 1)[1]
+            self._file = self.tmp_path.open("a", encoding="utf-8")
+        else:
+            self.timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            self.path = self.root / f"{self.run_id}-{self.timestamp}.jsonl"
+            self.tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
+            _ensure_dir(self.tmp_path)
+            self._file = self.tmp_path.open("a", encoding="utf-8")
+
+    def log(
+        self,
+        skill: str,
+        op: str,
+        diff: str,
+        ok: bool,
+        ms_base: float,
+        ms_new: float,
+        score_base: float,
+        score_new: float,
+    ) -> None:
+        """Append a record to the log file.
+
+        The line is flushed and fsynced to guarantee durability.
+        """
+
+        record: dict[str, Any] = {
+            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "skill": skill,
+            "op": op,
+            "diff": diff,
+            "ok": ok,
+            "ms_base": ms_base,
+            "ms_new": ms_new,
+            "score_base": score_base,
+            "score_new": score_new,
+            "improved": score_new > score_base,
+        }
+        self._file.write(json.dumps(record) + "\n")
+        self._file.flush()
+        os.fsync(self._file.fileno())
+
+    def close(self) -> None:
+        """Flush and finalize the log file atomically."""
+        if not self._file.closed:
+            self._file.flush()
+            os.fsync(self._file.fileno())
+            self._file.close()
+            os.replace(self.tmp_path, self.path)
+
+    def __enter__(self) -> RunLogger:  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        self.close()
+

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+from singular.runs import RunLogger
+
+
+def test_log_creation(tmp_path: Path) -> None:
+    logger = RunLogger("test", root=tmp_path)
+    logger.log("skill", "op", "diff", True, 1.0, 2.0, 0.1, 0.2)
+    logger.close()
+    files = list(tmp_path.glob("test-*.jsonl"))
+    assert len(files) == 1
+    with files[0].open(encoding="utf-8") as fh:
+        line = json.loads(fh.readline())
+    assert line["skill"] == "skill"
+    assert line["improved"] is True
+
+
+def test_resume_after_crash(tmp_path: Path) -> None:
+    logger1 = RunLogger("run", root=tmp_path)
+    logger1.log("a", "op", "diff", True, 1.0, 2.0, 0.1, 0.2)
+    # Simulate crash without closing (file already flushed in log)
+    logger1._file.close()
+
+    logger2 = RunLogger("run", root=tmp_path)
+    logger2.log("b", "op", "diff", False, 2.0, 3.0, 0.2, 0.3)
+    logger2.close()
+
+    files = list(tmp_path.glob("run-*.jsonl"))
+    assert len(files) == 1
+    with files[0].open(encoding="utf-8") as fh:
+        records = [json.loads(line) for line in fh]
+    assert [r["skill"] for r in records] == ["a", "b"]


### PR DESCRIPTION
## Summary
- implement `RunLogger` to persist JSONL run files with atomic writes and resume capability
- expose `RunLogger` via `singular.runs`
- add tests covering log creation and crash recovery

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af9a7dd4fc832a87f3bf2f1bc9a9c8