### PR TITLE
Fix mutation acceptance condition

### DIFF
--- a/life/loop.py
+++ b/life/loop.py
@@ -231,7 +231,7 @@ def run(
             if mutated_score == float("-inf"):
                 if hasattr(psyche, "feel"):
                     psyche.feel("pain")
-            elif mutated_score >= base_score:
+            elif mutated_score <= base_score:
                 if hasattr(psyche, "feel"):
                     psyche.feel("pleasure")
 
@@ -249,7 +249,7 @@ def run(
                     psyche.feel("curious")
                 seen_diffs.add(diff)
 
-            if mutated_score >= base_score:
+            if mutated_score <= base_score:
                 skill_path.write_text(mutated, encoding="utf-8")
                 key = (
                     f"{org_name}:{skill_path.stem}"
@@ -263,7 +263,7 @@ def run(
                 org.energy -= 0.1
 
             stats[op_name]["count"] += 1
-            stats[op_name]["reward"] += mutated_score - base_score
+            stats[op_name]["reward"] += base_score - mutated_score
             state.stats = stats
 
             # Shared resource competition
@@ -301,7 +301,7 @@ def run(
             save_checkpoint(checkpoint_path, state)
 
             dead, reason = org.monitor.check(
-                state.iteration, psyche, mutated_score >= base_score, org.resources
+                state.iteration, psyche, mutated_score <= base_score, org.resources
             )
             if dead:
                 logger.log_death(reason or "unknown", age=state.iteration)

--- a/tests/test_death.py
+++ b/tests/test_death.py
@@ -1,9 +1,7 @@
-import json
 import ast
+import functools
 import random
 from pathlib import Path
-
-import functools
 
 import life.loop as life_loop
 from life.loop import run
@@ -105,7 +103,7 @@ def test_death_by_failures(tmp_path: Path, monkeypatch):
         budget_seconds=1.0,
         rng=random.Random(0),
         run_id="loop",
-        operators={"dec": _dec_operator},
+        operators={"inc": _inc_operator},
         mortality=monitor,
     )
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -40,10 +40,10 @@ def test_mutation_persistence(tmp_path: Path):
         checkpoint,
         budget_seconds=0.1,
         rng=random.Random(0),
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
     )
 
-    assert _read_result(skill) > 1
+    assert _read_result(skill) < 1
     state = json.loads(checkpoint.read_text(encoding="utf-8"))
     assert state["iteration"] >= 1
 
@@ -61,7 +61,7 @@ def test_resume_from_checkpoint(tmp_path: Path):
         checkpoint,
         budget_seconds=0.1,
         rng=rng,
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
     )
     first_val = _read_result(skill)
     first_iter = load_checkpoint(checkpoint).iteration
@@ -71,13 +71,13 @@ def test_resume_from_checkpoint(tmp_path: Path):
         checkpoint,
         budget_seconds=0.1,
         rng=rng,
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
     )
     second_val = _read_result(skill)
     second_iter = load_checkpoint(checkpoint).iteration
 
     assert second_iter > first_iter
-    assert second_val > first_val
+    assert second_val < first_val
 
 
 def test_log_and_memory_update(tmp_path: Path, monkeypatch):
@@ -108,11 +108,11 @@ def test_log_and_memory_update(tmp_path: Path, monkeypatch):
         budget_seconds=0.1,
         rng=random.Random(0),
         run_id="loop",
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
     )
 
     assert any((tmp_path / "logs").glob("loop-*.jsonl"))
-    assert json.loads(mem_file.read_text())["foo"]["score"] > 1
+    assert json.loads(mem_file.read_text())["foo"]["score"] < 1
 
 
 def test_corrupted_checkpoint(tmp_path: Path, caplog):
@@ -259,5 +259,5 @@ def test_bandit_persistence_and_exploitation(tmp_path: Path, monkeypatch):
     )
 
     second_stats = load_checkpoint(checkpoint).stats
-    assert second_stats["inc"]["count"] > first_stats["inc"]["count"]
-    assert second_stats["dec"]["count"] == first_stats["dec"]["count"]
+    assert second_stats["dec"]["count"] > first_stats["dec"]["count"]
+    assert second_stats["inc"]["count"] == first_stats["inc"]["count"]

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -1,17 +1,17 @@
-import json
-import random
 from pathlib import Path
 
 import ast
+import json
+import random
 
 import life.loop as life_loop
 from life.loop import WorldState
 
 
-def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
+def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
     for node in ast.walk(tree):
         if isinstance(node, ast.Constant) and isinstance(node.value, int):
-            node.value += 1
+            node.value -= 1
             break
     return tree
 
@@ -46,7 +46,7 @@ def test_multi_organisms_independent(tmp_path: Path, monkeypatch):
         checkpoint,
         budget_seconds=0.3,
         rng=random.Random(1),
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
         world=world,
     )
     life_loop.run(
@@ -54,14 +54,14 @@ def test_multi_organisms_independent(tmp_path: Path, monkeypatch):
         checkpoint,
         budget_seconds=0.3,
         rng=random.Random(5),
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
         world=world,
     )
 
     val1 = _read_result(skill1)
     val2 = _read_result(skill2)
-    assert val1 > 1
-    assert val2 > 1
+    assert val1 < 1
+    assert val2 < 1
 
     scores = json.loads(mem_file.read_text())
     assert scores["org1:foo"]["score"] == val1


### PR DESCRIPTION
## Summary
- treat lower scores as improvements in evolutionary loop
- adjust reward and mortality checks accordingly
- update tests for new scoring semantics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0cc9895e0832aac36bc6c80ab68a3