### PR TITLE
feat: expand psyche traits

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -39,6 +39,8 @@ def test_birth_initializes_identity_profile_and_psyche(
         "curiosity": 0.5,
         "patience": 0.5,
         "playfulness": 0.5,
+        "optimism": 0.5,
+        "resilience": 0.5,
         "last_mood": None,
     }
 

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -11,6 +11,8 @@ def test_feel_updates_traits_and_last_mood() -> None:
     assert psyche.curiosity > 0.5
     assert psyche.patience > 0.5
     assert psyche.playfulness > 0.5
+    assert psyche.optimism > 0.5
+    assert psyche.resilience > 0.5
 
     # Test clamping at upper bound
     for _ in range(20):
@@ -18,21 +20,43 @@ def test_feel_updates_traits_and_last_mood() -> None:
     assert 0.0 <= psyche.curiosity <= 1.0
     assert 0.0 <= psyche.patience <= 1.0
     assert 0.0 <= psyche.playfulness <= 1.0
+    assert 0.0 <= psyche.optimism <= 1.0
+    assert 0.0 <= psyche.resilience <= 1.0
 
 
 def test_policies_and_lower_clamp() -> None:
-    psyche = Psyche(curiosity=0.05, patience=0.1, playfulness=0.05)
+    psyche = Psyche(
+        curiosity=0.05,
+        patience=0.1,
+        playfulness=0.05,
+        optimism=0.05,
+        resilience=0.05,
+    )
     psyche.feel("frustrated")
     assert psyche.curiosity >= 0.0
     assert psyche.patience >= 0.0
     assert psyche.playfulness >= 0.0
-    assert psyche.interaction_policy() == "retry"
-    assert psyche.mutation_policy() == "explore"
+    assert psyche.optimism >= 0.0
+    assert psyche.resilience >= 0.0
+    assert psyche.interaction_policy() == "cautious"
+    assert psyche.mutation_policy() == "analyze"
+
+
+def test_trait_based_policy_overrides() -> None:
+    high_traits = Psyche(optimism=0.9, resilience=0.9)
+    assert high_traits.interaction_policy() == "engaging"
+    assert high_traits.mutation_policy() == "exploit"
 
 
 def test_state_persistence(tmp_path: Path) -> None:
     path = tmp_path / "mem" / "psyche.json"
-    psyche = Psyche(curiosity=0.2, patience=0.3, playfulness=0.4)
+    psyche = Psyche(
+        curiosity=0.2,
+        patience=0.3,
+        playfulness=0.4,
+        optimism=0.6,
+        resilience=0.7,
+    )
     psyche.feel("proud")
     psyche.save_state(path)
     assert path.exists()
@@ -41,4 +65,6 @@ def test_state_persistence(tmp_path: Path) -> None:
     assert loaded.curiosity == psyche.curiosity
     assert loaded.patience == psyche.patience
     assert loaded.playfulness == psyche.playfulness
+    assert loaded.optimism == psyche.optimism
+    assert loaded.resilience == psyche.resilience
     assert loaded.last_mood == psyche.last_mood


### PR DESCRIPTION
## Summary
- track optimism and resilience alongside existing psyche traits
- tailor interaction and mutation policies using new traits
- extend tests to cover additional traits and policies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b06ffb4f38832a9a4f1e589a99d19a