### PR TITLE
Use raw user messages for context and prevent reminder amplification

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -67,7 +67,15 @@ def talk(
         add_episode({"event": "perception", **signals})
         psyche.consume()
         episodes = read_episodes()
-        last_event = next((e["text"] for e in reversed(episodes) if "text" in e), None)
+        episodes_by_role = {
+            "user": [e for e in episodes if e.get("role") == "user"],
+            "assistant": [e for e in episodes if e.get("role") == "assistant"],
+        }
+        user_episodes = episodes_by_role["user"]
+        last_event = next(
+            (e.get("text") for e in reversed(user_episodes) if e.get("text")),
+            None,
+        )
         latest_mutation = next(
             (e for e in reversed(episodes) if e.get("event") == "mutation"),
             None,
@@ -121,7 +129,10 @@ def talk(
         reply = generate_reply(user_input)
 
         parts = [reply]
-        if last_event:
+        should_add_reminder = bool(last_event) and (
+            "Reminder:" not in reply and last_event not in reply
+        )
+        if should_add_reminder:
             parts.append(f"Reminder: {last_event}")
         if last_success:
             parts.append(f"Last success: {last_success.get('op')}")
@@ -133,7 +144,14 @@ def talk(
         response = " | ".join(parts)
 
         print(response)
-        add_episode({"role": "assistant", "text": response, "mood": mood.value})
+        add_episode(
+            {
+                "role": "assistant",
+                "text": response,
+                "raw_reply": reply,
+                "mood": mood.value,
+            }
+        )
         psyche.gain()
         psyche.save_state()
 

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -21,6 +21,7 @@ def test_talk_loop(monkeypatch, tmp_path):
     assert len(episodes) == 4
     assert episodes[0]["role"] == "user"
     assert episodes[1]["role"] == "assistant"
+    assert episodes[1]["raw_reply"]
     assert "Mood: neutral" in episodes[1]["text"]
     assert any("Reminder:" in out for out in outputs)
 
@@ -111,3 +112,21 @@ def test_talk_seed_controls_stub(monkeypatch, tmp_path):
     assert second == expected_first
     assert third == expected_third
     assert first != third
+
+
+def test_talk_does_not_accumulate_reminder_or_mood(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    inputs = iter(["hello", "next", "again", "quit"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
+    outputs: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
+
+    talk(seed=7)
+
+    replies = [out for out in outputs if "Mood:" in out]
+    assert len(replies) == 3
+    for reply in replies:
+        assert reply.count("Reminder:") <= 1
+        assert reply.count("Mood:") == 1


### PR DESCRIPTION
### Motivation
- Prevent using assistant-enriched text as the conversational "last event" so reminders don't echo amplified content.
- Keep the raw model output separate from the displayed/enriched response to avoid re-reading concatenated text.
- Stop appending duplicate `Reminder:`/`Mood:` fragments across multiple turns.

### Description
- Updated `gather_context()` in `src/singular/organisms/talk.py` to group episodes by role and derive `last_event` exclusively from the last `role: user` episode `text` field. 
- Added a structured `raw_reply` field to assistant episodes when calling `add_episode()` so the raw model reply is persisted separately from the enriched `text` response. 
- Modified `respond()` to skip adding a `Reminder:` segment when the same reminder content (or `"Reminder:"` token) is already present in the generated `reply`. 
- Tests updated in `tests/test_talk.py` to assert presence of `raw_reply` and to add `test_talk_does_not_accumulate_reminder_or_mood` which verifies `Reminder:`/`Mood:` do not accumulate over multiple turns.

### Testing
- Ran the unit tests with `pytest -q tests/test_talk.py`, which passed: `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc162b4b4832aa820e9aadcc8c303)