### PR TITLE
Expose life loop via CLI and log mutations

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import random
+from pathlib import Path
 from typing import Callable, Any
 
 from .organisms.birth import birth
@@ -12,6 +13,7 @@ from .organisms.status import status
 from .runs.run import run as run_run
 from .runs.synthesize import synthesize
 from .runs.report import report
+from .runs.loop import loop as loop_run
 Command = Callable[..., Any]
 
 
@@ -26,6 +28,14 @@ def main(argv: list[str] | None = None) -> int:
 
     subparsers.add_parser("birth", help="Birth a new organism").set_defaults(func=birth)
     subparsers.add_parser("run", help="Execute a run").set_defaults(func=run_run)
+    loop_parser = subparsers.add_parser("loop", help="Execute evolutionary loop")
+    loop_parser.add_argument("--skills-dir", type=Path, default=Path("skills"))
+    loop_parser.add_argument(
+        "--checkpoint", type=Path, default=Path("life_checkpoint.json")
+    )
+    loop_parser.add_argument("--budget-seconds", type=float, required=True)
+    loop_parser.add_argument("--run-id", default="loop", help="Run identifier")
+    loop_parser.set_defaults(func=loop_run)
 
     subparsers.add_parser("status", help="Show current status").set_defaults(func=status)
 
@@ -50,6 +60,14 @@ def main(argv: list[str] | None = None) -> int:
         func(run_id=args.id, seed=args.seed)
     elif args.command == "talk":
         func(provider=args.provider, seed=args.seed)
+    elif args.command == "loop":
+        func(
+            skills_dir=args.skills_dir,
+            checkpoint=args.checkpoint,
+            budget_seconds=args.budget_seconds,
+            run_id=args.run_id,
+            seed=args.seed,
+        )
     else:
         func(seed=args.seed)
     return 0

--- a/src/singular/runs/loop.py
+++ b/src/singular/runs/loop.py
@@ -1,0 +1,22 @@
+"""Expose :func:`life.loop.run` for the CLI."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from life.loop import run as life_run
+
+
+def loop(
+    *,
+    skills_dir: Path,
+    checkpoint: Path,
+    budget_seconds: float,
+    run_id: str = "loop",
+    seed: int | None = None,
+) -> None:
+    """Wrapper around :func:`life.loop.run` used by the CLI."""
+
+    rng = random.Random(seed) if seed is not None else None
+    life_run(skills_dir, checkpoint, budget_seconds, rng=rng, run_id=run_id)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,9 +1,16 @@
 import json
 import random
+import functools
+import sys
 from pathlib import Path
 
 import pytest
 
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.append(str(root_dir))
+sys.path.append(str(root_dir / "src"))
+
+import life.loop as life_loop
 from life.loop import run, load_checkpoint
 
 
@@ -43,3 +50,37 @@ def test_resume_from_checkpoint(tmp_path: Path):
 
     assert second_iter > first_iter
     assert second_val > first_val
+
+
+def test_log_and_memory_update(tmp_path: Path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = 1", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(RL, root=tmp_path / "logs")
+    )
+
+    mem_file = tmp_path / "skills.json"
+
+    def fake_update_score(skill: str, score: float) -> None:
+        data = json.loads(mem_file.read_text()) if mem_file.exists() else {}
+        data[skill] = score
+        mem_file.write_text(json.dumps(data))
+
+    monkeypatch.setattr(life_loop, "update_score", fake_update_score)
+
+    run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.1,
+        rng=random.Random(0),
+        run_id="loop",
+    )
+
+    assert any((tmp_path / "logs").glob("loop-*.jsonl"))
+    assert json.loads(mem_file.read_text())["foo"] > 1


### PR DESCRIPTION
## Summary
- add `loop` CLI subcommand to run the evolutionary loop
- log each skill mutation and update skill scores
- test logging and memory updates for loop runs

## Testing
- `pytest tests/test_loop.py -q`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68afb2949c50832aaa6652d75ac37d5d