### PR TITLE
Validate type of YAML values in memory loader

### DIFF
--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -126,7 +126,9 @@ def read_values(path: Path | str | None = None) -> dict[str, Any]:
         return {}
     with path.open(encoding="utf-8") as file:
         data = yaml.safe_load(file)
-    return data or {}
+    if not isinstance(data, dict):
+        return {}
+    return data
 
 
 def write_values(values: dict[str, Any], path: Path | str | None = None) -> None:


### PR DESCRIPTION
## Summary
- Ensure `read_values` returns a dict by checking the result of `yaml.safe_load`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24302cf6c832a84aa715bbdfd7071