### PR TITLE
Validate crossover inputs and expand reproduction tests

### DIFF
--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
+import ast
 import pytest
 
 from singular.organisms.spawn import spawn
+from life.reproduction import crossover
 
 
 def test_reproduction(tmp_path: Path):
@@ -24,6 +26,7 @@ def test_reproduction(tmp_path: Path):
     hybrids = list(child_dir.glob("hybrid_*.py"))
     assert hybrids, "no hybrid skills generated"
     code = hybrids[0].read_text(encoding="utf-8")
+    ast.parse(code)
     assert "y = 1" in code and "return z" in code and "x * y" in code
 
 
@@ -44,3 +47,57 @@ def test_reproduction_invalid_skill(tmp_path: Path):
 
     with pytest.raises(ValueError, match="invalid syntax"):
         spawn(parent_a, parent_b, out_dir=tmp_path / "child", seed=0)
+
+
+def test_crossover_signature_mismatch(tmp_path: Path):
+    parent_a = tmp_path / "parent_a"
+    parent_b = tmp_path / "parent_b"
+    parent_a.mkdir()
+    parent_b.mkdir()
+
+    (parent_a / "skill_a.py").write_text(
+        "def mix(x):\n    return x\n",
+        encoding="utf-8",
+    )
+    (parent_b / "skill_b.py").write_text(
+        "def mix(x, y):\n    return x + y\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="matching signatures"):
+        crossover(parent_a, parent_b)
+
+
+def test_crossover_missing_return(tmp_path: Path):
+    parent_a = tmp_path / "parent_a"
+    parent_b = tmp_path / "parent_b"
+    parent_a.mkdir()
+    parent_b.mkdir()
+
+    (parent_a / "skill_a.py").write_text(
+        "def mix(x) -> int:\n    return x\n",
+        encoding="utf-8",
+    )
+    (parent_b / "skill_b.py").write_text(
+        "def mix(x) -> int:\n    y = x\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="return statement"):
+        crossover(parent_a, parent_b)
+
+
+def test_crossover_empty_ast(tmp_path: Path):
+    parent_a = tmp_path / "parent_a"
+    parent_b = tmp_path / "parent_b"
+    parent_a.mkdir()
+    parent_b.mkdir()
+
+    (parent_a / "skill_a.py").write_text(
+        "def mix(x):\n    return x\n",
+        encoding="utf-8",
+    )
+    (parent_b / "empty.py").write_text("", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="function definition"):
+        crossover(parent_a, parent_b)


### PR DESCRIPTION
## Summary
- Document limitations of the crossover algorithm
- Validate parent compatibility and return semantics during crossover
- Add tests covering signature mismatches, required returns, empty ASTs, and ensure generated code parses

## Testing
- `pytest tests/test_reproduction.py`

------
https://chatgpt.com/codex/tasks/task_e_68b28169d700832a9a7a2421ebf330a9