### PR TITLE
feat: add refusal and delay decisions

### DIFF
--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -173,6 +173,33 @@ class RunLogger:
         os.fsync(self._file.fileno())
         add_episode(record)
 
+    def log_refusal(self, skill: str) -> None:
+        """Record a refusal to mutate ``skill``."""
+
+        record: dict[str, Any] = {
+            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "event": "refuse",
+            "skill": skill,
+        }
+        self._file.write(json.dumps(record) + "\n")
+        self._file.flush()
+        os.fsync(self._file.fileno())
+        add_episode(record)
+
+    def log_delay(self, skill: str, resume_at: float) -> None:
+        """Record a procrastination event for ``skill``."""
+
+        record: dict[str, Any] = {
+            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "event": "delay",
+            "skill": skill,
+            "resume_at": resume_at,
+        }
+        self._file.write(json.dumps(record) + "\n")
+        self._file.flush()
+        os.fsync(self._file.fileno())
+        add_episode(record)
+
     def close(self) -> None:
         """Flush and finalize the log file atomically."""
         if not self._file.closed:


### PR DESCRIPTION
## Summary
- extend psyche irrational decisions to explicit REFUSE, DELAY, ACCEPT states
- skip iterations or schedule delayed runs based on decisions
- log refusal and delay episodes for traceability
- test refusal and delay behaviours in the main loop

## Testing
- `pytest tests/test_loop.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1aae4af28832aa95a5205e0b1a11a