### PR TITLE
Add real-time dashboard streaming via WebSocket

### DIFF
--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -92,7 +92,8 @@ class RunLogger:
         self._file.flush()
         os.fsync(self._file.fileno())
         self.psyche.process_run_record(record)
-        add_episode({"event": "mutation", "mood": self.psyche.last_mood, **record})
+        mood = getattr(self.psyche, "last_mood", None)
+        add_episode({"event": "mutation", "mood": mood, **record})
 
     def log_death(self, reason: str, **info: Any) -> None:
         """Record a death event with optional additional information."""


### PR DESCRIPTION
## Summary
- Extend FastAPI stub and test client with minimal WebSocket support
- Serve a `/ws` endpoint that streams psyche state and run logs in real time
- Update dashboard HTML to apply WebSocket updates on arrival
- Add test simulating WebSocket client for live updates
- Harden RunLogger to handle missing `last_mood`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0578f1ac8832aaa40e600197176c8