### PR TITLE
Initialize default arithmetic skills in birth

### DIFF
--- a/mem/skills.json
+++ b/mem/skills.json
@@ -1,0 +1,1 @@
+{"addition": 0.0, "subtraction": 0.0, "multiplication": 0.0}

--- a/skills/addition.py
+++ b/skills/addition.py
@@ -1,0 +1,7 @@
+"""Simple addition skill."""
+
+
+def add(a: float, b: float) -> float:
+    """Return the sum of ``a`` and ``b``."""
+    return a + b
+

--- a/skills/multiplication.py
+++ b/skills/multiplication.py
@@ -1,0 +1,7 @@
+"""Simple multiplication skill."""
+
+
+def multiply(a: float, b: float) -> float:
+    """Return the product of ``a`` and ``b``."""
+    return a * b
+

--- a/skills/subtraction.py
+++ b/skills/subtraction.py
@@ -1,0 +1,7 @@
+"""Simple subtraction skill."""
+
+
+def subtract(a: float, b: float) -> float:
+    """Return the difference of ``a`` and ``b``."""
+    return a - b
+

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import random
 import string
+from pathlib import Path
 
 from ..identity import create_identity
-from ..memory import ensure_memory_structure, write_profile
+from ..memory import ensure_memory_structure, update_score, write_profile
 from ..psyche import Psyche
 
 
@@ -19,6 +20,33 @@ def birth(seed: int | None = None) -> None:
         Optional random seed for reproducibility.
     """
     ensure_memory_structure()
+
+    skills_dir = Path("skills")
+    if not skills_dir.exists() or not any(skills_dir.iterdir()):
+        skills_dir.mkdir(parents=True, exist_ok=True)
+        default_skills = {
+            "addition.py": (
+                '"""Simple addition skill."""\n\n'
+                "def add(a: float, b: float) -> float:\n"
+                "    \"\"\"Return the sum of ``a`` and ``b``.\"\"\"\n"
+                "    return a + b\n"
+            ),
+            "subtraction.py": (
+                '"""Simple subtraction skill."""\n\n'
+                "def subtract(a: float, b: float) -> float:\n"
+                "    \"\"\"Return the difference of ``a`` and ``b``.\"\"\"\n"
+                "    return a - b\n"
+            ),
+            "multiplication.py": (
+                '"""Simple multiplication skill."""\n\n'
+                "def multiply(a: float, b: float) -> float:\n"
+                "    \"\"\"Return the product of ``a`` and ``b``.\"\"\"\n"
+                "    return a * b\n"
+            ),
+        }
+        for filename, code in default_skills.items():
+            (skills_dir / filename).write_text(code, encoding="utf-8")
+            update_score(filename.removesuffix(".py"), 0.0)
 
     if seed is not None:
         random.seed(seed)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -54,3 +54,24 @@ def test_update_trait_and_score(tmp_path: Path) -> None:
 
     update_score("archery", 10, path=skills_path)
     assert json.loads(skills_path.read_text(encoding="utf-8")) == {"archery": 10}
+
+
+def test_birth_initializes_default_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    birth()
+
+    skills_dir = tmp_path / "skills"
+    assert (skills_dir / "addition.py").exists()
+    assert (skills_dir / "subtraction.py").exists()
+    assert (skills_dir / "multiplication.py").exists()
+
+    skills_data = json.loads(
+        (tmp_path / "mem" / "skills.json").read_text(encoding="utf-8")
+    )
+    assert skills_data == {
+        "addition": 0.0,
+        "subtraction": 0.0,
+        "multiplication": 0.0,
+    }


### PR DESCRIPTION
## Summary
- add simple arithmetic skill examples
- create skills and initial scores during birth if skills folder empty
- track default skill scores in memory

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb1620260832a9a305d12d27d742c