### PR TITLE
Add ecosystem multi-life CLI and interaction telemetry

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -430,6 +430,33 @@ def main(argv: list[str] | None = None) -> int:
     )
     lives_delete.add_argument("name", help="Slug or name of the life to delete")
 
+    ecosystem_parser = subparsers.add_parser(
+        "ecosystem", help="Run multiple lives in a shared ecosystem"
+    )
+    ecosystem_subparsers = ecosystem_parser.add_subparsers(
+        dest="ecosystem_command", required=True
+    )
+    ecosystem_run = ecosystem_subparsers.add_parser(
+        "run", help="Execute an ecosystem loop across multiple lives"
+    )
+    ecosystem_run.add_argument(
+        "--life",
+        dest="ecosystem_lives",
+        action="append",
+        default=[],
+        help="Life slug/name to include (repeatable)",
+    )
+    ecosystem_run.add_argument(
+        "--life-group",
+        dest="ecosystem_groups",
+        action="append",
+        default=[],
+        help="Comma-separated list of life slugs/names",
+    )
+    ecosystem_run.add_argument("--checkpoint", type=Path, default=None)
+    ecosystem_run.add_argument("--budget-seconds", type=float, required=True)
+    ecosystem_run.add_argument("--run-id", default="ecosystem", help="Run identifier")
+
     uninstall_parser = subparsers.add_parser(
         "uninstall", help="Remove Singular data from SINGULAR_ROOT"
     )
@@ -514,6 +541,38 @@ def main(argv: list[str] | None = None) -> int:
         checkpoint = args.checkpoint or life_dir / "life_checkpoint.json"
         loop_run(
             skills_dir=skills_dir,
+            checkpoint=checkpoint,
+            budget_seconds=args.budget_seconds,
+            run_id=args.run_id,
+            seed=args.seed,
+        )
+
+    elif args.command == "ecosystem":
+        from .runs.loop import loop as loop_run
+
+        if args.ecosystem_command != "run":
+            raise SystemExit(f"Sous-commande ecosystem inconnue: {args.ecosystem_command}")
+
+        names = list(args.ecosystem_lives)
+        for group in args.ecosystem_groups:
+            names.extend(part.strip() for part in group.split(",") if part.strip())
+
+        if not names:
+            raise SystemExit(
+                "Aucune vie fournie. Utilisez --life (multiple) ou --life-group."
+            )
+
+        organisms: dict[str, Path] = {}
+        for life_name in names:
+            life_dir = resolve_life(life_name)
+            if life_dir is None:
+                raise SystemExit(f"Vie introuvable: {life_name}")
+            organisms[life_name] = life_dir / "skills"
+
+        root = get_registry_root()
+        checkpoint = args.checkpoint or (root / "runs" / "ecosystem_checkpoint.json")
+        loop_run(
+            skills_dirs=organisms,
             checkpoint=checkpoint,
             budget_seconds=args.budget_seconds,
             run_id=args.run_id,

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -24,6 +24,74 @@ def create_app(
     )
     app = FastAPI()
 
+    def _compute_ecosystem() -> dict:
+        organisms: dict[str, dict[str, object]] = {}
+        if runs_path.exists():
+            for file in runs_path.iterdir():
+                if not file.is_file() or file.suffix != ".jsonl":
+                    continue
+                for line in file.read_text(encoding="utf-8").splitlines():
+                    if not line.strip():
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    event = record.get("event")
+                    interaction = record.get("interaction")
+
+                    if event == "interaction" and isinstance(
+                        record.get("organism"), str
+                    ):
+                        name = str(record["organism"])
+                        state = organisms.setdefault(name, {"status": "alive"})
+                        if "energy" in record:
+                            state["energy"] = record["energy"]
+                        if "resources" in record:
+                            state["resources"] = record["resources"]
+                        if "score" in record:
+                            state["score"] = record["score"]
+                        if "alive" in record:
+                            state["status"] = (
+                                "alive" if bool(record["alive"]) else "extinct"
+                            )
+                        if interaction:
+                            state["last_interaction"] = interaction
+                    elif event == "death":
+                        skill = str(record.get("skill", ""))
+                        if ":" in skill:
+                            name, _ = skill.split(":", 1)
+                            state = organisms.setdefault(name, {})
+                            state["status"] = "extinct"
+                    elif event is None and isinstance(record.get("skill"), str):
+                        skill = record["skill"]
+                        if ":" in skill:
+                            name, _ = skill.split(":", 1)
+                            state = organisms.setdefault(name, {"status": "alive"})
+                            state["score"] = record.get("score_new")
+
+        alive = sum(1 for state in organisms.values() if state.get("status") != "extinct")
+        total_energy = sum(
+            float(state.get("energy", 0.0))
+            for state in organisms.values()
+            if isinstance(state.get("energy"), (int, float))
+        )
+        total_resources = sum(
+            float(state.get("resources", 0.0))
+            for state in organisms.values()
+            if isinstance(state.get("resources"), (int, float))
+        )
+        return {
+            "organisms": organisms,
+            "summary": {
+                "total_organisms": len(organisms),
+                "alive_organisms": alive,
+                "total_energy": total_energy,
+                "total_resources": total_resources,
+            },
+        }
+
     @app.get("/logs")
     def read_logs() -> dict[str, str]:
         logs: dict[str, str] = {}
@@ -38,6 +106,10 @@ def create_app(
         if not psyche_path.exists():
             raise HTTPException(status_code=404, detail="psyche.json not found")
         return json.loads(psyche_path.read_text())
+
+    @app.get("/ecosystem")
+    def read_ecosystem() -> dict:
+        return _compute_ecosystem()
 
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:
@@ -84,8 +156,12 @@ def create_app(
             "<html><head><title>Singular Dashboard</title></head><body>"
             "<h1>Singular Dashboard</h1>"
             "<h2>Psyche</h2><pre id='psyche'></pre>"
+            "<h2>Ecosystem Summary</h2><pre id='ecosystem-summary'></pre>"
+            "<h2>Organisms</h2><pre id='organisms'></pre>"
             "<h2>Runs</h2><div id='logs'></div>"
             "<script>const ws=new WebSocket(`ws://${location.host}/ws`);"
+            "const loadEco=()=>fetch('/ecosystem').then(r=>r.json()).then(d=>{document.getElementById('ecosystem-summary').textContent=JSON.stringify(d.summary,null,2);document.getElementById('organisms').textContent=JSON.stringify(d.organisms,null,2);});"
+            "loadEco();setInterval(loadEco,500);"
             "ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);}else if(m.type==='logs'){const d=document.getElementById('logs');d.innerHTML='';for(const [n,c] of Object.entries(m.data)){const pre=document.createElement('pre');pre.textContent=n+'\n'+c;d.appendChild(pre);}}};"
             "</script></body></html>"
         )

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -11,7 +11,7 @@ import time
 import heapq
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, Iterable
+from typing import Callable, Dict, Iterable, Mapping
 
 from singular.memory import add_episode, update_score
 from singular.psyche import Psyche, Mood
@@ -65,6 +65,13 @@ class WorldState:
 
     organisms: Dict[str, Organism] = field(default_factory=dict)
     resource_pool: float = 100.0
+
+
+OrganismInputs = Mapping[str, Path] | Iterable[Path] | Path
+
+INTERACTION_RESOURCE_COMPETITION = "resource_competition"
+INTERACTION_CROSSOVER = "crossover"
+INTERACTION_EXTINCTION = "extinction"
 
 
 def load_checkpoint(path: Path) -> Checkpoint:
@@ -223,8 +230,19 @@ def _choose_skill(
     return org_name, rng.choice(available)
 
 
+def _normalize_organism_inputs(skills_dirs: OrganismInputs) -> Dict[str, Path]:
+    """Normalize organism inputs into a ``name -> skills_dir`` mapping."""
+
+    if isinstance(skills_dirs, Path):
+        return {skills_dirs.name: skills_dirs}
+    if isinstance(skills_dirs, Mapping):
+        return {str(name): Path(path) for name, path in skills_dirs.items()}
+    paths = [Path(path) for path in skills_dirs]
+    return {path.name: path for path in paths}
+
+
 def run(
-    skills_dirs: Iterable[Path] | Path,
+    skills_dirs: OrganismInputs,
     checkpoint_path: Path,
     budget_seconds: float,
     rng: random.Random | None = None,
@@ -241,9 +259,10 @@ def run(
     Parameters
     ----------
     skills_dirs:
-        A collection of directories, each representing an organism and
-        containing its skill files. A single :class:`~pathlib.Path` is accepted
-        for backward compatibility.
+        Organism inputs accepted as:
+        - ``Path``: single organism.
+        - ``Iterable[Path]``: multiple organisms (name inferred from folder).
+        - ``Mapping[str, Path]``: explicit ``organism_name -> skills_dir`` contract.
     map_elites:
         Optional :class:`MapElites` instance. When provided, mutations are
         inserted into the MAP-Elites grid and only persisted if they improve
@@ -253,17 +272,14 @@ def run(
     rng = rng or random.Random()
     state = load_checkpoint(checkpoint_path)
 
-    if isinstance(skills_dirs, Path):
-        skills_dirs = [skills_dirs]
-    else:
-        skills_dirs = list(skills_dirs)
+    organisms_input = _normalize_organism_inputs(skills_dirs)
 
     world = world or WorldState()
-    for skills_dir in skills_dirs:
+    for org_name, skills_dir in organisms_input.items():
         skills_dir.mkdir(parents=True, exist_ok=True)
-        if skills_dir.name not in world.organisms:
+        if org_name not in world.organisms:
             prototype = mortality or DeathMonitor()
-            world.organisms[skills_dir.name] = Organism(skills_dir, monitor=prototype)
+            world.organisms[org_name] = Organism(skills_dir, monitor=prototype)
 
     operators = operators or _load_default_operators()
     stats: Dict[str, Dict[str, float]] = state.stats
@@ -440,6 +456,16 @@ def run(
                 other.energy -= 0.05
                 other.resources -= 0.02
 
+            logger.log_interaction(
+                INTERACTION_RESOURCE_COMPETITION,
+                organism=org_name,
+                resource_pool=world.resource_pool,
+                energy=org.energy,
+                resources=org.resources,
+                score=org.last_score,
+                alive=True,
+            )
+
             key = (
                 f"{org_name}:{skill_path.stem}"
                 if len(world.organisms) > 1
@@ -470,6 +496,12 @@ def run(
             )
             if dead:
                 logger.log_death(reason or "unknown", age=state.iteration)
+                logger.log_interaction(
+                    INTERACTION_EXTINCTION,
+                    organism=org_name,
+                    reason=reason or "unknown",
+                    alive=False,
+                )
                 del world.organisms[org_name]
                 if not world.organisms:
                     break
@@ -482,6 +514,12 @@ def run(
                 if o.energy <= 0 or o.resources <= 0
             ]
             for name in to_remove:
+                logger.log_interaction(
+                    INTERACTION_EXTINCTION,
+                    organism=name,
+                    reason="depleted_stores",
+                    alive=False,
+                )
                 del world.organisms[name]
 
             # Periodic crossover
@@ -494,6 +532,13 @@ def run(
                 fname, code = crossover(pa, pb, rng)
                 (child_dir / fname).write_text(code, encoding="utf-8")
                 world.organisms[child_dir.name] = Organism(child_dir)
+                logger.log_interaction(
+                    INTERACTION_CROSSOVER,
+                    parents=parent_names,
+                    child=child_dir.name,
+                    child_skills_dir=str(child_dir),
+                    alive=True,
+                )
 
     return state
 

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -215,6 +215,20 @@ class RunLogger:
         os.fsync(self._file.fileno())
         add_episode(record)
 
+    def log_interaction(self, event: str, **info: Any) -> None:
+        """Record an explicit ecosystem interaction event."""
+
+        record: dict[str, Any] = {
+            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "event": "interaction",
+            "interaction": event,
+            **info,
+        }
+        self._file.write(json.dumps(record) + "\n")
+        self._file.flush()
+        os.fsync(self._file.fileno())
+        add_episode(record)
+
     def close(self) -> None:
         """Flush and finalize the log file atomically."""
         if not self._file.closed:

--- a/src/singular/runs/loop.py
+++ b/src/singular/runs/loop.py
@@ -4,19 +4,32 @@ from __future__ import annotations
 
 import random
 from pathlib import Path
+from typing import Iterable, Mapping
 
 from singular.life.loop import run
 
 
 def loop(
     *,
-    skills_dir: Path,
+    skills_dir: Path | None = None,
+    skills_dirs: Mapping[str, Path] | Iterable[Path] | None = None,
     checkpoint: Path,
     budget_seconds: float,
     run_id: str = "loop",
     seed: int | None = None,
 ) -> None:
-    """Wrapper around :func:`life.loop.run` used by the CLI."""
+    """Wrapper around :func:`life.loop.run` used by the CLI.
+
+    Accepts either:
+    - ``skills_dir`` for backward-compatible single-organism runs.
+    - ``skills_dirs`` for multi-organism runs (iterable or explicit mapping).
+    """
 
     rng = random.Random(seed) if seed is not None else None
-    run(skills_dir, checkpoint, budget_seconds, rng=rng, run_id=run_id)
+    if skills_dirs is None:
+        if skills_dir is None:
+            raise ValueError("skills_dir or skills_dirs must be provided")
+        payload: Mapping[str, Path] | Iterable[Path] | Path = skills_dir
+    else:
+        payload = skills_dirs
+    run(payload, checkpoint, budget_seconds, rng=rng, run_id=run_id)

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -61,3 +61,45 @@ def test_loop_ticks_legacy_message(capsys: pytest.CaptureFixture[str]) -> None:
     assert "--ticks" in stderr
     assert "singular loop --budget-seconds <secondes>" in stderr
     assert "1 tick ≈ 1 seconde" in stderr
+
+
+def test_ecosystem_run_accepts_multiple_lives(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "ecosystem"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+    alpha_slug = load_registry()["active"]
+    assert isinstance(alpha_slug, str)
+    main(["--root", str(root), "lives", "create", "--name", "Beta"])
+    beta_slug = load_registry()["active"]
+    assert isinstance(beta_slug, str)
+
+    called: dict[str, object] = {}
+
+    def fake_loop_run(**kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr("singular.runs.loop.loop", fake_loop_run)
+    main(
+        [
+            "--root",
+            str(root),
+            "ecosystem",
+            "run",
+            "--life",
+            alpha_slug,
+            "--life-group",
+            beta_slug,
+            "--budget-seconds",
+            "0.1",
+        ]
+    )
+
+    skills_dirs = called["skills_dirs"]
+    assert isinstance(skills_dirs, dict)
+    assert alpha_slug in skills_dirs
+    assert beta_slug in skills_dirs
+    assert Path(skills_dirs[alpha_slug]).name == "skills"

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -6,6 +6,8 @@ import random
 
 import singular.life.loop as life_loop
 from singular.life.loop import WorldState
+from singular.dashboard import create_app
+from fastapi_stub import TestClient
 
 
 def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
@@ -69,3 +71,43 @@ def test_multi_organisms_independent(tmp_path: Path, monkeypatch):
 
     assert world.organisms["org1"].last_score == val1
     assert world.organisms["org2"].last_score == val2
+
+
+def test_multi_organism_events_and_dashboard(tmp_path: Path, monkeypatch) -> None:
+    org1 = tmp_path / "org1"
+    org2 = tmp_path / "org2"
+    org1.mkdir()
+    org2.mkdir()
+    (org1 / "foo.py").write_text("result = 1", encoding="utf-8")
+    (org2 / "foo.py").write_text("result = 1", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+    runs_dir = tmp_path / "runs"
+
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", lambda *a, **k: RL(*a, root=runs_dir, **k)
+    )
+    world = WorldState(resource_pool=0.0)
+    life_loop.run(
+        {"org1": org1, "org2": org2},
+        checkpoint,
+        budget_seconds=0.2,
+        rng=random.Random(2),
+        operators={"dec": _dec_operator},
+        world=world,
+    )
+
+    log_file = next(runs_dir.glob("loop-*.jsonl"))
+    rows = [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+    interactions = [row for row in rows if row.get("event") == "interaction"]
+    assert any(
+        row.get("interaction") == life_loop.INTERACTION_RESOURCE_COMPETITION
+        for row in interactions
+    )
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "missing_psyche.json")
+    client = TestClient(app)
+    ecosystem = client.get("/ecosystem").json()
+    assert "org1" in ecosystem["organisms"]
+    assert ecosystem["summary"]["total_organisms"] >= 1


### PR DESCRIPTION
### Motivation
- Permettre l'exécution d'un loop partagé sur plusieurs vies (organismes) depuis la CLI en acceptant des sélections répétées ou groupées de vies. 
- Formaliser le contrat d'entrée pour la boucle de vie afin de supporter un ensemble multi-organismes `name -> skills_dir` et faciliter les interactions entre organismes. 
- Exposer des métriques et événements d'interaction (compétition de ressources, crossover, extinction) pour permettre un affichage par organisme dans le dashboard et une traçabilité persistante.

### Description
- Ajout d'une commande CLI `ecosystem run` dans `src/singular/cli.py` acceptant `--life` (répétable) et `--life-group` (CSV) et résolvant chaque vie vers son dossier `skills`. 
- Formalisation de l'API d'entrée de la boucle dans `src/singular/life/loop.py` en acceptant `Path | Iterable[Path] | Mapping[str, Path]` avec normalisation en mapping `organism_name -> skills_dir`, et émission explicite d'événements nommés pour `resource_competition`, `crossover` et `extinction`. 
- Ajout de `RunLogger.log_interaction(...)` dans `src/singular/runs/logger.py` et émission de ces interactions depuis la boucle pour persistance JSONL et historique mémoire. 
- Mise à jour du wrapper CLI `src/singular/runs/loop.py` pour supporter à la fois le mode legacy single-organism (`skills_dir`) et le nouveau `skills_dirs` multi-organismes, et enrichissement du dashboard `src/singular/dashboard/__init__.py` avec un endpoint `/ecosystem` et sections UI pour le résumé global et l'état par organisme. 
- Ajout de tests d’intégration: `tests/test_multi_organisms.py` (événements multi-organismes + endpoint `/ecosystem`) et `tests/test_cli_lives.py` (flux CLI `ecosystem run` et payload `skills_dirs`).

### Testing
- Exécuté `pytest -q tests/test_multi_organisms.py tests/test_cli_lives.py` and both test modules passed (`5 passed` for the multi-organisms suite in the run). 
- Exécuté `pytest -q tests/test_dashboard.py -k endpoints` and the dashboard endpoint tests passed. 
- All modified tests included in the PR passed in the environment where changes were validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd75361b8832abff982dec2d3575f)