### PR TITLE
Refactor moods to enum

### DIFF
--- a/life/loop.py
+++ b/life/loop.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterable
 
 from singular.memory import add_episode, update_score
-from singular.psyche import Psyche
+from singular.psyche import Psyche, Mood
 from singular.runs.logger import RunLogger
 from singular.organisms.spawn import mutation_absurde
 from singular.perception import capture_signals
@@ -282,10 +282,10 @@ def run(
 
             if mutated_score == float("-inf"):
                 if hasattr(psyche, "feel"):
-                    psyche.feel("pain")
+                    psyche.feel(Mood.PAIN)
             elif mutated_score <= base_score:
                 if hasattr(psyche, "feel"):
-                    psyche.feel("pleasure")
+                    psyche.feel(Mood.PLEASURE)
 
             diff = "".join(
                 difflib.unified_diff(
@@ -298,7 +298,7 @@ def run(
 
             if diff not in seen_diffs:
                 if hasattr(psyche, "feel"):
-                    psyche.feel("curious")
+                    psyche.feel(Mood.CURIOUS)
                 seen_diffs.add(diff)
 
             accepted = (
@@ -344,12 +344,12 @@ def run(
             moods = resource_manager.mood()
             if "tired" in moods:
                 if hasattr(psyche, "feel"):
-                    psyche.feel("fatigue")
+                    psyche.feel(Mood.FATIGUE)
                 time.sleep(0.01)
             if "angry" in moods and hasattr(psyche, "feel"):
-                psyche.feel("anger")
+                psyche.feel(Mood.ANGER)
             if "cold" in moods and hasattr(psyche, "feel"):
-                psyche.feel("lonely")
+                psyche.feel(Mood.LONELY)
 
             if time.time() - last_post >= 0.05:
                 env_notifications.auto_post(

--- a/src/singular/organisms/quest.py
+++ b/src/singular/organisms/quest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from life.synthesis import synthesise
 
 from ..memory import add_episode, ensure_memory_structure, update_score
-from ..psyche import Psyche
+from ..psyche import Psyche, Mood
 
 
 def quest(spec: Path) -> None:
@@ -25,17 +25,27 @@ def quest(spec: Path) -> None:
     try:
         skill_path = synthesise(spec, Path("skills"))
     except Exception as exc:  # pragma: no cover - re-raised after logging
-        mood = psyche.feel("frustrated")
+        mood = psyche.feel(Mood.FRUSTRATED)
         add_episode(
-            {"event": "quest", "status": "failure", "error": str(exc), "mood": mood}
+            {
+                "event": "quest",
+                "status": "failure",
+                "error": str(exc),
+                "mood": mood.value,
+            }
         )
         psyche.save_state()
         raise
 
     update_score(skill_path.stem, 0.0)
-    mood = psyche.feel("proud")
+    mood = psyche.feel(Mood.PROUD)
     add_episode(
-        {"event": "quest", "status": "success", "skill": skill_path.stem, "mood": mood}
+        {
+            "event": "quest",
+            "status": "success",
+            "skill": skill_path.stem,
+            "mood": mood.value,
+        }
     )
     psyche.gain()
     psyche.save_state()

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -37,7 +37,7 @@ def status() -> None:
         print("No run logs found.")
 
     psyche = Psyche.load_state()
-    mood = psyche.last_mood or "neutral"
+    mood = psyche.last_mood.value if psyche.last_mood else "neutral"
     print(f"Mood: {mood}")
     print("Traits:")
     print(f"  curiosity: {psyche.curiosity:.2f}")

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -8,7 +8,7 @@ from typing import Callable
 
 from ..memory import add_episode, ensure_memory_structure, read_episodes
 from ..perception import capture_signals
-from ..psyche import Psyche
+from ..psyche import Psyche, Mood
 from ..providers import load_llm_provider
 
 
@@ -111,8 +111,8 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
 
         add_episode({"role": "user", "text": user_input})
 
-        mood = psyche.feel("neutral")
-        mood_report = mood_event or mood or "neutral"
+        mood = psyche.feel(Mood.NEUTRAL)
+        mood_report = mood_event or mood.value
         reply = generate_reply(user_input)
 
         parts = [reply]
@@ -128,6 +128,6 @@ def talk(provider: str | None = None, seed: int | None = None) -> None:
         response = " | ".join(parts)
 
         print(response)
-        add_episode({"role": "assistant", "text": response, "mood": mood})
+        add_episode({"role": "assistant", "text": response, "mood": mood.value})
         psyche.gain()
         psyche.save_state()

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -13,6 +13,21 @@ from .motivation import Objective
 from .resource_manager import ResourceManager
 
 
+class Mood(Enum):
+    """Enumerate all possible moods."""
+
+    PROUD = "proud"
+    FRUSTRATED = "frustrated"
+    ANXIOUS = "anxious"
+    CURIOUS = "curious"
+    PLEASURE = "pleasure"
+    PAIN = "pain"
+    NEUTRAL = "neutral"
+    FATIGUE = "fatigue"
+    ANGER = "anger"
+    LONELY = "lonely"
+
+
 def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
     """Clamp ``value`` to the given range.
 
@@ -28,7 +43,7 @@ def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
     return max(minimum, min(maximum, value))
 
 
-def derive_mood(record: dict) -> str:
+def derive_mood(record: dict) -> Mood:
     """Derive a mood from a run ``record``.
 
     ``record`` is expected to contain the fields produced by
@@ -43,15 +58,15 @@ def derive_mood(record: dict) -> str:
     """
 
     if record.get("improved"):
-        return "proud"
+        return Mood.PROUD
 
     ms_base = record.get("ms_base")
     ms_new = record.get("ms_new")
     if isinstance(ms_base, (int, float)) and isinstance(ms_new, (int, float)):
         if ms_new > ms_base:
-            return "frustrated"
+            return Mood.FRUSTRATED
 
-    return "anxious"
+    return Mood.ANXIOUS
 
 
 @dataclass
@@ -73,56 +88,56 @@ class Psyche:
 
     # ``last_mood`` is updated every time :meth:`feel` is called and can be
     # queried by other subsystems (interaction and mutation policies).
-    last_mood: str | None = field(default=None, init=False)
+    last_mood: Mood | None = field(default=None, init=False)
 
     # Mapping of moods to their effects on the internal traits. The deltas are
     # added after every event and clamped.
-    _MOOD_EFFECTS: Dict[str, Dict[str, float]] = field(
+    _MOOD_EFFECTS: Dict[Mood, Dict[str, float]] = field(
         default_factory=lambda: {
-            "proud": {
+            Mood.PROUD: {
                 "curiosity": 0.1,
                 "patience": 0.05,
                 "playfulness": 0.1,
                 "optimism": 0.1,
                 "resilience": 0.1,
             },
-            "frustrated": {
+            Mood.FRUSTRATED: {
                 "curiosity": -0.1,
                 "patience": -0.2,
                 "playfulness": -0.1,
                 "optimism": -0.2,
                 "resilience": -0.1,
             },
-            "anxious": {
+            Mood.ANXIOUS: {
                 "curiosity": -0.05,
                 "patience": -0.1,
                 "playfulness": -0.05,
                 "optimism": -0.1,
                 "resilience": -0.05,
             },
-            "curious": {
+            Mood.CURIOUS: {
                 "curiosity": 0.1,
             },
-            "pleasure": {
+            Mood.PLEASURE: {
                 "optimism": 0.1,
                 "resilience": 0.1,
             },
-            "pain": {
+            Mood.PAIN: {
                 "optimism": -0.1,
                 "resilience": -0.1,
             },
-            "neutral": {},
-            "fatigue": {
+            Mood.NEUTRAL: {},
+            Mood.FATIGUE: {
                 "curiosity": -0.05,
                 "playfulness": -0.05,
                 "optimism": -0.1,
             },
-            "anger": {
+            Mood.ANGER: {
                 "patience": -0.2,
                 "playfulness": -0.1,
                 "optimism": -0.1,
             },
-            "lonely": {
+            Mood.LONELY: {
                 "optimism": -0.1,
                 "resilience": -0.1,
             },
@@ -131,45 +146,45 @@ class Psyche:
         repr=False,
     )
 
-    _INTERACTION_POLICIES: Dict[str, str] = field(
+    _INTERACTION_POLICIES: Dict[Mood, str] = field(
         default_factory=lambda: {
-            "proud": "engaging",
-            "frustrated": "retry",
-            "anxious": "cautious",
-            "neutral": "balanced",
+            Mood.PROUD: "engaging",
+            Mood.FRUSTRATED: "retry",
+            Mood.ANXIOUS: "cautious",
+            Mood.NEUTRAL: "balanced",
         },
         init=False,
         repr=False,
     )
 
-    _MUTATION_POLICIES: Dict[str, str] = field(
+    _MUTATION_POLICIES: Dict[Mood, str] = field(
         default_factory=lambda: {
-            "proud": "exploit",
-            "frustrated": "explore",
-            "anxious": "analyze",
-            "neutral": "default",
+            Mood.PROUD: "exploit",
+            Mood.FRUSTRATED: "explore",
+            Mood.ANXIOUS: "analyze",
+            Mood.NEUTRAL: "default",
         },
         init=False,
         repr=False,
     )
 
-    _MUTATION_RATES: Dict[str, float] = field(
+    _MUTATION_RATES: Dict[Mood, float] = field(
         default_factory=lambda: {
-            "frustrated": 2.0,
-            "anxious": 0.5,
-            "proud": 1.2,
-            "neutral": 1.0,
+            Mood.FRUSTRATED: 2.0,
+            Mood.ANXIOUS: 0.5,
+            Mood.PROUD: 1.2,
+            Mood.NEUTRAL: 1.0,
         },
         init=False,
         repr=False,
     )
 
-    _RESOURCE_MOOD_MAP: Dict[str, str] = field(
+    _RESOURCE_MOOD_MAP: Dict[str, Mood] = field(
         default_factory=lambda: {
-            "tired": "fatigue",
-            "angry": "anger",
-            "cold": "lonely",
-            "content": "pleasure",
+            "tired": Mood.FATIGUE,
+            "angry": Mood.ANGER,
+            "cold": Mood.LONELY,
+            "content": Mood.PLEASURE,
         },
         init=False,
         repr=False,
@@ -178,10 +193,10 @@ class Psyche:
     @property
     def mutation_rate(self) -> float:
         """Return a mutation rate derived from the latest mood."""
-        mood = self.last_mood or "neutral"
+        mood = self.last_mood or Mood.NEUTRAL
         return self._MUTATION_RATES.get(mood, 1.0)
 
-    def update_from_resource_manager(self, rm: ResourceManager) -> str:
+    def update_from_resource_manager(self, rm: ResourceManager) -> Mood:
         """Adjust mood based on ``rm`` resource metrics.
 
         The :class:`~singular.resource_manager.ResourceManager` exposes a
@@ -197,14 +212,14 @@ class Psyche:
 
         Returns
         -------
-        str
+        Mood
             The final mood after processing all resource states.
         """
 
         moods = rm.mood()
-        last = "neutral"
+        last: Mood = Mood.NEUTRAL
         for state in moods:
-            event = self._RESOURCE_MOOD_MAP.get(state, "neutral")
+            event = self._RESOURCE_MOOD_MAP.get(state, Mood.NEUTRAL)
             last = self.feel(event)
         return last
 
@@ -225,11 +240,11 @@ class Psyche:
         """
 
         rng = rng or random
-        mood = self.last_mood or "neutral"
+        mood = self.last_mood or Mood.NEUTRAL
         base = {
-            "proud": 0.05,
-            "frustrated": 0.3,
-            "anxious": 0.2,
+            Mood.PROUD: 0.05,
+            Mood.FRUSTRATED: 0.3,
+            Mood.ANXIOUS: 0.2,
         }.get(mood, 0.1)
         if rng.random() < base:
             return rng.choice([self.Decision.REFUSE, self.Decision.DELAY])
@@ -248,34 +263,32 @@ class Psyche:
         self.feel(derive_mood(record))
         self.save_state()
 
-    def feel(self, event: str) -> str:
+    def feel(self, event: Mood) -> Mood:
         """Register an event and update internal state.
 
         Parameters
         ----------
         event:
-            A string describing the event; it is mapped to a mood using
-            :attr:`_MOOD_EFFECTS`. If the event is unknown it is treated as
-            ``neutral``.
+            The mood-inducing event.
 
         Returns
         -------
-        str
+        Mood
             The mood resulting from the event.
         """
-        mood = event.lower()
+        mood = event
         if mood not in self._MOOD_EFFECTS:
-            mood = "neutral"
+            mood = Mood.NEUTRAL
         self.last_mood = mood
 
         for attr, delta in self._MOOD_EFFECTS[mood].items():
             value = getattr(self, attr)
             setattr(self, attr, _clamp(value + delta))
 
-        if mood == "pleasure":
+        if mood == Mood.PLEASURE:
             for obj in self.objectives.values():
                 obj.apply_delta(0.1)
-        elif mood == "pain":
+        elif mood == Mood.PAIN:
             for obj in self.objectives.values():
                 obj.apply_delta(-0.1)
         self.adjust_objectives()
@@ -290,7 +303,7 @@ class Psyche:
     # Exposed helpers -----------------------------------------------------
     def interaction_policy(self) -> str:
         """Return the interaction policy based on mood and traits."""
-        mood = self.last_mood or "neutral"
+        mood = self.last_mood or Mood.NEUTRAL
         if self.optimism >= 0.7:
             return "engaging"
         if self.resilience <= 0.3:
@@ -299,7 +312,7 @@ class Psyche:
 
     def mutation_policy(self) -> str:
         """Return the mutation policy based on mood and traits."""
-        mood = self.last_mood or "neutral"
+        mood = self.last_mood or Mood.NEUTRAL
         if self.resilience >= 0.7:
             return "exploit"
         if self.optimism <= 0.3:
@@ -330,7 +343,7 @@ class Psyche:
             "optimism": self.optimism,
             "resilience": self.resilience,
             "energy": self.energy,
-            "last_mood": self.last_mood,
+            "last_mood": self.last_mood.value if self.last_mood else None,
         }
         if self.objectives:
             state["objectives"] = {
@@ -365,5 +378,6 @@ class Psyche:
                 for name, obj in data.get("objectives", {}).items()
             },
         )
-        psyche.last_mood = data.get("last_mood")
+        mood_val = data.get("last_mood")
+        psyche.last_mood = Mood(mood_val) if mood_val else None
         return psyche

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -155,8 +155,9 @@ class RunLogger:
         os.fsync(self._file.fileno())
         self.psyche.process_run_record(record)
         mood = getattr(self.psyche, "last_mood", None)
+        mood_val = getattr(mood, "value", mood)
         add_episode(
-            {"event": "mutation", "mood": mood, **record}, mood_styles=mood_styles
+            {"event": "mutation", "mood": mood_val, **record}, mood_styles=mood_styles
         )
 
     def log_death(self, reason: str, **info: Any) -> None:

--- a/src/singular/runs/run.py
+++ b/src/singular/runs/run.py
@@ -81,7 +81,13 @@ def run(seed: int | None = None) -> str:
     }
 
     psyche.process_run_record(record)
-    add_episode({"event": "mutation", **record, "mood": psyche.last_mood})
+    add_episode(
+        {
+            "event": "mutation",
+            **record,
+            "mood": psyche.last_mood.value if psyche.last_mood else None,
+        }
+    )
     psyche.save_state()
 
     return mutated if mutated_score <= base_score else base

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -15,7 +15,7 @@ sys.path.append(str(root_dir / "src"))
 import life.loop as life_loop  # noqa: E402
 from life.loop import run, load_checkpoint  # noqa: E402
 from singular.resource_manager import ResourceManager  # noqa: E402
-from singular.psyche import Psyche  # noqa: E402
+from singular.psyche import Psyche, Mood  # noqa: E402
 
 
 def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
@@ -313,7 +313,7 @@ def test_angry_increases_proposals(tmp_path: Path, monkeypatch):
     checkpoint = tmp_path / "ckpt.json"
 
     psyche = life_loop.Psyche()
-    psyche.last_mood = "frustrated"
+    psyche.last_mood = Mood.FRUSTRATED
     psyche.energy = 100.0
 
     monkeypatch.setattr(life_loop, "propose_mutations", fake_propose)
@@ -359,7 +359,7 @@ def test_fatigue_reduces_proposals(tmp_path: Path, monkeypatch):
     checkpoint = tmp_path / "ckpt.json"
 
     psyche = life_loop.Psyche()
-    psyche.last_mood = "frustrated"
+    psyche.last_mood = Mood.FRUSTRATED
     psyche.energy = 20.0
 
     monkeypatch.setattr(life_loop, "propose_mutations", fake_propose)
@@ -384,7 +384,7 @@ def _setup_dummy_psyche(monkeypatch, tmp_path, decisions):
     episodes: list[dict] = []
 
     class DummyPsyche:
-        last_mood = "anxious"
+        last_mood = Mood.ANXIOUS
 
         def mutation_policy(self):
             return "default"
@@ -548,7 +548,7 @@ def test_energy_debit_and_food_credit(tmp_path: Path, monkeypatch):
 
     assert rm.energy < 50.0
     assert rm.food >= 3.0
-    assert "fatigue" not in events and "anger" not in events
+    assert Mood.FATIGUE not in events and Mood.ANGER not in events
 
 
 def test_resource_moods_trigger(monkeypatch, tmp_path):
@@ -574,8 +574,8 @@ def test_resource_moods_trigger(monkeypatch, tmp_path):
         test_runner=lambda: 0,
     )
 
-    assert "fatigue" in events
-    assert "anger" in events
+    assert Mood.FATIGUE in events
+    assert Mood.ANGER in events
 
 
 def test_warmth_interaction_api(tmp_path: Path):

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,18 +1,18 @@
-from singular.psyche import Psyche
+from singular.psyche import Psyche, Mood
 from singular.motivation import Objective
 
 def test_curiosity_increases():
     psyche = Psyche()
     base = psyche.curiosity
-    psyche.feel("curious")
+    psyche.feel(Mood.CURIOUS)
     assert psyche.curiosity > base
 
 def test_objective_weights_adapt():
     psyche = Psyche(objectives={"goal": Objective("goal", weight=0.5)})
     base = psyche.objectives["goal"].weight
-    psyche.feel("pleasure")
+    psyche.feel(Mood.PLEASURE)
     increased = psyche.objectives["goal"].weight
     assert increased > base
-    psyche.feel("pain")
+    psyche.feel(Mood.PAIN)
     decreased = psyche.objectives["goal"].weight
     assert decreased < increased

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -1,14 +1,14 @@
 from pathlib import Path
 
-from singular.psyche import Psyche
+from singular.psyche import Psyche, Mood
 from singular.resource_manager import ResourceManager
 
 
 def test_feel_updates_traits_and_last_mood() -> None:
     psyche = Psyche()
-    mood = psyche.feel("proud")
-    assert mood == "proud"
-    assert psyche.last_mood == "proud"
+    mood = psyche.feel(Mood.PROUD)
+    assert mood is Mood.PROUD
+    assert psyche.last_mood is Mood.PROUD
     assert psyche.curiosity > 0.5
     assert psyche.patience > 0.5
     assert psyche.playfulness > 0.5
@@ -17,7 +17,7 @@ def test_feel_updates_traits_and_last_mood() -> None:
 
     # Test clamping at upper bound
     for _ in range(20):
-        psyche.feel("proud")
+        psyche.feel(Mood.PROUD)
     assert 0.0 <= psyche.curiosity <= 1.0
     assert 0.0 <= psyche.patience <= 1.0
     assert 0.0 <= psyche.playfulness <= 1.0
@@ -33,7 +33,7 @@ def test_policies_and_lower_clamp() -> None:
         optimism=0.05,
         resilience=0.05,
     )
-    psyche.feel("frustrated")
+    psyche.feel(Mood.FRUSTRATED)
     assert psyche.curiosity >= 0.0
     assert psyche.patience >= 0.0
     assert psyche.playfulness >= 0.0
@@ -58,7 +58,7 @@ def test_state_persistence(tmp_path: Path) -> None:
         optimism=0.6,
         resilience=0.7,
     )
-    psyche.feel("proud")
+    psyche.feel(Mood.PROUD)
     psyche.save_state(path)
     assert path.exists()
 
@@ -76,15 +76,15 @@ def test_resource_manager_influences_mood(tmp_path: Path) -> None:
 
     rm = ResourceManager(energy=5.0, path=tmp_path / "res.json")
     mood = psyche.update_from_resource_manager(rm)
-    assert mood == "fatigue"
-    assert psyche.last_mood == "fatigue"
+    assert mood is Mood.FATIGUE
+    assert psyche.last_mood is Mood.FATIGUE
 
     rm = ResourceManager(food=5.0, path=tmp_path / "res2.json")
     mood = psyche.update_from_resource_manager(rm)
-    assert mood == "anger"
-    assert psyche.last_mood == "anger"
+    assert mood is Mood.ANGER
+    assert psyche.last_mood is Mood.ANGER
 
     rm = ResourceManager(warmth=5.0, path=tmp_path / "res3.json")
     mood = psyche.update_from_resource_manager(rm)
-    assert mood == "lonely"
-    assert psyche.last_mood == "lonely"
+    assert mood is Mood.LONELY
+    assert psyche.last_mood is Mood.LONELY


### PR DESCRIPTION
## Summary
- introduce `Mood` enum to centralize mood handling
- update psyche logic and related modules to use `Mood` instead of strings
- adjust tests for new enum-based API

## Testing
- `pytest tests/test_psyche.py tests/test_objectives.py tests/test_loop.py tests/test_cli_quest.py tests/test_talk.py tests/test_runs_logger.py`
- `pytest` *(attempted, interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b26eb370c0832a97cdb89a27434964