### PR TITLE
chore: remove unused typing import

### DIFF
--- a/life/operators/unrolling.py
+++ b/life/operators/unrolling.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import ast
 import copy
 import random
-from typing import Iterable
 
 # mypy: ignore-errors
 


### PR DESCRIPTION
## Summary
- tidy unrolling operator imports by removing unused typing import

## Testing
- `ruff check life/operators/unrolling.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0879a6448832a8864d2ba5a57f99f