### PR TITLE
feat: metabolize food into energy each tick

### DIFF
--- a/life/loop.py
+++ b/life/loop.py
@@ -272,8 +272,10 @@ def run(
     resource_manager = resource_manager or ResourceManager()
     start = time.time()
     last_post = 0.0
-    freq = max(1, int(getattr(psyche, "mutation_rate", 1.0) * (getattr(psyche, "energy", 100.0) / 100)))
-    for _ in range(freq):
+    initial_freq = max(
+        1, int(getattr(psyche, "mutation_rate", 1.0) * (getattr(psyche, "energy", 100.0) / 100))
+    )
+    for _ in range(initial_freq):
         propose_mutations([])
     mortality = mortality or DeathMonitor()
     seen_diffs: set[str] = set()
@@ -281,6 +283,14 @@ def run(
     with RunLogger(run_id, psyche=psyche) as logger:
         delayed: list[tuple[float, str, Path]] = []
         while time.time() - start < budget_seconds:
+            freq = max(
+                1,
+                int(
+                    getattr(psyche, "mutation_rate", 1.0)
+                    * (getattr(psyche, "energy", 100.0) / 100)
+                ),
+            )
+            resource_manager.metabolize()
             signals = capture_signals()
             add_episode({"event": "perception", **signals})
             state.iteration += 1

--- a/src/singular/resource_manager.py
+++ b/src/singular/resource_manager.py
@@ -67,6 +67,19 @@ class ResourceManager:
         self._clamp()
         self._save()
 
+    def metabolize(self, rate: float = 0.1) -> None:
+        """Convert stored food into energy.
+
+        ``rate`` units of food are consumed and twice that amount of energy is
+        regenerated. Values are clamped to the ``[0, 100]`` range and the state
+        is persisted.
+        """
+
+        self.food -= rate
+        self.energy += rate * 2
+        self._clamp()
+        self._save()
+
     def cool_down(self, amount: float) -> None:
         self.warmth -= amount
         self._clamp()

--- a/tests/test_metabolism.py
+++ b/tests/test_metabolism.py
@@ -1,0 +1,8 @@
+from singular.resource_manager import ResourceManager
+
+
+def test_metabolize(tmp_path):
+    rm = ResourceManager(energy=50.0, food=30.0, path=tmp_path / "resources.json")
+    rm.metabolize(rate=5.0)
+    assert rm.energy == 60.0
+    assert rm.food == 25.0


### PR DESCRIPTION
## Summary
- add ResourceManager.metabolize to convert food into energy
- call metabolize during each life loop tick after frequency calculation
- test metabolism increases energy and reduces food

## Testing
- `pytest -q`
- `pytest tests/test_metabolism.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2ef3ec080832ab0ca8137218cb316