### PR TITLE
Ensure identity path parent exists

### DIFF
--- a/src/singular/identity.py
+++ b/src/singular/identity.py
@@ -46,6 +46,7 @@ def create_identity(name: str, soulseed: str, path: Path | str = Path("id.json")
     )
 
     path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="utf-8") as file:
         json.dump(identity.__dict__, file)
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -19,3 +19,13 @@ def test_create_and_read_identity(tmp_path: Path) -> None:
     assert loaded.id == expected_id
     # Ensure born_at is a valid ISO timestamp
     datetime.fromisoformat(loaded.born_at)
+
+
+def test_create_identity_in_subdirectory(tmp_path: Path) -> None:
+    nested_path = tmp_path / "sub" / "id.json"
+    data = create_identity("Bob", "99", nested_path)
+
+    assert nested_path.exists()
+    loaded = read_identity(nested_path)
+
+    assert loaded == data


### PR DESCRIPTION
## Summary
- ensure identity files create missing parent directories
- test creating an identity in a non-existent subdirectory

## Testing
- `PYTHONPATH=src pytest tests/test_identity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc01b0740832a917764429ec3a675