### PR TITLE
Fix ruff CI failures

### DIFF
--- a/graine/evolver/generate.py
+++ b/graine/evolver/generate.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Generate candidate patches based on configuration zones.
 
 This module reads the ``zones.yaml`` configuration and produces minimal
@@ -7,6 +5,8 @@ This module reads the ``zones.yaml`` configuration and produces minimal
 specified for each zone. The parsing logic mirrors the lightweight approach
 used elsewhere in the project to avoid external dependencies.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List

--- a/graine/evolver/main.py
+++ b/graine/evolver/main.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Orchestrator for evolutionary runs.
 
 This module coordinates patch generation, selection and meta-rule evolution.
@@ -7,6 +5,8 @@ Each generation is logged using a hash chained JSONL logger and a snapshot is
 written to disk capturing the current meta rules and history. Meta rules are
 mutated and conditionally adopted every ``K`` generations.
 """
+
+from __future__ import annotations
 
 import json
 import random

--- a/graine/evolver/select.py
+++ b/graine/evolver/select.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Selection utilities implementing a minimal NSGA-II algorithm.
 
 The selection process accepts at most a single patch per cycle. All other
@@ -9,6 +7,8 @@ is retained unless dominated by a newcomer. Candidates that do not satisfy
 all required thresholds (tests, performance, quality and stability) are
 rejected before the multi-objective selection is performed.
 """
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Dict, List

--- a/graine/meta/__init__.py
+++ b/graine/meta/__init__.py
@@ -1,3 +1,5 @@
 """Meta-evolution package."""
 
 from .dsl import MetaSpec, MetaValidationError, MAX_POPULATION_CAP
+
+__all__ = ["MetaSpec", "MetaValidationError", "MAX_POPULATION_CAP"]

--- a/graine/runs/replay.py
+++ b/graine/runs/replay.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Snapshot capture and deterministic replay for evolutionary runs."""
+
+from __future__ import annotations
 
 import json
 import random

--- a/graine/runs/report.py
+++ b/graine/runs/report.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Generate static reports and KPI exports from run snapshots."""
+
+from __future__ import annotations
 
 import csv
 import json

--- a/life/quest.py
+++ b/life/quest.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Specification loading utilities."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/life/synthesis.py
+++ b/life/synthesis.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Skill synthesis from specifications."""
+
+from __future__ import annotations
 
 from pathlib import Path
 import ast

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -47,7 +47,8 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
         provider_name = "openai" if os.getenv("OPENAI_API_KEY") else "stub"
     generate_reply: Callable[[str], str] | None = load_llm_provider(provider_name)
     if generate_reply is None:
-        generate_reply = lambda prompt: _default_reply(prompt, rng)
+        def generate_reply(prompt: str) -> str:
+            return _default_reply(prompt, rng)
 
     psyche = Psyche.load_state()
 

--- a/tests/test_death.py
+++ b/tests/test_death.py
@@ -3,7 +3,6 @@ import ast
 import random
 from pathlib import Path
 
-import pytest
 import functools
 
 import life.loop as life_loop

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,20 +1,18 @@
-import json
-import random
-import functools
-import sys
 from pathlib import Path
 
 import ast
-
+import functools
+import json
 import logging
-import pytest
+import random
+import sys
 
 root_dir = Path(__file__).resolve().parents[1]
 sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / "src"))
 
-import life.loop as life_loop
-from life.loop import run, load_checkpoint
+import life.loop as life_loop  # noqa: E402
+from life.loop import run, load_checkpoint  # noqa: E402
 
 
 def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import json
 
 from singular.cli import main

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,4 +1,3 @@
-import math
 from life.score import score
 
 


### PR DESCRIPTION
## Summary
- place module docstrings above imports across core modules to satisfy ruff's E402 rule
- export meta types via __all__
- clean up tests and replace lambda in talk command to pass lint

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_68b0415c7180832aa418744089019ee7