### PR TITLE
Add `singular config openai` command with secure key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,16 @@ Les variables d'environnement suivantes contrôlent le comportement :
 - `SINGULAR_RUNS_KEEP` : nombre de journaux `runs/` conservés (20 par défaut).
 - `OPENAI_API_KEY` : clé API requise si l'option OpenAI est activée.
 
+Vous pouvez configurer la clé OpenAI directement via la CLI :
+
+```bash
+# mode interactif (saisie masquée)
+singular config openai
+
+# mode non interactif (CI) + test rapide provider
+singular config openai --api-key sk-... --test
+```
+
 Exemples :
 
 ```bash

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import getpass
 import os
 import random
 import sys
@@ -134,6 +135,111 @@ def _doctor(*, fix: bool = False) -> None:
     if fix:
         print("\nApplication du correctif automatique (`--fix`)…")
         _doctor_fix_windows_user_path(scripts_path)
+
+
+def _mask_api_key(api_key: str) -> str:
+    """Return a masked API key string safe for display."""
+
+    if not api_key:
+        return "(vide)"
+    if len(api_key) <= 7:
+        return "sk-****..."
+    return f"{api_key[:3]}****...{api_key[-4:]}"
+
+
+def _validate_openai_api_key(api_key: str) -> list[str]:
+    """Return non-blocking validation warnings for an OpenAI API key."""
+
+    warnings: list[str] = []
+    if not api_key.strip():
+        warnings.append("clé vide")
+        return warnings
+    if not api_key.startswith("sk-"):
+        warnings.append("préfixe inattendu (attendu: sk-)")
+    if len(api_key) < 12:
+        warnings.append("longueur inhabituelle (très courte)")
+    return warnings
+
+
+def _set_windows_user_env_var(name: str, value: str) -> None:
+    """Persist an environment variable in HKCU\\Environment on Windows."""
+
+    import winreg as _winreg
+
+    winreg: Any = _winreg
+    with winreg.OpenKey(
+        winreg.HKEY_CURRENT_USER,
+        "Environment",
+        0,
+        winreg.KEY_READ | winreg.KEY_SET_VALUE,
+    ) as key:
+        winreg.SetValueEx(key, name, 0, winreg.REG_EXPAND_SZ, value)
+
+
+def _append_export_to_shell_profile(profile_path: Path, api_key: str) -> bool:
+    """Append OPENAI_API_KEY export line to a shell profile (idempotent)."""
+
+    profile = profile_path.expanduser()
+    profile.parent.mkdir(parents=True, exist_ok=True)
+    export_line = f"export OPENAI_API_KEY='{api_key}'"
+    existing = profile.read_text(encoding="utf-8") if profile.exists() else ""
+    if export_line in existing:
+        print(f"✅ La configuration existe déjà dans {profile}.")
+        return False
+    with profile.open("a", encoding="utf-8") as handle:
+        if existing and not existing.endswith("\n"):
+            handle.write("\n")
+        handle.write(f"{export_line}\n")
+    print(f"✅ Variable OPENAI_API_KEY ajoutée à {profile}.")
+    return True
+
+
+def _configure_openai(api_key: str, *, shell_profile: str | None, test: bool) -> int:
+    """Configure OPENAI_API_KEY for current platform and optionally test it."""
+
+    warnings = _validate_openai_api_key(api_key)
+    if "clé vide" in warnings:
+        print("❌ Clé API vide: configuration annulée.", file=sys.stderr)
+        return 1
+    for warning in warnings:
+        print(f"⚠️ Validation clé API: {warning}.")
+
+    os.environ["OPENAI_API_KEY"] = api_key
+    masked_key = _mask_api_key(api_key)
+    print(f"✅ Clé OpenAI chargée (masquée): {masked_key}")
+
+    if os.name == "nt":
+        _set_windows_user_env_var("OPENAI_API_KEY", api_key)
+        print("✅ OPENAI_API_KEY enregistrée dans HKCU\\Environment.")
+        print("➡️ Veuillez redémarrer PowerShell pour recharger l'environnement.")
+    else:
+        if shell_profile:
+            profile_path = Path(shell_profile)
+            answer = input(
+                f"Confirmer l'écriture dans {profile_path.expanduser()} ? "
+                "Tapez OUI pour confirmer: "
+            )
+            if answer.strip() == "OUI":
+                _append_export_to_shell_profile(profile_path, api_key)
+                print("➡️ Ouvrez un nouveau shell (ou `source` le profil) pour appliquer.")
+            else:
+                print("Écriture annulée. Aucune persistance shell effectuée.")
+        else:
+            print("Pour persister la clé sur Linux/macOS, ajoutez à votre profil shell:")
+            print("export OPENAI_API_KEY='sk-...'")
+
+    if test:
+        from .providers import llm_openai
+
+        reply = llm_openai.generate_reply("Reply with: ok")
+        if reply in {
+            "OpenAI API key not configured.",
+            "Error communicating with OpenAI.",
+        }:
+            print(f"❌ Test OpenAI échoué: {reply}")
+            return 1
+        print("✅ Test OpenAI réussi (provider joignable).")
+    return 0
 
 
 def _preparse_environment(argv: list[str] | None) -> argparse.Namespace:
@@ -285,6 +391,28 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Try to add user Scripts directory to user Path on Windows",
     )
+    config_parser = subparsers.add_parser("config", help="Configure providers and env")
+    config_subparsers = config_parser.add_subparsers(
+        dest="config_command", required=True
+    )
+    config_openai_parser = config_subparsers.add_parser(
+        "openai", help="Configure OPENAI_API_KEY"
+    )
+    config_openai_parser.add_argument(
+        "--api-key",
+        default=None,
+        help="OpenAI API key (non-interactive mode, useful in CI)",
+    )
+    config_openai_parser.add_argument(
+        "--shell-profile",
+        default=None,
+        help="Shell profile path to append export (e.g. ~/.bashrc or ~/.zshrc)",
+    )
+    config_openai_parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Run a short provider ping after configuration",
+    )
 
     lives_parser = subparsers.add_parser("lives", help="Manage lives")
     lives_subparsers = lives_parser.add_subparsers(dest="lives_command", required=True)
@@ -429,6 +557,19 @@ def main(argv: list[str] | None = None) -> int:
 
     elif args.command == "doctor":
         _doctor(fix=args.fix)
+
+    elif args.command == "config":
+        if args.config_command == "openai":
+            api_key = (
+                args.api_key
+                if args.api_key is not None
+                else getpass.getpass("OpenAI API key (input hidden): ").strip()
+            )
+            return _configure_openai(
+                api_key,
+                shell_profile=args.shell_profile,
+                test=args.test,
+            )
 
     elif args.command == "lives":
         if args.lives_command == "list":

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+import types
+
+import singular.cli as cli
+
+
+def test_config_openai_non_interactive_masks_output(monkeypatch, capsys) -> None:
+    api_key = "sk-secretkey123456"
+    monkeypatch.setattr(cli.os, "name", "posix")
+
+    exit_code = cli.main(["config", "openai", "--api-key", api_key])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Clé OpenAI chargée" in out
+    assert api_key not in out
+    assert "sk-****" in out
+
+
+def test_config_openai_interactive_uses_getpass(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli.os, "name", "posix")
+    monkeypatch.setattr(cli.getpass, "getpass", lambda _prompt: "sk-from-getpass-1234")
+
+    exit_code = cli.main(["config", "openai"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "sk-from-getpass-1234" not in out
+
+
+def test_config_openai_empty_key_returns_error(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli.os, "name", "posix")
+
+    exit_code = cli.main(["config", "openai", "--api-key", ""])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "Clé API vide" in captured.err
+
+
+def test_config_openai_windows_writes_hkcu_environment(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli.os, "name", "nt")
+    store: dict[str, str] = {}
+
+    class _FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    fake_winreg = types.SimpleNamespace(
+        HKEY_CURRENT_USER=1,
+        KEY_READ=0x20019,
+        KEY_SET_VALUE=0x0002,
+        REG_EXPAND_SZ=2,
+        OpenKey=lambda *_args, **_kwargs: _FakeKey(),
+        SetValueEx=lambda _key, value_name, *_args: store.__setitem__(
+            value_name, _args[-1]
+        ),
+    )
+    monkeypatch.setitem(cli.sys.modules, "winreg", fake_winreg)
+
+    raw_key = "sk-win-secret-123456"
+    exit_code = cli.main(
+        ["--home", "/tmp/singular-life", "config", "openai", "--api-key", raw_key]
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert store["OPENAI_API_KEY"] == raw_key
+    assert "HKCU\\Environment" in out
+    assert "redémarrer PowerShell" in out
+    assert raw_key not in out
+
+
+def test_config_openai_shell_profile_append_with_confirmation(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    monkeypatch.setattr(cli.os, "name", "posix")
+    monkeypatch.setattr("builtins.input", lambda _prompt: "OUI")
+    profile = tmp_path / ".bashrc"
+
+    raw_key = "sk-profile-secret-abcdef"
+    exit_code = cli.main(
+        [
+            "config",
+            "openai",
+            "--api-key",
+            raw_key,
+            "--shell-profile",
+            str(profile),
+        ]
+    )
+
+    out = capsys.readouterr().out
+    content = profile.read_text(encoding="utf-8")
+    assert exit_code == 0
+    assert "OPENAI_API_KEY" in content
+    assert raw_key in content
+    assert raw_key not in out
+
+
+def test_config_openai_test_ping_success(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli.os, "name", "posix")
+    monkeypatch.setattr(
+        "singular.providers.llm_openai.generate_reply", lambda _prompt: "ok"
+    )
+
+    exit_code = cli.main(["config", "openai", "--api-key", "sk-test-ok-1234", "--test"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Test OpenAI réussi" in out
+
+
+def test_config_openai_test_ping_failure(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli.os, "name", "posix")
+    monkeypatch.setattr(
+        "singular.providers.llm_openai.generate_reply",
+        lambda _prompt: "Error communicating with OpenAI.",
+    )
+
+    exit_code = cli.main(
+        ["config", "openai", "--api-key", "sk-test-ko-1234", "--test"]
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "Test OpenAI échoué" in out


### PR DESCRIPTION
### Motivation
- Fournir une sous-commande CLI pour configurer l’accès OpenAI de façon sécurisée et scriptable.
- Permettre à la fois une saisie interactive (masquée) et un mode non interactif adapté au CI tout en évitant de divulguer la clé.

### Description
- Ajout d’un nouveau sous-parseur `config openai` avec options `--api-key`, `--shell-profile` et `--test` dans `src/singular/cli.py`.
- Implémentation de la saisie interactive via `getpass.getpass`, validation basique non bloquante (vide/prefixe `sk-`/longueur) et masquage des sorties (`sk-****...`).
- Persistance Windows via écriture dans `HKCU\\Environment` (fonction similaire à `_doctor_fix_windows_user_path`) et instruction de redémarrage PowerShell, et persistance Unix via ajout idempotent dans un profil shell avec confirmation explicite si `--shell-profile` est fourni.
- Option `--test` qui pingue le provider via `singular.providers.llm_openai.generate_reply` et retourne un code/sortie claire selon le résultat.
- Ne jamais afficher la clé en clair dans la sortie utilisateur (masquage appliqué) ; ajout d’utilitaires pour masquage/validation/écriture.
- Mise à jour de `README.md` (section Configuration) avec exemples d’usage interactif et non-interactif.

### Testing
- Tests unitaires ajoutés dans `tests/test_cli_config.py` couvrant parsing, mode interactif/non-interactif, mock `winreg` Windows, append de profil shell, et `--test` success/failure.
- Commande exécutée: `pytest -q tests/test_cli_config.py tests/test_cli_doctor.py`.
- Résultat: `11 passed` (tous les tests exécutés ont réussi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd28fd0b8832a9b87488a4859c69e)