### PR TITLE
Add console script entry for Singular CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Installez les dépendances du tableau de bord :
 pip install -e .
 ```
 
+Après installation, la commande CLI `singular` est disponible :
+
+```bash
+singular --help
+```
+
 ### Utilisation
 
 Lancez le serveur local :

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "uvicorn",
 ]
 
+[project.scripts]
+singular = "singular.cli:main"
+
 [build-system]
 requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -17,6 +17,8 @@ from .runs.report import report
 from .runs.loop import loop as loop_run
 from .dashboard import run as dashboard_run
 
+__all__ = ["main"]
+
 Command = Callable[..., Any]
 
 


### PR DESCRIPTION
## Summary
- Expose `singular` command via project scripts mapping to `singular.cli:main`
- Export `main` from CLI module for console entry and clarify README usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b08cfaf974832aaf4a1d02c4ae2cd9