### PR TITLE
Add conversational CLI with optional LLM provider and episodic memory

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -2,6 +2,19 @@
 
 from __future__ import annotations
 
+import os
+from typing import Callable
+
+from ..memory import add_episode, ensure_memory_structure, read_episodes
+from ..psyche import Psyche
+from ..providers import load_llm_provider
+
+
+def _default_reply(prompt: str) -> str:
+    """Fallback reply generation when no provider is available."""
+
+    return f"I heard you say: {prompt}"
+
 
 def talk(seed: int | None = None) -> None:
     """Handle the ``talk`` subcommand.
@@ -11,3 +24,38 @@ def talk(seed: int | None = None) -> None:
     seed:
         Optional random seed for reproducibility.
     """
+
+    ensure_memory_structure()
+
+    provider_name = os.getenv("LLM_PROVIDER") or "dummy"
+    generate_reply: Callable[[str], str] | None = load_llm_provider(provider_name)
+    if generate_reply is None:
+        generate_reply = _default_reply
+
+    psyche = Psyche()
+
+    while True:
+        episodes = read_episodes()
+        last_event = episodes[-1]["text"] if episodes else None
+
+        try:
+            user_input = input("you: ")
+        except EOFError:
+            break
+
+        if user_input.strip().lower() in {"exit", "quit"}:
+            break
+
+        add_episode({"role": "user", "text": user_input})
+
+        mood = psyche.feel("neutral")
+        reply = generate_reply(user_input)
+
+        parts = [reply]
+        if last_event:
+            parts.append(f"Reminder: {last_event}")
+        parts.append(f"Mood: {psyche.last_mood}")
+        response = " | ".join(parts)
+
+        print(response)
+        add_episode({"role": "assistant", "text": response, "mood": mood})

--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -1,0 +1,23 @@
+"""Utilities for loading LLM providers."""
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Callable
+
+
+def load_llm_provider(name: str | None) -> Callable[[str], str] | None:
+    """Load an LLM provider's ``generate_reply`` function.
+
+    Parameters
+    ----------
+    name:
+        Provider name suffix, looked up as ``llm_<name>`` in this package.
+    """
+    if not name:
+        return None
+    module_name = f"singular.providers.llm_{name}"
+    try:
+        module = import_module(module_name)
+    except ModuleNotFoundError:
+        return None
+    return getattr(module, "generate_reply", None)

--- a/src/singular/providers/llm_dummy.py
+++ b/src/singular/providers/llm_dummy.py
@@ -1,0 +1,7 @@
+"""Dummy LLM provider for tests and offline usage."""
+from __future__ import annotations
+
+
+def generate_reply(prompt: str) -> str:
+    """Return a simple echoed reply for ``prompt``."""
+    return f"Echo: {prompt}"

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -1,0 +1,20 @@
+from singular.organisms.talk import talk
+from singular.memory import read_episodes
+
+
+def test_talk_loop(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    inputs = iter(["hello", "next", "quit"])
+    monkeypatch.setenv("LLM_PROVIDER", "dummy")
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    outputs = []
+    monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
+
+    talk()
+
+    episodes = read_episodes()
+    assert len(episodes) == 4
+    assert episodes[0]["role"] == "user"
+    assert episodes[1]["role"] == "assistant"
+    assert "Mood: neutral" in episodes[1]["text"]
+    assert any("Reminder:" in out for out in outputs)


### PR DESCRIPTION
## Summary
- Implement interactive talk loop that logs conversation to episodic memory and includes mood and recent reminder in responses
- Add plugin loader for LLM providers with a dummy provider implementation
- Cover conversation workflow with unit test

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9e391eac832a8042af4e777a9e63