### PR TITLE
Sécurise la détection de SINGULAR_ROOT et renforce la sécurité de purge (uninstall)

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -14,6 +14,12 @@ from typing import Any, Callable
 __all__ = ["main"]
 
 
+def _looks_like_dev_repo_root(path: Path) -> bool:
+    """Heuristic to detect a development repository root."""
+
+    return (path / "pyproject.toml").exists() and (path / "src" / "singular").is_dir()
+
+
 def _in_path(target: Path, env_path: str | None = None) -> bool:
     """Return True when *target* is present in PATH."""
 
@@ -306,6 +312,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip confirmation prompt",
     )
+    uninstall_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow purge even if root looks like a development repository",
+    )
 
     args = parser.parse_args(argv_list)
 
@@ -437,13 +448,22 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "uninstall":
         purge_lives = bool(args.purge_lives)
         root = get_registry_root()
+        if purge_lives and _looks_like_dev_repo_root(root) and not args.force:
+            print(
+                "Refus de purge: le root cible ressemble au repo de développement "
+                f"('{root}'). Utilisez --force pour confirmer explicitement.",
+                file=sys.stderr,
+            )
+            return 1
+
         if purge_lives and not args.yes:
             confirmation = input(
-                "ATTENTION: cette commande supprimera toutes les vies et "
-                "artefacts Singular sous "
-                f"'{root}' (lives/, mem/, runs/). Continuer ? [y/N] "
+                "⚠️ PURGE COMPLÈTE demandée.\n"
+                f"Chemin cible : {root}\n"
+                "Cette action supprimera définitivement lives/, mem/ et runs/.\n"
+                "Tapez 'PURGE' pour confirmer: "
             )
-            if confirmation.strip().lower() not in {"y", "yes", "o", "oui"}:
+            if confirmation.strip() != "PURGE":
                 print("Désinstallation annulée.")
                 return 0
         try:

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -54,17 +54,24 @@ def get_registry_root() -> Path:
 
     raw = os.environ.get("SINGULAR_ROOT")
     if raw:
-        root = Path(raw).expanduser()
-    else:
-        cwd = Path.cwd()
-        default_home = Path.home() / ".singular"
-        # Prefer the current working directory when it already contains
-        # Singular artefacts. Otherwise fall back to ``~/.singular``.
-        if (cwd / _REGISTRY_DIRNAME).exists() or (cwd / "mem").exists():
-            root = cwd
-        else:
-            root = default_home
-    return root
+        return Path(raw).expanduser()
+
+    default_home = Path.home() / ".singular"
+    cwd = Path.cwd()
+    registry_path = cwd / _REGISTRY_DIRNAME / _REGISTRY_FILENAME
+
+    # CWD fallback is allowed only when an explicit, valid registry marker
+    # exists. This avoids accidental detection based on unrelated directories
+    # such as a plain ``mem/`` folder.
+    if registry_path.exists():
+        try:
+            payload = json.loads(registry_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return default_home
+        if isinstance(payload, dict) and isinstance(payload.get("lives"), dict):
+            return cwd
+
+    return default_home
 
 
 def load_registry() -> dict[str, Any]:

--- a/tests/test_cli_uninstall.py
+++ b/tests/test_cli_uninstall.py
@@ -64,10 +64,47 @@ def test_uninstall_purge_requires_confirmation_without_yes(
     _mkdir(mem_dir)
     _mkdir(runs_dir)
 
-    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+    monkeypatch.setattr("builtins.input", lambda _prompt: "nope")
     exit_code = cli.main(["--root", str(root), "uninstall", "--purge-lives"])
 
     assert exit_code == 0
     assert lives_dir.exists()
     assert mem_dir.exists()
     assert runs_dir.exists()
+
+
+def test_uninstall_purge_detects_dev_repo_root_without_force(
+    tmp_path: Path, capsys
+) -> None:
+    root = tmp_path / "devrepo"
+    _mkdir(root / "lives" / "alpha")
+    _mkdir(root / "mem")
+    _mkdir(root / "runs")
+    (root / "pyproject.toml").write_text("[project]\nname='singular'\n", encoding="utf-8")
+    (root / "src" / "singular").mkdir(parents=True, exist_ok=True)
+
+    exit_code = cli.main(["--root", str(root), "uninstall", "--purge-lives", "--yes"])
+
+    assert exit_code == 1
+    assert "Refus de purge" in capsys.readouterr().err
+    assert (root / "lives").exists()
+    assert (root / "mem").exists()
+    assert (root / "runs").exists()
+
+
+def test_uninstall_purge_accepts_dev_repo_root_with_force(tmp_path: Path) -> None:
+    root = tmp_path / "devrepo"
+    _mkdir(root / "lives" / "alpha")
+    _mkdir(root / "mem")
+    _mkdir(root / "runs")
+    (root / "pyproject.toml").write_text("[project]\nname='singular'\n", encoding="utf-8")
+    (root / "src" / "singular").mkdir(parents=True, exist_ok=True)
+
+    exit_code = cli.main(
+        ["--root", str(root), "uninstall", "--purge-lives", "--yes", "--force"]
+    )
+
+    assert exit_code == 0
+    assert not (root / "lives").exists()
+    assert not (root / "mem").exists()
+    assert not (root / "runs").exists()

--- a/tests/test_cli_uninstall.py
+++ b/tests/test_cli_uninstall.py
@@ -80,7 +80,9 @@ def test_uninstall_purge_detects_dev_repo_root_without_force(
     _mkdir(root / "lives" / "alpha")
     _mkdir(root / "mem")
     _mkdir(root / "runs")
-    (root / "pyproject.toml").write_text("[project]\nname='singular'\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        "[project]\nname='singular'\n", encoding="utf-8"
+    )
     (root / "src" / "singular").mkdir(parents=True, exist_ok=True)
 
     exit_code = cli.main(["--root", str(root), "uninstall", "--purge-lives", "--yes"])
@@ -97,7 +99,9 @@ def test_uninstall_purge_accepts_dev_repo_root_with_force(tmp_path: Path) -> Non
     _mkdir(root / "lives" / "alpha")
     _mkdir(root / "mem")
     _mkdir(root / "runs")
-    (root / "pyproject.toml").write_text("[project]\nname='singular'\n", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        "[project]\nname='singular'\n", encoding="utf-8"
+    )
     (root / "src" / "singular").mkdir(parents=True, exist_ok=True)
 
     exit_code = cli.main(

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -4,7 +4,12 @@ from pathlib import Path
 
 import pytest
 
-from singular.lives import bootstrap_life, get_registry_root, load_registry, resolve_life
+from singular.lives import (
+    bootstrap_life,
+    get_registry_root,
+    load_registry,
+    resolve_life,
+)
 from singular.organisms.birth import birth
 
 

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from singular.lives import bootstrap_life, load_registry, resolve_life
+from singular.lives import bootstrap_life, get_registry_root, load_registry, resolve_life
 from singular.organisms.birth import birth
 
 
@@ -51,3 +51,32 @@ def test_registry_tracks_multiple_lives(
     registry_path = tmp_path / "lives" / "registry.json"
     assert registry_path.exists()
     assert registry_path.read_text(encoding="utf-8")
+
+
+def test_registry_root_defaults_to_home_without_explicit_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir(parents=True, exist_ok=True)
+    (workspace / "mem").mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(workspace)
+
+    assert get_registry_root() == tmp_path / "home" / ".singular"
+
+
+def test_registry_root_uses_cwd_with_valid_registry_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    workspace = tmp_path / "workspace"
+    (workspace / "lives").mkdir(parents=True, exist_ok=True)
+    (workspace / "lives" / "registry.json").write_text(
+        '{"active": null, "lives": {}}',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    assert get_registry_root() == workspace


### PR DESCRIPTION
### Motivation
- Éviter la détection implicite du root basée uniquement sur la présence de `cwd/mem` pour prévenir l'utilisation accidentelle d'un dossier de travail comme `SINGULAR_ROOT`.
- Forcer une confirmation plus explicite et protéger contre la suppression involontaire d'un dépôt de développement lors de `uninstall --purge-lives`.

### Description
- Modifie `get_registry_root()` pour prioriser `SINGULAR_ROOT`, puis `~/.singular`, et n'utiliser `cwd` que si `lives/registry.json` existe et contient un JSON valide avec une clé `lives` de type `dict` (`src/singular/lives.py`).
- Ajoute l'heuristique `_looks_like_dev_repo_root(path: Path)` qui détecte un repo de dev par la présence de `pyproject.toml` et `src/singular` (`src/singular/cli.py`).
- Renforce le prompt de `uninstall --purge-lives` pour afficher le chemin cible et exiger la saisie exacte `PURGE` (sauf si `--yes`), et ajoute l'option `--force` pour contourner la protection développeur (`src/singular/cli.py`).
- Ajoute/ajuste des tests pour couvrir le nouveau comportement de résolution du root et les cas `uninstall` (détection de repo dev et `--force`) (`tests/test_lives.py`, `tests/test_cli_uninstall.py`).

### Testing
- Tests unitaires exécutés: `pytest -q tests/test_lives.py tests/test_cli_uninstall.py`.
- Résultat: les tests ciblés ont réussi (`9 passed in 0.21s`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb7ba5270832aad097812592b9862)