### PR TITLE
Add mortality checks and death logging to life loop

### DIFF
--- a/life/death.py
+++ b/life/death.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+from singular.psyche import Psyche
+
+
+@dataclass
+class DeathMonitor:
+    """Track mortality conditions for an organism."""
+
+    max_failures: int = 5
+    max_age: int = 1000
+    min_trait: float = 0.05
+    failures: int = 0
+
+    def check(
+        self, iteration: int, psyche: Psyche, success: bool
+    ) -> Tuple[bool, str | None]:
+        """Update state and return ``(dead, reason)`` for current iteration."""
+        if not success:
+            self.failures += 1
+        else:
+            self.failures = 0
+
+        if self.failures >= self.max_failures:
+            return True, "too many failures"
+        if iteration >= self.max_age:
+            return True, "old age"
+        traits_low = [
+            getattr(psyche, attr, 1.0) <= self.min_trait
+            for attr in ("curiosity", "patience", "playfulness")
+        ]
+        if all(traits_low):
+            return True, "traits exhausted"
+        return False, None

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -94,6 +94,20 @@ class RunLogger:
         self.psyche.process_run_record(record)
         add_episode({"event": "mutation", "mood": self.psyche.last_mood, **record})
 
+    def log_death(self, reason: str, **info: Any) -> None:
+        """Record a death event with optional additional information."""
+
+        record: dict[str, Any] = {
+            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "event": "death",
+            "reason": reason,
+            **info,
+        }
+        self._file.write(json.dumps(record) + "\n")
+        self._file.flush()
+        os.fsync(self._file.fileno())
+        add_episode(record)
+
     def close(self) -> None:
         """Flush and finalize the log file atomically."""
         if not self._file.closed:

--- a/tests/test_death.py
+++ b/tests/test_death.py
@@ -1,0 +1,152 @@
+import json
+import ast
+import random
+from pathlib import Path
+
+import pytest
+import functools
+
+import life.loop as life_loop
+from life.loop import run
+from life.death import DeathMonitor
+
+
+def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            node.value += 1
+            break
+    return tree
+
+
+def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            node.value -= 1
+            break
+    return tree
+
+
+def _setup(tmp_path: Path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = 1", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+    return skills_dir, checkpoint
+
+
+def _patch_logger(monkeypatch, tmp_path: Path):
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(RL, root=tmp_path / "logs")
+    )
+
+
+def _patch_memory(monkeypatch, tmp_path: Path):
+    import singular.runs.logger as logger_mod
+    import json
+
+    episodic = tmp_path / "mem" / "episodic.jsonl"
+
+    def fake_add_episode(episode, path=episodic):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(episode) + "\n")
+
+    monkeypatch.setattr(logger_mod, "add_episode", fake_add_episode)
+    monkeypatch.setattr(life_loop, "update_score", lambda *a, **k: None)
+    monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: life_loop.Psyche()))
+    return episodic
+
+
+def _read_log(tmp_path: Path):
+    logs = list((tmp_path / "logs").glob("loop-*.jsonl"))
+    assert logs
+    return [json.loads(line) for line in logs[0].read_text().splitlines()]
+
+
+def test_death_by_age(tmp_path: Path, monkeypatch):
+    skills_dir, ckpt = _setup(tmp_path)
+    _patch_logger(monkeypatch, tmp_path)
+    episodic = _patch_memory(monkeypatch, tmp_path)
+
+    monitor = DeathMonitor(max_age=2, max_failures=99, min_trait=0.0)
+
+    state = run(
+        skills_dir,
+        ckpt,
+        budget_seconds=10.0,
+        rng=random.Random(0),
+        run_id="loop",
+        operators={"inc": _inc_operator},
+        mortality=monitor,
+    )
+
+    assert state.iteration == 2
+    log = _read_log(tmp_path)
+    assert log[-1]["event"] == "death"
+    episodes = episodic.read_text().splitlines()
+    assert any(json.loads(line)["event"] == "death" for line in episodes)
+
+
+def test_death_by_failures(tmp_path: Path, monkeypatch):
+    skills_dir, ckpt = _setup(tmp_path)
+    _patch_logger(monkeypatch, tmp_path)
+    _patch_memory(monkeypatch, tmp_path)
+
+    monitor = DeathMonitor(max_age=99, max_failures=2)
+
+    state = run(
+        skills_dir,
+        ckpt,
+        budget_seconds=1.0,
+        rng=random.Random(0),
+        run_id="loop",
+        operators={"dec": _dec_operator},
+        mortality=monitor,
+    )
+
+    assert state.iteration == 2
+    log = _read_log(tmp_path)
+    assert log[-1]["event"] == "death"
+
+
+def test_death_by_traits(tmp_path: Path, monkeypatch):
+    skills_dir, ckpt = _setup(tmp_path)
+    _patch_logger(monkeypatch, tmp_path)
+    _patch_memory(monkeypatch, tmp_path)
+
+    class LowPsyche:
+        curiosity = 0.0
+        patience = 0.0
+        playfulness = 0.0
+        last_mood = None
+
+        def mutation_policy(self):
+            return "explore"
+
+        def process_run_record(self, record):
+            pass
+
+        def save_state(self):
+            pass
+
+    monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: LowPsyche()))
+
+    monitor = DeathMonitor(max_age=99, max_failures=99, min_trait=0.1)
+
+    state = run(
+        skills_dir,
+        ckpt,
+        budget_seconds=1.0,
+        rng=random.Random(0),
+        run_id="loop",
+        operators={"inc": _inc_operator},
+        mortality=monitor,
+    )
+
+    assert state.iteration == 1
+    log = _read_log(tmp_path)
+    assert log[-1]["event"] == "death"


### PR DESCRIPTION
## Summary
- add `DeathMonitor` module to track failure streaks, age limits, and depleted traits
- wire mortality checks into `life.loop.run` with `RunLogger.log_death`
- cover death scenarios with dedicated tests

## Testing
- `PYTHONPATH=src pytest tests/test_runs_logger.py tests/test_loop.py tests/test_death.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03e856638832a84c8c52ed0b91094