### PR TITLE
Integrate environmental temperature into resource management

### DIFF
--- a/life/loop.py
+++ b/life/loop.py
@@ -17,7 +17,7 @@ from singular.memory import add_episode, update_score
 from singular.psyche import Psyche, Mood
 from singular.runs.logger import RunLogger
 from singular.organisms.spawn import mutation_absurde
-from singular.perception import capture_signals
+from singular.perception import capture_signals, get_temperature
 from graine.evolver.generate import propose_mutations
 from singular.environment import artifacts as env_artifacts
 from singular.environment import files as env_files
@@ -314,6 +314,9 @@ def run(
             )
             resource_manager.metabolize()
             signals = capture_signals()
+            temp = get_temperature()
+            signals["temperature"] = temp
+            resource_manager.update_from_environment(temp)
             add_episode({"event": "perception", **signals})
             state.iteration += 1
 

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -47,6 +47,31 @@ def _query_optional_weather_api() -> Dict[str, Any]:
         return {}
 
 
+def get_temperature() -> float:
+    """Return the current temperature.
+
+    A weather API can be provided via ``SINGULAR_WEATHER_API``. When present
+    and a ``temp`` or ``temperature`` field is found in the returned JSON it is
+    used.  Otherwise a simulated temperature is produced.
+    """
+
+    data = _query_optional_weather_api()
+    weather = data.get("weather") if isinstance(data, dict) else None
+    if isinstance(weather, dict):
+        containers = [weather]
+        main = weather.get("main")
+        if isinstance(main, dict):
+            containers.append(main)
+        for container in containers:
+            for key in ("temp", "temperature"):
+                if key in container:
+                    try:
+                        return float(container[key])
+                    except (TypeError, ValueError):
+                        pass
+    return random.uniform(-20.0, 40.0)
+
+
 def capture_signals() -> Dict[str, Any]:
     """Collect sensory signals from virtual and optional real sources."""
     signals: Dict[str, Any] = {

--- a/src/singular/resource_manager.py
+++ b/src/singular/resource_manager.py
@@ -90,6 +90,20 @@ class ResourceManager:
         self._clamp()
         self._save()
 
+    def update_from_environment(self, temp: float) -> None:
+        """Adjust ``warmth`` based on the surrounding temperature.
+
+        ``20°C`` is treated as neutral. Temperatures above this increase
+        warmth while colder values decrease it.
+        """
+
+        neutral = 20.0
+        diff = temp - neutral
+        if diff > 0:
+            self.add_warmth(diff * 0.1)
+        elif diff < 0:
+            self.cool_down(-diff * 0.1)
+
     def simulate_human_interaction(self, amount: float = 5.0) -> None:
         """API used by tests/CLI to increase warmth."""
         self.add_warmth(amount)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,15 @@
+from singular.resource_manager import ResourceManager
+
+
+def test_update_from_environment_increases_warmth(tmp_path):
+    path = tmp_path / "resources.json"
+    rm = ResourceManager(warmth=50.0, path=path)
+    rm.update_from_environment(30.0)
+    assert rm.warmth > 50.0
+
+
+def test_update_from_environment_decreases_warmth(tmp_path):
+    path = tmp_path / "resources.json"
+    rm = ResourceManager(warmth=50.0, path=path)
+    rm.update_from_environment(10.0)
+    assert rm.warmth < 50.0


### PR DESCRIPTION
## Summary
- expose `get_temperature` in perception with optional weather API integration
- adapt `ResourceManager` to adjust warmth via `update_from_environment`
- invoke temperature sensing each loop tick and propagate to resource manager
- test warmth changes in response to external temperature

## Testing
- `pytest tests/test_environment.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2fb98a010832aa89c82012de0b575