### PR TITLE
Handle KeyboardInterrupt in talk loop

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -102,6 +102,9 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
             user_input = input("you: ")
         except EOFError:
             break
+        except KeyboardInterrupt:
+            print("\nExiting conversation.")
+            break
 
         if user_input.strip().lower() in {"exit", "quit"}:
             break


### PR DESCRIPTION
## Summary
- handle `KeyboardInterrupt` in `talk` to exit cleanly
- add unit test to simulate `KeyboardInterrupt`

## Testing
- `pytest tests/test_talk.py::test_talk_handles_keyboard_interrupt tests/test_talk.py::test_talk_loop tests/test_talk.py::test_cli_provider_precedence tests/test_talk.py::test_talk_seed_controls_stub -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d07229cc832aa397bf408ae4cf3a