### PR TITLE
feat: add configurable weather timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ pip install -e .
 
 - `pip install -e .[dashboard]` pour activer le tableau de bord web.
 - `pip install -e .[yaml]` pour ajouter **PyYAML** et gérer `values.yaml`.
+- `pip install -e .[sensors]` pour activer la récupération météo via une API.
 - `pip install openai>=1.0.0` pour permettre à l'organisme de parler via l'API OpenAI.
 - `pip install transformers` pour activer un modèle local via Hugging Face.
 
@@ -160,6 +161,17 @@ SINGULAR_RUNS_KEEP=50 singular report
 # Utiliser l'API OpenAI
 OPENAI_API_KEY=sk-... singular talk "Salut"
 ```
+
+#### Capteur météo
+
+Pour tenter de récupérer la météo réelle :
+
+- installez `pip install -e .[sensors]` pour ajouter la dépendance `requests` ;
+- définissez la variable `SINGULAR_WEATHER_API` avec l'URL de l'API désirée ;
+- optionnellement, ajustez `SINGULAR_HTTP_TIMEOUT` (en secondes, 5 par défaut).
+
+Si la requête échoue ou dépasse le délai d'attente, l'organisme ignore le
+capteur et continue avec des valeurs simulées.
 
 ### Utilisation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = []
 [project.optional-dependencies]
 yaml = ["pyyaml"]
 dashboard = ["fastapi", "uvicorn"]
+sensors = ["requests"]
 
 [project.scripts]
 singular = "singular.cli:main"

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -35,7 +35,12 @@ def _query_optional_weather_api() -> Dict[str, Any]:
     try:  # pragma: no cover - network failures are expected
         import requests
 
-        response = requests.get(url, timeout=5)
+        timeout_str = os.getenv("SINGULAR_HTTP_TIMEOUT", "5")
+        try:
+            timeout = float(timeout_str)
+        except ValueError:
+            timeout = 5.0
+        response = requests.get(url, timeout=timeout)
         response.raise_for_status()
         return {"weather": response.json()}
     except Exception:

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -1,3 +1,7 @@
+import sys
+import time
+import types
+
 from singular.perception import capture_signals
 from singular.memory import add_episode, read_episodes
 
@@ -22,3 +26,22 @@ def test_capture_and_persist_signals(tmp_path, monkeypatch):
     assert episodes[0]["event"] == "perception"
     for key in ["temperature", "is_daytime", "noise", "file"]:
         assert key in episodes[0]
+
+
+def test_weather_api_timeout(monkeypatch):
+    monkeypatch.setenv("SINGULAR_WEATHER_API", "http://example.com")
+    monkeypatch.setenv("SINGULAR_HTTP_TIMEOUT", "0.1")
+
+    def slow_get(url, timeout):
+        time.sleep(timeout)
+        raise Exception("timeout")
+
+    fake_requests = types.SimpleNamespace(get=slow_get)
+    monkeypatch.setitem(sys.modules, "requests", fake_requests)
+
+    start = time.time()
+    signals = capture_signals()
+    duration = time.time() - start
+
+    assert duration < 0.5
+    assert "weather" not in signals


### PR DESCRIPTION
## Summary
- make weather requests timeout configurable via `SINGULAR_HTTP_TIMEOUT`
- document optional weather sensor and how to configure it
- test weather API timeout behavior

## Testing
- `pytest -q`
- `pytest tests/test_perception.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2723f0d38832a8c44d32503e52da5