### PR TITLE
Introduce crossover reproduction and resource-aware life loop

### DIFF
--- a/life/death.py
+++ b/life/death.py
@@ -16,7 +16,7 @@ class DeathMonitor:
     failures: int = 0
 
     def check(
-        self, iteration: int, psyche: Psyche, success: bool
+        self, iteration: int, psyche: Psyche, success: bool, resources: float | None = None
     ) -> Tuple[bool, str | None]:
         """Update state and return ``(dead, reason)`` for current iteration."""
         if not success:
@@ -30,6 +30,8 @@ class DeathMonitor:
             return True, "old age"
         if getattr(psyche, "energy", 1.0) <= 0:
             return True, "energy depleted"
+        if resources is not None and resources <= 0:
+            return True, "resources exhausted"
         traits_low = [
             getattr(psyche, attr, 1.0) <= self.min_trait
             for attr in ("curiosity", "patience", "playfulness")

--- a/life/reproduction.py
+++ b/life/reproduction.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Utilities for reproducing organisms by combining skills."""
+
+import ast
+import random
+from pathlib import Path
+from typing import Tuple
+
+
+__all__ = ["crossover"]
+
+
+def crossover(parent_a: Path, parent_b: Path, rng: random.Random | None = None) -> Tuple[str, str]:
+    """Create a hybrid skill from two parent skill directories.
+
+    Parameters
+    ----------
+    parent_a, parent_b:
+        Directories containing skill ``.py`` files. A random skill from each
+        parent is chosen and their abstract syntax trees are combined to form a
+        new hybrid skill. The hybrid function uses the argument signature of the
+        first parent's function and merges the bodies by taking the first half of
+        ``parent_a``'s statements followed by the second half of ``parent_b``'s
+        statements.
+    rng:
+        Optional :class:`random.Random` instance for reproducibility.
+
+    Returns
+    -------
+    tuple
+        ``(filename, code)`` of the newly created hybrid skill.
+    """
+
+    rng = rng or random.Random()
+
+    skills_a = list(Path(parent_a).glob("*.py"))
+    skills_b = list(Path(parent_b).glob("*.py"))
+    if not skills_a or not skills_b:
+        raise ValueError("both parents must have at least one skill")
+
+    file_a = rng.choice(skills_a)
+    file_b = rng.choice(skills_b)
+
+    tree_a = ast.parse(file_a.read_text(encoding="utf-8"))
+    tree_b = ast.parse(file_b.read_text(encoding="utf-8"))
+
+    func_a = next((n for n in tree_a.body if isinstance(n, ast.FunctionDef)), None)
+    func_b = next((n for n in tree_b.body if isinstance(n, ast.FunctionDef)), None)
+    if func_a is None or func_b is None:
+        raise ValueError("skills must contain a function definition")
+
+    split_a = len(func_a.body) // 2
+    split_b = len(func_b.body) // 2
+    new_body = func_a.body[:split_a] + func_b.body[split_b:]
+    if not new_body:
+        new_body = [ast.Pass()]
+
+    new_func = ast.FunctionDef(
+        name=f"hybrid_{func_a.name}_{func_b.name}",
+        args=func_a.args,
+        body=new_body,
+        decorator_list=[],
+        returns=func_a.returns or func_b.returns,
+        type_comment=None,
+    )
+
+    module = ast.Module(body=[new_func], type_ignores=[])
+    ast.fix_missing_locations(module)
+    code = ast.unparse(module)
+    filename = f"{new_func.name}.py"
+    return filename, code

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -16,6 +16,7 @@ if _early_args.home:
     os.environ["SINGULAR_HOME"] = str(_early_args.home)
 
 from .organisms.birth import birth
+from .organisms.spawn import spawn
 from .organisms.talk import talk
 from .organisms.status import status
 from .organisms.quest import quest
@@ -46,6 +47,13 @@ def main(argv: list[str] | None = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     subparsers.add_parser("birth", help="Birth a new organism").set_defaults(func=birth)
+    spawn_parser = subparsers.add_parser(
+        "spawn", help="Create child organism from two parents"
+    )
+    spawn_parser.add_argument("parent_a", type=Path)
+    spawn_parser.add_argument("parent_b", type=Path)
+    spawn_parser.add_argument("--out-dir", type=Path, default=None)
+    spawn_parser.set_defaults(func=spawn)
     subparsers.add_parser("run", help="Execute a run").set_defaults(func=run_run)
     loop_parser = subparsers.add_parser("loop", help="Execute evolutionary loop")
     loop_parser.add_argument("--skills-dir", type=Path, default=Path("skills"))
@@ -108,6 +116,13 @@ def main(argv: list[str] | None = None) -> int:
         func(spec=args.spec)
     elif args.command == "status":
         func()
+    elif args.command == "spawn":
+        func(
+            parent_a=args.parent_a,
+            parent_b=args.parent_b,
+            out_dir=args.out_dir,
+            seed=args.seed,
+        )
     elif args.command in {"birth", "run"}:
         func(seed=args.seed)
     else:

--- a/src/singular/organisms/spawn.py
+++ b/src/singular/organisms/spawn.py
@@ -1,0 +1,36 @@
+"""Spawn command for creating a child organism from two parents."""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from life.reproduction import crossover
+
+
+def spawn(parent_a: Path, parent_b: Path, out_dir: Path | None = None, seed: int | None = None) -> Path:
+    """Generate a child organism by crossing over two parents.
+
+    Parameters
+    ----------
+    parent_a, parent_b:
+        Paths to the parent skill directories.
+    out_dir:
+        Directory where the child's skills will be written. If ``None``, a
+        directory named ``child`` next to the parents is used.
+    seed:
+        Optional seed for deterministic behaviour.
+
+    Returns
+    -------
+    Path
+        The directory containing the child's skills.
+    """
+
+    rng = random.Random(seed)
+    out_dir = out_dir or parent_a.parent / "child"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    filename, code = crossover(parent_a, parent_b, rng)
+    (out_dir / filename).write_text(code, encoding="utf-8")
+    return out_dir

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from singular.organisms.spawn import spawn
+
+
+def test_reproduction(tmp_path: Path):
+    parent_a = tmp_path / "parent_a"
+    parent_b = tmp_path / "parent_b"
+    parent_a.mkdir()
+    parent_b.mkdir()
+
+    (parent_a / "skill_a.py").write_text(
+        "def mix(x):\n    y = 1\n    z = x + y\n    return z\n",
+        encoding="utf-8",
+    )
+    (parent_b / "skill_b.py").write_text(
+        "def mix(x):\n    y = 2\n    z = x * y\n    return z\n",
+        encoding="utf-8",
+    )
+
+    child_dir = spawn(parent_a, parent_b, out_dir=tmp_path / "child", seed=0)
+    hybrids = list(child_dir.glob("hybrid_*.py"))
+    assert hybrids, "no hybrid skills generated"
+    code = hybrids[0].read_text(encoding="utf-8")
+    assert "y = 1" in code and "return z" in code and "x * y" in code


### PR DESCRIPTION
## Summary
- add `crossover` utility to merge skills from two parents
- expose new `spawn` CLI for creating children and wire into main CLI
- track organism energy/resources in loop with periodic crossovers and resource-based death monitoring
- adjust `DeathMonitor` for shared resource depletion
- test reproduction of hybrid skill

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b09c6e0450832aa1c6edc0b7d19581