### PR TITLE
Add provider argument for talk CLI

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -25,7 +25,11 @@ def main(argv: list[str] | None = None) -> int:
 
     subparsers.add_parser("birth", help="Birth a new organism").set_defaults(func=birth)
     subparsers.add_parser("run", help="Execute a run").set_defaults(func=run_run)
-    subparsers.add_parser("talk", help="Talk with the system").set_defaults(func=talk)
+
+    talk_parser = subparsers.add_parser("talk", help="Talk with the system")
+    talk_parser.add_argument("--provider", default=None, help="LLM provider to use")
+    talk_parser.set_defaults(func=talk)
+
     subparsers.add_parser("synthesize", help="Synthesize results").set_defaults(func=synthesize)
     report_parser = subparsers.add_parser(
         "report", help="Summarize performance from a run"
@@ -41,6 +45,8 @@ def main(argv: list[str] | None = None) -> int:
     func: Command = args.func
     if args.command == "report":
         func(run_id=args.id, seed=args.seed)
+    elif args.command == "talk":
+        func(provider=args.provider, seed=args.seed)
     else:
         func(seed=args.seed)
     return 0

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -16,18 +16,20 @@ def _default_reply(prompt: str) -> str:
     return f"I heard you say: {prompt}"
 
 
-def talk(seed: int | None = None) -> None:
+def talk(provider: str | None = None, seed: int | None = None) -> None:
     """Handle the ``talk`` subcommand.
 
     Parameters
     ----------
+    provider:
+        Optional name of the LLM provider. Overrides environment variables.
     seed:
         Optional random seed for reproducibility.
     """
 
     ensure_memory_structure()
 
-    provider_name = os.getenv("LLM_PROVIDER")
+    provider_name = provider or os.getenv("LLM_PROVIDER")
     if not provider_name:
         provider_name = "openai" if os.getenv("OPENAI_API_KEY") else "stub"
     generate_reply: Callable[[str], str] | None = load_llm_provider(provider_name)

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -1,3 +1,4 @@
+from singular.cli import main
 from singular.organisms.talk import talk
 from singular.memory import read_episodes
 
@@ -18,3 +19,25 @@ def test_talk_loop(monkeypatch, tmp_path):
     assert episodes[1]["role"] == "assistant"
     assert "Mood: neutral" in episodes[1]["text"]
     assert any("Reminder:" in out for out in outputs)
+
+
+def test_cli_provider_precedence(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LLM_PROVIDER", "env")
+
+    captured: dict[str, str] = {}
+
+    def fake_load(name: str | None):
+        captured["provider"] = name or ""
+        return lambda _: "ok"
+
+    monkeypatch.setattr(
+        "singular.organisms.talk.load_llm_provider", fake_load
+    )
+    inputs = iter(["quit"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    monkeypatch.setattr("builtins.print", lambda _msg: None)
+
+    main(["talk", "--provider", "cli"])
+
+    assert captured["provider"] == "cli"


### PR DESCRIPTION
## Summary
- allow specifying LLM provider via `--provider` in `talk` subcommand
- let `talk` accept provider argument and use before env vars
- test CLI provider argument precedence over environment variables

## Testing
- `PYTHONPATH=.:src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa7191c90832a99c5e1b62e19e8c3