### PR TITLE
Display optimism and resilience in status output

### DIFF
--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -43,3 +43,5 @@ def status() -> None:
     print(f"  curiosity: {psyche.curiosity:.2f}")
     print(f"  patience: {psyche.patience:.2f}")
     print(f"  playfulness: {psyche.playfulness:.2f}")
+    print(f"  optimism: {psyche.optimism:.2f}")
+    print(f"  resilience: {psyche.resilience:.2f}")


### PR DESCRIPTION
## Summary
- show optimism and resilience alongside other traits in status command

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b09fd4451c832a92900f23d68f1161