### PR TITLE
Add spec schema and constraint validation

### DIFF
--- a/life/quest.py
+++ b/life/quest.py
@@ -8,6 +8,10 @@ from typing import Any, List
 import json
 
 
+class SpecValidationError(ValueError):
+    """Raised when a specification fails validation."""
+
+
 @dataclass
 class Example:
     """Single input/output pair."""
@@ -17,11 +21,22 @@ class Example:
 
 
 @dataclass
+class Constraints:
+    """Execution constraints for a generated skill."""
+
+    pure: bool
+    no_import: bool
+    time_ms_max: int
+
+
+@dataclass
 class Spec:
     """Loaded specification data."""
 
     name: str
+    signature: str
     examples: List[Example]
+    constraints: Constraints
 
 
 def load(path: Path) -> Spec:
@@ -31,21 +46,65 @@ def load(path: Path) -> Spec:
 
         {
             "name": "skill_name",
+            "signature": "skill(arg1, arg2)",
             "examples": [
                 {"input": [..], "output": ..},
-                ...
-            ]
+                ...,
+            ],
+            "constraints": {
+                "pure": true,
+                "no_import": true,
+                "time_ms_max": 1000
+            }
         }
 
     Each example's ``input`` may be a single value or a list of positional
-    arguments.
+    arguments.  The ``constraints`` object is mandatory and must request pure
+    operation, disallow imports and specify a positive ``time_ms_max`` value.
     """
 
     data = json.loads(path.read_text(encoding="utf-8"))
-    name = data["name"]
+
+    name = data.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise SpecValidationError("'name' must be a non-empty string")
+
+    signature = data.get("signature")
+    if not isinstance(signature, str) or not signature.strip():
+        raise SpecValidationError("'signature' must be a non-empty string")
+
+    examples_raw = data.get("examples")
+    if not isinstance(examples_raw, list) or not examples_raw:
+        raise SpecValidationError("'examples' must be a non-empty list")
+
     examples: List[Example] = []
-    for entry in data.get("examples", []):
+    for idx, entry in enumerate(examples_raw):
+        if not isinstance(entry, dict):
+            raise SpecValidationError(f"example {idx} must be an object")
+        if "input" not in entry:
+            raise SpecValidationError(f"example {idx} missing 'input'")
+        if "output" not in entry:
+            raise SpecValidationError(f"example {idx} missing 'output'")
         inp = entry.get("input")
         inputs = inp if isinstance(inp, list) else [inp]
         examples.append(Example(inputs=inputs, output=entry.get("output")))
-    return Spec(name=name, examples=examples)
+
+    constraints_raw = data.get("constraints")
+    if not isinstance(constraints_raw, dict):
+        raise SpecValidationError("'constraints' must be an object")
+
+    pure = constraints_raw.get("pure")
+    if pure is not True:
+        raise SpecValidationError("'constraints.pure' must be true")
+
+    no_import = constraints_raw.get("no_import")
+    if no_import is not True:
+        raise SpecValidationError("'constraints.no_import' must be true")
+
+    time_ms_max = constraints_raw.get("time_ms_max")
+    if not isinstance(time_ms_max, int) or time_ms_max <= 0:
+        raise SpecValidationError("'constraints.time_ms_max' must be a positive integer")
+
+    constraints = Constraints(pure=True, no_import=True, time_ms_max=time_ms_max)
+
+    return Spec(name=name, signature=signature, examples=examples, constraints=constraints)

--- a/tests/test_quest.py
+++ b/tests/test_quest.py
@@ -1,0 +1,41 @@
+import json
+import pytest
+
+from life import quest
+
+
+def test_load_valid_spec(tmp_path):
+    spec_data = {
+        "name": "adder",
+        "signature": "adder(a, b)",
+        "examples": [{"input": [1, 2], "output": 3}],
+        "constraints": {"pure": True, "no_import": True, "time_ms_max": 50},
+    }
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(spec_data), encoding="utf-8")
+    spec = quest.load(path)
+    assert spec.name == "adder"
+    assert spec.signature == "adder(a, b)"
+    assert spec.constraints.time_ms_max == 50
+
+
+@pytest.mark.parametrize(
+    "constraints",
+    [
+        {"pure": "yes", "no_import": True, "time_ms_max": 10},
+        {"pure": True, "no_import": True, "time_ms_max": -1},
+        {"pure": True},
+    ],
+)
+def test_load_invalid_constraints(tmp_path, constraints):
+    spec_data = {
+        "name": "adder",
+        "signature": "adder(a, b)",
+        "examples": [{"input": [1, 2], "output": 3}],
+        "constraints": constraints,
+    }
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(spec_data), encoding="utf-8")
+    with pytest.raises(quest.SpecValidationError):
+        quest.load(path)
+


### PR DESCRIPTION
## Summary
- define schema structures for specs with constraints and signature
- validate purity, import restrictions and time limits with detailed errors
- add tests for spec loading and constraint validation

## Testing
- `pytest -q` *(fails: No module named 'singular')*
- `PYTHONPATH=. pytest tests/test_quest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa01c956c832aa6d79aa517568563