### PR TITLE
Add end-to-end workflow and CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . ruff black mypy pytest pytest-cov
+      - name: Ruff
+        run: ruff check .
+      - name: Black
+        run: black --check .
+      - name: Mypy
+        run: mypy src
+      - name: Pytest
+        run: pytest --cov=src/singular --cov-report=term-missing
+

--- a/src/singular/runs/run.py
+++ b/src/singular/runs/run.py
@@ -2,12 +2,39 @@
 
 from __future__ import annotations
 
+import ast
 
-def run(seed: int | None = None) -> None:
-    """Handle the ``run`` subcommand.
+from life.operators.eq_rewrite_reduce_sum import apply
+from life.score import score
+
+
+def run(seed: int | None = None) -> str:
+    """Generate a candidate mutation and return the winning code string.
+
+    This is a very small demo that mutates a naive accumulation loop into a
+    ``sum`` call using :mod:`life.operators.eq_rewrite_reduce_sum`. Both the
+    original and mutated versions are scored via :func:`life.score.score` with a
+    strong complexity penalty so that the simpler variant wins deterministically.
+    The function returns the code snippet with the better score.
 
     Parameters
     ----------
     seed:
-        Optional random seed for reproducibility.
+        Optional random seed for reproducibility. (Currently unused.)
     """
+
+    base = (
+        "total = 0\n"
+        "for i in range(1000):\n"
+        "    total += i\n"
+        "result = total\n"
+    )
+
+    tree = ast.parse(base)
+    mutated_tree = apply(tree)
+    mutated = ast.unparse(mutated_tree)
+
+    base_score, _ = score(base, runs=1, alpha=100.0)
+    mutated_score, _ = score(mutated, runs=1, alpha=100.0)
+
+    return mutated if mutated_score <= base_score else base

--- a/src/singular/runs/synthesize.py
+++ b/src/singular/runs/synthesize.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from ..memory import add_episode, ensure_memory_structure
 
-def synthesize(seed: int | None = None) -> None:
-    """Handle the ``synthesize`` subcommand.
+
+def synthesize(code: str, seed: int | None = None) -> None:
+    """Persist the winning *code* snippet into episodic memory.
 
     Parameters
     ----------
+    code:
+        Code to store. It is appended as a "system" episode so that the talk
+        loop can recall it as a reminder.
     seed:
-        Optional random seed for reproducibility.
+        Optional random seed for reproducibility. (Currently unused.)
     """
+
+    ensure_memory_structure()
+    add_episode({"role": "system", "text": code})

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,33 @@
+"""End-to-end scenario: birth → run → synthesize → talk."""
+
+from singular.organisms.birth import birth
+from singular.organisms.talk import talk
+from singular.runs.run import run
+from singular.runs.synthesize import synthesize
+from singular.memory import read_episodes
+
+
+def test_full_workflow(monkeypatch, tmp_path):
+    """Ensure the basic workflow stores code and recalls it in conversation."""
+
+    monkeypatch.chdir(tmp_path)
+
+    birth()
+    code = run()
+    synthesize(code)
+
+    inputs = iter(["hi", "quit"])
+    outputs: list[str] = []
+    monkeypatch.setenv("LLM_PROVIDER", "dummy")
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
+
+    talk()
+
+    episodes = read_episodes()
+    # After synthesize and one talk exchange we should have three episodes:
+    #   system (code), user, assistant
+    assert len(episodes) == 3
+    assert episodes[0]["text"] == code
+    assert any(f"Reminder: {code}" in out for out in outputs)
+


### PR DESCRIPTION
## Summary
- implement demonstration run() and synthesize() commands to produce and store a winning mutation
- add end-to-end test covering birth → run → synthesize → talk
- configure GitHub Actions to run ruff, black, mypy, and pytest with coverage

## Testing
- `ruff check .` *(fails: E402 and other errors)*
- `black --check .` *(fails: would reformat multiple files)*
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afa344a1d8832a85cabf1fcc9cdb5f