### PR TITLE
Add `doctor --fix` to auto-repair Windows user PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,15 @@ Si PowerShell affiche que `singular` n’est pas reconnu, vérifiez le dossier
    Tant que l’entrypoint `singular` n’est pas résolu dans `PATH`, utilisez
    `python -m singular ...`.
 
-2. Si le diagnostic indique que `Scripts` n’est pas dans `PATH`, copiez-collez
-   les commandes proposées par `python -m singular doctor` dans PowerShell.
+2. Si le diagnostic indique que `Scripts` n’est pas dans `PATH`, appliquez le
+   correctif automatique :
+
+   ```powershell
+   python -m singular doctor --fix
+   ```
+
+   Puis redémarrez PowerShell. Vous pouvez aussi copier-coller les commandes
+   proposées par `python -m singular doctor`.
 
 3. Alternative manuelle (si `singular` est indisponible), récupérez d’abord la
    base utilisateur Python :

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -31,7 +31,59 @@ def _in_path(target: Path, env_path: str | None = None) -> bool:
     return False
 
 
-def _doctor() -> None:
+def _normalize_windows_path_entry(entry: str) -> str:
+    """Normalize a PATH entry for case-insensitive Windows comparisons."""
+
+    return os.path.normcase(os.path.normpath(entry.strip().strip('"')))
+
+
+def _doctor_fix_windows_user_path(scripts_path: Path) -> bool:
+    """Add scripts_path to the Windows user Path variable when missing."""
+
+    if os.name != "nt":
+        print("⚠️ `doctor --fix` non supporté sur cette plateforme.")
+        return False
+
+    import winreg
+
+    target = str(scripts_path)
+    target_norm = _normalize_windows_path_entry(target)
+
+    with winreg.OpenKey(
+        winreg.HKEY_CURRENT_USER,
+        "Environment",
+        0,
+        winreg.KEY_READ | winreg.KEY_SET_VALUE,
+    ) as key:
+        try:
+            raw_user_path, _ = winreg.QueryValueEx(key, "Path")
+        except FileNotFoundError:
+            raw_user_path = ""
+
+        entries = [entry for entry in raw_user_path.split(";") if entry.strip()]
+        deduped_entries: list[str] = []
+        seen: set[str] = set()
+        for entry in [*entries, target]:
+            normalized = _normalize_windows_path_entry(entry)
+            if not normalized or normalized in seen:
+                continue
+            deduped_entries.append(entry.strip())
+            seen.add(normalized)
+
+        if target_norm in {_normalize_windows_path_entry(entry) for entry in entries}:
+            print("✅ Le dossier Scripts est déjà présent dans le Path utilisateur.")
+            print("➡️ Pensez à redémarrer PowerShell pour recharger l'environnement.")
+            return False
+
+        new_user_path = ";".join(deduped_entries)
+        winreg.SetValueEx(key, "Path", 0, winreg.REG_EXPAND_SZ, new_user_path)
+
+    print("✅ Le dossier Scripts a été ajouté au Path utilisateur Windows.")
+    print("➡️ Veuillez redémarrer PowerShell pour appliquer ce changement.")
+    return True
+
+
+def _doctor(*, fix: bool = False) -> None:
     """Display environment diagnostics for CLI installation."""
 
     python_executable = Path(sys.executable).resolve()
@@ -68,6 +120,10 @@ def _doctor() -> None:
     print(f"$env:Path = [Environment]::GetEnvironmentVariable('Path', 'User')")
     print("Get-Command singular")
     print("singular --help")
+
+    if fix:
+        print("\nApplication du correctif automatique (`--fix`)…")
+        _doctor_fix_windows_user_path(scripts_path)
 
 
 def _preparse_environment(argv: list[str] | None) -> argparse.Namespace:
@@ -203,7 +259,14 @@ def main(argv: list[str] | None = None) -> int:
     report_parser.add_argument("--id", required=True, help="Run identifier")
 
     subparsers.add_parser("dashboard", help="Launch web dashboard")
-    subparsers.add_parser("doctor", help="Diagnose CLI installation and PATH")
+    doctor_parser = subparsers.add_parser(
+        "doctor", help="Diagnose CLI installation and PATH"
+    )
+    doctor_parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Try to add user Scripts directory to user Path on Windows",
+    )
 
     lives_parser = subparsers.add_parser("lives", help="Manage lives")
     lives_subparsers = lives_parser.add_subparsers(
@@ -295,7 +358,7 @@ def main(argv: list[str] | None = None) -> int:
         dashboard_run()
 
     elif args.command == "doctor":
-        _doctor()
+        _doctor(fix=args.fix)
 
     elif args.command == "lives":
         if args.lives_command == "list":

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import types
 
 import singular.cli as cli
 
@@ -41,3 +42,66 @@ def test_doctor_confirms_when_scripts_are_in_path(
     out = capsys.readouterr().out
     assert "- Scripts dans PATH      : oui" in out
     assert "PATH semble correctement configuré" in out
+
+
+def test_doctor_fix_calls_windows_path_update_when_missing(
+    monkeypatch, capsys
+) -> None:
+    scripts_dir = Path("/tmp/singular-user-scripts")
+    monkeypatch.setattr(cli.sys, "executable", "/tmp/python/bin/python")
+    monkeypatch.setattr(
+        cli.sysconfig,
+        "get_path",
+        lambda *_args, **_kwargs: str(scripts_dir),
+    )
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    called: list[Path] = []
+
+    def fake_fix(path: Path) -> bool:
+        called.append(path)
+        return True
+
+    monkeypatch.setattr(cli, "_doctor_fix_windows_user_path", fake_fix)
+
+    cli.main(["doctor", "--fix"])
+
+    out = capsys.readouterr().out
+    assert "Application du correctif automatique (`--fix`)…" in out
+    assert called == [scripts_dir.resolve()]
+
+
+def test_doctor_fix_windows_user_path_is_idempotent(
+    monkeypatch, capsys
+) -> None:
+    scripts_dir = Path(r"C:\Users\Ada\AppData\Roaming\Python\Python313\Scripts")
+    monkeypatch.setattr(cli.os, "name", "nt")
+
+    store: dict[str, str] = {"Path": f"{scripts_dir};C:\\Windows\\System32"}
+
+    class _FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    fake_winreg = types.SimpleNamespace(
+        HKEY_CURRENT_USER=1,
+        KEY_READ=0x20019,
+        KEY_SET_VALUE=0x0002,
+        REG_EXPAND_SZ=2,
+        OpenKey=lambda *_args, **_kwargs: _FakeKey(),
+        QueryValueEx=lambda _key, value_name: (store[value_name], 1),
+        SetValueEx=lambda _key, value_name, *_args: store.__setitem__(
+            value_name, _args[-1]
+        ),
+    )
+    monkeypatch.setitem(cli.sys.modules, "winreg", fake_winreg)
+
+    changed = cli._doctor_fix_windows_user_path(scripts_dir)
+    out = capsys.readouterr().out
+
+    assert changed is False
+    assert store["Path"] == f"{scripts_dir};C:\\Windows\\System32"
+    assert "déjà présent" in out


### PR DESCRIPTION
### Motivation

- Faciliter la réparation automatique du `PATH` utilisateur Windows lorsque l’entrée `Scripts` manque et que l’entrypoint CLI `singular` n’est pas trouvé. 
- Éviter aux utilisateurs Windows les étapes manuelles répétitives de modification des variables d’environnement en leur proposant une option intégrée `--fix`.

### Description

- Ajout d’un argument `--fix` au sous-parser `doctor` et propagation de cette option à l’appel ` _doctor(fix=args.fix)` dans `main()` de `src/singular/cli.py`.
- Refactor de `_doctor()` pour conserver l’affichage diagnostic existant et lancer le correctif automatique seulement si `--fix` est demandé et que le dossier `Scripts` n’est pas présent dans `PATH`.
- Implémentation de ` _doctor_fix_windows_user_path(scripts_path: Path) -> bool` qui cible la clé utilisateur HKCU `Environment`, ajoute `sysconfig.get_path("scripts", scheme="nt_user")` si nécessaire, effectue une déduplication insensible à la casse et affiche un message invitant à redémarrer PowerShell; la routine retourne un booléen pour indiquer si une modification a été appliquée.
- Gestion sûre des autres plateformes : si `os.name != 'nt'`, `--fix` affiche un message de non‑support et ne lève pas d’erreur, et la `README.md` est mise à jour pour documenter l’usage `python -m singular doctor --fix`.

### Testing

- Exécution de `pytest -q tests/test_cli_doctor.py` qui a réussi avec `4 passed` et aucune régression détectée.
- Tests ajoutés/ajustés couvrant le comportement informatif de `doctor`, l’appel de la routine de mise à jour lorsque `--fix` est passé, et l’idempotence (pas d’ajout en double dans la valeur `Path`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8e69974c832aa249ae496f003522)