### PR TITLE
Add agent motivations and goal selection

### DIFF
--- a/src/singular/agents/__init__.py
+++ b/src/singular/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agents package exposing the :class:`Agent` implementation."""
+
+from .agent import Agent
+
+__all__ = ["Agent"]

--- a/src/singular/agents/agent.py
+++ b/src/singular/agents/agent.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Core agent implementation handling motivations and goals."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from singular.models.agents.motivation import Motivation
+
+
+@dataclass
+class Agent:
+    """Simple agent driven by motivations."""
+
+    motivations: Motivation = field(default_factory=Motivation)
+
+    def update_motivations(self, context: Dict[str, float]) -> None:
+        """Adjust motivation priorities based on ``context``.
+
+        ``context`` is a mapping of need names to delta values. Each delta is
+        added to the current motivation for that need. Missing needs are
+        initialised to zero before applying the delta.
+        """
+
+        for need, delta in context.items():
+            self.motivations.needs[need] = (
+                self.motivations.needs.get(need, 0.0) + delta
+            )
+
+    def choose_goal(self) -> Optional[str]:
+        """Return the need with the highest motivation.
+
+        If no needs are present, ``None`` is returned.
+        """
+
+        if not self.motivations.needs:
+            return None
+        return max(self.motivations.needs, key=self.motivations.needs.get)

--- a/src/singular/models/__init__.py
+++ b/src/singular/models/__init__.py
@@ -1,0 +1,1 @@
+"""Data models used across the Singular project."""

--- a/src/singular/models/agents/__init__.py
+++ b/src/singular/models/agents/__init__.py
@@ -1,0 +1,5 @@
+"""Agent-related data models."""
+
+from .motivation import Motivation
+
+__all__ = ["Motivation"]

--- a/src/singular/models/agents/motivation.py
+++ b/src/singular/models/agents/motivation.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Motivation data structure for agent needs."""
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class Motivation:
+    """Store motivation values for various needs.
+
+    Each key of :attr:`needs` represents a need (e.g. ``"hunger"``) and the
+    associated value is its priority. Higher values indicate stronger
+    motivation to satisfy the need.
+    """
+
+    needs: Dict[str, float] = field(default_factory=dict)

--- a/tests/test_agent_motivation.py
+++ b/tests/test_agent_motivation.py
@@ -1,0 +1,15 @@
+from singular.models.agents import Motivation
+from singular.agents import Agent
+
+
+def test_update_and_choose_goal():
+    agent = Agent()
+    agent.update_motivations({"hunger": 1.0, "thirst": 0.5})
+    agent.update_motivations({"thirst": 1.0})  # hunger=1.0, thirst=1.5
+    assert agent.motivations.needs["thirst"] == 1.5
+    assert agent.choose_goal() == "thirst"
+
+
+def test_motivation_storage():
+    motivation = Motivation({"rest": 0.2})
+    assert motivation.needs["rest"] == 0.2


### PR DESCRIPTION
## Summary
- add `Motivation` model for tracking need priorities
- implement `Agent` with motivation updating and goal choosing
- test motivation updates and goal selection

## Testing
- `pytest tests/test_agent_motivation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3bcf14dec832ab133c08c8061abc5