### PR TITLE
Add thinking module with reasoning and episodic memory

### DIFF
--- a/thinking/memory.py
+++ b/thinking/memory.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+
+class EpisodicMemory:
+    """Simple store for (action, result) pairs."""
+
+    def __init__(self) -> None:
+        self._episodes: List[Tuple[Any, Any]] = []
+
+    def remember(self, action: Any, result: Any) -> None:
+        """Record the outcome of ``action``."""
+        self._episodes.append((action, result))
+
+    def recall(self, action: Any | None = None) -> Any:
+        """Return the most recent result for ``action``.
+
+        If ``action`` is ``None``, a list of all stored episodes is returned.
+        """
+        if action is None:
+            return list(self._episodes)
+        for past_action, result in reversed(self._episodes):
+            if past_action == action:
+                return result
+        return None

--- a/thinking/reasoner.py
+++ b/thinking/reasoner.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+
+def evaluate_actions(agent: Any, options: Iterable[Any]) -> Any:
+    """Return the action that best aligns with the agent's motivations.
+
+    Parameters
+    ----------
+    agent:
+        Object exposing a ``motivations`` mapping of motivation names to
+        numeric weights.
+    options:
+        Iterable of candidate actions.  Each option should provide an
+        ``outcomes`` mapping describing the expected value for each motivation.
+
+    The function computes a score for each option by taking the weighted sum
+    of its outcomes using the agent's motivations and returns the option with
+    the highest score.  If multiple options tie, the first one encountered is
+    returned.
+    """
+
+    motivations: Mapping[str, float] = getattr(agent, "motivations", {})
+    best_option: Any | None = None
+    best_score = float("-inf")
+
+    for option in options:
+        outcomes: Mapping[str, float] = getattr(option, "outcomes", option)
+        score = 0.0
+        for name, weight in motivations.items():
+            score += weight * outcomes.get(name, 0.0)
+        if score > best_score:
+            best_score = score
+            best_option = option
+
+    return best_option


### PR DESCRIPTION
## Summary
- add `evaluate_actions` helper to pick options based on agent motivations
- implement simple `EpisodicMemory` to record and recall action outcomes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3be60d0a4832a9ee2e5eb6fef93f8