### PR TITLE
Refactor OpenAI provider to use new client

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,10 @@ singular dashboard
 
 Ouvrez ensuite http://127.0.0.1:8000 dans votre navigateur.
 
+### Fournisseur OpenAI
+
+Pour permettre à l'organisme de parler en utilisant l'API d'OpenAI, installez
+la dépendance optionnelle ``openai>=1.0.0`` et définissez la variable
+d'environnement ``OPENAI_API_KEY``. Les versions plus anciennes du paquet
+``openai`` ne sont pas compatibles avec le fournisseur actuel.
+

--- a/src/singular/providers/llm_openai.py
+++ b/src/singular/providers/llm_openai.py
@@ -1,4 +1,9 @@
-"""OpenAI LLM provider using the ChatCompletion API."""
+"""OpenAI LLM provider using the Chat Completions API.
+
+This module targets the ``openai`` package version 1.x which exposes the
+``OpenAI`` client.  Older versions using ``openai.ChatCompletion`` are not
+supported.
+"""
 
 from __future__ import annotations
 
@@ -6,9 +11,9 @@ import os
 from typing import Any
 
 try:  # pragma: no cover - optional dependency
-    import openai  # type: ignore
+    from openai import OpenAI  # type: ignore
 except Exception:  # pragma: no cover - handle missing package
-    openai = None  # type: ignore
+    OpenAI = None  # type: ignore
 
 
 def _filter(text: str) -> str:
@@ -19,17 +24,17 @@ def _filter(text: str) -> str:
 def generate_reply(prompt: str) -> str:
     """Generate a reply via OpenAI if an API key is configured."""
     api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key or openai is None:
+    if not api_key or OpenAI is None:
         return "OpenAI API key not configured."
 
-    openai.api_key = api_key
     try:  # pragma: no cover - network call
-        response: Any = openai.ChatCompletion.create(
+        client = OpenAI(api_key=api_key)
+        response: Any = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
             max_tokens=100,
         )
-        text: str = response["choices"][0]["message"]["content"]
+        text: str = response.choices[0].message.content
     except Exception:
         return "Error communicating with OpenAI."
 

--- a/tests/providers/test_llm_openai.py
+++ b/tests/providers/test_llm_openai.py
@@ -1,0 +1,45 @@
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from singular.providers import llm_openai
+
+
+def test_generate_reply_without_key(monkeypatch):
+    """If no API key is set the provider should return an explicit message."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert llm_openai.generate_reply("hi") == "OpenAI API key not configured."
+
+
+def test_generate_reply_success(monkeypatch):
+    """Mock the OpenAI client to test successful replies and filtering."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    class FakeCompletions:
+        def create(self, *, model, messages, max_tokens):
+            assert model == "gpt-3.5-turbo"
+            assert messages == [{"role": "user", "content": "hi"}]
+            assert max_tokens == 100
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="hello\x00"))]
+            )
+
+    class FakeClient:
+        def __init__(self, api_key):
+            assert api_key == "test-key"
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
+    assert llm_openai.generate_reply("hi") == "hello"
+
+
+def test_openai_version():
+    """If ``openai`` is installed ensure it is the modern client (>=1.0)."""
+    try:
+        import openai
+    except Exception:  # pragma: no cover - optional dependency missing
+        pytest.skip("openai not installed")
+    from packaging import version
+
+    assert version.parse(openai.__version__) >= version.parse("1.0.0")


### PR DESCRIPTION
## Summary
- refactor OpenAI LLM provider to use `OpenAI().chat.completions.create` client and handle API key with new response schema
- document OpenAI provider and note requirement for `openai>=1.0.0`
- add tests covering API key handling, successful reply, and OpenAI version compatibility

## Testing
- `python -m pytest tests/providers/test_llm_openai.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0913447f8832a9afad8dff7b87363