### PR TITLE
feat: add quest CLI for skill synthesis

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -10,10 +10,12 @@ from typing import Callable, Any
 from .organisms.birth import birth
 from .organisms.talk import talk
 from .organisms.status import status
+from .organisms.quest import quest
 from .runs.run import run as run_run
 from .runs.synthesize import synthesize
 from .runs.report import report
 from .runs.loop import loop as loop_run
+
 Command = Callable[..., Any]
 
 
@@ -43,7 +45,15 @@ def main(argv: list[str] | None = None) -> int:
     talk_parser.add_argument("--provider", default=None, help="LLM provider to use")
     talk_parser.set_defaults(func=talk)
 
-    subparsers.add_parser("synthesize", help="Synthesize results").set_defaults(func=synthesize)
+    quest_parser = subparsers.add_parser(
+        "quest", help="Generate a skill from a specification"
+    )
+    quest_parser.add_argument("spec", type=Path, help="Path to specification JSON")
+    quest_parser.set_defaults(func=quest)
+
+    subparsers.add_parser("synthesize", help="Synthesize results").set_defaults(
+        func=synthesize
+    )
     report_parser = subparsers.add_parser(
         "report", help="Summarize performance from a run"
     )
@@ -68,6 +78,8 @@ def main(argv: list[str] | None = None) -> int:
             run_id=args.run_id,
             seed=args.seed,
         )
+    elif args.command == "quest":
+        func(spec=args.spec, seed=args.seed)
     else:
         func(seed=args.seed)
     return 0
@@ -75,3 +87,4 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
     raise SystemExit(main())
+

--- a/src/singular/organisms/quest.py
+++ b/src/singular/organisms/quest.py
@@ -1,0 +1,39 @@
+"""Quest command implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from life.synthesis import synthesise
+
+from ..memory import add_episode, ensure_memory_structure, update_score
+from ..psyche import Psyche
+
+
+def quest(spec: Path, seed: int | None = None) -> None:
+    """Handle the ``quest`` subcommand.
+
+    Parameters
+    ----------
+    spec:
+        Path to the JSON specification describing the desired skill.
+    seed:
+        Optional random seed for reproducibility. (Currently unused.)
+    """
+
+    ensure_memory_structure()
+    psyche = Psyche.load_state()
+
+    try:
+        skill_path = synthesise(spec, Path("skills"))
+    except Exception as exc:  # pragma: no cover - re-raised after logging
+        mood = psyche.feel("frustrated")
+        add_episode({"event": "quest", "status": "failure", "error": str(exc), "mood": mood})
+        psyche.save_state()
+        raise
+
+    update_score(skill_path.stem, 0.0)
+    mood = psyche.feel("proud")
+    add_episode({"event": "quest", "status": "success", "skill": skill_path.stem, "mood": mood})
+    psyche.save_state()
+

--- a/tests/test_cli_quest.py
+++ b/tests/test_cli_quest.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from singular.cli import main
+from singular.memory import read_episodes, read_skills
+
+
+def _write_spec(path: Path, name: str, examples: list[dict]) -> None:
+    spec = {
+        "name": name,
+        "signature": f"{name}(x)",
+        "examples": examples,
+        "constraints": {"pure": True, "no_import": True, "time_ms_max": 1000},
+    }
+    path.write_text(json.dumps(spec), encoding="utf-8")
+
+
+def test_quest_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    spec_path = tmp_path / "square.json"
+    _write_spec(
+        spec_path,
+        "square",
+        [{"input": [2], "output": 4}, {"input": [3], "output": 9}],
+    )
+
+    main(["quest", str(spec_path)])
+
+    skill_file = tmp_path / "skills" / "square.py"
+    assert skill_file.exists()
+
+    skills_data = read_skills(tmp_path / "mem" / "skills.json")
+    assert skills_data == {"square": 0.0}
+
+    episodes = read_episodes(tmp_path / "mem" / "episodic.jsonl")
+    assert episodes[-1]["status"] == "success"
+    assert episodes[-1]["skill"] == "square"
+
+    psyche = json.loads((tmp_path / "mem" / "psyche.json").read_text())
+    assert psyche["last_mood"] == "proud"
+
+
+def test_quest_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    spec_path = tmp_path / "bad.json"
+    _write_spec(
+        spec_path,
+        "badskill",
+        [{"input": [2], "output": 4}, {"input": [2], "output": 5}],
+    )
+
+    with pytest.raises(RuntimeError):
+        main(["quest", str(spec_path)])
+
+    assert not (tmp_path / "skills" / "badskill.py").exists()
+    skills_data = read_skills(tmp_path / "mem" / "skills.json")
+    assert skills_data == {}
+
+    episodes = read_episodes(tmp_path / "mem" / "episodic.jsonl")
+    assert episodes[-1]["status"] == "failure"
+
+    psyche = json.loads((tmp_path / "mem" / "psyche.json").read_text())
+    assert psyche["last_mood"] == "frustrated"
+


### PR DESCRIPTION
## Summary
- add `quest` CLI subcommand to generate skills from JSON specs
- log quest outcomes to episodic memory and adjust psyche state
- test successful and failing quests update memory and mood

## Testing
- `PYTHONPATH=src:. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb538944c832aaf95d75a9aa95604