### PR TITLE
feat: add local LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ pip install -e .
 
 - `pip install -e .[yaml]` pour ajouter **PyYAML** et gérer `values.yaml`.
 - `pip install openai>=1.0.0` pour permettre à l'organisme de parler via l'API OpenAI.
+- `pip install transformers` pour activer un modèle local via Hugging Face.
 
 Après installation, la commande CLI `singular` est disponible :
 
@@ -166,4 +167,16 @@ Pour permettre à l'organisme de parler en utilisant l'API d'OpenAI, installez
 la dépendance optionnelle ``openai>=1.0.0`` et définissez la variable
 d'environnement ``OPENAI_API_KEY``. Les versions plus anciennes du paquet
 ``openai`` ne sont pas compatibles avec le fournisseur actuel.
+
+### Fournisseur local
+
+Installez ``transformers`` pour utiliser un petit modèle embarqué :
+
+```bash
+pip install transformers
+singular talk --provider local "Bonjour"
+```
+
+Le fournisseur local utilise le modèle ``sshleifer/tiny-gpt2`` de Hugging Face
+pour fonctionner hors-ligne.
 

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -69,7 +69,11 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     talk_parser = subparsers.add_parser("talk", help="Talk with the system")
-    talk_parser.add_argument("--provider", default=None, help="LLM provider to use")
+    talk_parser.add_argument(
+        "--provider",
+        default=None,
+        help="LLM provider to use (e.g. 'openai' or 'local')",
+    )
     talk_parser.set_defaults(func=talk)
 
     quest_parser = subparsers.add_parser(

--- a/src/singular/providers/llm_local.py
+++ b/src/singular/providers/llm_local.py
@@ -1,0 +1,45 @@
+"""Local LLM provider using a small transformers model."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    from transformers import pipeline  # type: ignore
+except Exception:  # pragma: no cover - handle missing package
+    pipeline = None  # type: ignore
+
+_pipe: Any | None = None
+
+
+def _get_pipe() -> Any | None:
+    """Return a cached text generation pipeline or ``None`` if unavailable."""
+    global _pipe
+    if pipeline is None:
+        return None
+    if _pipe is None:
+        try:  # pragma: no cover - model download
+            _pipe = pipeline("text-generation", model="sshleifer/tiny-gpt2")
+        except Exception:
+            _pipe = None
+    return _pipe
+
+
+def _filter(text: str) -> str:
+    """Return only printable characters from ``text``."""
+    return "".join(ch for ch in text if ch.isprintable())
+
+
+def generate_reply(prompt: str) -> str:
+    """Generate a reply using a small local transformers model."""
+    pipe = _get_pipe()
+    if pipe is None:
+        return "Local model not available."
+    try:  # pragma: no cover - model inference
+        outputs = pipe(prompt, max_new_tokens=50, num_return_sequences=1)
+        text: str = outputs[0]["generated_text"]
+    except Exception:
+        return "Error running local model."
+    # ``text`` includes the original prompt at the beginning
+    reply = text[len(prompt) :].strip()
+    return _filter(reply)

--- a/tests/providers/test_llm_local.py
+++ b/tests/providers/test_llm_local.py
@@ -1,0 +1,7 @@
+from singular.providers import llm_local, load_llm_provider
+
+
+def test_load_llm_provider_local():
+    """Ensure the 'local' provider can be loaded."""
+    func = load_llm_provider("local")
+    assert func is llm_local.generate_reply


### PR DESCRIPTION
## Summary
- add local LLM provider based on transformers
- document local provider usage and expose in CLI help
- test that `load_llm_provider('local')` returns the generator

## Testing
- `pytest tests/providers -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d497944c832aa42c5ffc31806de4