### PR TITLE
Initialize identity, profile, and psyche during birth

### DIFF
--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from ..memory import ensure_memory_structure
+import random
+import string
+
+from ..identity import create_identity
+from ..memory import ensure_memory_structure, write_profile
+from ..psyche import Psyche
 
 
 def birth(seed: int | None = None) -> None:
@@ -14,3 +19,20 @@ def birth(seed: int | None = None) -> None:
         Optional random seed for reproducibility.
     """
     ensure_memory_structure()
+
+    if seed is not None:
+        random.seed(seed)
+
+    # Generate a random name and soulseed for the new identity
+    name = f"organism-{random.randint(0, 999999):06d}"
+    soulseed = "".join(
+        random.choices(string.ascii_lowercase + string.digits, k=16)
+    )
+
+    # Create the identity file and persist a base profile
+    identity = create_identity(name, soulseed)
+    write_profile(identity.__dict__)
+
+    # Initialize the psyche with default traits and save its state
+    psyche = Psyche()
+    psyche.save_state()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -16,6 +16,27 @@ def test_birth_creates_memory_files(tmp_path: Path, monkeypatch: pytest.MonkeyPa
         assert (mem / name).exists()
 
 
+def test_birth_initializes_identity_profile_and_psyche(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    birth(seed=123)
+
+    identity_data = json.loads((tmp_path / "id.json").read_text(encoding="utf-8"))
+    profile_data = json.loads(
+        (tmp_path / "mem" / "profile.json").read_text(encoding="utf-8")
+    )
+    assert profile_data["id"] == identity_data["id"]
+
+    psyche_data = json.loads(
+        (tmp_path / "mem" / "psyche.json").read_text(encoding="utf-8")
+    )
+    assert psyche_data == {
+        "curiosity": 0.5,
+        "patience": 0.5,
+        "playfulness": 0.5,
+        "last_mood": None,
+    }
+
+
 def test_add_episode(tmp_path: Path) -> None:
     episode_path = tmp_path / "mem" / "episodic.jsonl"
     add_episode({"event": "test"}, path=episode_path)


### PR DESCRIPTION
## Summary
- Generate a random identity during `birth` and persist it to `id.json`
- Store a base profile and default psyche state in memory
- Test that birth initializes identity, profile, and psyche files

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afb02ca41c832aacae2d792f1d4d44