### PR TITLE
Store mutation episodes and recall in talk

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -40,9 +40,25 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
 
     while True:
         episodes = read_episodes()
-        last_event = episodes[-1]["text"] if episodes else None
+        last_event = next((e["text"] for e in reversed(episodes) if "text" in e), None)
         latest_mutation = next(
             (e for e in reversed(episodes) if e.get("event") == "mutation"),
+            None,
+        )
+        last_success = next(
+            (
+                e
+                for e in reversed(episodes)
+                if e.get("event") == "mutation" and e.get("improved")
+            ),
+            None,
+        )
+        last_failure = next(
+            (
+                e
+                for e in reversed(episodes)
+                if e.get("event") == "mutation" and not e.get("improved")
+            ),
             None,
         )
         mood_event = latest_mutation.get("mood") if latest_mutation else None
@@ -80,6 +96,10 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
         parts = [reply]
         if last_event:
             parts.append(f"Reminder: {last_event}")
+        if last_success:
+            parts.append(f"Last success: {last_success.get('op')}")
+        if last_failure:
+            parts.append(f"Last failure: {last_failure.get('op')}")
         if perf_msg:
             parts.append(perf_msg)
         parts.append(f"Mood: {mood_report}")

--- a/src/singular/runs/run.py
+++ b/src/singular/runs/run.py
@@ -10,6 +10,7 @@ from life.operators import const_tune, deadcode_elim, eq_rewrite_reduce_sum
 from life.score import score
 
 from ..psyche import Psyche
+from ..memory import add_episode
 
 
 def run(seed: int | None = None) -> str:
@@ -78,6 +79,8 @@ def run(seed: int | None = None) -> str:
     }
 
     psyche.process_run_record(record)
+    add_episode({"event": "mutation", **record, "mood": psyche.last_mood})
+    psyche.save_state()
 
     return mutated if mutated_score <= base_score else base
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -25,9 +25,10 @@ def test_full_workflow(monkeypatch, tmp_path):
     talk()
 
     episodes = read_episodes()
-    # After synthesize and one talk exchange we should have three episodes:
-    #   system (code), user, assistant
-    assert len(episodes) == 3
-    assert episodes[0]["text"] == code
+    # After run, synthesize and one talk exchange we should have four episodes:
+    #   mutation, system (code), user, assistant
+    assert len(episodes) == 4
+    assert episodes[0]["event"] == "mutation"
+    assert episodes[1]["text"] == code
     assert any(f"Reminder: {code}" in out for out in outputs)
 


### PR DESCRIPTION
## Summary
- Record each run's mutation in episodic memory and persist psyche state
- Talk command references last success and failure mutation events
- Update end-to-end test for new mutation episode

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb7367770832a9129f0c33999ac75