### PR TITLE
feat: add single prompt talk mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,17 @@ Contrairement aux chatbots classiques (qui ne changent pas leur cœur) ou aux si
 ```bash
 pip install -e .[yaml,dashboard,viz]
 singular birth --name Lumen
-singular talk "Bonjour"
+singular talk
 singular loop --ticks 10
 singular report
 singular dashboard
+```
+
+Par défaut, ``talk`` ouvre une session interactive. Pour obtenir une réponse
+unique et quitter immédiatement :
+
+```bash
+singular talk --prompt "Bonjour"
 ```
 
 ## 🧬 Reproduction
@@ -159,7 +166,7 @@ singular --home /chemin/personnel birth
 SINGULAR_RUNS_KEEP=50 singular report
 
 # Utiliser l'API OpenAI
-OPENAI_API_KEY=sk-... singular talk "Salut"
+OPENAI_API_KEY=sk-... singular talk --prompt "Salut"
 ```
 
 #### Capteur météo
@@ -197,7 +204,7 @@ Installez ``transformers`` pour utiliser un petit modèle embarqué :
 
 ```bash
 pip install transformers
-singular talk --provider local "Bonjour"
+singular talk --provider local --prompt "Bonjour"
 ```
 
 Le fournisseur local utilise le modèle ``sshleifer/tiny-gpt2`` de Hugging Face

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -74,6 +74,11 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="LLM provider to use (e.g. 'openai' or 'local')",
     )
+    talk_parser.add_argument(
+        "--prompt",
+        default=None,
+        help="If provided, generate a single response to the prompt and exit",
+    )
     talk_parser.set_defaults(func=talk)
 
     quest_parser = subparsers.add_parser(
@@ -107,7 +112,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "report":
         func(run_id=args.id)
     elif args.command == "talk":
-        func(provider=args.provider, seed=args.seed)
+        func(provider=args.provider, seed=args.seed, prompt=args.prompt)
     elif args.command == "loop":
         func(
             skills_dir=args.skills_dir,

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -62,6 +62,22 @@ def test_talk_handles_keyboard_interrupt(monkeypatch, tmp_path):
     assert episodes == []
 
 
+def test_talk_single_prompt(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
+    outputs: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
+
+    main(["--seed", "123", "talk", "--prompt", "hello"])
+
+    episodes = [e for e in read_episodes() if e.get("event") != "perception"]
+    assert len(episodes) == 2
+    assert episodes[0]["role"] == "user"
+    assert episodes[0]["text"] == "hello"
+    expected = _default_reply("hello", random.Random(123)) + " | Mood: neutral"
+    assert outputs[0] == expected
+
+
 def _run_talk(monkeypatch, tmp_path, seed, run):
     subdir = tmp_path / f"{seed}_{run}"
     subdir.mkdir()


### PR DESCRIPTION
## Summary
- allow `talk` to accept an optional `prompt` for a single reply
- expose `--prompt` flag in CLI and document usage
- cover single-prompt mode with tests

## Testing
- `pytest tests/test_talk.py::test_talk_single_prompt -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ec7196e4832a98cb6173e0372109