### PR TITLE
Add energy management to psyche

### DIFF
--- a/life/death.py
+++ b/life/death.py
@@ -28,6 +28,8 @@ class DeathMonitor:
             return True, "too many failures"
         if iteration >= self.max_age:
             return True, "old age"
+        if getattr(psyche, "energy", 1.0) <= 0:
+            return True, "energy depleted"
         traits_low = [
             getattr(psyche, attr, 1.0) <= self.min_trait
             for attr in ("curiosity", "patience", "playfulness")

--- a/life/loop.py
+++ b/life/loop.py
@@ -256,6 +256,12 @@ def run(
                 mutated_score,
             )
 
+            # Energy consumption per mutation
+            if hasattr(psyche, "consume"):
+                psyche.consume()
+            if hasattr(psyche, "save_state"):
+                psyche.save_state()
+
             save_checkpoint(checkpoint_path, state)
 
             dead, reason = mortality.check(

--- a/src/singular/organisms/quest.py
+++ b/src/singular/organisms/quest.py
@@ -37,4 +37,5 @@ def quest(spec: Path) -> None:
     add_episode(
         {"event": "quest", "status": "success", "skill": skill_path.stem, "mood": mood}
     )
+    psyche.gain()
     psyche.save_state()

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -57,6 +57,7 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
     while True:
         signals = capture_signals()
         add_episode({"event": "perception", **signals})
+        psyche.consume()
         episodes = read_episodes()
         last_event = next((e["text"] for e in reversed(episodes) if "text" in e), None)
         latest_mutation = next(
@@ -125,4 +126,5 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
 
         print(response)
         add_episode({"role": "assistant", "text": response, "mood": mood})
+        psyche.gain()
         psyche.save_state()

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -64,6 +64,7 @@ class Psyche:
     playfulness: float = 0.5
     optimism: float = 0.5
     resilience: float = 0.5
+    energy: float = 100.0
 
     # ``last_mood`` is updated every time :meth:`feel` is called and can be
     # queried by other subsystems (interaction and mutation policies).
@@ -178,6 +179,20 @@ class Psyche:
             return "analyze"
         return self._MUTATION_POLICIES.get(mood, "default")
 
+    # Energy management ---------------------------------------------------
+    def consume(self, amount: float = 1.0) -> float:
+        """Decrease energy by ``amount`` and return the new value.
+
+        Energy will not drop below ``0``.
+        """
+        self.energy = max(0.0, self.energy - amount)
+        return self.energy
+
+    def gain(self, amount: float = 1.0) -> float:
+        """Increase energy by ``amount`` and return the new value."""
+        self.energy += amount
+        return self.energy
+
     # Persistence helpers -------------------------------------------------
     def save_state(self, path: Path | str | None = None) -> None:
         """Persist current psyche state to disk."""
@@ -187,6 +202,7 @@ class Psyche:
             "playfulness": self.playfulness,
             "optimism": self.optimism,
             "resilience": self.resilience,
+            "energy": self.energy,
             "last_mood": self.last_mood,
         }
         if path is None:
@@ -207,6 +223,7 @@ class Psyche:
             playfulness=data.get("playfulness", 0.5),
             optimism=data.get("optimism", 0.5),
             resilience=data.get("resilience", 0.5),
+            energy=data.get("energy", 100.0),
         )
         psyche.last_mood = data.get("last_mood")
         return psyche

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,0 +1,23 @@
+from life.death import DeathMonitor
+from singular.psyche import Psyche
+
+
+def test_energy_persistence(tmp_path):
+    path = tmp_path / "psyche.json"
+    psyche = Psyche()
+    psyche.consume(10)
+    psyche.save_state(path)
+    loaded = Psyche.load_state(path)
+    assert loaded.energy == psyche.energy
+    loaded.gain(5)
+    assert loaded.energy == psyche.energy + 5
+
+
+def test_energy_death():
+    psyche = Psyche(energy=1.0)
+    monitor = DeathMonitor(max_age=99, max_failures=99, min_trait=0.0)
+    dead, _ = monitor.check(0, psyche, success=True)
+    assert not dead
+    psyche.consume(1.0)
+    dead, reason = monitor.check(1, psyche, success=True)
+    assert dead and reason == "energy depleted"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -41,6 +41,7 @@ def test_birth_initializes_identity_profile_and_psyche(
         "playfulness": 0.5,
         "optimism": 0.5,
         "resilience": 0.5,
+        "energy": 100.0,
         "last_mood": None,
     }
 


### PR DESCRIPTION
## Summary
- track an organism's energy with consume and gain helpers
- persist energy to psyche.json and adjust quest/talk/run to update it
- declare death when energy is depleted and add tests for energy persistence and exhaustion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b099d33c20832a9fb7e9842471ed2f