### PR TITLE
Add dashboard CLI with FastAPI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,25 @@ Contrairement aux chatbots classiques (qui ne changent pas leur cœur) ou aux si
   - Personnalités plus complexes.
   - “Écosystème” multi-organismes → possibilité de faire interagir plusieurs compagnons.
 
+## 🖥️ Tableau de bord web
+
+Un petit serveur web permet de consulter les fichiers de `runs/` et l'état de `psyche.json`.
+
+### Installation
+
+Installez les dépendances du tableau de bord :
+
+```bash
+pip install -e .
+```
+
+### Utilisation
+
+Lancez le serveur local :
+
+```bash
+singular dashboard
+```
+
+Ouvrez ensuite http://127.0.0.1:8000 dans votre navigateur.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{name = "Singular Contributors"}]
-dependencies = []
+dependencies = [
+    "fastapi",
+    "uvicorn",
+]
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -15,6 +15,7 @@ from .runs.run import run as run_run
 from .runs.synthesize import synthesize
 from .runs.report import report
 from .runs.loop import loop as loop_run
+from .dashboard import run as dashboard_run
 
 Command = Callable[..., Any]
 
@@ -59,6 +60,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     report_parser.add_argument("--id", required=True, help="Run identifier")
     report_parser.set_defaults(func=report)
+
+    subparsers.add_parser("dashboard", help="Launch web dashboard").set_defaults(
+        func=dashboard_run
+    )
 
     args = parser.parse_args(argv)
 

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+
+
+def create_app(runs_dir: Path | str = Path("runs"), psyche_file: Path | str = Path("psyche.json")) -> FastAPI:
+    """Create the dashboard FastAPI application."""
+    runs_path = Path(runs_dir)
+    psyche_path = Path(psyche_file)
+    app = FastAPI()
+
+    @app.get("/logs")
+    def read_logs() -> dict[str, str]:
+        logs: dict[str, str] = {}
+        if runs_path.exists():
+            for file in runs_path.iterdir():
+                if file.is_file():
+                    logs[file.name] = file.read_text()
+        return logs
+
+    @app.get("/psyche")
+    def read_psyche() -> dict:
+        if not psyche_path.exists():
+            raise HTTPException(status_code=404, detail="psyche.json not found")
+        return json.loads(psyche_path.read_text())
+
+    @app.get("/", response_class=HTMLResponse)
+    def index() -> str:
+        return (
+            "<html><head><title>Singular Dashboard</title></head><body>"
+            "<h1>Singular Dashboard</h1>"
+            "<h2>Psyche</h2><pre id='psyche'></pre>"
+            "<h2>Runs</h2><div id='logs'></div>"
+            "<script>async function load(){"
+            "const ps=await fetch('/psyche').then(r=>r.json()).catch(()=>null);"
+            "document.getElementById('psyche').textContent=JSON.stringify(ps,null,2);"
+            "const ls=await fetch('/logs').then(r=>r.json());"
+            "const div=document.getElementById('logs');"
+            "for(const [n,c] of Object.entries(ls)){const pre=document.createElement('pre');pre.textContent=n+'\n'+c;div.appendChild(pre);}"
+            "}load();</script></body></html>"
+        )
+
+    return app
+
+
+def run(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Launch the dashboard using Uvicorn."""
+    import uvicorn
+
+    app = create_app()
+    uvicorn.run(app, host=host, port=port)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from singular.dashboard import create_app
+
+
+def test_dashboard_endpoints(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "log.txt").write_text("hello")
+    psyche_file = tmp_path / "psyche.json"
+    data = {"mood": "happy"}
+    psyche_file.write_text(json.dumps(data))
+
+    app = create_app(runs_dir=runs_dir, psyche_file=psyche_file)
+    client = TestClient(app)
+
+    assert client.get("/logs").json() == {"log.txt": "hello"}
+    assert client.get("/psyche").json() == data
+
+
+def test_psyche_missing_returns_404(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+
+    response = client.get("/psyche")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- serve logs and psyche state via FastAPI dashboard
- expose `singular dashboard` CLI command
- document dashboard usage

## Testing
- `pip install -e .` *(failed: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest tests/test_dashboard.py` *(failed: ModuleNotFoundError: No module named 'fastapi')*
- `pytest` *(failed: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b04075c074832a87803b06131001d3