### PR TITLE
Add visible provider diagnostics in talk session

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -52,8 +52,22 @@ def talk(
     provider_name = provider or os.getenv("LLM_PROVIDER")
     if not provider_name:
         provider_name = "openai" if os.getenv("OPENAI_API_KEY") else "stub"
+    print(f"Provider: {provider_name}")
+
+    if provider_name == "openai":
+        api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+        if not api_key:
+            print(
+                "OPENAI_API_KEY is required when provider is 'openai'. "
+                "Falling back to local default replies if unavailable."
+            )
+
     generate_reply: Callable[[str], str] | None = load_llm_provider(provider_name)
     if generate_reply is None:
+        print(
+            f"Warning: provider '{provider_name}' not found; "
+            "falling back to _default_reply."
+        )
 
         def generate_reply(prompt: str) -> str:
             return _default_reply(prompt, rng)

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -23,6 +23,8 @@ def test_talk_loop(monkeypatch, tmp_path):
     assert episodes[1]["role"] == "assistant"
     assert episodes[1]["raw_reply"]
     assert "Mood: neutral" in episodes[1]["text"]
+    assert outputs[0] == "Provider: idontexist"
+    assert any("provider 'idontexist' not found" in out for out in outputs)
     assert any("Reminder:" in out for out in outputs)
 
 
@@ -85,7 +87,8 @@ def test_talk_single_prompt(monkeypatch, tmp_path):
     assert episodes[0]["role"] == "user"
     assert episodes[0]["text"] == "hello"
     expected = _default_reply("hello", random.Random(123)) + " | Mood: neutral"
-    assert outputs[0] == expected
+    assert outputs[0] == "Provider: stub"
+    assert outputs[-1] == expected
 
 
 def _run_talk(monkeypatch, tmp_path, seed, run):
@@ -99,7 +102,7 @@ def _run_talk(monkeypatch, tmp_path, seed, run):
     outputs = []
     monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
     talk(seed=seed)
-    return outputs[0]
+    return outputs
 
 
 def test_talk_seed_controls_stub(monkeypatch, tmp_path):
@@ -108,10 +111,13 @@ def test_talk_seed_controls_stub(monkeypatch, tmp_path):
     third = _run_talk(monkeypatch, tmp_path, 321, 3)
     expected_first = _default_reply("hello", random.Random(123)) + " | Mood: neutral"
     expected_third = _default_reply("hello", random.Random(321)) + " | Mood: neutral"
-    assert first == expected_first
-    assert second == expected_first
-    assert third == expected_third
-    assert first != third
+    assert first[0] == "Provider: stub"
+    assert second[0] == "Provider: stub"
+    assert third[0] == "Provider: stub"
+    assert first[-1] == expected_first
+    assert second[-1] == expected_first
+    assert third[-1] == expected_third
+    assert first[-1] != third[-1]
 
 
 def test_talk_does_not_accumulate_reminder_or_mood(monkeypatch, tmp_path):
@@ -130,3 +136,20 @@ def test_talk_does_not_accumulate_reminder_or_mood(monkeypatch, tmp_path):
     for reply in replies:
         assert reply.count("Reminder:") <= 1
         assert reply.count("Mood:") == 1
+
+
+def test_talk_openai_without_api_key_warns(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
+    inputs = iter(["quit"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    outputs: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
+
+    talk(provider="openai")
+
+    assert outputs[0] == "Provider: openai"
+    assert any("OPENAI_API_KEY is required" in out for out in outputs)
+    assert any("falling back to _default_reply" in out for out in outputs)


### PR DESCRIPTION
### Motivation

- Make the resolved LLM provider visible at the start of a `talk` session to aid debugging and user clarity.
- Surface the reason for non-fatal fallbacks so the cause of degraded behavior is obvious instead of silent.
- Provide a clear message when `provider == "openai"` but `OPENAI_API_KEY` is missing so users know why OpenAI cannot be used.

### Description

- Print the resolved provider with `print(f"Provider: {provider_name}")` immediately after provider resolution in `talk`.
- When `provider_name == "openai"` and `OPENAI_API_KEY` is empty or missing, print a clear warning that `OPENAI_API_KEY` is required and that a fallback will be used.
- When `load_llm_provider(provider_name)` returns `None`, print an explicit warning before falling back to the local `_default_reply` implementation so the cause is visible.
- Update `tests/test_talk.py` to assert the new status and warning lines and add `test_talk_openai_without_api_key_warns` to cover the `openai`-without-key case.

### Testing

- Ran `pytest -q tests/test_talk.py` and all tests passed (`7 passed`).
- The updated tests assert presence of `Provider: <name>` lines, the provider-missing warning, and the `OPENAI_API_KEY` warning when applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd1e6d54c832a899c8873f8573ce2)