### PR TITLE
Add `uninstall` CLI with `--keep-lives` / `--purge-lives` modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,27 @@ Les sous-commandes qui consultent la mémoire (``talk``, ``run``, ``loop``,
 sélectionnée. Utilisez ``singular lives delete <nom>`` pour supprimer une vie et
 libérer son espace disque.
 
+## 🧹 Désinstallation
+
+Singular propose une sous-commande pour nettoyer les données stockées dans
+``SINGULAR_ROOT`` (ou via ``--root``). Deux modes explicites existent :
+
+- conserver les vies et supprimer uniquement les artefacts globaux techniques
+  (``mem/`` et ``runs/`` à la racine) ;
+- purger toutes les données Singular (``lives/``, ``mem/``, ``runs/``).
+
+```bash
+python -m singular uninstall --keep-lives --yes
+python -m singular uninstall --purge-lives --yes
+```
+
+> Cette commande nettoie les données, mais ne désinstalle pas le package
+> Python. Pour retirer le package, utilisez :
+>
+> ```bash
+> pip uninstall singular
+> ```
+
 ## 🧬 Reproduction
 
 ```bash

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -175,7 +175,14 @@ def main(argv: list[str] | None = None) -> int:
     argv_list = list(argv) if argv is not None else None
     _preparse_environment(argv_list)
 
-    from .lives import bootstrap_life, delete_life, load_registry, resolve_life
+    from .lives import (
+        bootstrap_life,
+        delete_life,
+        get_registry_root,
+        load_registry,
+        resolve_life,
+        uninstall_singular,
+    )
     from .organisms.quest import quest
     from .organisms.spawn import spawn
     from .organisms.status import status
@@ -285,6 +292,26 @@ def main(argv: list[str] | None = None) -> int:
         "delete", help="Delete a life and its data"
     )
     lives_delete.add_argument("name", help="Slug or name of the life to delete")
+
+    uninstall_parser = subparsers.add_parser(
+        "uninstall", help="Remove Singular data from SINGULAR_ROOT"
+    )
+    uninstall_mode_group = uninstall_parser.add_mutually_exclusive_group(required=True)
+    uninstall_mode_group.add_argument(
+        "--keep-lives",
+        action="store_true",
+        help="Remove only global technical artefacts (mem/, runs/)",
+    )
+    uninstall_mode_group.add_argument(
+        "--purge-lives",
+        action="store_true",
+        help="Remove all Singular data (lives/, mem/, runs/)",
+    )
+    uninstall_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
 
     args = parser.parse_args(argv_list)
 
@@ -400,6 +427,38 @@ def main(argv: list[str] | None = None) -> int:
                 os.environ["SINGULAR_HOME"] = str(next_life)
             else:
                 os.environ.pop("SINGULAR_HOME", None)
+
+    elif args.command == "uninstall":
+        purge_lives = bool(args.purge_lives)
+        root = get_registry_root()
+        if purge_lives and not args.yes:
+            confirmation = input(
+                "ATTENTION: cette commande supprimera toutes les vies et "
+                "artefacts Singular sous "
+                f"'{root}' (lives/, mem/, runs/). Continuer ? [y/N] "
+            )
+            if confirmation.strip().lower() not in {"y", "yes", "o", "oui"}:
+                print("Désinstallation annulée.")
+                return 0
+        try:
+            uninstall_singular(purge_lives=purge_lives)
+        except PermissionError as exc:
+            print(
+                f"Erreur: permissions insuffisantes pour supprimer '{exc.filename or root}'.",
+                file=sys.stderr,
+            )
+            return 1
+        except OSError as exc:
+            print(
+                f"Erreur lors de la désinstallation: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+        if purge_lives:
+            print(f"Données Singular supprimées sous: {root}")
+        else:
+            print(f"Artefacts globaux supprimés sous: {root} (mem/, runs/)")
 
     else:  # pragma: no cover - defensive programming
         raise SystemExit(f"Commande inconnue: {args.command}")

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -232,3 +232,41 @@ def delete_life(name: str) -> LifeMetadata:
     save_registry(registry)
 
     return metadata
+
+
+def _remove_tree(path: Path) -> None:
+    """Remove a directory tree if it exists."""
+
+    try:
+        shutil.rmtree(path)
+    except FileNotFoundError:
+        return
+
+
+def uninstall_singular(purge_lives: bool) -> None:
+    """Uninstall Singular data from ``SINGULAR_ROOT``.
+
+    Cleanup targets are intentionally explicit:
+
+    - ``--keep-lives`` mode removes only legacy/global technical artefacts
+      at the root level: ``mem/`` and ``runs/``.
+    - ``--purge-lives`` mode removes all Singular data trees under the root:
+      ``lives/``, ``mem/`` and ``runs/``.
+    """
+
+    root = get_registry_root()
+    if not root.exists():
+        return
+
+    targets = ["lives", "mem", "runs"] if purge_lives else ["mem", "runs"]
+    for target in targets:
+        _remove_tree(root / target)
+
+    if purge_lives:
+        try:
+            root.rmdir()
+        except FileNotFoundError:
+            return
+        except OSError:
+            # Root is kept when not empty (e.g. user-managed files).
+            return

--- a/tests/test_cli_uninstall.py
+++ b/tests/test_cli_uninstall.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import singular.cli as cli
+
+
+def _mkdir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".sentinel").write_text("ok", encoding="utf-8")
+
+
+def test_uninstall_keep_lives_preserves_lives_tree(tmp_path: Path) -> None:
+    root = tmp_path / "universe"
+    lives_dir = root / "lives"
+    registry = lives_dir / "registry.json"
+    life_dir = lives_dir / "alpha"
+    mem_dir = root / "mem"
+    runs_dir = root / "runs"
+
+    _mkdir(life_dir)
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text('{"active": null, "lives": {}}', encoding="utf-8")
+    _mkdir(mem_dir)
+    _mkdir(runs_dir)
+
+    exit_code = cli.main(
+        ["--root", str(root), "uninstall", "--keep-lives", "--yes"]
+    )
+
+    assert exit_code == 0
+    assert lives_dir.exists()
+    assert registry.exists()
+    assert life_dir.exists()
+    assert not mem_dir.exists()
+    assert not runs_dir.exists()
+
+
+def test_uninstall_purge_lives_removes_all_data(tmp_path: Path) -> None:
+    root = tmp_path / "universe"
+    lives_dir = root / "lives"
+    life_dir = lives_dir / "alpha"
+    mem_dir = root / "mem"
+    runs_dir = root / "runs"
+
+    _mkdir(life_dir)
+    _mkdir(mem_dir)
+    _mkdir(runs_dir)
+
+    exit_code = cli.main(
+        ["--root", str(root), "uninstall", "--purge-lives", "--yes"]
+    )
+
+    assert exit_code == 0
+    assert not lives_dir.exists()
+    assert not mem_dir.exists()
+    assert not runs_dir.exists()
+    assert not root.exists()
+
+
+def test_uninstall_purge_requires_confirmation_without_yes(
+    monkeypatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "universe"
+    lives_dir = root / "lives"
+    life_dir = lives_dir / "alpha"
+    mem_dir = root / "mem"
+    runs_dir = root / "runs"
+    _mkdir(life_dir)
+    _mkdir(mem_dir)
+    _mkdir(runs_dir)
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+    exit_code = cli.main(["--root", str(root), "uninstall", "--purge-lives"])
+
+    assert exit_code == 0
+    assert lives_dir.exists()
+    assert mem_dir.exists()
+    assert runs_dir.exists()


### PR DESCRIPTION
### Motivation

- Fournir une commande explicite pour nettoyer les données stockées sous `SINGULAR_ROOT` avec deux modes strictement exclusifs pour éviter les suppressions accidentelles.
- Permettre un comportement non interactif via `--yes` tout en exigeant une confirmation explicite pour les opérations destructrices complètes.

### Description

- Ajout de la sous-commande `uninstall` dans `src/singular/cli.py` avec un groupe mutuellement exclusif requis entre `--keep-lives` et `--purge-lives` et l'option `--yes` pour bypasser la confirmation interactive, et prise en compte prioritaire de `--root` via `get_registry_root()`.
- Implémentation de `uninstall_singular(purge_lives: bool)` dans `src/singular/lives.py` qui utilise `get_registry_root()` et supprime explicitement les cibles racines : en mode `--keep-lives` supprime `mem/` et `runs/` tout en conservant `lives/` et `lives/registry.json`, et en mode `--purge-lives` supprime `lives/`, `mem/` et `runs/` puis tente de retirer le `root` s'il est vide.
- Gestion des cas limites : chemins absents sont tolérés (pas d'erreur), les erreurs de permissions et autres `OSError` sont interceptées dans le CLI et retournent un code de sortie non nul avec message explicite.
- Ajout de tests CLI `tests/test_cli_uninstall.py` couvrant `--keep-lives`, `--purge-lives` et la garde de confirmation lorsque `--yes` est absent, et mise à jour de la documentation `README.md` (section « Désinstallation ») avec exemples d'utilisation.

### Testing

- Exécuté `pytest -q tests/test_cli_uninstall.py tests/test_cli_lives.py` et obtenu `4 passed`.
- Les nouveaux tests vérifient que `--keep-lives` préserve le répertoire `lives/` et `registry.json`, que `--purge-lives` supprime `lives/`, `mem/` et `runs/` et que l'absence de confirmation annule la purge; tous sont passés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db94a01414832a82052e2cea683784)