### PR TITLE
feat: support external LLM providers via entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,3 +204,16 @@ singular talk --provider local "Bonjour"
 Le fournisseur local utilise le modèle ``sshleifer/tiny-gpt2`` de Hugging Face
 pour fonctionner hors-ligne.
 
+### Fournisseurs externes
+
+Pour enregistrer un provider LLM personnalisé, ajoutez un entry point dans le
+``pyproject.toml`` de votre paquet :
+
+```toml
+[project.entry-points."singular.llm"]
+mon_provider = "mon_package.module:generate_reply"
+```
+
+Une fois le paquet installé, ``singular`` peut le charger via
+``--provider mon_provider``.
+

--- a/tests/providers/ep_provider.py
+++ b/tests/providers/ep_provider.py
@@ -1,0 +1,2 @@
+def generate_reply(prompt: str) -> str:
+    return f"ep:{prompt}"

--- a/tests/providers/test_llm_entry_point.py
+++ b/tests/providers/test_llm_entry_point.py
@@ -1,0 +1,17 @@
+from importlib.metadata import EntryPoint
+
+from singular.providers import load_llm_provider
+from tests.providers import ep_provider
+
+
+def test_load_llm_provider_entry_point(monkeypatch):
+    ep = EntryPoint(name="ext", value="tests.providers.ep_provider:generate_reply", group="singular.llm")
+
+    def fake_entry_points(*, group):
+        assert group == "singular.llm"
+        return [ep]
+
+    monkeypatch.setattr("singular.providers.entry_points", fake_entry_points)
+    func = load_llm_provider("ext")
+    assert func is not None
+    assert func("hello") == ep_provider.generate_reply("hello")


### PR DESCRIPTION
## Summary
- discover LLM providers registered via `singular.llm` entry point group
- document registering custom providers through `pyproject.toml`
- test entry-point based provider loading

## Testing
- `pytest tests/providers/test_llm_entry_point.py tests/providers/test_llm_local.py tests/providers/test_llm_openai.py`

------
https://chatgpt.com/codex/tasks/task_e_68b276713ed0832ab91b3b15a66b3f6a