### PR TITLE
Add psyche module with mood mapping and trait adjustment

### DIFF
--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -1,0 +1,110 @@
+"""Simple modeling of mood and behavioural traits."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
+    """Clamp ``value`` to the given range.
+
+    Parameters
+    ----------
+    value:
+        Value to clamp.
+    minimum:
+        Lower bound of the range.
+    maximum:
+        Upper bound of the range.
+    """
+    return max(minimum, min(maximum, value))
+
+
+@dataclass
+class Psyche:
+    """Represents mutable traits and current mood of an organism.
+
+    The attributes ``curiosity``, ``patience`` and ``playfulness`` are kept in
+    the ``[0, 1]`` range and modified according to experienced moods.
+    """
+
+    curiosity: float = 0.5
+    patience: float = 0.5
+    playfulness: float = 0.5
+
+    # ``last_mood`` is updated every time :meth:`feel` is called and can be
+    # queried by other subsystems (interaction and mutation policies).
+    last_mood: str | None = field(default=None, init=False)
+
+    # Mapping of moods to their effects on the internal traits. The deltas are
+    # added after every event and clamped.
+    _MOOD_EFFECTS: Dict[str, Dict[str, float]] = field(
+        default_factory=lambda: {
+            "proud": {"curiosity": 0.1, "patience": 0.05, "playfulness": 0.1},
+            "frustrated": {"curiosity": -0.1, "patience": -0.2, "playfulness": -0.1},
+            "anxious": {"curiosity": -0.05, "patience": -0.1, "playfulness": -0.05},
+            "neutral": {},
+        },
+        init=False,
+        repr=False,
+    )
+
+    _INTERACTION_POLICIES: Dict[str, str] = field(
+        default_factory=lambda: {
+            "proud": "engaging",
+            "frustrated": "retry",
+            "anxious": "cautious",
+            "neutral": "balanced",
+        },
+        init=False,
+        repr=False,
+    )
+
+    _MUTATION_POLICIES: Dict[str, str] = field(
+        default_factory=lambda: {
+            "proud": "exploit",
+            "frustrated": "explore",
+            "anxious": "analyze",
+            "neutral": "default",
+        },
+        init=False,
+        repr=False,
+    )
+
+    def feel(self, event: str) -> str:
+        """Register an event and update internal state.
+
+        Parameters
+        ----------
+        event:
+            A string describing the event; it is mapped to a mood using
+            :attr:`_MOOD_EFFECTS`. If the event is unknown it is treated as
+            ``neutral``.
+
+        Returns
+        -------
+        str
+            The mood resulting from the event.
+        """
+        mood = event.lower()
+        if mood not in self._MOOD_EFFECTS:
+            mood = "neutral"
+        self.last_mood = mood
+
+        for attr, delta in self._MOOD_EFFECTS[mood].items():
+            value = getattr(self, attr)
+            setattr(self, attr, _clamp(value + delta))
+
+        return mood
+
+    # Exposed helpers -----------------------------------------------------
+    def interaction_policy(self) -> str:
+        """Return the interaction policy associated with ``last_mood``."""
+        mood = self.last_mood or "neutral"
+        return self._INTERACTION_POLICIES.get(mood, "balanced")
+
+    def mutation_policy(self) -> str:
+        """Return the mutation policy associated with ``last_mood``."""
+        mood = self.last_mood or "neutral"
+        return self._MUTATION_POLICIES.get(mood, "default")

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -1,0 +1,28 @@
+from singular.psyche import Psyche
+
+
+def test_feel_updates_traits_and_last_mood() -> None:
+    psyche = Psyche()
+    mood = psyche.feel("proud")
+    assert mood == "proud"
+    assert psyche.last_mood == "proud"
+    assert psyche.curiosity > 0.5
+    assert psyche.patience > 0.5
+    assert psyche.playfulness > 0.5
+
+    # Test clamping at upper bound
+    for _ in range(20):
+        psyche.feel("proud")
+    assert 0.0 <= psyche.curiosity <= 1.0
+    assert 0.0 <= psyche.patience <= 1.0
+    assert 0.0 <= psyche.playfulness <= 1.0
+
+
+def test_policies_and_lower_clamp() -> None:
+    psyche = Psyche(curiosity=0.05, patience=0.1, playfulness=0.05)
+    psyche.feel("frustrated")
+    assert psyche.curiosity >= 0.0
+    assert psyche.patience >= 0.0
+    assert psyche.playfulness >= 0.0
+    assert psyche.interaction_policy() == "retry"
+    assert psyche.mutation_policy() == "explore"


### PR DESCRIPTION
## Summary
- implement `Psyche` class modeling moods and traits with clamped updates
- expose last mood along with interaction and mutation policy helpers
- test mood-to-trait mapping and policy retrieval

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9d7c4d50832a9d4a5b036ae7674f