### PR TITLE
Refactor life loop with bandit operator selection

### DIFF
--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -4,6 +4,8 @@ import functools
 import sys
 from pathlib import Path
 
+import ast
+
 import logging
 import pytest
 
@@ -13,6 +15,14 @@ sys.path.append(str(root_dir / "src"))
 
 import life.loop as life_loop
 from life.loop import run, load_checkpoint
+
+
+def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            node.value += 1
+            break
+    return tree
 
 
 def _read_result(path: Path) -> int:
@@ -26,7 +36,13 @@ def test_mutation_persistence(tmp_path: Path):
     skill.write_text("result = 1", encoding="utf-8")
     checkpoint = tmp_path / "ckpt.json"
 
-    run(skills_dir, checkpoint, budget_seconds=0.1, rng=random.Random(0))
+    run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.1,
+        rng=random.Random(0),
+        operators={"inc": _inc_operator},
+    )
 
     assert _read_result(skill) > 1
     state = json.loads(checkpoint.read_text(encoding="utf-8"))
@@ -41,11 +57,23 @@ def test_resume_from_checkpoint(tmp_path: Path):
     checkpoint = tmp_path / "ckpt.json"
     rng = random.Random(0)
 
-    run(skills_dir, checkpoint, budget_seconds=0.1, rng=rng)
+    run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.1,
+        rng=rng,
+        operators={"inc": _inc_operator},
+    )
     first_val = _read_result(skill)
     first_iter = load_checkpoint(checkpoint).iteration
 
-    run(skills_dir, checkpoint, budget_seconds=0.1, rng=rng)
+    run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.1,
+        rng=rng,
+        operators={"inc": _inc_operator},
+    )
     second_val = _read_result(skill)
     second_iter = load_checkpoint(checkpoint).iteration
 
@@ -81,6 +109,7 @@ def test_log_and_memory_update(tmp_path: Path, monkeypatch):
         budget_seconds=0.1,
         rng=random.Random(0),
         run_id="loop",
+        operators={"inc": _inc_operator},
     )
 
     assert any((tmp_path / "logs").glob("loop-*.jsonl"))
@@ -98,3 +127,58 @@ def test_corrupted_checkpoint(tmp_path: Path, caplog):
     assert any(
         "failed to load checkpoint" in record.message for record in caplog.records
     )
+
+
+def _inc2_operator(tree: ast.AST, rng=None) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            node.value += 2
+            break
+    return tree
+
+
+def test_multi_operator_selection(tmp_path: Path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = 1", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(RL, root=tmp_path / "logs")
+    )
+
+    class DummyPsyche:
+        last_mood = None
+
+        def mutation_policy(self):
+            return "analyze"
+
+        def process_run_record(self, record):
+            pass
+
+        def save_state(self):
+            pass
+
+    monkeypatch.setattr(
+        life_loop.Psyche, "load_state", staticmethod(lambda: DummyPsyche())
+    )
+
+    operators = {"op1": _inc_operator, "op2": _inc2_operator}
+
+    run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.2,
+        rng=random.Random(0),
+        run_id="loop",
+        operators=operators,
+    )
+
+    log_files = list((tmp_path / "logs").glob("loop-*.jsonl"))
+    assert log_files
+    entries = [json.loads(line) for line in log_files[0].read_text().splitlines()]
+    used = {e["op"] for e in entries}
+    assert {"op1", "op2"} <= used


### PR DESCRIPTION
## Summary
- Allow multiple mutation operators and dynamically pick them using psyche mutation policy
- Track operator performance with a simple bandit strategy
- Add tests for multi-operator selection and adjust existing tests

## Testing
- `pytest tests/test_loop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03d5ca124832ab5ec3c617e6e5547