### PR TITLE
Add environment utilities and loop integration

### DIFF
--- a/life/loop.py
+++ b/life/loop.py
@@ -17,6 +17,9 @@ from singular.psyche import Psyche
 from singular.runs.logger import RunLogger
 from singular.perception import capture_signals
 from graine.evolver.generate import propose_mutations
+from singular.environment import artifacts as env_artifacts
+from singular.environment import files as env_files
+from singular.environment import notifications as env_notifications
 
 from . import sandbox
 from .death import DeathMonitor
@@ -286,8 +289,16 @@ def run(
                 update_score(key, mutated_score)
                 org.last_score = mutated_score
                 org.energy += 0.2
+                env_artifacts.save_text(
+                    f"mutation_{state.iteration}", diff
+                )
             else:
                 org.energy -= 0.1
+
+            env_notifications.notify(
+                f"iteration {state.iteration}: {op_name}", channel=log.info
+            )
+            _ = env_files.list_files()
 
             stats[op_name]["count"] += 1
             stats[op_name]["reward"] += base_score - mutated_score

--- a/src/singular/environment/__init__.py
+++ b/src/singular/environment/__init__.py
@@ -1,0 +1,5 @@
+"""Environment helper modules providing I/O and artifact utilities."""
+
+from . import files, notifications, artifacts
+
+__all__ = ["files", "notifications", "artifacts"]

--- a/src/singular/environment/artifacts.py
+++ b/src/singular/environment/artifacts.py
@@ -1,0 +1,49 @@
+"""Utilities to generate and persist simple artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+ARTIFACTS_DIR = Path("./artifacts")
+
+
+def _ensure_dir(directory: Path | None = None) -> Path:
+    directory = directory or ARTIFACTS_DIR
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def save_text(name: str, content: str, directory: Path | None = None) -> Path:
+    """Save *content* as a text artifact named *name*.
+
+    Returns the path to the created file.
+    """
+
+    directory = _ensure_dir(directory)
+    path = directory / f"{name}.txt"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def save_drawing(
+    name: str,
+    width: int,
+    height: int,
+    char: str = "*",
+    directory: Path | None = None,
+) -> Path:
+    """Generate a simple ASCII drawing and persist it as a text file."""
+
+    lines = [char * width for _ in range(height)]
+    content = "\n".join(lines)
+    return save_text(name, content, directory)
+
+
+def save_music(name: str, notes: Iterable[str], directory: Path | None = None) -> Path:
+    """Store a sequence of *notes* as a rudimentary music artifact."""
+
+    directory = _ensure_dir(directory)
+    path = directory / f"{name}.abc"
+    path.write_text(" ".join(notes), encoding="utf-8")
+    return path

--- a/src/singular/environment/files.py
+++ b/src/singular/environment/files.py
@@ -1,0 +1,50 @@
+"""Read-only access to a predefined sandbox directory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+# Root of the sandbox; resolves relative to the current working directory
+SANDBOX_ROOT = Path("./sandbox").resolve()
+
+
+def _resolve(path: str | Path) -> Path:
+    """Return the absolute :class:`Path` inside :data:`SANDBOX_ROOT`.
+
+    A :class:`ValueError` is raised if *path* escapes the sandbox directory.
+    """
+
+    candidate = (SANDBOX_ROOT / path).resolve()
+    if not str(candidate).startswith(str(SANDBOX_ROOT)):
+        raise ValueError("attempted access outside sandbox")
+    return candidate
+
+
+def list_files() -> List[str]:
+    """Return a list of file names available in the sandbox.
+
+    The paths are returned relative to :data:`SANDBOX_ROOT`.
+    """
+
+    if not SANDBOX_ROOT.exists():
+        return []
+    files: List[str] = []
+    for p in SANDBOX_ROOT.rglob("*"):
+        if p.is_file():
+            files.append(str(p.relative_to(SANDBOX_ROOT)))
+    return files
+
+
+def read_file(path: str | Path, encoding: str = "utf-8") -> str:
+    """Return the contents of *path* inside the sandbox.
+
+    The file is opened in text mode using *encoding* and the content is
+    returned as a string. Attempts to access paths outside the sandbox raise
+    :class:`ValueError`.
+    """
+
+    target = _resolve(path)
+    if not target.is_file():
+        raise FileNotFoundError(path)
+    return target.read_text(encoding=encoding)

--- a/src/singular/environment/notifications.py
+++ b/src/singular/environment/notifications.py
@@ -1,0 +1,15 @@
+"""Simple notification helpers."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def notify(message: str, channel: Callable[[str], None] | None = None) -> None:
+    """Send *message* through *channel*.
+
+    By default messages are printed to standard output. A different callable
+    can be provided via *channel* (for example ``logging.getLogger(__name__).info``).
+    """
+
+    (channel or print)(message)


### PR DESCRIPTION
## Summary
- add environment modules for sandbox file access, notifications, and artifacts
- integrate environment utilities into life loop with notifications and artifact persistence

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after ~80s; 8 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ec438150832a992dc8c9e16744ac