### PR TITLE
Move dashboard dependencies to optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Contrairement aux chatbots classiques (qui ne changent pas leur cœur) ou aux si
 ## ⚡ Quickstart
 
 ```bash
-pip install -e .[yaml]
+pip install -e .[yaml,dashboard]
 singular birth --name Lumen
 singular talk "Bonjour"
 singular loop --ticks 10
@@ -117,6 +117,7 @@ pip install -e .
 
 #### Dépendances optionnelles
 
+- `pip install -e .[dashboard]` pour activer le tableau de bord web.
 - `pip install -e .[yaml]` pour ajouter **PyYAML** et gérer `values.yaml`.
 - `pip install openai>=1.0.0` pour permettre à l'organisme de parler via l'API OpenAI.
 - `pip install transformers` pour activer un modèle local via Hugging Face.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,11 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{name = "Singular Contributors"}]
-dependencies = [
-    "fastapi",
-    "uvicorn",
-]
+dependencies = []
 
 [project.optional-dependencies]
 yaml = ["pyyaml"]
+dashboard = ["fastapi", "uvicorn"]
 
 [project.scripts]
 singular = "singular.cli:main"


### PR DESCRIPTION
## Summary
- Move FastAPI and Uvicorn from core dependencies to dashboard optional group
- Document how to install dashboard extras

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b253daf114832a8c6569977bc34d88