### PR TITLE
Add status CLI subcommand for run metrics and psyche overview

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -8,6 +8,7 @@ from typing import Callable, Any
 
 from .organisms.birth import birth
 from .organisms.talk import talk
+from .organisms.status import status
 from .runs.run import run as run_run
 from .runs.synthesize import synthesize
 from .runs.report import report
@@ -25,6 +26,8 @@ def main(argv: list[str] | None = None) -> int:
 
     subparsers.add_parser("birth", help="Birth a new organism").set_defaults(func=birth)
     subparsers.add_parser("run", help="Execute a run").set_defaults(func=run_run)
+
+    subparsers.add_parser("status", help="Show current status").set_defaults(func=status)
 
     talk_parser = subparsers.add_parser("talk", help="Talk with the system")
     talk_parser.add_argument("--provider", default=None, help="LLM provider to use")

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -1,0 +1,47 @@
+"""Status command implementation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..psyche import Psyche
+from ..runs.logger import RUNS_DIR
+
+
+def status(seed: int | None = None) -> None:
+    """Display basic metrics and current psyche state."""
+
+    del seed  # unused
+
+    runs_dir = Path(RUNS_DIR)
+    files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
+    if files:
+        latest = files[-1]
+        records = []
+        with latest.open(encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    records.append(json.loads(line))
+        if records:
+            last = records[-1]
+            ms_new = last.get("ms_new")
+            ok_count = sum(1 for r in records if r.get("ok"))
+            success_rate = ok_count / len(records) * 100
+            print(f"Latest run: {latest.stem}")
+            if isinstance(ms_new, (int, float)):
+                print(f"Last execution speed: {ms_new:.2f}ms")
+            print(f"Success rate: {success_rate:.0f}%")
+        else:
+            print(f"Run log {latest.name} is empty.")
+    else:
+        print("No run logs found.")
+
+    psyche = Psyche.load_state()
+    mood = psyche.last_mood or "neutral"
+    print(f"Mood: {mood}")
+    print("Traits:")
+    print(f"  curiosity: {psyche.curiosity:.2f}")
+    print(f"  patience: {psyche.patience:.2f}")
+    print(f"  playfulness: {psyche.playfulness:.2f}")


### PR DESCRIPTION
## Summary
- introduce `status` organism command to display latest run metrics and psyche state
- wire `status` into CLI as a new subcommand
- accept seed argument for consistency

## Testing
- `PYTHONPATH=src:. pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68afae43f3f0832ab641e1eaef5ecb90