### PR TITLE
Add psyche state persistence

### DIFF
--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -13,6 +13,7 @@ PROFILE_FILE = MEM_DIR / "profile.json"
 VALUES_FILE = MEM_DIR / "values.yaml"
 EPISODIC_FILE = MEM_DIR / "episodic.jsonl"
 SKILLS_FILE = MEM_DIR / "skills.json"
+PSYCHE_FILE = MEM_DIR / "psyche.json"
 
 
 def _ensure_dir(path: Path) -> None:
@@ -28,6 +29,7 @@ def ensure_memory_structure(mem_dir: Path | str = MEM_DIR) -> None:
     (mem_dir / "values.yaml").touch(exist_ok=True)
     (mem_dir / "episodic.jsonl").touch(exist_ok=True)
     (mem_dir / "skills.json").touch(exist_ok=True)
+    (mem_dir / "psyche.json").touch(exist_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -143,3 +145,28 @@ def update_score(skill: str, score: float, path: Path | str = SKILLS_FILE) -> di
     skills[skill] = score
     write_skills(skills, path)
     return skills
+
+
+# ---------------------------------------------------------------------------
+# Psyche helpers
+# ---------------------------------------------------------------------------
+
+
+def read_psyche(path: Path | str = PSYCHE_FILE) -> dict[str, Any]:
+    """Read the psyche JSON file."""
+    path = Path(path)
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as file:
+        try:
+            return json.load(file)
+        except json.JSONDecodeError:
+            return {}
+
+
+def write_psyche(state: dict[str, Any], path: Path | str = PSYCHE_FILE) -> None:
+    """Write the psyche JSON file."""
+    path = Path(path)
+    _ensure_dir(path)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(state, file)

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -36,7 +36,7 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
     if generate_reply is None:
         generate_reply = _default_reply
 
-    psyche = Psyche()
+    psyche = Psyche.load_state()
 
     while True:
         episodes = read_episodes()
@@ -63,3 +63,4 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
 
         print(response)
         add_episode({"role": "assistant", "text": response, "mood": mood})
+        psyche.save_state()

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from singular.psyche import Psyche
 
 
@@ -26,3 +28,17 @@ def test_policies_and_lower_clamp() -> None:
     assert psyche.playfulness >= 0.0
     assert psyche.interaction_policy() == "retry"
     assert psyche.mutation_policy() == "explore"
+
+
+def test_state_persistence(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "psyche.json"
+    psyche = Psyche(curiosity=0.2, patience=0.3, playfulness=0.4)
+    psyche.feel("proud")
+    psyche.save_state(path)
+    assert path.exists()
+
+    loaded = Psyche.load_state(path)
+    assert loaded.curiosity == psyche.curiosity
+    assert loaded.patience == psyche.patience
+    assert loaded.playfulness == psyche.playfulness
+    assert loaded.last_mood == psyche.last_mood


### PR DESCRIPTION
## Summary
- add memory helpers for `psyche.json`
- persist psyche state with `load_state` and `save_state`
- load and save psyche state in talk command
- test psyche state persistence

## Testing
- `PYTHONPATH=src:. pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68afa90db494832a8cbed112ac032797