### PR TITLE
Add life registry management and scoped birth initialization

### DIFF
--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -1,0 +1,192 @@
+"""Utilities for managing multiple lives."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+_REGISTRY_DIRNAME = "lives"
+_REGISTRY_FILENAME = "registry.json"
+
+
+@dataclass(slots=True)
+class LifeMetadata:
+    """Metadata describing a single life instance."""
+
+    name: str
+    slug: str
+    path: Path
+    created_at: str
+
+    def to_payload(self) -> Dict[str, str]:
+        """Return a JSON-serialisable representation."""
+        return {
+            "name": self.name,
+            "slug": self.slug,
+            "path": str(self.path),
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_payload(cls, data: Dict[str, Any]) -> "LifeMetadata":
+        """Build metadata from a registry payload."""
+        return cls(
+            name=str(data["name"]),
+            slug=str(data["slug"]),
+            path=Path(data["path"]),
+            created_at=str(data["created_at"]),
+        )
+
+
+def _registry_path(root: Path | None = None) -> Path:
+    root = root or get_registry_root()
+    return root / _REGISTRY_DIRNAME / _REGISTRY_FILENAME
+
+
+def get_registry_root() -> Path:
+    """Return the directory where the life registry is stored."""
+
+    raw = os.environ.get("SINGULAR_ROOT")
+    if raw:
+        root = Path(raw).expanduser()
+    else:
+        cwd = Path.cwd()
+        default_home = Path.home() / ".singular"
+        # Prefer the current working directory when it already contains
+        # Singular artefacts. Otherwise fall back to ``~/.singular``.
+        if (cwd / _REGISTRY_DIRNAME).exists() or (cwd / "mem").exists():
+            root = cwd
+        else:
+            root = default_home
+    return root
+
+
+def load_registry() -> dict[str, Any]:
+    """Load the life registry from disk."""
+
+    path = _registry_path()
+    if not path.exists():
+        return {"active": None, "lives": {}}
+
+    with path.open(encoding="utf-8") as fh:
+        payload = json.load(fh)
+
+    lives_payload = payload.get("lives", {})
+    lives: dict[str, LifeMetadata] = {}
+    for slug, data in lives_payload.items():
+        try:
+            lives[slug] = LifeMetadata.from_payload(data)
+        except KeyError:
+            continue
+
+    active = payload.get("active")
+    if active not in lives:
+        active = None
+
+    return {"active": active, "lives": lives}
+
+
+def save_registry(registry: dict[str, Any]) -> None:
+    """Persist the life registry to disk."""
+
+    path = _registry_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    lives_payload: dict[str, Dict[str, str]] = {}
+    for slug, meta in registry.get("lives", {}).items():
+        if isinstance(meta, LifeMetadata):
+            lives_payload[slug] = meta.to_payload()
+        else:
+            lives_payload[slug] = LifeMetadata.from_payload(meta).to_payload()
+
+    payload = {
+        "active": registry.get("active"),
+        "lives": lives_payload,
+    }
+
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _slugify(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "life"
+
+
+def create_life(name: str) -> LifeMetadata:
+    """Create a new life directory and register it."""
+
+    registry = load_registry()
+    lives: dict[str, LifeMetadata] = registry.setdefault("lives", {})
+
+    base_slug = _slugify(name)
+    slug = base_slug
+    counter = 1
+    while slug in lives:
+        counter += 1
+        slug = f"{base_slug}-{counter}"
+
+    root = get_registry_root()
+    life_dir = root / _REGISTRY_DIRNAME / slug
+    life_dir.mkdir(parents=True, exist_ok=True)
+
+    created_at = datetime.now(timezone.utc).isoformat()
+    metadata = LifeMetadata(name=name, slug=slug, path=life_dir, created_at=created_at)
+
+    lives[slug] = metadata
+    registry["active"] = slug
+    save_registry(registry)
+
+    return metadata
+
+
+def resolve_life(name: str | None) -> Path | None:
+    """Return the directory for the requested or active life."""
+
+    registry = load_registry()
+    lives: dict[str, LifeMetadata] = registry.get("lives", {})
+    if not lives:
+        return None
+
+    target: LifeMetadata | None = None
+    if name is None:
+        active = registry.get("active")
+        if isinstance(active, str):
+            target = lives.get(active)
+    else:
+        if name in lives:
+            target = lives[name]
+        else:
+            slug = _slugify(name)
+            target = lives.get(slug)
+            if target is None:
+                for meta in lives.values():
+                    if meta.name == name:
+                        target = meta
+                        break
+
+    if target is None:
+        return None
+
+    if registry.get("active") != target.slug:
+        registry["active"] = target.slug
+        save_registry(registry)
+
+    return target.path
+
+
+def bootstrap_life(name: str, seed: int | None = None) -> LifeMetadata:
+    """Create and initialise a life."""
+
+    metadata = create_life(name)
+
+    from .organisms.birth import birth  # Imported lazily to avoid cycles.
+
+    birth(seed=seed, home=metadata.path)
+    registry = load_registry()
+    lives: dict[str, LifeMetadata] = registry.get("lives", {})
+    return lives.get(metadata.slug, metadata)

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from singular.lives import bootstrap_life, load_registry, resolve_life
+from singular.organisms.birth import birth
+
+
+def test_birth_uses_isolated_homes(tmp_path: Path) -> None:
+    home1 = tmp_path / "vie1"
+    home2 = tmp_path / "vie2"
+
+    birth(home=home1)
+    birth(home=home2)
+
+    assert not (tmp_path / "id.json").exists()
+    assert not (tmp_path / "mem").exists()
+    assert not (tmp_path / "skills").exists()
+
+    for home in (home1, home2):
+        assert (home / "id.json").exists()
+        assert (home / "mem" / "psyche.json").exists()
+        assert (home / "skills").is_dir()
+
+
+def test_registry_tracks_multiple_lives(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+
+    life1 = bootstrap_life("Vie 1", seed=1)
+    life2 = bootstrap_life("Vie 2", seed=2)
+
+    registry = load_registry()
+    lives = registry["lives"]
+    assert set(lives) == {life1.slug, life2.slug}
+    assert registry["active"] == life2.slug
+
+    assert resolve_life(None) == life2.path
+    assert resolve_life(life1.name) == life1.path
+
+    registry = load_registry()
+    assert registry["active"] == life1.slug
+    assert resolve_life(life2.slug) == life2.path
+
+    registry = load_registry()
+    assert registry["active"] == life2.slug
+
+    registry_path = tmp_path / "lives" / "registry.json"
+    assert registry_path.exists()
+    assert registry_path.read_text(encoding="utf-8")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -9,22 +9,16 @@ import singular.memory as memory
 from singular.organisms.birth import birth
 
 
-def test_birth_creates_memory_files(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.chdir(tmp_path)
-    birth()
+def test_birth_creates_memory_files(tmp_path: Path) -> None:
+    birth(home=tmp_path)
     mem = tmp_path / "mem"
     assert mem.is_dir()
     for name in ["profile.json", "values.yaml", "episodic.jsonl", "skills.json"]:
         assert (mem / name).exists()
 
 
-def test_birth_initializes_identity_profile_and_psyche(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.chdir(tmp_path)
-    birth(seed=123)
+def test_birth_initializes_identity_profile_and_psyche(tmp_path: Path) -> None:
+    birth(seed=123, home=tmp_path)
 
     identity_data = json.loads((tmp_path / "id.json").read_text(encoding="utf-8"))
     profile_data = json.loads(
@@ -68,11 +62,8 @@ def test_update_trait_score_and_note(tmp_path: Path) -> None:
     }
 
 
-def test_birth_initializes_default_skills(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.chdir(tmp_path)
-    birth()
+def test_birth_initializes_default_skills(tmp_path: Path) -> None:
+    birth(home=tmp_path)
 
     skills_dir = tmp_path / "skills"
     assert (skills_dir / "addition.py").exists()


### PR DESCRIPTION
## Summary
- add a `singular.lives` module that records life metadata, resolves the active life, and bootstraps new life directories
- update `birth` so all generated files live under a provided home directory while supporting the existing `SINGULAR_HOME` behaviour
- refresh memory tests and add new coverage to ensure isolated life directories and persistent registry state

## Testing
- pytest tests/test_memory.py tests/test_lives.py tests/test_end_to_end.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2a7f68c4832aa20f06c078699943