### PR TITLE
feat: add note field to skills

### DIFF
--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -212,9 +212,34 @@ def write_skills(skills: dict[str, Any], path: Path | str | None = None) -> None
 def update_score(
     skill: str, score: float, path: Path | str | None = None
 ) -> dict[str, Any]:
-    """Update a skill score in the skills file."""
+    """Update a skill score in the skills file.
+
+    Existing note text for ``skill`` is preserved if present.
+    """
+
     skills = read_skills(path)
-    skills[skill] = score
+    entry = skills.get(skill)
+    if isinstance(entry, dict):
+        entry["score"] = score
+    else:
+        entry = {"score": score}
+    skills[skill] = entry
+    write_skills(skills, path)
+    return skills
+
+
+def update_note(
+    skill: str, note: str, path: Path | str | None = None
+) -> dict[str, Any]:
+    """Update or add a free-form note for ``skill`` in the skills file."""
+
+    skills = read_skills(path)
+    entry = skills.get(skill)
+    if isinstance(entry, dict):
+        entry["note"] = note
+    else:
+        entry = {"score": 0.0, "note": note}
+    skills[skill] = entry
     write_skills(skills, path)
     return skills
 

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -68,7 +68,16 @@ def report(
     skills = read_skills(path=skills_path)
     if skills:
         print("Skills:")
-        for skill, score in skills.items():
-            print(f"  {skill}: {score}")
+        for skill, data in skills.items():
+            if isinstance(data, dict):
+                score = data.get("score")
+                note = data.get("note")
+            else:
+                score = data
+                note = None
+            line = f"  {skill}: {score}"
+            if note:
+                line += f" ({note})"
+            print(line)
     else:
         print("No skills recorded.")

--- a/tests/test_cli_quest.py
+++ b/tests/test_cli_quest.py
@@ -32,7 +32,7 @@ def test_quest_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert skill_file.exists()
 
     skills_data = read_skills(tmp_path / "mem" / "skills.json")
-    assert skills_data == {"square": 0.0}
+    assert skills_data == {"square": {"score": 0.0}}
 
     episodes = read_episodes(tmp_path / "mem" / "episodic.jsonl")
     assert episodes[-1]["status"] == "success"

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -97,7 +97,7 @@ def test_log_and_memory_update(tmp_path: Path, monkeypatch):
 
     def fake_update_score(skill: str, score: float) -> None:
         data = json.loads(mem_file.read_text()) if mem_file.exists() else {}
-        data[skill] = score
+        data[skill] = {"score": score}
         mem_file.write_text(json.dumps(data))
 
     monkeypatch.setattr(life_loop, "update_score", fake_update_score)
@@ -112,7 +112,7 @@ def test_log_and_memory_update(tmp_path: Path, monkeypatch):
     )
 
     assert any((tmp_path / "logs").glob("loop-*.jsonl"))
-    assert json.loads(mem_file.read_text())["foo"] > 1
+    assert json.loads(mem_file.read_text())["foo"]["score"] > 1
 
 
 def test_corrupted_checkpoint(tmp_path: Path, caplog):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4,7 +4,7 @@ import json
 import pytest
 from typing import Any
 
-from singular.memory import add_episode, update_trait, update_score
+from singular.memory import add_episode, update_trait, update_score, update_note
 import singular.memory as memory
 from singular.organisms.birth import birth
 
@@ -54,7 +54,7 @@ def test_add_episode(tmp_path: Path) -> None:
     assert json.loads(lines[0]) == {"event": "test"}
 
 
-def test_update_trait_and_score(tmp_path: Path) -> None:
+def test_update_trait_score_and_note(tmp_path: Path) -> None:
     profile_path = tmp_path / "mem" / "profile.json"
     skills_path = tmp_path / "mem" / "skills.json"
 
@@ -62,7 +62,10 @@ def test_update_trait_and_score(tmp_path: Path) -> None:
     assert json.loads(profile_path.read_text(encoding="utf-8")) == {"courage": "high"}
 
     update_score("archery", 10, path=skills_path)
-    assert json.loads(skills_path.read_text(encoding="utf-8")) == {"archery": 10}
+    update_note("archery", "bullseye", path=skills_path)
+    assert json.loads(skills_path.read_text(encoding="utf-8")) == {
+        "archery": {"score": 10, "note": "bullseye"}
+    }
 
 
 def test_birth_initializes_default_skills(
@@ -80,9 +83,9 @@ def test_birth_initializes_default_skills(
         (tmp_path / "mem" / "skills.json").read_text(encoding="utf-8")
     )
     assert skills_data == {
-        "addition": 0.0,
-        "subtraction": 0.0,
-        "multiplication": 0.0,
+        "addition": {"score": 0.0},
+        "subtraction": {"score": 0.0},
+        "multiplication": {"score": 0.0},
     }
 
 

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -35,7 +35,7 @@ def test_multi_organisms_independent(tmp_path: Path, monkeypatch):
 
     def fake_update_score(skill: str, score: float) -> None:
         data = json.loads(mem_file.read_text()) if mem_file.exists() else {}
-        data[skill] = score
+        data[skill] = {"score": score}
         mem_file.write_text(json.dumps(data))
 
     monkeypatch.setattr(life_loop, "update_score", fake_update_score)
@@ -64,8 +64,8 @@ def test_multi_organisms_independent(tmp_path: Path, monkeypatch):
     assert val2 > 1
 
     scores = json.loads(mem_file.read_text())
-    assert scores["org1:foo"] == val1
-    assert scores["org2:foo"] == val2
+    assert scores["org1:foo"]["score"] == val1
+    assert scores["org2:foo"]["score"] == val2
 
     assert world.organisms["org1"].last_score == val1
     assert world.organisms["org2"].last_score == val2

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -17,7 +17,9 @@ def test_report_cli(monkeypatch, tmp_path, capsys):
             fh.write(json.dumps(rec) + "\n")
     mem = tmp_path / "mem"
     mem.mkdir()
-    (mem / "skills.json").write_text(json.dumps({"skillA": 0.8}), encoding="utf-8")
+    (mem / "skills.json").write_text(
+        json.dumps({"skillA": {"score": 0.8}}), encoding="utf-8"
+    )
 
     main(["report", "--id", "run1"])
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- allow skills to retain a free-form note alongside score
- show optional notes when reporting skills
- test skill notes through memory and loop scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0affd1230832aa34f81d76960cdb4