### PR TITLE
Ensure mood report uses current psyche state

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -97,7 +97,6 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
                         perf_msg = f"runtime increased by {diff:.2f}ms"
                     elif diff < 0:
                         perf_msg = f"runtime decreased by {abs(diff):.2f}ms"
-        mood_report = mood_event or psyche.last_mood or "neutral"
 
         try:
             user_input = input("you: ")
@@ -110,6 +109,7 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
         add_episode({"role": "user", "text": user_input})
 
         mood = psyche.feel("neutral")
+        mood_report = mood_event or mood or "neutral"
         reply = generate_reply(user_input)
 
         parts = [reply]


### PR DESCRIPTION
## Summary
- Recompute `mood_report` after invoking `psyche.feel` so reports use the current mood

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0a0808304832ab9218d615ba73869