### PR TITLE
Add reporting CLI and visualization script

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -10,8 +10,8 @@ from .organisms.birth import birth
 from .organisms.talk import talk
 from .runs.run import run as run_run
 from .runs.synthesize import synthesize
-
-Command = Callable[[int | None], Any]
+from .runs.report import report
+Command = Callable[..., Any]
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -27,6 +27,11 @@ def main(argv: list[str] | None = None) -> int:
     subparsers.add_parser("run", help="Execute a run").set_defaults(func=run_run)
     subparsers.add_parser("talk", help="Talk with the system").set_defaults(func=talk)
     subparsers.add_parser("synthesize", help="Synthesize results").set_defaults(func=synthesize)
+    report_parser = subparsers.add_parser(
+        "report", help="Summarize performance from a run"
+    )
+    report_parser.add_argument("--id", required=True, help="Run identifier")
+    report_parser.set_defaults(func=report)
 
     args = parser.parse_args(argv)
 
@@ -34,7 +39,10 @@ def main(argv: list[str] | None = None) -> int:
         random.seed(args.seed)
 
     func: Command = args.func
-    func(seed=args.seed)
+    if args.command == "report":
+        func(run_id=args.id, seed=args.seed)
+    else:
+        func(seed=args.seed)
     return 0
 
 

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -1,0 +1,70 @@
+"""Utilities for summarizing run performance."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+import json
+from typing import Any
+
+from .logger import RUNS_DIR
+from ..memory import read_skills, SKILLS_FILE
+
+
+def load_run_records(run_id: str, runs_dir: Path | str = RUNS_DIR) -> list[dict[str, Any]]:
+    """Load run records for ``run_id`` from JSONL log file."""
+    runs_dir = Path(runs_dir)
+    pattern = f"{run_id}-*.jsonl"
+    files = sorted(runs_dir.glob(pattern))
+    if not files:
+        raise FileNotFoundError(f"No log file found for id {run_id}")
+    path = files[-1]
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+    return records
+
+
+def report(
+    run_id: str,
+    *,
+    runs_dir: Path | str = RUNS_DIR,
+    skills_path: Path | str = SKILLS_FILE,
+    seed: int | None = None,
+) -> None:
+    """Summarize performance for a given run."""
+
+    try:
+        records = load_run_records(run_id, runs_dir)
+    except FileNotFoundError:
+        print(f"No run log found for id {run_id}")
+        return
+
+    if not records:
+        print(f"No records for id {run_id}")
+        return
+
+    scores = [r.get("score_new", 0.0) for r in records]
+    ops = [r.get("op", "?") for r in records]
+
+    print(f"Run {run_id}")
+    print(f"Generations: {len(scores)}")
+    print(f"Final score: {scores[-1]}")
+    print(f"Best score: {max(scores)}")
+
+    counter = Counter(ops)
+    print("Operator histogram:")
+    for op, count in counter.items():
+        print(f"  {op}: {count}")
+
+    skills = read_skills(path=skills_path)
+    if skills:
+        print("Skills:")
+        for skill, score in skills.items():
+            print(f"  {skill}: {score}")
+    else:
+        print("No skills recorded.")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import json
+
+from singular.cli import main
+
+
+def test_report_cli(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    log = runs / "run1-000.jsonl"
+    records = [
+        {"op": "mutate", "score_new": 1.0},
+        {"op": "crossover", "score_new": 1.5},
+    ]
+    with log.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+    mem = tmp_path / "mem"
+    mem.mkdir()
+    (mem / "skills.json").write_text(json.dumps({"skillA": 0.8}), encoding="utf-8")
+
+    main(["report", "--id", "run1"])
+    out = capsys.readouterr().out
+    assert "Run run1" in out
+    assert "Generations: 2" in out
+    assert "skillA" in out

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,20 @@
+import json
+import viz
+
+
+def test_viz_ascii(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    log = runs / "r1-000.jsonl"
+    records = [
+        {"op": "mutate", "score_new": 1.0},
+        {"op": "mutate", "score_new": 1.2},
+    ]
+    with log.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+    viz.main(["--id", "r1", "--ascii"])
+    out = capsys.readouterr().out
+    assert "Generation 1" in out
+    assert "mutate" in out

--- a/viz.py
+++ b/viz.py
@@ -1,0 +1,67 @@
+"""Visualize run performance with plots or ASCII charts."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+
+from singular.runs.report import load_run_records
+
+
+def _ascii_charts(scores: list[float], ops: list[str]) -> None:
+    for idx, score in enumerate(scores, 1):
+        print(f"Generation {idx}: {score}")
+    print("Operator histogram:")
+    counts = Counter(ops)
+    for op, count in counts.items():
+        print(f"{op}: {'#' * count}")
+
+
+def _png_charts(scores: list[float], ops: list[str], output: Path) -> None:
+    import matplotlib.pyplot as plt  # type: ignore
+
+    counts = Counter(ops)
+    fig, axes = plt.subplots(2, 1, figsize=(6, 6))
+    axes[0].plot(range(1, len(scores) + 1), scores, marker="o")
+    axes[0].set_xlabel("Generation")
+    axes[0].set_ylabel("Score")
+    axes[1].bar(list(counts.keys()), list(counts.values()))
+    axes[1].set_xlabel("Operator")
+    axes[1].set_ylabel("Count")
+    fig.tight_layout()
+    fig.savefig(output)
+    plt.close(fig)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Visualize run performance")
+    parser.add_argument("--id", required=True, help="Run identifier")
+    parser.add_argument("--ascii", action="store_true", help="Output ASCII charts")
+    parser.add_argument("--output", type=Path, help="PNG file to write")
+    args = parser.parse_args(argv)
+
+    try:
+        records = load_run_records(args.id)
+    except FileNotFoundError:
+        print(f"No run log found for id {args.id}")
+        return 1
+
+    scores = [r.get("score_new", 0.0) for r in records]
+    ops = [r.get("op", "?") for r in records]
+
+    if args.ascii:
+        _ascii_charts(scores, ops)
+    else:
+        try:
+            output = args.output or Path(f"{args.id}.png")
+            _png_charts(scores, ops, output)
+            print(f"Saved plot to {output}")
+        except Exception:
+            print("matplotlib is required for PNG output; use --ascii if unavailable")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `report` subcommand to summarize run logs and skill scores
- create `viz.py` for plotting scores across generations and operator histograms
- cover new utilities with tests

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afa220cb98832ab462457c92bf4183