### PR TITLE
Handle missing uvicorn dependency

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
@@ -74,7 +75,14 @@ def create_app(
 
 def run(host: str = "127.0.0.1", port: int = 8000) -> None:
     """Launch the dashboard using Uvicorn."""
-    import uvicorn
+    try:
+        import uvicorn
+    except ImportError as exc:
+        print(
+            "Uvicorn is required to run the dashboard. Install it with 'pip install uvicorn'.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
 
     app = create_app()
     uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
## Summary
- Handle missing `uvicorn` in dashboard by warning users and exiting cleanly
- Test dashboard run behavior when `uvicorn` is unavailable

## Testing
- `pytest tests/test_dashboard.py::test_run_requires_uvicorn -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d215c97c832abf8c2bfb1c014480