### PR TITLE
Document optional PyYAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ Installez les dépendances du tableau de bord :
 pip install -e .
 ```
 
+PyYAML est une dépendance optionnelle utilisée pour manipuler le fichier `values.yaml`.
+Vous pouvez l'installer via l'extra `yaml` :
+
+```bash
+pip install -e .[yaml]
+```
+
 Après installation, la commande CLI `singular` est disponible :
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "uvicorn",
 ]
 
+[project.optional-dependencies]
+yaml = ["pyyaml"]
+
 [project.scripts]
 singular = "singular.cli:main"
 

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -1,4 +1,8 @@
-"""Memory management utilities."""
+"""Memory management utilities.
+
+JSON is used for most memory files.  The ``values.yaml`` file is only handled
+when the optional :mod:`PyYAML <yaml>` package is available.
+"""
 
 from __future__ import annotations
 
@@ -74,7 +78,10 @@ def update_trait(
 
 
 def read_values(path: Path | str = VALUES_FILE) -> dict[str, Any]:
-    """Read the values YAML file."""
+    """Read the values YAML file.
+
+    Returns an empty dict if :mod:`pyyaml` is not installed.
+    """
     path = Path(path)
     if not path.exists():
         return {}
@@ -89,7 +96,10 @@ def read_values(path: Path | str = VALUES_FILE) -> dict[str, Any]:
 
 
 def write_values(values: dict[str, Any], path: Path | str = VALUES_FILE) -> None:
-    """Write the values YAML file."""
+    """Write the values YAML file.
+
+    Requires :mod:`pyyaml` to be installed.
+    """
     path = Path(path)
     _ensure_dir(path)
     try:


### PR DESCRIPTION
## Summary
- Declare `pyyaml` as optional dependency via `yaml` extra
- Explain optional PyYAML usage in README and memory helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b08fbcd398832a8e57a6f2424bb40c