### PR TITLE
Format unrolling operator and tests

### DIFF
--- a/life/operators/unrolling.py
+++ b/life/operators/unrolling.py
@@ -181,9 +181,7 @@ class _Unroll(ast.NodeTransformer):
         node.orelse = self._transform_body(node.orelse)
         return node
 
-    def visit_While(
-        self, node: ast.While
-    ) -> ast.AST:  # pragma: no cover - delegating
+    def visit_While(self, node: ast.While) -> ast.AST:  # pragma: no cover - delegating
         node.body = self._transform_body(node.body)
         node.orelse = self._transform_body(node.orelse)
         return node
@@ -211,4 +209,3 @@ def apply(tree: ast.AST, rng: random.Random | None = None) -> ast.AST:
 
     _Unroll().visit(tree)
     return ast.fix_missing_locations(tree)
-

--- a/tests/test_unrolling.py
+++ b/tests/test_unrolling.py
@@ -58,4 +58,3 @@ def f():
     new_tree = unrolling.apply(tree)
     assert _dump(new_tree) == _dump(ast.parse(expected))
     compile(ast.unparse(new_tree), "<test>", "exec")
-


### PR DESCRIPTION
## Summary
- run Black on loop-unrolling operator and corresponding tests
- verify formatting with `black --check`

## Testing
- `black --check life/operators/unrolling.py tests/test_unrolling.py`
- `pytest tests/test_unrolling.py`


------
https://chatgpt.com/codex/tasks/task_e_68b088dcd550832a8bc3931e4cb0e9e6