### PR TITLE
Respect specification time limits in synthesis

### DIFF
--- a/life/synthesis.py
+++ b/life/synthesis.py
@@ -61,7 +61,7 @@ def _verify(code: str, spec: quest.Spec) -> bool:
         args = ", ".join(repr(x) for x in ex.inputs)
         test = f"{code}\nresult = {spec.name}({args})"
         try:
-            out = sandbox.run(test)
+            out = sandbox.run(test, timeout=spec.constraints.time_ms_max / 1000)
         except Exception:
             return False
         if out != ex.output:
@@ -72,7 +72,9 @@ def _verify(code: str, spec: quest.Spec) -> bool:
 def synthesise(spec_path: Path, skills_dir: Path | None = None) -> Path:
     """Generate a skill from *spec_path* and persist it to *skills_dir*.
 
-    A :class:`RuntimeError` is raised if the synthesised code fails any example.
+    A :class:`RuntimeError` is raised if the synthesised code fails any
+    example. The time limit declared in the specification is enforced during
+    verification.
     """
 
     spec = quest.load(spec_path)

--- a/tests/test_synthesis_time.py
+++ b/tests/test_synthesis_time.py
@@ -1,0 +1,17 @@
+from life import quest, synthesis
+
+
+def test_verification_honours_time_limit():
+    spec = quest.Spec(
+        name="slow",
+        signature="slow()",
+        examples=[quest.Example(inputs=[], output=1)],
+        constraints=quest.Constraints(pure=True, no_import=True, time_ms_max=50),
+    )
+    code = (
+        "def slow():\n"
+        "    for _ in range(10**7):\n"
+        "        pass\n"
+        "    return 1"
+    )
+    assert not synthesis._verify(code, spec)


### PR DESCRIPTION
## Summary
- enforce spec-defined execution timeout when verifying generated skills
- document that `synthesise` enforces the time constraint
- add regression test for timeout during verification

## Testing
- `PYTHONPATH=. pytest tests/test_synthesis_time.py tests/test_sandbox.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68afc351504c832a83a291e0f2156f9b