### PR TITLE
Add decision noise and goal reevaluation scheduler

### DIFF
--- a/src/singular/agents/agent.py
+++ b/src/singular/agents/agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Core agent implementation handling motivations and goals."""
 
 from dataclasses import dataclass, field
+from random import choice, random
 from typing import Dict, Optional
 
 from singular.models.agents.motivation import Motivation
@@ -13,6 +14,7 @@ class Agent:
     """Simple agent driven by motivations."""
 
     motivations: Motivation = field(default_factory=Motivation)
+    decision_noise: float = 0.0
 
     def update_motivations(self, context: Dict[str, float]) -> None:
         """Adjust motivation priorities based on ``context``.
@@ -36,3 +38,24 @@ class Agent:
         if not self.motivations.needs:
             return None
         return max(self.motivations.needs, key=self.motivations.needs.get)
+
+    def choose_action(self, actions: Dict[str, float]) -> Optional[str]:
+        """Select an action, occasionally exploring suboptimal options.
+
+        ``actions`` maps action identifiers to a numeric value representing its
+        desirability. The action with the highest value is normally chosen. With
+        probability ``decision_noise`` a random non-optimal action is returned
+        instead. If ``actions`` is empty, ``None`` is returned.
+        """
+
+        if not actions:
+            return None
+
+        best_action = max(actions, key=actions.get)
+        # Explore a non-optimal action with probability ``decision_noise``
+        if len(actions) > 1 and random() < self.decision_noise:
+            alternatives = [act for act in actions if act != best_action]
+            if alternatives:
+                return choice(alternatives)
+
+        return best_action

--- a/src/singular/schedulers/__init__.py
+++ b/src/singular/schedulers/__init__.py
@@ -1,0 +1,6 @@
+"""Schedulers for periodic agent operations."""
+
+from .reevaluation import reevaluate_goals, start
+
+__all__ = ["reevaluate_goals", "start"]
+

--- a/src/singular/schedulers/reevaluation.py
+++ b/src/singular/schedulers/reevaluation.py
@@ -1,0 +1,37 @@
+"""Periodic reevaluation of an agent's goals."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from singular.agents import Agent
+
+
+def reevaluate_goals(agent: Agent) -> None:
+    """Trigger the agent to reconsider its current goal."""
+
+    agent.choose_goal()
+
+
+def start(interval: float, agent: Agent) -> threading.Event:
+    """Start a background scheduler calling ``reevaluate_goals``.
+
+    The scheduler reevaluates ``agent``'s goals every ``interval`` seconds.
+    A :class:`threading.Event` is returned which can be set to stop the
+    scheduler.
+    """
+
+    stop_event = threading.Event()
+
+    def loop() -> None:
+        while not stop_event.is_set():
+            reevaluate_goals(agent)
+            time.sleep(interval)
+
+    threading.Thread(target=loop, daemon=True).start()
+    return stop_event
+
+
+__all__ = ["reevaluate_goals", "start"]
+

--- a/tests/test_agent_action_noise.py
+++ b/tests/test_agent_action_noise.py
@@ -1,0 +1,15 @@
+from singular.agents import Agent
+
+
+def test_choose_action_optimal_without_noise():
+    agent = Agent()
+    actions = {"a": 0.1, "b": 0.5}
+    assert agent.choose_action(actions) == "b"
+
+
+def test_choose_action_with_noise_selects_non_optimal():
+    agent = Agent(decision_noise=1.0)
+    actions = {"a": 0.1, "b": 0.5}
+    # With decision_noise=1.0 the agent should always explore a non-optimal action
+    assert agent.choose_action(actions) == "a"
+

--- a/tests/test_scheduler_reevaluation.py
+++ b/tests/test_scheduler_reevaluation.py
@@ -1,0 +1,22 @@
+import time
+
+from singular.agents import Agent
+from singular.schedulers import start
+
+
+def test_scheduler_triggers_goal_reevaluation():
+    agent = Agent()
+    calls = {"count": 0}
+
+    def spy() -> None:
+        calls["count"] += 1
+
+    # Replace choose_goal with spy to count invocations
+    agent.choose_goal = spy  # type: ignore[assignment]
+
+    stop_event = start(0.01, agent)
+    time.sleep(0.05)
+    stop_event.set()
+
+    assert calls["count"] > 0
+


### PR DESCRIPTION
## Summary
- allow agents to make occasional exploratory decisions via new `decision_noise`
- add `choose_action` supporting noisy selection
- introduce periodic goal reevaluation scheduler
- test decision noise and scheduler behavior

## Testing
- `pytest`
- `pytest tests/test_agent_action_noise.py tests/test_agent_motivation.py tests/test_scheduler_reevaluation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b494a80da4832a80510ade4855786d