### PR TITLE
Refactor sandbox worker for spawn-safe multiprocessing

### DIFF
--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -63,6 +63,31 @@ def _validate_ast(tree: ast.AST) -> None:
             raise SandboxError(f"use of '{node.id}' is forbidden")
 
 
+def _sandbox_worker(
+    code: str,
+    timeout: float,
+    memory_limit: int,
+    queue: multiprocessing.Queue[Any],
+) -> None:
+    """Execute sandboxed code in a child process and return output through *queue*."""
+    if resource_module is not None and sys.platform != "win32":
+        resource_module.setrlimit(resource_module.RLIMIT_AS, (memory_limit, memory_limit))
+        cpu_seconds = max(1, int(timeout))
+        resource_module.setrlimit(resource_module.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+
+    tree = ast.parse(code, mode="exec")
+    os.environ.clear()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        allowed = {name: ALLOWED_BUILTINS[name] for name in ALLOWED_BUILTINS}
+        env: Dict[str, Any] = {"__builtins__": allowed}
+        try:
+            exec(compile(tree, "<sandbox>", "exec"), env, env)
+            queue.put(env.get("result"))
+        except Exception as exc:  # pragma: no cover - delivered to parent
+            queue.put(exc)
+
+
 def run(code: str, timeout: float = 1.5, memory_limit: int = 256 * 1024 * 1024) -> Any:
     """Execute *code* in a restricted environment and return the value of `result`.
 
@@ -76,29 +101,9 @@ def run(code: str, timeout: float = 1.5, memory_limit: int = 256 * 1024 * 1024) 
     tree = ast.parse(code, mode="exec")
     _validate_ast(tree)
 
-    queue: multiprocessing.Queue[Any] = multiprocessing.Queue()
-
-    def target(q: multiprocessing.Queue[Any]) -> None:
-        if resource_module is not None and sys.platform != "win32":
-            resource_module.setrlimit(
-                resource_module.RLIMIT_AS, (memory_limit, memory_limit)
-            )
-            cpu_seconds = max(1, int(timeout))
-            resource_module.setrlimit(
-                resource_module.RLIMIT_CPU, (cpu_seconds, cpu_seconds)
-            )
-        os.environ.clear()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            os.chdir(tmpdir)
-            allowed = {name: ALLOWED_BUILTINS[name] for name in ALLOWED_BUILTINS}
-            env: Dict[str, Any] = {"__builtins__": allowed}
-            try:
-                exec(compile(tree, "<sandbox>", "exec"), env, env)
-                q.put(env.get("result"))
-            except Exception as exc:  # pragma: no cover - delivered to parent
-                q.put(exc)
-
-    proc = multiprocessing.Process(target=target, args=(queue,))
+    ctx = multiprocessing.get_context("spawn")
+    queue: multiprocessing.Queue[Any] = ctx.Queue()
+    proc = ctx.Process(target=_sandbox_worker, args=(code, timeout, memory_limit, queue))
     proc.start()
     proc.join(timeout)
     if proc.is_alive():

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -7,6 +7,10 @@ def test_basic_execution():
     assert run("result = max(1, 2)") == 2
 
 
+def test_spawn_context_simple_execution():
+    assert run("result = 1") == 1
+
+
 def test_forbidden_import():
     with pytest.raises(SandboxError):
         run("import os")


### PR DESCRIPTION
### Motivation
- Rendre la logique d'exécution enfant compatible avec le démarrage `spawn` pour éviter des erreurs de handle/spawn sur Windows et assurer des arguments sérialisables vers le worker.
- Uniformiser le comportement multiprocessing cross-platform et préparer le code pour des environnements où les closures ne sont pas picklables.

### Description
- Extraction de la logique d'exécution enfant depuis la closure locale vers une fonction module-level `_sandbox_worker` prenant uniquement des arguments sérialisables (`code`, `timeout`, `memory_limit`, `queue`).
- Remplacement de l'usage implicite de `multiprocessing.Queue()`/`multiprocessing.Process(...)` par un contexte explicite `multiprocessing.get_context("spawn")` et création de la queue/process via `ctx.Queue()` et `ctx.Process(...)`.
- Conservation de la validation AST préalable via `_validate_ast` et préservation de la propagation d'exception enfant->parent ainsi que du comportement de timeout (`TimeoutError`).
- Ajout d'un test Windows-friendly qui exécute un appel simple `run("result = 1")` pour vérifier l'absence d'erreurs liées au spawn/handles.

### Testing
- Exécuté `pytest -q tests/test_sandbox.py` et tous les tests ont réussi.
- Résultat des tests : `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc006e06c832a9db3a8f9116d40fe)