### PR TITLE
Add configurable base paths and log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ Après installation, la commande CLI `singular` est disponible :
 singular --help
 ```
 
+### Configuration
+
+Par défaut, les fichiers persistants sont écrits dans les dossiers `mem/` et
+`runs/` situés à la racine du projet. Vous pouvez changer cet emplacement en
+définissant la variable d'environnement `SINGULAR_HOME` ou en passant l'option
+CLI `--home` :
+
+```bash
+SINGULAR_HOME=/chemin/personnel singular birth
+# ou
+singular --home /chemin/personnel birth
+```
+
+Les journaux de `runs/` sont soumis à une rétention automatique : seuls les 20
+fichiers les plus récents sont conservés. Ce nombre peut être ajusté via
+`SINGULAR_RUNS_KEEP`.
+
 ### Utilisation
 
 Lancez le serveur local :

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -6,6 +6,14 @@ import argparse
 import random
 from pathlib import Path
 from typing import Callable, Any
+import os
+
+# Pre-parse ``--home`` before importing modules that depend on it
+_early_parser = argparse.ArgumentParser(add_help=False)
+_early_parser.add_argument("--home", type=Path)
+_early_args, _ = _early_parser.parse_known_args()
+if _early_args.home:
+    os.environ["SINGULAR_HOME"] = str(_early_args.home)
 
 from .organisms.birth import birth
 from .organisms.talk import talk
@@ -28,6 +36,12 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="singular")
     parser.add_argument(
         "--seed", type=int, default=None, help="Random seed for reproducibility"
+    )
+    parser.add_argument(
+        "--home",
+        type=Path,
+        default=os.environ.get("SINGULAR_HOME"),
+        help="Base directory for mem/ and runs/ (env: SINGULAR_HOME)",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -70,6 +84,9 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv)
+
+    if args.home:
+        os.environ["SINGULAR_HOME"] = str(args.home)
 
     if args.seed is not None:
         random.seed(args.seed)

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 import json
+import os
 
+# Base directory for persistent files
+_BASE_DIR = Path(os.environ.get("SINGULAR_HOME", "."))
 # Base memory directory
-MEM_DIR = Path("mem")
+MEM_DIR = _BASE_DIR / "mem"
 
 # File paths within the memory directory
 PROFILE_FILE = MEM_DIR / "profile.json"

--- a/tests/test_runs_retention.py
+++ b/tests/test_runs_retention.py
@@ -1,0 +1,16 @@
+import importlib
+
+
+def test_log_rotation(tmp_path, monkeypatch):
+    monkeypatch.setenv("SINGULAR_RUNS_KEEP", "2")
+    import singular.runs.logger as logger
+    importlib.reload(logger)
+    for i in range(3):
+        rl = logger.RunLogger(f"r{i}", root=tmp_path)
+        rl.log("s", "op", "d", True, 1.0, 2.0, 0.1, 0.05)
+        rl.close()
+    files = list(tmp_path.glob("*.jsonl"))
+    assert len(files) == 2
+    assert not list(tmp_path.glob("r0-*.jsonl"))
+    monkeypatch.delenv("SINGULAR_RUNS_KEEP", raising=False)
+    importlib.reload(logger)

--- a/tests/test_singular_home.py
+++ b/tests/test_singular_home.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def test_singular_home_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    import singular.memory as memory
+    import singular.runs.logger as logger
+    importlib.reload(memory)
+    importlib.reload(logger)
+    assert memory.MEM_DIR == tmp_path / "mem"
+    assert logger.RUNS_DIR == tmp_path / "runs"
+    # cleanup: restore modules to default state
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    importlib.reload(memory)
+    importlib.reload(logger)


### PR DESCRIPTION
## Summary
- allow overriding storage base via `SINGULAR_HOME` env var or `--home` CLI option
- rotate run logs, keeping a configurable number of files
- document home directory configuration and log retention

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0922b1940832aa7fde2ebed4e8f29