### PR TITLE
Handle invalid skill syntax during reproduction

### DIFF
--- a/life/reproduction.py
+++ b/life/reproduction.py
@@ -42,8 +42,15 @@ def crossover(parent_a: Path, parent_b: Path, rng: random.Random | None = None) 
     file_a = rng.choice(skills_a)
     file_b = rng.choice(skills_b)
 
-    tree_a = ast.parse(file_a.read_text(encoding="utf-8"))
-    tree_b = ast.parse(file_b.read_text(encoding="utf-8"))
+    try:
+        tree_a = ast.parse(file_a.read_text(encoding="utf-8"))
+    except SyntaxError as e:
+        raise ValueError(f"invalid syntax in skill file {file_a}") from e
+
+    try:
+        tree_b = ast.parse(file_b.read_text(encoding="utf-8"))
+    except SyntaxError as e:
+        raise ValueError(f"invalid syntax in skill file {file_b}") from e
 
     func_a = next((n for n in tree_a.body if isinstance(n, ast.FunctionDef)), None)
     func_b = next((n for n in tree_b.body if isinstance(n, ast.FunctionDef)), None)

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from singular.organisms.spawn import spawn
 
 
@@ -23,3 +25,22 @@ def test_reproduction(tmp_path: Path):
     assert hybrids, "no hybrid skills generated"
     code = hybrids[0].read_text(encoding="utf-8")
     assert "y = 1" in code and "return z" in code and "x * y" in code
+
+
+def test_reproduction_invalid_skill(tmp_path: Path):
+    parent_a = tmp_path / "parent_a"
+    parent_b = tmp_path / "parent_b"
+    parent_a.mkdir()
+    parent_b.mkdir()
+
+    (parent_a / "bad.py").write_text(
+        "def mix(x):\n    y =\n",
+        encoding="utf-8",
+    )
+    (parent_b / "skill_b.py").write_text(
+        "def mix(x):\n    return x\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="invalid syntax"):
+        spawn(parent_a, parent_b, out_dir=tmp_path / "child", seed=0)


### PR DESCRIPTION
## Summary
- Catch `SyntaxError` when parsing parent skill files and raise clear `ValueError`
- Test `spawn` behavior with an invalid skill file

## Testing
- `pytest tests/test_reproduction.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0af504e54832abaec7a30d3f3daa5