### PR TITLE
Guard sandbox worker cwd restoration during TemporaryDirectory cleanup

### DIFF
--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import logging
 import multiprocessing
 import os
 import sys
@@ -15,6 +16,9 @@ try:
     import resource as resource_module
 except ImportError:  # pragma: no cover - Windows or unsupported platforms
     resource_module = None
+
+
+logger = logging.getLogger(__name__)
 
 
 ALLOWED_BUILTINS = {
@@ -77,15 +81,22 @@ def _sandbox_worker(
 
     tree = ast.parse(code, mode="exec")
     os.environ.clear()
+    prev_cwd = os.getcwd()
     with tempfile.TemporaryDirectory() as tmpdir:
-        os.chdir(tmpdir)
-        allowed = {name: ALLOWED_BUILTINS[name] for name in ALLOWED_BUILTINS}
-        env: Dict[str, Any] = {"__builtins__": allowed}
         try:
-            exec(compile(tree, "<sandbox>", "exec"), env, env)
-            queue.put(env.get("result"))
-        except Exception as exc:  # pragma: no cover - delivered to parent
-            queue.put(exc)
+            os.chdir(tmpdir)
+            allowed = {name: ALLOWED_BUILTINS[name] for name in ALLOWED_BUILTINS}
+            env: Dict[str, Any] = {"__builtins__": allowed}
+            try:
+                exec(compile(tree, "<sandbox>", "exec"), env, env)
+                queue.put(env.get("result"))
+            except Exception as exc:  # pragma: no cover - delivered to parent
+                queue.put(exc)
+        finally:
+            try:
+                os.chdir(prev_cwd)
+            except OSError as exc:  # pragma: no cover - platform specific cleanup guard
+                logger.warning("failed to restore cwd during sandbox cleanup: %s", exc)
 
 
 def run(code: str, timeout: float = 1.5, memory_limit: int = 256 * 1024 * 1024) -> Any:

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -39,3 +39,65 @@ def test_forbidden_network_access():
 def test_forbidden_subprocess_access():
     with pytest.raises(SandboxError):
         run("import subprocess\nsubprocess.run(['echo', 'hi'])")
+
+def test_run_windows_cleanup_guard(monkeypatch, caplog):
+    import singular.life.sandbox as sandbox_module
+
+    class InlineProcess:
+        def __init__(self, target, args):
+            self._target = target
+            self._args = args
+            self._alive = False
+
+        def start(self):
+            self._alive = True
+            self._target(*self._args)
+            self._alive = False
+
+        def join(self, _timeout=None):
+            return None
+
+        def is_alive(self):
+            return self._alive
+
+        def terminate(self):
+            self._alive = False
+
+    class InlineQueue:
+        def __init__(self):
+            self._items = []
+
+        def put(self, value):
+            self._items.append(value)
+
+        def get(self):
+            return self._items.pop(0)
+
+        def empty(self):
+            return not self._items
+
+    class InlineContext:
+        def Queue(self):
+            return InlineQueue()
+
+        def Process(self, target, args):
+            return InlineProcess(target, args)
+
+    monkeypatch.setattr(sandbox_module.multiprocessing, "get_context", lambda _name: InlineContext())
+
+    real_chdir = sandbox_module.os.chdir
+    chdir_calls = []
+
+    def fake_chdir(path):
+        chdir_calls.append(path)
+        if len(chdir_calls) == 2:
+            raise OSError("simulated windows cleanup lock")
+        return real_chdir(path)
+
+    monkeypatch.setattr(sandbox_module.os, "chdir", fake_chdir)
+
+    caplog.set_level("WARNING", logger=sandbox_module.__name__)
+    assert sandbox_module.run("result = 1") == 1
+    assert len(chdir_calls) == 2
+    assert "failed to restore cwd during sandbox cleanup" in caplog.text
+


### PR DESCRIPTION
### Motivation
- Prevent the sandbox worker from leaving the process working directory changed after using a temporary directory. 
- Avoid cleanup-time exceptions (notably on Windows where file-locks can make `chdir` fail) that would crash the worker. 

### Description
- Save the previous working directory with `prev_cwd = os.getcwd()` before entering the `TemporaryDirectory`. 
- Wrap `os.chdir(tmpdir)` and sandbox execution in a `try/finally` so restoration is always attempted before exiting the tempdir. 
- Restore the cwd in the `finally` and guard the restore with `except OSError` that logs a warning instead of raising, using a module `logger`. 
- Add `test_run_windows_cleanup_guard` in `tests/test_sandbox.py` which simulates the multiprocessing context and a failing `os.chdir` on restore via `monkeypatch` and asserts the run succeeds and a cleanup warning is logged. 

### Testing
- Ran `pytest tests/test_sandbox.py -q` and all tests passed. 
- The new `test_run_windows_cleanup_guard` was executed as part of the suite and succeeded (no cleanup exception surfaced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd14e132c832aa5fcc3bf37d08b9a)