### PR TITLE
feat: add LLM providers

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -27,7 +27,9 @@ def talk(seed: int | None = None) -> None:
 
     ensure_memory_structure()
 
-    provider_name = os.getenv("LLM_PROVIDER") or "dummy"
+    provider_name = os.getenv("LLM_PROVIDER")
+    if not provider_name:
+        provider_name = "openai" if os.getenv("OPENAI_API_KEY") else "stub"
     generate_reply: Callable[[str], str] | None = load_llm_provider(provider_name)
     if generate_reply is None:
         generate_reply = _default_reply

--- a/src/singular/providers/llm_openai.py
+++ b/src/singular/providers/llm_openai.py
@@ -1,0 +1,35 @@
+"""OpenAI LLM provider using the ChatCompletion API."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - handle missing package
+    openai = None  # type: ignore
+
+
+def _filter(text: str) -> str:
+    """Return only printable characters from ``text``."""
+    return "".join(ch for ch in text if ch.isprintable())
+
+
+def generate_reply(prompt: str) -> str:
+    """Generate a reply via OpenAI if an API key is configured."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or openai is None:
+        return "OpenAI API key not configured."
+
+    openai.api_key = api_key
+    try:  # pragma: no cover - network call
+        response: Any = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=100,
+        )
+        text: str = response["choices"][0]["message"]["content"]
+    except Exception:
+        return "Error communicating with OpenAI."
+
+    return _filter(text)

--- a/src/singular/providers/llm_stub.py
+++ b/src/singular/providers/llm_stub.py
@@ -1,0 +1,14 @@
+"""Rule-based stub LLM provider for offline usage."""
+from __future__ import annotations
+
+import re
+
+
+def generate_reply(prompt: str) -> str:
+    """Generate a deterministic reply without network access."""
+    text = prompt.strip().lower()
+    if re.search(r"\b(hi|hello|salut|bonjour)\b", text):
+        return "Hello!"
+    if text.endswith("?"):
+        return "I'm not sure about that."
+    return f"You said: {prompt}"


### PR DESCRIPTION
## Summary
- add rule-based offline LLM stub provider
- add OpenAI provider that filters responses and uses OPENAI_API_KEY
- select provider in talk based on LLM_PROVIDER/OPENAI_API_KEY

## Testing
- `PYTHONPATH=src pytest tests/test_talk.py`

------
https://chatgpt.com/codex/tasks/task_e_68af9f12fcd4832a935858e30474fc90