### PR TITLE
Use lower score as improvement indicator

### DIFF
--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -31,7 +31,8 @@ def derive_mood(record: dict) -> str:
     :class:`~singular.runs.logger.RunLogger`.  The heuristic is intentionally
     simple:
 
-    * If the run ``improved`` a score, the psyche feels ``"proud"``.
+    * If the run ``improved`` a score (``score_new < score_base``), the psyche
+      feels ``"proud"``.
     * If execution became slower (``ms_new`` > ``ms_base``) without improving,
       the psyche is ``"frustrated"``.
     * In all other cases we assume an ``"anxious"`` mood.

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -84,7 +84,9 @@ class RunLogger:
             "ms_new": ms_new,
             "score_base": score_base,
             "score_new": score_new,
-            "improved": score_new > score_base,
+            # ``improved`` is ``True`` when the new score is lower than the
+            # baseline score.  Lower values indicate better performance.
+            "improved": score_new < score_base,
         }
         self._file.write(json.dumps(record) + "\n")
         self._file.flush()

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -54,7 +54,8 @@ def report(
     print(f"Run {run_id}")
     print(f"Generations: {len(scores)}")
     print(f"Final score: {scores[-1]}")
-    print(f"Best score: {max(scores)}")
+    # Lower scores indicate better performance.
+    print(f"Best score: {min(scores)}")
 
     counter = Counter(ops)
     print("Operator histogram:")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -24,4 +24,5 @@ def test_report_cli(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "Run run1" in out
     assert "Generations: 2" in out
+    assert "Best score: 1.0" in out
     assert "skillA" in out

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -6,7 +6,7 @@ from singular.runs import RunLogger
 
 def test_log_creation(tmp_path: Path) -> None:
     logger = RunLogger("test", root=tmp_path)
-    logger.log("skill", "op", "diff", True, 1.0, 2.0, 0.1, 0.2)
+    logger.log("skill", "op", "diff", True, 1.0, 2.0, 0.2, 0.1)
     logger.close()
     files = list(tmp_path.glob("test-*.jsonl"))
     assert len(files) == 1


### PR DESCRIPTION
## Summary
- Treat lower scores as improvements in run logging
- Document the new scoring convention and adjust reports accordingly
- Update tests to validate the revised behavior

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afb9875530832abfedbc3a47c66699