### PR TITLE
Add `singular doctor` subcommand for CLI installation diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,19 +182,35 @@ singular --help
 Si PowerShell affiche que `singular` n’est pas reconnu, vérifiez le dossier
 `Scripts` de votre installation Python utilisateur :
 
-1. Exécutez la commande de diagnostic suivante :
+1. Exécutez le diagnostic intégré :
+
+   ```powershell
+   singular doctor
+   ```
+
+   Cette commande affiche :
+   - le chemin de l’exécutable Python actif ;
+   - le dossier `Scripts` utilisateur détecté ;
+   - si ce dossier est présent dans `PATH` ;
+   - la version installée de `singular`.
+
+2. Si le diagnostic indique que `Scripts` n’est pas dans `PATH`, copiez-collez
+   les commandes proposées par `singular doctor` dans PowerShell.
+
+3. Alternative manuelle (si `singular` est indisponible), récupérez d’abord la
+   base utilisateur Python :
 
    ```powershell
    python -m site --user-base
    ```
 
-2. Prenez le chemin renvoyé et ajoutez `\Scripts` à la fin. Exemple typique :
+4. Prenez le chemin renvoyé et ajoutez `\Scripts` à la fin. Exemple typique :
    `C:\Users\<VotreNom>\AppData\Roaming\Python\Python313\Scripts`
-3. Ouvrez **Variables d’environnement** → Variables utilisateur → `PATH` →
+5. Ouvrez **Variables d’environnement** → Variables utilisateur → `PATH` →
    **Modifier** → **Nouveau**, puis collez ce chemin.
-4. Enregistrez, **fermez puis redémarrez PowerShell** (ou votre terminal) pour
+6. Enregistrez, **fermez puis redémarrez PowerShell** (ou votre terminal) pour
    recharger le `PATH`.
-5. Vérifiez ensuite :
+7. Vérifiez ensuite :
 
    ```powershell
    Get-Command singular

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -5,10 +5,69 @@ from __future__ import annotations
 import argparse
 import os
 import random
+import sys
+import sysconfig
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Callable
 
 __all__ = ["main"]
+
+
+def _in_path(target: Path, env_path: str | None = None) -> bool:
+    """Return True when *target* is present in PATH."""
+
+    path_value = env_path if env_path is not None else os.environ.get("PATH", "")
+    target_norm = os.path.normcase(str(target.resolve()))
+    for entry in path_value.split(os.pathsep):
+        if not entry:
+            continue
+        try:
+            entry_norm = os.path.normcase(str(Path(entry).resolve()))
+        except OSError:
+            entry_norm = os.path.normcase(entry)
+        if entry_norm == target_norm:
+            return True
+    return False
+
+
+def _doctor() -> None:
+    """Display environment diagnostics for CLI installation."""
+
+    python_executable = Path(sys.executable).resolve()
+    scripts_path = Path(sysconfig.get_path("scripts", scheme=f"{os.name}_user")).resolve()
+    scripts_in_path = _in_path(scripts_path)
+
+    try:
+        installed_version = version("singular")
+    except PackageNotFoundError:
+        installed_version = "non installée (package introuvable)"
+
+    print("Diagnostic Singular")
+    print(f"- Python actif           : {python_executable}")
+    print(f"- Scripts utilisateur    : {scripts_path}")
+    print(f"- Scripts dans PATH      : {'oui' if scripts_in_path else 'non'}")
+    print(f"- Version singular       : {installed_version}")
+
+    if scripts_in_path:
+        print("\n✅ PATH semble correctement configuré pour les scripts utilisateur.")
+        return
+
+    escaped_scripts = str(scripts_path).replace("'", "''")
+    print("\n⚠️ Le dossier des scripts utilisateur n'est pas présent dans PATH.")
+    print("Actions PowerShell (copier-coller) :")
+    print(
+        "[Environment]::SetEnvironmentVariable("
+        "'Path', "
+        "$env:Path + ';"
+        f"{escaped_scripts}"
+        "', "
+        "'User'"
+        ")"
+    )
+    print(f"$env:Path = [Environment]::GetEnvironmentVariable('Path', 'User')")
+    print("Get-Command singular")
+    print("singular --help")
 
 
 def _preparse_environment(argv: list[str] | None) -> argparse.Namespace:
@@ -144,6 +203,7 @@ def main(argv: list[str] | None = None) -> int:
     report_parser.add_argument("--id", required=True, help="Run identifier")
 
     subparsers.add_parser("dashboard", help="Launch web dashboard")
+    subparsers.add_parser("doctor", help="Diagnose CLI installation and PATH")
 
     lives_parser = subparsers.add_parser("lives", help="Manage lives")
     lives_subparsers = lives_parser.add_subparsers(
@@ -233,6 +293,9 @@ def main(argv: list[str] | None = None) -> int:
         from .dashboard import run as dashboard_run
 
         dashboard_run()
+
+    elif args.command == "doctor":
+        _doctor()
 
     elif args.command == "lives":
         if args.lives_command == "list":

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import singular.cli as cli
+
+
+def test_doctor_reports_status_and_powershell_fix(
+    monkeypatch, capsys
+) -> None:
+    scripts_dir = Path("/tmp/singular-user-scripts")
+    monkeypatch.setattr(cli.sys, "executable", "/tmp/python/bin/python")
+    monkeypatch.setattr(
+        cli.sysconfig,
+        "get_path",
+        lambda *_args, **_kwargs: str(scripts_dir),
+    )
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    cli.main(["doctor"])
+
+    out = capsys.readouterr().out
+    assert "Diagnostic Singular" in out
+    assert "- Scripts dans PATH      : non" in out
+    assert "SetEnvironmentVariable" in out
+    assert "Get-Command singular" in out
+
+
+def test_doctor_confirms_when_scripts_are_in_path(
+    monkeypatch, capsys
+) -> None:
+    scripts_dir = Path("/tmp/singular-user-scripts")
+    monkeypatch.setattr(cli.sys, "executable", "/tmp/python/bin/python")
+    monkeypatch.setattr(
+        cli.sysconfig,
+        "get_path",
+        lambda *_args, **_kwargs: str(scripts_dir),
+    )
+    monkeypatch.setenv("PATH", f"/usr/bin:{scripts_dir}")
+
+    cli.main(["doctor"])
+
+    out = capsys.readouterr().out
+    assert "- Scripts dans PATH      : oui" in out
+    assert "PATH semble correctement configuré" in out


### PR DESCRIPTION
### Motivation
- Provide an easy built-in diagnostic for users who cannot run the `singular` console script (especially on Windows/PowerShell) to surface common installation/PATH issues.

### Description
- Add a `_doctor()` helper in `src/singular/cli.py` that prints the active Python executable, the user `Scripts` directory, whether that directory is present in `PATH`, and the installed `singular` version (with a fallback when package metadata is missing). 
- Add `_in_path()` helper used by the doctor to robustly compare resolved paths against the `PATH` entries. 
- Register a `doctor` subcommand in the CLI so users can run `singular doctor` and copy/paste provided PowerShell remediation commands when the scripts folder is missing from `PATH`. 
- Update `README.md` troubleshooting section to document `singular doctor` usage and recommend copying the PowerShell fix when needed. 
- Add `tests/test_cli_doctor.py` covering both cases (`Scripts` in `PATH` and `Scripts` missing from `PATH`).

### Testing
- Ran `pytest -q tests/test_cli_doctor.py tests/test_cli_lives.py`, all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d32aad32bc832a9b486e2398c305c3)