### PR TITLE
Add mood-based styling for run episodes

### DIFF
--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -7,7 +7,7 @@ when the optional :mod:`PyYAML <yaml>` package is available.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Mapping
 import json
 import os
 
@@ -170,8 +170,22 @@ def read_episodes(path: Path | str | None = None) -> list[dict[str, Any]]:
     return episodes
 
 
-def add_episode(episode: dict[str, Any], path: Path | str | None = None) -> None:
-    """Append a new episode to the episodic memory file."""
+def add_episode(
+    episode: dict[str, Any],
+    path: Path | str | None = None,
+    mood_styles: Mapping[str | None, Callable[[str], str]] | None = None,
+) -> None:
+    """Append a new episode to the episodic memory file.
+
+    If ``mood_styles`` is provided and the episode contains a ``mood`` field,
+    the corresponding rendering function is applied to the mood value before the
+    episode is serialized.
+    """
+
+    if mood_styles and (mood := episode.get("mood")) is not None:
+        style = mood_styles.get(mood) or mood_styles.get(None) or (lambda x: x)
+        episode = {**episode, "mood": style(mood)}
+
     if path is None:
         path = get_episodic_file()
     path = Path(path)

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from ..psyche import Psyche
 from ..memory import add_episode
+from typing import Callable, Dict
 
 # Base directory for persistent files
 _BASE_DIR = Path(os.environ.get("SINGULAR_HOME", "."))
@@ -18,6 +19,37 @@ _BASE_DIR = Path(os.environ.get("SINGULAR_HOME", "."))
 RUNS_DIR = _BASE_DIR / "runs"
 # Number of run logs to retain
 MAX_RUN_LOGS = int(os.environ.get("SINGULAR_RUNS_KEEP", "20"))
+
+# ---------------------------------------------------------------------------
+# Mood style helpers
+# ---------------------------------------------------------------------------
+
+
+def _style_colere(mood: str) -> str:
+    """Rendering for the ``colere`` (anger) mood."""
+
+    return mood.upper()
+
+
+def _style_fatigue(mood: str) -> str:
+    """Rendering for the ``fatigue`` (tired) mood."""
+
+    return f"{mood}..."
+
+
+def _style_neutre(mood: str) -> str:
+    """Rendering for the ``neutre`` (neutral) mood."""
+
+    return mood
+
+
+mood_styles: Dict[str | None, Callable[[str], str]] = {
+    "colere": _style_colere,
+    "colère": _style_colere,
+    "fatigue": _style_fatigue,
+    "neutre": _style_neutre,
+    None: _style_neutre,
+}
 
 
 def _ensure_dir(path: Path) -> None:
@@ -123,7 +155,9 @@ class RunLogger:
         os.fsync(self._file.fileno())
         self.psyche.process_run_record(record)
         mood = getattr(self.psyche, "last_mood", None)
-        add_episode({"event": "mutation", "mood": mood, **record})
+        add_episode(
+            {"event": "mutation", "mood": mood, **record}, mood_styles=mood_styles
+        )
 
     def log_death(self, reason: str, **info: Any) -> None:
         """Record a death event with optional additional information."""

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -115,6 +115,26 @@ def test_log_and_memory_update(tmp_path: Path, monkeypatch):
     assert json.loads(mem_file.read_text())["foo"]["score"] < 1
 
 
+def test_mood_style_logged(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+
+    class DummyPsyche:
+        last_mood = "colere"
+
+        def process_run_record(self, record):
+            pass
+
+    from singular.runs.logger import RunLogger, mood_styles
+
+    logger = RunLogger("mood", root=tmp_path / "logs", psyche=DummyPsyche())
+    logger.log("skill", "op", "diff", True, 0, 0, 0, 0)
+    logger.close()
+
+    episodes = (tmp_path / "mem" / "episodic.jsonl").read_text().splitlines()
+    rec = json.loads(episodes[-1])
+    assert rec["mood"] == mood_styles["colere"]("colere")
+
+
 def test_corrupted_checkpoint(tmp_path: Path, caplog):
     ckpt = tmp_path / "ckpt.json"
     ckpt.write_text("{", encoding="utf-8")


### PR DESCRIPTION
## Summary
- introduce `mood_styles` mapping to render moods like *colere*, *fatigue* and *neutre*
- apply mood style when recording episodes in memory
- test logging to ensure mood styling is persisted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0dfd57ec4832aaa392b18ed10592d