### PR TITLE
docs: privilégier `python -m singular` sous PowerShell lorsque l’entrypoint n’est pas résolu

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Si PowerShell affiche que `singular` n’est pas reconnu, vérifiez le dossier
 1. Exécutez le diagnostic intégré :
 
    ```powershell
-   singular doctor
+   python -m singular doctor
    ```
 
    Cette commande affiche :
@@ -193,9 +193,11 @@ Si PowerShell affiche que `singular` n’est pas reconnu, vérifiez le dossier
    - le dossier `Scripts` utilisateur détecté ;
    - si ce dossier est présent dans `PATH` ;
    - la version installée de `singular`.
+   Tant que l’entrypoint `singular` n’est pas résolu dans `PATH`, utilisez
+   `python -m singular ...`.
 
 2. Si le diagnostic indique que `Scripts` n’est pas dans `PATH`, copiez-collez
-   les commandes proposées par `singular doctor` dans PowerShell.
+   les commandes proposées par `python -m singular doctor` dans PowerShell.
 
 3. Alternative manuelle (si `singular` est indisponible), récupérez d’abord la
    base utilisateur Python :
@@ -210,11 +212,13 @@ Si PowerShell affiche que `singular` n’est pas reconnu, vérifiez le dossier
    **Modifier** → **Nouveau**, puis collez ce chemin.
 6. Enregistrez, **fermez puis redémarrez PowerShell** (ou votre terminal) pour
    recharger le `PATH`.
-7. Vérifiez ensuite :
+7. Vérifiez ensuite (puis, une fois le `PATH` corrigé, confirmez la résolution
+   de l’entrypoint) :
 
    ```powershell
+   python -m singular --help
+   python -m singular doctor
    Get-Command singular
-   singular --help
    ```
 
 > Le segment `Python313` dépend de votre version Python (par ex. `Python312`,


### PR DESCRIPTION
### Motivation
- Clarifier les étapes d'investigation sous Windows/PowerShell quand l’entrypoint `singular` n’est pas trouvé afin d’éviter les erreurs et proposer une démarche robuste.
- Assurer une cohérence entre les commandes de diagnostic et les instructions d’ajout au `PATH` pour faciliter la résolution du problème.

### Description
- Remplace l’exemple `singular doctor` par `python -m singular doctor` dans la section « Si `singular` n’est pas reconnu ». 
- Ajoute la note explicite : tant que l’entrypoint `singular` n’est pas résolu dans `PATH`, utiliser `python -m singular ...`.
- Met à jour les références pour copier-coller les commandes proposées par `python -m singular doctor` lorsqu’on corrige le `PATH`.
- Harmonise la séquence de vérification finale en proposant `python -m singular --help`, `python -m singular doctor` puis `Get-Command singular` (après correction du `PATH`).

### Testing
- Examiné le diff ciblé avec `git diff -- README.md` et confirmé les modifications présentes, succès.
- Affiché la zone modifiée avec `nl -ba README.md | sed -n '176,226p'` pour validation du contenu, succès.
- Ajouté et commit des changements avec `git commit` pour enregistrer la mise à jour de la documentation, succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8cff9c90832aa07f92f07d71940a)