### PR TITLE
Add perception sensors and logging

### DIFF
--- a/life/loop.py
+++ b/life/loop.py
@@ -12,9 +12,10 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, Iterable
 
-from singular.memory import update_score
+from singular.memory import add_episode, update_score
 from singular.psyche import Psyche
 from singular.runs.logger import RunLogger
+from singular.perception import capture_signals
 
 from . import sandbox
 from .death import DeathMonitor
@@ -198,6 +199,8 @@ def run(
 
     with RunLogger(run_id, psyche=psyche) as logger:
         while time.time() - start < budget_seconds:
+            signals = capture_signals()
+            add_episode({"event": "perception", **signals})
             state.iteration += 1
 
             org_name, skill_path = _choose_skill(rng, world.organisms)

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -7,6 +7,7 @@ import random
 from typing import Callable
 
 from ..memory import add_episode, ensure_memory_structure, read_episodes
+from ..perception import capture_signals
 from ..psyche import Psyche
 from ..providers import load_llm_provider
 
@@ -54,6 +55,8 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
     psyche = Psyche.load_state()
 
     while True:
+        signals = capture_signals()
+        add_episode({"event": "perception", **signals})
         episodes = read_episodes()
         last_event = next((e["text"] for e in reversed(episodes) if "text" in e), None)
         latest_mutation = next(

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Perception utilities.
+
+This module provides a :func:`capture_signals` function that gathers basic
+sensory inputs.  It includes a few virtual sensors (temperature, a simple
+cycle to indicate day or night, and ambient noise).  Optional connectors can
+supply real-world data by reading from a file or querying a weather API.  Any
+failures in these connectors are ignored so that perception always succeeds.
+"""
+
+from pathlib import Path
+import os
+import random
+import time
+from typing import Any, Dict
+
+
+def _read_optional_file() -> Dict[str, Any]:
+    """Read data from ``SINGULAR_SENSOR_FILE`` if available."""
+    path = os.getenv("SINGULAR_SENSOR_FILE")
+    if not path:
+        return {}
+    try:
+        return {"file": Path(path).read_text(encoding="utf-8").strip()}
+    except Exception:
+        return {}
+
+
+def _query_optional_weather_api() -> Dict[str, Any]:
+    """Query ``SINGULAR_WEATHER_API`` for weather data if possible."""
+    url = os.getenv("SINGULAR_WEATHER_API")
+    if not url:
+        return {}
+    try:  # pragma: no cover - network failures are expected
+        import requests
+
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+        return {"weather": response.json()}
+    except Exception:
+        return {}
+
+
+def capture_signals() -> Dict[str, Any]:
+    """Collect sensory signals from virtual and optional real sources."""
+    signals: Dict[str, Any] = {
+        "temperature": random.uniform(-20.0, 40.0),
+        "is_daytime": 6 <= time.localtime().tm_hour < 18,
+        "noise": random.random(),
+    }
+    signals.update(_read_optional_file())
+    signals.update(_query_optional_weather_api())
+    return signals

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -24,9 +24,9 @@ def test_full_workflow(monkeypatch, tmp_path):
 
     talk()
 
-    episodes = read_episodes()
-    # After run, synthesize and one talk exchange we should have four episodes:
-    #   mutation, system (code), user, assistant
+    episodes = [e for e in read_episodes() if e.get("event") != "perception"]
+    # After run, synthesize and one talk exchange we should have four episodes
+    # excluding perception captures: mutation, system (code), user, assistant
     assert len(episodes) == 4
     assert episodes[0]["event"] == "mutation"
     assert episodes[1]["text"] == code

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -1,0 +1,24 @@
+from singular.perception import capture_signals
+from singular.memory import add_episode, read_episodes
+
+
+def test_capture_and_persist_signals(tmp_path, monkeypatch):
+    # Prepare optional file sensor
+    sensor_file = tmp_path / "sensor.txt"
+    sensor_file.write_text("42", encoding="utf-8")
+    monkeypatch.setenv("SINGULAR_SENSOR_FILE", str(sensor_file))
+
+    # Capture signals
+    signals = capture_signals()
+    assert "temperature" in signals
+    assert "is_daytime" in signals
+    assert "noise" in signals
+    assert signals.get("file") == "42"
+
+    # Persist and verify
+    episodic = tmp_path / "mem" / "episodic.jsonl"
+    add_episode({"event": "perception", **signals}, path=episodic)
+    episodes = read_episodes(path=episodic)
+    assert episodes[0]["event"] == "perception"
+    for key in ["temperature", "is_daytime", "noise", "file"]:
+        assert key in episodes[0]

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -16,7 +16,7 @@ def test_talk_loop(monkeypatch, tmp_path):
 
     talk()
 
-    episodes = read_episodes()
+    episodes = [e for e in read_episodes() if e.get("event") != "perception"]
     assert len(episodes) == 4
     assert episodes[0]["role"] == "user"
     assert episodes[1]["role"] == "assistant"


### PR DESCRIPTION
## Summary
- add `capture_signals` with virtual and optional real sensors
- log sensory data in life loop and talk command
- test perception and adjust existing tests for new episodes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b098a62e98832ab356eb136ef5747c