### PR TITLE
Organize optional dependencies and add viz extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Contrairement aux chatbots classiques (qui ne changent pas leur cœur) ou aux si
 ## ⚡ Quickstart
 
 ```bash
-pip install -e .[yaml,dashboard]
+pip install -e .[yaml,dashboard,viz]
 singular birth --name Lumen
 singular talk "Bonjour"
 singular loop --ticks 10
@@ -129,8 +129,8 @@ pip install -e .
 #### Dépendances optionnelles
 
 - `pip install -e .[dashboard]` pour activer le tableau de bord web.
+- `pip install -e .[viz]` pour générer des graphiques via `viz.py`.
 - `pip install -e .[yaml]` pour ajouter **PyYAML** et gérer `values.yaml`.
-- `pip install -e .[sensors]` pour activer la récupération météo via une API.
 - `pip install openai>=1.0.0` pour permettre à l'organisme de parler via l'API OpenAI.
 - `pip install transformers` pour activer un modèle local via Hugging Face.
 
@@ -166,7 +166,6 @@ OPENAI_API_KEY=sk-... singular talk "Salut"
 
 Pour tenter de récupérer la météo réelle :
 
-- installez `pip install -e .[sensors]` pour ajouter la dépendance `requests` ;
 - définissez la variable `SINGULAR_WEATHER_API` avec l'URL de l'API désirée ;
 - optionnellement, ajustez `SINGULAR_HTTP_TIMEOUT` (en secondes, 5 par défaut).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,14 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{name = "Singular Contributors"}]
-dependencies = []
+dependencies = [
+    "requests",
+]
 
 [project.optional-dependencies]
 yaml = ["pyyaml"]
 dashboard = ["fastapi", "uvicorn"]
-sensors = ["requests"]
+viz = ["matplotlib"]
 
 [project.scripts]
 singular = "singular.cli:main"


### PR DESCRIPTION
## Summary
- declare `requests` as a core dependency
- add `viz` optional group for matplotlib and document extras in README
- clean up outdated sensor instructions

## Testing
- `pytest tests/test_perception.py -q`
- `pytest graine/tests/test_selection.py -q`
- ⚠️ `pip install .[viz]` *(missing setuptools in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68b27d6e666c832a91e77f2f75eebef1