### PR TITLE
Add code transformation operators with tests

### DIFF
--- a/life/operators/__init__.py
+++ b/life/operators/__init__.py
@@ -1,0 +1,7 @@
+"""Code transformation operators for the life module."""
+
+__all__ = [
+    "eq_rewrite_reduce_sum",
+    "const_tune",
+    "deadcode_elim",
+]

--- a/life/operators/const_tune.py
+++ b/life/operators/const_tune.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import ast
+import random
+
+
+class _ConstTune(ast.NodeTransformer):
+    """Randomly adjust small integer constants by ±1."""
+
+    def __init__(self, rng: random.Random, probability: float) -> None:
+        self.rng = rng
+        self.probability = probability
+
+    def visit_Constant(self, node: ast.Constant) -> ast.AST:  # pragma: no cover - trivial
+        if isinstance(node.value, int) and -16 <= node.value <= 16:
+            if self.rng.random() < self.probability:
+                delta = self.rng.choice([-1, 1])
+                return ast.copy_location(ast.Constant(node.value + delta), node)
+        return node
+
+
+def apply(
+    tree: ast.AST,
+    rng: random.Random | None = None,
+    probability: float = 0.5,
+) -> ast.AST:
+    """Tune integer constants within ``[-16, 16]`` by one with given probability."""
+
+    rng = rng or random
+    _ConstTune(rng, probability).visit(tree)
+    return ast.fix_missing_locations(tree)

--- a/life/operators/deadcode_elim.py
+++ b/life/operators/deadcode_elim.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import ast
+
+
+class _DeadCodeElim(ast.NodeTransformer):
+    """Eliminate obviously dead code such as ``if False`` blocks."""
+
+    def visit_If(self, node: ast.If) -> ast.AST:  # pragma: no cover - delegating
+        node = self.generic_visit(node)
+
+        if isinstance(node.test, ast.Constant):
+            return node.body if node.test.value else node.orelse
+
+        if len(node.body) == 1 and isinstance(node.body[0], ast.Pass):
+            if not node.orelse:
+                return []
+            new_test = ast.UnaryOp(op=ast.Not(), operand=node.test)
+            new_node = ast.If(test=new_test, body=node.orelse, orelse=[])
+            return ast.fix_missing_locations(new_node)
+
+        if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.Pass):
+            node.orelse = []
+
+        return node
+
+
+def apply(tree: ast.AST) -> ast.AST:
+    """Return *tree* with trivial ``if`` statements removed."""
+
+    new_tree = _DeadCodeElim().visit(tree)
+    return ast.fix_missing_locations(new_tree)

--- a/life/operators/eq_rewrite_reduce_sum.py
+++ b/life/operators/eq_rewrite_reduce_sum.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import ast
+
+
+class _ReduceSum(ast.NodeTransformer):
+    """Rewrite simple accumulation loops into ``sum`` calls."""
+
+    def _transform_body(self, body: list[ast.stmt]) -> list[ast.stmt]:
+        new_body: list[ast.stmt] = []
+        i = 0
+        while i < len(body):
+            stmt = body[i]
+            if (
+                i + 1 < len(body)
+                and isinstance(stmt, ast.Assign)
+                and len(stmt.targets) == 1
+                and isinstance(stmt.targets[0], ast.Name)
+                and isinstance(stmt.value, ast.Constant)
+                and stmt.value.value == 0
+            ):
+                nxt = body[i + 1]
+                if (
+                    isinstance(nxt, ast.For)
+                    and isinstance(nxt.target, ast.Name)
+                    and not nxt.orelse
+                    and len(nxt.body) == 1
+                    and isinstance(nxt.body[0], ast.AugAssign)
+                    and isinstance(nxt.body[0].op, ast.Add)
+                    and isinstance(nxt.body[0].target, ast.Name)
+                    and nxt.body[0].target.id == stmt.targets[0].id
+                    and isinstance(nxt.body[0].value, ast.Name)
+                    and nxt.body[0].value.id == nxt.target.id
+                ):
+                    sum_call = ast.Call(
+                        func=ast.Name("sum", ast.Load()),
+                        args=[nxt.iter],
+                        keywords=[],
+                    )
+                    assign = ast.Assign(targets=[stmt.targets[0]], value=sum_call)
+                    new_body.append(ast.copy_location(assign, stmt))
+                    i += 2
+                    continue
+            new_body.append(self.visit(stmt))
+            i += 1
+        return new_body
+
+    def visit_Module(self, node: ast.Module) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        return node
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        return node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        return node
+
+    def visit_For(self, node: ast.For) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        node.orelse = self._transform_body(node.orelse)
+        return node
+
+    def visit_While(self, node: ast.While) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        node.orelse = self._transform_body(node.orelse)
+        return node
+
+    def visit_If(self, node: ast.If) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        node.orelse = self._transform_body(node.orelse)
+        return node
+
+    def visit_With(self, node: ast.With) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        return node
+
+    def visit_Try(self, node: ast.Try) -> ast.AST:  # pragma: no cover - delegating
+        node.body = self._transform_body(node.body)
+        node.orelse = self._transform_body(node.orelse)
+        node.finalbody = self._transform_body(node.finalbody)
+        for handler in node.handlers:
+            handler.body = self._transform_body(handler.body)
+        return node
+
+
+def apply(tree: ast.AST) -> ast.AST:
+    """Return *tree* with simple ``for``-accumulation loops replaced by ``sum``."""
+
+    _ReduceSum().visit(tree)
+    return ast.fix_missing_locations(tree)

--- a/tests/test_const_tune.py
+++ b/tests/test_const_tune.py
@@ -1,0 +1,13 @@
+import ast
+import random
+
+from life.operators import const_tune
+
+
+def test_const_tune_adjusts_small_ints():
+    tree = ast.parse("a = 5\nb = 30")
+    rng = random.Random(0)
+    new_tree = const_tune.apply(tree, rng=rng, probability=1.0)
+    code = ast.unparse(new_tree)
+    assert "a = 6" in code
+    assert "b = 30" in code

--- a/tests/test_deadcode_elim.py
+++ b/tests/test_deadcode_elim.py
@@ -1,0 +1,36 @@
+import ast
+
+from life.operators import deadcode_elim
+
+
+def test_deadcode_elim_removes_trivial_ifs():
+    source = """
+def f(x):
+    if False:
+        x += 1
+    if True:
+        x += 2
+    if x > 0:
+        pass
+    else:
+        x -= 1
+    if x < 0:
+        x += 3
+    else:
+        pass
+    return x
+"""
+    expected = """
+def f(x):
+    x += 2
+    if not (x > 0):
+        x -= 1
+    if x < 0:
+        x += 3
+    return x
+"""
+    tree = ast.parse(source)
+    new_tree = deadcode_elim.apply(tree)
+    assert ast.dump(new_tree, include_attributes=False) == ast.dump(
+        ast.parse(expected), include_attributes=False
+    )

--- a/tests/test_eq_rewrite_reduce_sum.py
+++ b/tests/test_eq_rewrite_reduce_sum.py
@@ -1,0 +1,27 @@
+import ast
+
+from life.operators import eq_rewrite_reduce_sum
+
+
+def test_reduce_sum_rewrites_loop():
+    source = """
+from typing import Iterable
+
+def f(arr: Iterable[int]):
+    total = 0
+    for x in arr:
+        total += x
+    return total
+"""
+    expected = """
+from typing import Iterable
+
+def f(arr: Iterable[int]):
+    total = sum(arr)
+    return total
+"""
+    tree = ast.parse(source)
+    new_tree = eq_rewrite_reduce_sum.apply(tree)
+    assert ast.dump(new_tree, include_attributes=False) == ast.dump(
+        ast.parse(expected), include_attributes=False
+    )


### PR DESCRIPTION
## Summary
- add operators for reducing simple accumulation loops to `sum`
- introduce constant tuning mutation and dead code elimination
- cover new operators with unit tests

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af9b738c20832ab86f9a9804382242