### PR TITLE
feat: add objectives and curiosity reward

### DIFF
--- a/src/singular/motivation.py
+++ b/src/singular/motivation.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Objective:
+    """Simple structure describing an objective with a weight and reward."""
+
+    name: str
+    weight: float = 1.0
+    reward: float = 0.0
+
+    def apply_delta(self, delta: float) -> None:
+        """Adjust weight by ``delta`` and accumulate reward."""
+        self.weight += delta
+        self.reward += delta

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -27,14 +27,22 @@ def _ensure_dir(path: Path) -> None:
 
 def _enforce_retention(root: Path, keep: int = MAX_RUN_LOGS) -> None:
     """Remove oldest log files beyond the retention limit."""
-    logs = sorted(root.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True)
+    logs = sorted(
+        root.glob("*.jsonl"),
+        key=lambda p: (p.stat().st_mtime, p.name),
+        reverse=True,
+    )
     for old in logs[keep:]:
         try:
             old.unlink()
         except FileNotFoundError:  # pragma: no cover - race condition
             pass
     # Clean up any leftover temporary files
-    tmps = sorted(root.glob("*.jsonl.tmp"), key=lambda p: p.stat().st_mtime, reverse=True)
+    tmps = sorted(
+        root.glob("*.jsonl.tmp"),
+        key=lambda p: (p.stat().st_mtime, p.name),
+        reverse=True,
+    )
     for old in tmps[keep:]:
         try:
             old.unlink()

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,0 +1,18 @@
+from singular.psyche import Psyche
+from singular.motivation import Objective
+
+def test_curiosity_increases():
+    psyche = Psyche()
+    base = psyche.curiosity
+    psyche.feel("curious")
+    assert psyche.curiosity > base
+
+def test_objective_weights_adapt():
+    psyche = Psyche(objectives={"goal": Objective("goal", weight=0.5)})
+    base = psyche.objectives["goal"].weight
+    psyche.feel("pleasure")
+    increased = psyche.objectives["goal"].weight
+    assert increased > base
+    psyche.feel("pain")
+    decreased = psyche.objectives["goal"].weight
+    assert decreased < increased


### PR DESCRIPTION
## Summary
- model objectives with adjustable weights and rewards
- reward novelty and outcomes via curiosity, pleasure, and pain
- ensure stable run-log retention sorting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b09b1aed34832aab93784390ed8c5f