### PR TITLE
feat: add MAP-Elites exploration

### DIFF
--- a/life/map_elites.py
+++ b/life/map_elites.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Tuple
+import random
+
+Descriptor = Tuple[int, int]
+DescriptorFunc = Callable[[str, float], Tuple[int, int]]
+
+
+@dataclass
+class MapElites:
+    """Simple MAP-Elites grid.
+
+    The grid is indexed by discrete descriptor values returned by a
+    ``descriptor_func`` which maps a code string and its score to a pair
+    of integers.  Each cell stores the best code (lowest score) observed
+    for that descriptor.
+    """
+
+    descriptor_func: DescriptorFunc
+    bins: Descriptor = (10, 10)
+    grid: Dict[Descriptor, Tuple[str, float]] = field(default_factory=dict)
+
+    def _bin(self, desc: Tuple[int, int]) -> Descriptor:
+        x, y = desc
+        bx = max(0, min(self.bins[0] - 1, int(x)))
+        by = max(0, min(self.bins[1] - 1, int(y)))
+        return bx, by
+
+    def add(self, code: str, score: float) -> bool:
+        """Insert ``code`` into the grid if it improves its cell.
+
+        Returns ``True`` if the code was stored, ``False`` otherwise.
+        """
+
+        cell = self._bin(self.descriptor_func(code, score))
+        current = self.grid.get(cell)
+        if current is None or score <= current[1]:
+            self.grid[cell] = (code, score)
+            return True
+        return False
+
+    def sample(self, rng: random.Random) -> str:
+        """Return a random elite code from the grid."""
+
+        if not self.grid:
+            raise RuntimeError("empty grid")
+        return rng.choice(list(self.grid.values()))[0]
+
+    def regions(self) -> Dict[Descriptor, str]:
+        """Return a mapping of filled cells to their stored code."""
+
+        return {cell: data[0] for cell, data in self.grid.items()}

--- a/tests/test_map_elites.py
+++ b/tests/test_map_elites.py
@@ -1,0 +1,59 @@
+import ast
+import random
+import sys
+from pathlib import Path
+
+root_dir = Path(__file__).resolve().parents[1]
+sys.path.append(str(root_dir))
+sys.path.append(str(root_dir / "src"))
+
+from life.map_elites import MapElites  # noqa: E402
+from life.loop import run  # noqa: E402
+
+
+def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            node.value += 1
+            break
+    return tree
+
+
+def test_distinct_regions_hold_unique_solutions():
+    def descriptor(code: str, score: float) -> tuple[int, int]:
+        val = int(code.split("=")[1])
+        return (0 if val < 5 else 1, val % 2)
+
+    me = MapElites(descriptor, bins=(2, 2))
+    assert me.add("result = 1", 1)
+    assert me.add("result = 6", 6)
+    regions = me.regions()
+    assert len(regions) == 2
+    assert len(set(regions.values())) == 2
+
+
+def test_loop_uses_map_elites_for_selection(tmp_path: Path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = 0", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+
+    def descriptor(code: str, score: float) -> tuple[int, int]:
+        val = int(code.split("=")[1])
+        return (0, val)
+
+    me = MapElites(descriptor, bins=(1, 10))
+
+    run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.1,
+        rng=random.Random(0),
+        operators={"inc": _inc_operator},
+        map_elites=me,
+    )
+
+    # Mutation produces a worse score but is kept due to MAP-Elites acceptance
+    assert skill.read_text(encoding="utf-8") == "result = 1"
+    assert me.grid


### PR DESCRIPTION
## Summary
- implement a simple MAP-Elites grid for diverse mutation tracking
- allow loop to optionally persist mutations via MAP-Elites
- test that MAP-Elites stores distinct solutions in separate regions

## Testing
- `pytest tests/test_map_elites.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d5fb16d4832a8f924ba18ca4d003