### PR TITLE
Allow spawn to combine parental psyches

### DIFF
--- a/src/singular/organisms/spawn.py
+++ b/src/singular/organisms/spawn.py
@@ -6,17 +6,24 @@ import random
 from pathlib import Path
 
 from life.reproduction import crossover
+from singular.memory import read_psyche, write_psyche
 
 
-def spawn(parent_a: Path, parent_b: Path, out_dir: Path | None = None, seed: int | None = None) -> Path:
+def spawn(
+    parent_a: Path,
+    parent_b: Path,
+    out_dir: Path | None = None,
+    seed: int | None = None,
+) -> Path:
     """Generate a child organism by crossing over two parents.
 
     Parameters
     ----------
     parent_a, parent_b:
-        Paths to the parent skill directories.
+        Paths to the parent organism directories containing ``skills`` and
+        ``mem/psyche.json``.
     out_dir:
-        Directory where the child's skills will be written. If ``None``, a
+        Directory where the child's data will be written. If ``None``, a
         directory named ``child`` next to the parents is used.
     seed:
         Optional seed for deterministic behaviour.
@@ -24,15 +31,39 @@ def spawn(parent_a: Path, parent_b: Path, out_dir: Path | None = None, seed: int
     Returns
     -------
     Path
-        The directory containing the child's skills.
+        The directory containing the child's data.
     """
 
     rng = random.Random(seed)
     out_dir = out_dir or parent_a.parent / "child"
-    out_dir.mkdir(parents=True, exist_ok=True)
 
-    filename, code = crossover(parent_a, parent_b, rng)
-    (out_dir / filename).write_text(code, encoding="utf-8")
+    # ------------------------------------------------------------------
+    # Generate hybrid skill
+    # ------------------------------------------------------------------
+    skills_out = out_dir / "skills"
+    skills_out.mkdir(parents=True, exist_ok=True)
+    filename, code = crossover(parent_a / "skills", parent_b / "skills", rng)
+    (skills_out / filename).write_text(code, encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Combine parental psyches
+    # ------------------------------------------------------------------
+    psyche_a = read_psyche(parent_a / "mem" / "psyche.json")
+    psyche_b = read_psyche(parent_b / "mem" / "psyche.json")
+
+    child_psyche: dict[str, object] = {}
+    keys = set(psyche_a) | set(psyche_b)
+    for key in keys:
+        val_a = psyche_a.get(key)
+        val_b = psyche_b.get(key)
+        if isinstance(val_a, (int, float)) and isinstance(val_b, (int, float)):
+            child_psyche[key] = (val_a + val_b) / 2
+        else:
+            options = [v for v in (val_a, val_b) if v is not None]
+            if options:
+                child_psyche[key] = rng.choice(options)
+
+    write_psyche(child_psyche, out_dir / "mem" / "psyche.json")
     return out_dir
 
 

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -10,37 +10,56 @@ from life.reproduction import crossover
 def test_reproduction(tmp_path: Path):
     parent_a = tmp_path / "parent_a"
     parent_b = tmp_path / "parent_b"
-    parent_a.mkdir()
-    parent_b.mkdir()
 
-    (parent_a / "skill_a.py").write_text(
+    # Skill setup
+    (parent_a / "skills").mkdir(parents=True)
+    (parent_b / "skills").mkdir(parents=True)
+    (parent_a / "skills" / "skill_a.py").write_text(
         "def mix(x):\n    y = 1\n    z = x + y\n    return z\n",
         encoding="utf-8",
     )
-    (parent_b / "skill_b.py").write_text(
+    (parent_b / "skills" / "skill_b.py").write_text(
         "def mix(x):\n    y = 2\n    z = x * y\n    return z\n",
         encoding="utf-8",
     )
 
+    # Psyche setup
+    (parent_a / "mem").mkdir()
+    (parent_b / "mem").mkdir()
+    (parent_a / "mem" / "psyche.json").write_text(
+        '{"curiosity": 0.2, "mood": "happy"}', encoding="utf-8"
+    )
+    (parent_b / "mem" / "psyche.json").write_text(
+        '{"curiosity": 0.8, "mood": "sad"}', encoding="utf-8"
+    )
+
     child_dir = spawn(parent_a, parent_b, out_dir=tmp_path / "child", seed=0)
-    hybrids = list(child_dir.glob("hybrid_*.py"))
+
+    hybrids = list((child_dir / "skills").glob("hybrid_*.py"))
     assert hybrids, "no hybrid skills generated"
     code = hybrids[0].read_text(encoding="utf-8")
     ast.parse(code)
     assert "y = 1" in code and "return z" in code and "x * y" in code
 
+    psyche = (child_dir / "mem" / "psyche.json").read_text(encoding="utf-8")
+    import json
+
+    state = json.loads(psyche)
+    assert state["curiosity"] == pytest.approx(0.5)
+    assert state["mood"] in {"happy", "sad"}
+
 
 def test_reproduction_invalid_skill(tmp_path: Path):
     parent_a = tmp_path / "parent_a"
     parent_b = tmp_path / "parent_b"
-    parent_a.mkdir()
-    parent_b.mkdir()
+    (parent_a / "skills").mkdir(parents=True)
+    (parent_b / "skills").mkdir(parents=True)
 
-    (parent_a / "bad.py").write_text(
+    (parent_a / "skills" / "bad.py").write_text(
         "def mix(x):\n    y =\n",
         encoding="utf-8",
     )
-    (parent_b / "skill_b.py").write_text(
+    (parent_b / "skills" / "skill_b.py").write_text(
         "def mix(x):\n    return x\n",
         encoding="utf-8",
     )


### PR DESCRIPTION
## Summary
- Accept full organism directories in `spawn` and output child `skills` and `mem/psyche.json`
- Merge parent psyches by averaging numeric traits and randomly choosing others
- Update reproduction tests to cover new behaviour and psyche inheritance

## Testing
- `pytest tests/test_reproduction.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3478e8b38832a83754a5293a821c0