### PR TITLE
Improve `loop` CLI UX for legacy `--ticks` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ unique et quitter immédiatement :
 singular talk --prompt "Bonjour"
 ```
 
+### CLI `loop` (budget en secondes)
+
+La syntaxe officielle utilise désormais un budget temporel explicite :
+
+```bash
+singular loop --budget-seconds 10
+singular loop --budget-seconds 60 --run-id benchmark
+```
+
+Compatibilité legacy : l’option `--ticks` existe uniquement pour guider les
+anciens usages basés sur des “ticks”. Elle n’est pas exécutable seule et renvoie
+un message explicite avec la commande correcte (`--budget-seconds`). Règle de
+conversion de référence pour migrer vos scripts : `1 tick ≈ 1 seconde`.
+
 ## 🧿 Gérer plusieurs vies
 
 Les organismes peuvent désormais partager un même répertoire racine tout en

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -237,7 +237,16 @@ def main(argv: list[str] | None = None) -> int:
     loop_parser = subparsers.add_parser("loop", help="Execute evolutionary loop")
     loop_parser.add_argument("--skills-dir", type=Path, default=None)
     loop_parser.add_argument("--checkpoint", type=Path, default=None)
-    loop_parser.add_argument("--budget-seconds", type=float, required=True)
+    loop_parser.add_argument("--budget-seconds", type=float, required=False)
+    loop_parser.add_argument(
+        "--ticks",
+        type=int,
+        default=None,
+        help=(
+            "Legacy alias from older tick-based syntax. "
+            "Use --budget-seconds instead."
+        ),
+    )
     loop_parser.add_argument("--run-id", default="loop", help="Run identifier")
 
     subparsers.add_parser("status", help="Show current status")
@@ -319,6 +328,19 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     args = parser.parse_args(argv_list)
+
+    if args.command == "loop":
+        if args.budget_seconds is None and args.ticks is not None:
+            parser.error(
+                "`--ticks` n'est plus accepté seul. "
+                "Utilisez `singular loop --budget-seconds <secondes>` "
+                "(conversion legacy: 1 tick ≈ 1 seconde)."
+            )
+        if args.budget_seconds is None:
+            parser.error(
+                "argument requis: --budget-seconds "
+                "(exemple: `singular loop --budget-seconds 10`)."
+            )
 
     if args.root:
         os.environ["SINGULAR_ROOT"] = str(args.root)

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -50,3 +50,14 @@ def test_lives_management(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> No
     assert registry["active"] == alpha_meta.slug
     assert not beta_path.exists()
     assert resolve_life(None) == alpha_path
+
+
+def test_loop_ticks_legacy_message(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["loop", "--ticks", "10"])
+
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "--ticks" in stderr
+    assert "singular loop --budget-seconds <secondes>" in stderr
+    assert "1 tick ≈ 1 seconde" in stderr


### PR DESCRIPTION
### Motivation
- Users coming from a tick-based workflow needed clearer guidance when the CLI switched to a time-based budget (`--budget-seconds`).
- Prevent silent misuses or surprising behavior by validating legacy `--ticks` use and offering an actionable migration message.

### Description
- Add an optional `--ticks` argument to the `loop` subparser while making `--budget-seconds` optional at parse time to allow custom validation (`src/singular/cli.py`).
- Introduce explicit parser validation for `loop` that rejects `--ticks` used alone with a clear migration error and shows a required-argument error with a correct example when no budget is provided (`src/singular/cli.py`).
- Document canonical `loop` usage and the legacy `--ticks` behavior (including the reference conversion `1 tick ≈ 1 seconde`) with exact examples in the README (`README.md`).
- Add a CLI test `test_loop_ticks_legacy_message` that asserts the user-facing error contains the `--ticks` hint, the recommended `singular loop --budget-seconds <secondes>` command, and the conversion note (`tests/test_cli_lives.py`).

### Testing
- Ran `pytest -q tests/test_cli_lives.py` and the suite completed successfully with `2 passed`.
- The new test `test_loop_ticks_legacy_message` passed and verifies the parser returns a `SystemExit` with the expected informative message when `--ticks` is provided without `--budget-seconds`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbc3c5db34832a88a492f2c6f7d1f9)