### PR TITLE
Use seed for deterministic stub replies and simplify API

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -67,7 +67,7 @@ def main(argv: list[str] | None = None) -> int:
 
     func: Command = args.func
     if args.command == "report":
-        func(run_id=args.id, seed=args.seed)
+        func(run_id=args.id)
     elif args.command == "talk":
         func(provider=args.provider, seed=args.seed)
     elif args.command == "loop":
@@ -79,9 +79,13 @@ def main(argv: list[str] | None = None) -> int:
             seed=args.seed,
         )
     elif args.command == "quest":
-        func(spec=args.spec, seed=args.seed)
-    else:
+        func(spec=args.spec)
+    elif args.command == "status":
+        func()
+    elif args.command in {"birth", "run"}:
         func(seed=args.seed)
+    else:
+        func()
     return 0
 
 

--- a/src/singular/organisms/quest.py
+++ b/src/singular/organisms/quest.py
@@ -10,15 +10,13 @@ from ..memory import add_episode, ensure_memory_structure, update_score
 from ..psyche import Psyche
 
 
-def quest(spec: Path, seed: int | None = None) -> None:
+def quest(spec: Path) -> None:
     """Handle the ``quest`` subcommand.
 
     Parameters
     ----------
     spec:
         Path to the JSON specification describing the desired skill.
-    seed:
-        Optional random seed for reproducibility. (Currently unused.)
     """
 
     ensure_memory_structure()

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -9,10 +9,8 @@ from ..psyche import Psyche
 from ..runs.logger import RUNS_DIR
 
 
-def status(seed: int | None = None) -> None:
+def status() -> None:
     """Display basic metrics and current psyche state."""
-
-    del seed  # unused
 
     runs_dir = Path(RUNS_DIR)
     files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import random
 from typing import Callable
 
 from ..memory import add_episode, ensure_memory_structure, read_episodes
@@ -10,10 +11,19 @@ from ..psyche import Psyche
 from ..providers import load_llm_provider
 
 
-def _default_reply(prompt: str) -> str:
-    """Fallback reply generation when no provider is available."""
+def _default_reply(prompt: str, rng: random.Random) -> str:
+    """Fallback reply generation when no provider is available.
 
-    return f"I heard you say: {prompt}"
+    The ``seed`` passed to :func:`talk` is used to seed ``rng`` so that stub
+    responses become deterministic when desired.
+    """
+
+    options = [
+        "I heard you say",
+        "You said",
+        "Echoing",
+    ]
+    return f"{rng.choice(options)}: {prompt}"
 
 
 def talk(provider: str | None = None, seed: int | None = None) -> None:
@@ -24,17 +34,20 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
     provider:
         Optional name of the LLM provider. Overrides environment variables.
     seed:
-        Optional random seed for reproducibility.
+        Optional random seed for reproducibility. It affects stub replies when
+        no provider is available.
     """
 
     ensure_memory_structure()
+
+    rng = random.Random(seed)
 
     provider_name = provider or os.getenv("LLM_PROVIDER")
     if not provider_name:
         provider_name = "openai" if os.getenv("OPENAI_API_KEY") else "stub"
     generate_reply: Callable[[str], str] | None = load_llm_provider(provider_name)
     if generate_reply is None:
-        generate_reply = _default_reply
+        generate_reply = lambda prompt: _default_reply(prompt, rng)
 
     psyche = Psyche.load_state()
 

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -34,7 +34,6 @@ def report(
     *,
     runs_dir: Path | str = RUNS_DIR,
     skills_path: Path | str = SKILLS_FILE,
-    seed: int | None = None,
 ) -> None:
     """Summarize performance for a given run."""
 

--- a/src/singular/runs/synthesize.py
+++ b/src/singular/runs/synthesize.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from ..memory import add_episode, ensure_memory_structure
 
 
-def synthesize(code: str, seed: int | None = None) -> None:
+def synthesize(code: str) -> None:
     """Persist the winning *code* snippet into episodic memory.
 
     Parameters
@@ -13,8 +13,6 @@ def synthesize(code: str, seed: int | None = None) -> None:
     code:
         Code to store. It is appended as a "system" episode so that the talk
         loop can recall it as a reminder.
-    seed:
-        Optional random seed for reproducibility. (Currently unused.)
     """
 
     ensure_memory_structure()


### PR DESCRIPTION
## Summary
- seed talk's stub generator to produce deterministic replies
- drop unused `seed` parameters from status, quest, synthesize, and report
- add regression test for seeded stub replies and update CLI dispatch

## Testing
- `PYTHONPATH=src:. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc1062538832aab4a35a847d9a55a