### PR TITLE
Invert score comparison in evolutionary loop

### DIFF
--- a/life/loop.py
+++ b/life/loop.py
@@ -231,7 +231,7 @@ def run(
             if mutated_score == float("-inf"):
                 if hasattr(psyche, "feel"):
                     psyche.feel("pain")
-            elif mutated_score >= base_score:
+            elif mutated_score <= base_score:
                 if hasattr(psyche, "feel"):
                     psyche.feel("pleasure")
 
@@ -249,7 +249,7 @@ def run(
                     psyche.feel("curious")
                 seen_diffs.add(diff)
 
-            if mutated_score >= base_score:
+            if mutated_score <= base_score:
                 skill_path.write_text(mutated, encoding="utf-8")
                 key = (
                     f"{org_name}:{skill_path.stem}"
@@ -258,9 +258,9 @@ def run(
                 )
                 update_score(key, mutated_score)
                 org.last_score = mutated_score
-                org.energy += 0.2
+                org.energy += 0.2  # reward improvements
             else:
-                org.energy -= 0.1
+                org.energy -= 0.1  # penalize regressions
 
             stats[op_name]["count"] += 1
             stats[op_name]["reward"] += mutated_score - base_score
@@ -301,7 +301,7 @@ def run(
             save_checkpoint(checkpoint_path, state)
 
             dead, reason = org.monitor.check(
-                state.iteration, psyche, mutated_score >= base_score, org.resources
+                state.iteration, psyche, mutated_score <= base_score, org.resources
             )
             if dead:
                 logger.log_death(reason or "unknown", age=state.iteration)

--- a/tests/test_death.py
+++ b/tests/test_death.py
@@ -105,7 +105,7 @@ def test_death_by_failures(tmp_path: Path, monkeypatch):
         budget_seconds=1.0,
         rng=random.Random(0),
         run_id="loop",
-        operators={"dec": _dec_operator},
+        operators={"inc": _inc_operator},
         mortality=monitor,
     )
 

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -1,17 +1,17 @@
-import json
-import random
 from pathlib import Path
 
 import ast
+import json
+import random
 
 import life.loop as life_loop
 from life.loop import WorldState
 
 
-def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
+def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
     for node in ast.walk(tree):
         if isinstance(node, ast.Constant) and isinstance(node.value, int):
-            node.value += 1
+            node.value -= 1
             break
     return tree
 
@@ -46,7 +46,7 @@ def test_multi_organisms_independent(tmp_path: Path, monkeypatch):
         checkpoint,
         budget_seconds=0.3,
         rng=random.Random(1),
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
         world=world,
     )
     life_loop.run(
@@ -54,14 +54,14 @@ def test_multi_organisms_independent(tmp_path: Path, monkeypatch):
         checkpoint,
         budget_seconds=0.3,
         rng=random.Random(5),
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
         world=world,
     )
 
     val1 = _read_result(skill1)
     val2 = _read_result(skill2)
-    assert val1 > 1
-    assert val2 > 1
+    assert val1 < 1
+    assert val2 < 1
 
     scores = json.loads(mem_file.read_text())
     assert scores["org1:foo"] == val1


### PR DESCRIPTION
## Summary
- Favor lower (better) scores when deciding to keep a mutation, rewarding accepted changes and penalizing regressions
- Cover score-based mutation outcomes with tests, including multi-organism and death scenarios
- Clarify comments around energy adjustments

## Testing
- `pytest tests/test_loop.py::test_worse_mutation_rejected tests/test_loop.py::test_better_score_preserved -q`
- `pytest -q` *(KeyboardInterrupt after completion: 7 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ba4d558c832ab5272799a0122a2d