### PR TITLE
Refine sandbox path resolution

### DIFF
--- a/src/singular/environment/files.py
+++ b/src/singular/environment/files.py
@@ -16,7 +16,7 @@ def _resolve(path: str | Path) -> Path:
     """
 
     candidate = (SANDBOX_ROOT / path).resolve()
-    if not str(candidate).startswith(str(SANDBOX_ROOT)):
+    if not candidate.is_relative_to(SANDBOX_ROOT):
         raise ValueError("attempted access outside sandbox")
     return candidate
 


### PR DESCRIPTION
## Summary
- ensure sandbox paths use `Path.is_relative_to` for validation

## Testing
- `pytest tests/test_sandbox.py`

------
https://chatgpt.com/codex/tasks/task_e_68b240fb2710832abfb8549f52102901