### PR TITLE
Unify LLM provider contract with typed errors, bounded retries, and talk fallback logging

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -4,20 +4,25 @@ from __future__ import annotations
 
 import os
 import random
-from typing import Callable
+import time
 
 from ..memory import add_episode, ensure_memory_structure, read_episodes
 from ..perception import capture_signals
-from ..psyche import Psyche, Mood
-from ..providers import load_llm_provider
+from ..psyche import Mood, Psyche
+from ..providers import (
+    LLMProviderError,
+    ProviderMisconfiguredError,
+    ProviderQuotaExceededError,
+    ProviderRetryExhaustedError,
+    ProviderTimeoutError,
+    ProviderUnavailableError,
+    load_llm_client,
+)
+from ..runs.logger import log_provider_event
 
 
 def _default_reply(prompt: str, rng: random.Random) -> str:
-    """Fallback reply generation when no provider is available.
-
-    The ``seed`` passed to :func:`talk` is used to seed ``rng`` so that stub
-    responses become deterministic when desired.
-    """
+    """Fallback reply generation when no provider is available."""
 
     options = [
         "I heard you say",
@@ -27,23 +32,32 @@ def _default_reply(prompt: str, rng: random.Random) -> str:
     return f"{rng.choice(options)}: {prompt}"
 
 
+def _user_message_for_error(provider: str, err: LLMProviderError) -> str:
+    if isinstance(err, ProviderMisconfiguredError):
+        return (
+            f"Provider '{provider}' is misconfigured (missing or invalid credentials). "
+            "Using local fallback replies."
+        )
+    if isinstance(err, ProviderQuotaExceededError):
+        return (
+            f"Provider '{provider}' quota is exceeded (or rate-limited). "
+            "Using local fallback replies."
+        )
+    if isinstance(err, ProviderTimeoutError):
+        return f"Provider '{provider}' timed out. Using local fallback replies."
+    if isinstance(err, ProviderUnavailableError):
+        return f"Provider '{provider}' is unavailable. Using local fallback replies."
+    if isinstance(err, ProviderRetryExhaustedError):
+        return f"Provider '{provider}' retries exhausted. Using local fallback replies."
+    return f"Provider '{provider}' failed unexpectedly. Using local fallback replies."
+
+
 def talk(
     provider: str | None = None,
     seed: int | None = None,
     prompt: str | None = None,
 ) -> None:
-    """Handle the ``talk`` subcommand.
-
-    Parameters
-    ----------
-    provider:
-        Optional name of the LLM provider. Overrides environment variables.
-    seed:
-        Optional random seed for reproducibility. It affects stub replies when
-        no provider is available.
-    prompt:
-        Optional user prompt. If provided, generate a single response and exit.
-    """
+    """Handle the ``talk`` subcommand."""
 
     ensure_memory_structure()
 
@@ -54,23 +68,12 @@ def talk(
         provider_name = "openai" if os.getenv("OPENAI_API_KEY") else "stub"
     print(f"Provider: {provider_name}")
 
-    if provider_name == "openai":
-        api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
-        if not api_key:
-            print(
-                "OPENAI_API_KEY is required when provider is 'openai'. "
-                "Falling back to local default replies if unavailable."
-            )
-
-    generate_reply: Callable[[str], str] | None = load_llm_provider(provider_name)
-    if generate_reply is None:
+    client = load_llm_client(provider_name)
+    if client is None:
         print(
-            f"Warning: provider '{provider_name}' not found; "
-            "falling back to _default_reply."
+            f"Provider '{provider_name}' not found. "
+            "Using local fallback replies."
         )
-
-        def generate_reply(prompt: str) -> str:
-            return _default_reply(prompt, rng)
 
     psyche = Psyche.load_state()
 
@@ -140,7 +143,29 @@ def talk(
         add_episode({"role": "user", "text": user_input})
         mood = psyche.feel(Mood.NEUTRAL)
         mood_report = mood_event or mood.value
-        reply = generate_reply(user_input)
+
+        start = time.perf_counter()
+        fallback_used = client is None
+        error_category: str | None = "provider_missing" if client is None else None
+
+        if client is None:
+            reply = _default_reply(user_input, rng)
+        else:
+            try:
+                reply = client.generate_reply(user_input)
+            except LLMProviderError as err:
+                fallback_used = True
+                error_category = getattr(err, "category", "provider_error")
+                print(_user_message_for_error(provider_name, err))
+                reply = _default_reply(user_input, rng)
+
+        latency_ms = (time.perf_counter() - start) * 1000
+        log_provider_event(
+            provider=provider_name,
+            latency_ms=latency_ms,
+            fallback=fallback_used,
+            error_category=error_category,
+        )
 
         parts = [reply]
         should_add_reminder = bool(last_event) and (

--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -1,30 +1,144 @@
-"""Utilities for loading LLM providers."""
+"""Utilities and shared contracts for LLM providers."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from importlib import import_module
 from importlib.metadata import entry_points
-from typing import Callable
+import inspect
+from typing import Callable, Protocol
+
+DEFAULT_PROVIDER_TIMEOUT_SECONDS = 8.0
+DEFAULT_PROVIDER_MAX_RETRIES = 2
 
 
-def load_llm_provider(name: str | None) -> Callable[[str], str] | None:
-    """Load an LLM provider's ``generate_reply`` function.
+class LLMProviderError(RuntimeError):
+    """Base class for provider-facing errors."""
 
-    Parameters
-    ----------
-    name:
-        Provider name suffix, looked up as ``llm_<name>`` in this package.
-    """
+    category = "provider_error"
+
+
+class ProviderUnavailableError(LLMProviderError):
+    """The provider cannot currently be reached or initialized."""
+
+    category = "unavailable"
+
+
+class ProviderMisconfiguredError(LLMProviderError):
+    """The provider is configured incorrectly."""
+
+    category = "misconfigured"
+
+
+class ProviderQuotaExceededError(LLMProviderError):
+    """The provider rejected the request due to quota/rate limits."""
+
+    category = "quota_exceeded"
+
+
+class ProviderTimeoutError(LLMProviderError):
+    """The provider timed out while serving a request."""
+
+    category = "timeout"
+
+
+class ProviderExecutionError(LLMProviderError):
+    """The provider failed for an unknown runtime reason."""
+
+    category = "execution_error"
+
+
+class ProviderRetryExhaustedError(LLMProviderError):
+    """Retry budget has been exhausted for transient provider failures."""
+
+    category = "retry_exhausted"
+
+
+class ReplyGenerator(Protocol):
+    """Runtime protocol for provider generation functions."""
+
+    def __call__(self, prompt: str, *, timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS) -> str:  # pragma: no cover - typing only
+        ...
+
+
+@dataclass
+class LLMProviderClient:
+    """Common client wrapper exposing timeout and bounded retries."""
+
+    name: str
+    generate: Callable[..., str]
+    max_retries: int = DEFAULT_PROVIDER_MAX_RETRIES
+
+    def generate_reply(
+        self,
+        prompt: str,
+        *,
+        timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS,
+    ) -> str:
+        attempts = self.max_retries + 1
+        last_error: LLMProviderError | None = None
+
+        for attempt in range(1, attempts + 1):
+            try:
+                return _invoke_provider(self.generate, prompt=prompt, timeout=timeout)
+            except ProviderTimeoutError as exc:
+                last_error = exc
+            except ProviderExecutionError as exc:
+                last_error = exc
+            except LLMProviderError:
+                raise
+
+            if attempt == attempts:
+                break
+
+        raise ProviderRetryExhaustedError(
+            f"Provider '{self.name}' failed after {attempts} attempts"
+        ) from last_error
+
+
+def _invoke_provider(fn: Callable[..., str], *, prompt: str, timeout: float) -> str:
+    """Invoke provider callables while supporting legacy signatures."""
+
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        signature = None
+
+    if signature is not None and "timeout" in signature.parameters:
+        return fn(prompt, timeout=timeout)
+    return fn(prompt)
+
+
+def load_llm_client(name: str | None) -> LLMProviderClient | None:
+    """Load an LLM provider and expose it through :class:`LLMProviderClient`."""
+
     if not name:
         return None
     module_name = f"singular.providers.llm_{name}"
     try:
         module = import_module(module_name)
-        return getattr(module, "generate_reply", None)
+        generate = getattr(module, "generate_reply", None)
+        if callable(generate):
+            retries = getattr(module, "MAX_RETRIES", DEFAULT_PROVIDER_MAX_RETRIES)
+            return LLMProviderClient(name=name, generate=generate, max_retries=retries)
     except ModuleNotFoundError:
         pass
+
     for ep in entry_points(group="singular.llm"):
-        if ep.name == name:
-            obj = ep.load()
-            return getattr(obj, "generate_reply", obj)
+        if ep.name != name:
+            continue
+        obj = ep.load()
+        generate = getattr(obj, "generate_reply", obj)
+        if callable(generate):
+            retries = getattr(obj, "MAX_RETRIES", DEFAULT_PROVIDER_MAX_RETRIES)
+            return LLMProviderClient(name=name, generate=generate, max_retries=retries)
     return None
+
+
+def load_llm_provider(name: str | None) -> Callable[[str], str] | None:
+    """Backward-compatible loader returning a plain ``generate_reply`` callable."""
+
+    client = load_llm_client(name)
+    if client is None:
+        return None
+    return lambda prompt: client.generate_reply(prompt)

--- a/src/singular/providers/llm_local.py
+++ b/src/singular/providers/llm_local.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from typing import Any
+
+from . import ProviderExecutionError, ProviderTimeoutError, ProviderUnavailableError
+
+MAX_RETRIES = 1
 
 try:  # pragma: no cover - optional dependency
     from transformers import pipeline  # type: ignore
@@ -12,34 +17,46 @@ except Exception:  # pragma: no cover - handle missing package
 _pipe: Any | None = None
 
 
-def _get_pipe() -> Any | None:
-    """Return a cached text generation pipeline or ``None`` if unavailable."""
+def _get_pipe() -> Any:
+    """Return a cached text generation pipeline or raise an availability error."""
+
     global _pipe
     if pipeline is None:
-        return None
+        raise ProviderUnavailableError("transformers is not installed")
     if _pipe is None:
         try:  # pragma: no cover - model download
             _pipe = pipeline("text-generation", model="sshleifer/tiny-gpt2")
-        except Exception:
-            _pipe = None
+        except Exception as exc:
+            raise ProviderUnavailableError("Local model is unavailable") from exc
     return _pipe
 
 
 def _filter(text: str) -> str:
     """Return only printable characters from ``text``."""
+
     return "".join(ch for ch in text if ch.isprintable())
 
 
-def generate_reply(prompt: str) -> str:
+def _infer(pipe: Any, prompt: str) -> str:
+    outputs = pipe(prompt, max_new_tokens=50, num_return_sequences=1)
+    text: str = outputs[0]["generated_text"]
+    return text
+
+
+def generate_reply(prompt: str, *, timeout: float = 8.0) -> str:
     """Generate a reply using a small local transformers model."""
+
     pipe = _get_pipe()
-    if pipe is None:
-        return "Local model not available."
-    try:  # pragma: no cover - model inference
-        outputs = pipe(prompt, max_new_tokens=50, num_return_sequences=1)
-        text: str = outputs[0]["generated_text"]
-    except Exception:
-        return "Error running local model."
-    # ``text`` includes the original prompt at the beginning
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(_infer, pipe, prompt)
+            text = future.result(timeout=timeout)
+    except FutureTimeoutError as exc:
+        raise ProviderTimeoutError("Local model inference timed out") from exc
+    except ProviderTimeoutError:
+        raise
+    except Exception as exc:
+        raise ProviderExecutionError("Error running local model") from exc
+
     reply = text[len(prompt) :].strip()
     return _filter(reply)

--- a/src/singular/providers/llm_openai.py
+++ b/src/singular/providers/llm_openai.py
@@ -1,19 +1,34 @@
-"""OpenAI LLM provider using the Chat Completions API.
-
-This module targets the ``openai`` package version 1.x which exposes the
-``OpenAI`` client.  Older versions using ``openai.ChatCompletion`` are not
-supported.
-"""
+"""OpenAI LLM provider using the Chat Completions API."""
 
 from __future__ import annotations
 
 import os
 from typing import Any
 
+from . import (
+    ProviderExecutionError,
+    ProviderMisconfiguredError,
+    ProviderQuotaExceededError,
+    ProviderTimeoutError,
+    ProviderUnavailableError,
+)
+
+MAX_RETRIES = 2
+
 try:  # pragma: no cover - optional dependency
-    from openai import OpenAI  # type: ignore
+    from openai import (  # type: ignore
+        APIConnectionError,
+        APITimeoutError,
+        AuthenticationError,
+        OpenAI,
+        RateLimitError,
+    )
 except Exception:  # pragma: no cover - handle missing package
-    OpenAI = None  # type: ignore
+    APIConnectionError = ()  # type: ignore[assignment]
+    APITimeoutError = ()  # type: ignore[assignment]
+    AuthenticationError = ()  # type: ignore[assignment]
+    RateLimitError = ()  # type: ignore[assignment]
+    OpenAI = None  # type: ignore[assignment]
 
 
 def _filter(text: str) -> str:
@@ -21,11 +36,14 @@ def _filter(text: str) -> str:
     return "".join(ch for ch in text if ch.isprintable())
 
 
-def generate_reply(prompt: str) -> str:
-    """Generate a reply via OpenAI if an API key is configured."""
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key or OpenAI is None:
-        return "OpenAI API key not configured."
+def generate_reply(prompt: str, *, timeout: float = 8.0) -> str:
+    """Generate a reply via OpenAI using typed errors for failures."""
+
+    api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+    if not api_key:
+        raise ProviderMisconfiguredError("OPENAI_API_KEY not configured")
+    if OpenAI is None:
+        raise ProviderUnavailableError("openai dependency is not installed")
 
     try:  # pragma: no cover - network call
         client = OpenAI(api_key=api_key)
@@ -33,9 +51,20 @@ def generate_reply(prompt: str) -> str:
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
             max_tokens=100,
+            timeout=timeout,
         )
         text: str = response.choices[0].message.content
-    except Exception:
-        return "Error communicating with OpenAI."
+    except APITimeoutError as exc:
+        raise ProviderTimeoutError("OpenAI request timed out") from exc
+    except TimeoutError as exc:
+        raise ProviderTimeoutError("OpenAI request timed out") from exc
+    except RateLimitError as exc:
+        raise ProviderQuotaExceededError("OpenAI quota exceeded or rate limited") from exc
+    except AuthenticationError as exc:
+        raise ProviderMisconfiguredError("OpenAI credentials are invalid") from exc
+    except APIConnectionError as exc:
+        raise ProviderUnavailableError("Unable to connect to OpenAI") from exc
+    except Exception as exc:
+        raise ProviderExecutionError("Unexpected OpenAI provider failure") from exc
 
     return _filter(text)

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 import json
+import logging
 import os
 from typing import Any
 
@@ -50,6 +51,27 @@ mood_styles: Dict[str | None, Callable[[str], str]] = {
     "neutre": _style_neutre,
     None: _style_neutre,
 }
+
+_provider_logger = logging.getLogger("singular.provider")
+
+
+def log_provider_event(
+    *,
+    provider: str,
+    latency_ms: float,
+    fallback: bool,
+    error_category: str | None,
+) -> None:
+    """Emit a structured provider log entry."""
+
+    payload = {
+        "event": "provider_call",
+        "provider": provider,
+        "latency_ms": round(latency_ms, 2),
+        "fallback": fallback,
+        "error_category": error_category,
+    }
+    _provider_logger.info("provider_call", extra={"payload": payload})
 
 
 def _ensure_dir(path: Path) -> None:

--- a/tests/providers/test_llm_local.py
+++ b/tests/providers/test_llm_local.py
@@ -1,7 +1,53 @@
-from singular.providers import llm_local, load_llm_provider
+import pytest
+
+from singular.providers import (
+    ProviderRetryExhaustedError,
+    ProviderTimeoutError,
+    load_llm_client,
+    load_llm_provider,
+)
+from singular.providers import llm_local
 
 
 def test_load_llm_provider_local():
     """Ensure the 'local' provider can be loaded."""
+
     func = load_llm_provider("local")
-    assert func is llm_local.generate_reply
+    assert callable(func)
+
+
+def test_load_llm_client_local():
+    client = load_llm_client("local")
+    assert client is not None
+    assert client.name == "local"
+
+
+def test_local_provider_timeout(monkeypatch):
+    monkeypatch.setattr(llm_local, "_get_pipe", lambda: object())
+
+    def fake_infer(_pipe, _prompt):
+        raise ProviderTimeoutError("timed out")
+
+    monkeypatch.setattr(llm_local, "_infer", fake_infer)
+
+    with pytest.raises(ProviderTimeoutError):
+        llm_local.generate_reply("hello")
+
+
+def test_local_retry_bounded(monkeypatch):
+    attempts = {"count": 0}
+
+    def timeout_then_count(prompt: str, *, timeout: float = 8.0) -> str:
+        del prompt, timeout
+        attempts["count"] += 1
+        raise ProviderTimeoutError("slow")
+
+    client = load_llm_client("local")
+    assert client is not None
+    monkeypatch.setattr(client, "generate", timeout_then_count)
+    client.max_retries = 1
+
+    with pytest.raises(ProviderRetryExhaustedError):
+        client.generate_reply("yo", timeout=0.1)
+
+    assert attempts["count"] == 2

--- a/tests/providers/test_llm_openai.py
+++ b/tests/providers/test_llm_openai.py
@@ -2,24 +2,35 @@ from types import SimpleNamespace
 
 import pytest
 
+from singular.providers import (
+    LLMProviderClient,
+    ProviderMisconfiguredError,
+    ProviderQuotaExceededError,
+    ProviderRetryExhaustedError,
+    ProviderTimeoutError,
+)
 from singular.providers import llm_openai
 
 
 def test_generate_reply_without_key(monkeypatch):
-    """If no API key is set the provider should return an explicit message."""
+    """No API key should raise an explicit misconfiguration error."""
+
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    assert llm_openai.generate_reply("hi") == "OpenAI API key not configured."
+    with pytest.raises(ProviderMisconfiguredError):
+        llm_openai.generate_reply("hi")
 
 
 def test_generate_reply_success(monkeypatch):
     """Mock the OpenAI client to test successful replies and filtering."""
+
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
     class FakeCompletions:
-        def create(self, *, model, messages, max_tokens):
+        def create(self, *, model, messages, max_tokens, timeout):
             assert model == "gpt-3.5-turbo"
             assert messages == [{"role": "user", "content": "hi"}]
             assert max_tokens == 100
+            assert timeout == 3.0
             return SimpleNamespace(
                 choices=[SimpleNamespace(message=SimpleNamespace(content="hello\x00"))]
             )
@@ -30,11 +41,48 @@ def test_generate_reply_success(monkeypatch):
             self.chat = SimpleNamespace(completions=FakeCompletions())
 
     monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
-    assert llm_openai.generate_reply("hi") == "hello"
+    assert llm_openai.generate_reply("hi", timeout=3.0) == "hello"
+
+
+def test_openai_quota_maps_to_typed_error(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    class FakeRateLimitError(Exception):
+        pass
+
+    class FakeCompletions:
+        def create(self, **_kwargs):
+            raise FakeRateLimitError("quota")
+
+    class FakeClient:
+        def __init__(self, api_key):
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
+    monkeypatch.setattr(llm_openai, "RateLimitError", FakeRateLimitError)
+
+    with pytest.raises(ProviderQuotaExceededError):
+        llm_openai.generate_reply("hi")
+
+
+def test_retry_strategy_is_bounded():
+    attempts = {"count": 0}
+
+    def always_timeout(_prompt: str, *, timeout: float = 8.0) -> str:
+        attempts["count"] += 1
+        raise ProviderTimeoutError(f"timeout={timeout}")
+
+    client = LLMProviderClient(name="openai", generate=always_timeout, max_retries=2)
+
+    with pytest.raises(ProviderRetryExhaustedError):
+        client.generate_reply("hello", timeout=1.0)
+
+    assert attempts["count"] == 3
 
 
 def test_openai_version():
     """If ``openai`` is installed ensure it is the modern client (>=1.0)."""
+
     try:
         import openai
     except Exception:  # pragma: no cover - optional dependency missing

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -1,8 +1,13 @@
 import random
 
 from singular.cli import main
-from singular.organisms.talk import talk, _default_reply
 from singular.memory import read_episodes
+from singular.organisms.talk import _default_reply, talk
+from singular.providers import (
+    LLMProviderClient,
+    ProviderQuotaExceededError,
+    ProviderTimeoutError,
+)
 
 
 def test_talk_loop(monkeypatch, tmp_path):
@@ -10,7 +15,7 @@ def test_talk_loop(monkeypatch, tmp_path):
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
     inputs = iter(["hello", "next", "quit"])
     monkeypatch.setenv("LLM_PROVIDER", "idontexist")
-    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
     monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
     outputs = []
     monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
@@ -24,7 +29,7 @@ def test_talk_loop(monkeypatch, tmp_path):
     assert episodes[1]["raw_reply"]
     assert "Mood: neutral" in episodes[1]["text"]
     assert outputs[0] == "Provider: idontexist"
-    assert any("provider 'idontexist' not found" in out for out in outputs)
+    assert any("not found" in out for out in outputs)
     assert any("Reminder:" in out for out in outputs)
 
 
@@ -38,9 +43,9 @@ def test_cli_provider_precedence(monkeypatch, tmp_path):
 
     def fake_load(name: str | None):
         captured["provider"] = name or ""
-        return lambda _: "ok"
+        return LLMProviderClient(name="cli", generate=lambda _prompt, timeout=8.0: "ok")
 
-    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", fake_load)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", fake_load)
     inputs = iter(["quit"])
     monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
     monkeypatch.setattr("builtins.print", lambda _msg: None)
@@ -54,7 +59,7 @@ def test_cli_provider_precedence(monkeypatch, tmp_path):
 def test_talk_handles_keyboard_interrupt(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
-    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
 
     def raise_interrupt(_=""):
         raise KeyboardInterrupt
@@ -74,7 +79,7 @@ def test_talk_single_prompt(monkeypatch, tmp_path):
     root = tmp_path / "world"
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
     monkeypatch.delenv("SINGULAR_ROOT", raising=False)
-    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
     outputs: list[str] = []
     monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
 
@@ -97,7 +102,7 @@ def _run_talk(monkeypatch, tmp_path, seed, run):
     monkeypatch.chdir(subdir)
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
     inputs = iter(["hello", "quit"])
-    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
     monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
     outputs = []
     monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
@@ -125,7 +130,7 @@ def test_talk_does_not_accumulate_reminder_or_mood(monkeypatch, tmp_path):
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
     inputs = iter(["hello", "next", "again", "quit"])
     monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
-    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
     outputs: list[str] = []
     monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
 
@@ -138,18 +143,68 @@ def test_talk_does_not_accumulate_reminder_or_mood(monkeypatch, tmp_path):
         assert reply.count("Mood:") == 1
 
 
-def test_talk_openai_without_api_key_warns(monkeypatch, tmp_path):
+def test_talk_provider_timeout_message_and_fallback(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setattr("singular.organisms.talk.load_llm_provider", lambda _name: None)
-    inputs = iter(["quit"])
+    inputs = iter(["hello", "quit"])
+
+    def raise_timeout(_prompt: str, *, timeout: float = 8.0) -> str:
+        del timeout
+        raise ProviderTimeoutError("slow")
+
+    client = LLMProviderClient(name="openai", generate=raise_timeout)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: client)
     monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
     outputs: list[str] = []
     monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
 
-    talk(provider="openai")
+    talk(provider="openai", seed=10)
 
     assert outputs[0] == "Provider: openai"
-    assert any("OPENAI_API_KEY is required" in out for out in outputs)
-    assert any("falling back to _default_reply" in out for out in outputs)
+    assert any("retries exhausted" in out for out in outputs)
+    assert any("Using local fallback replies" in out for out in outputs)
+
+
+def test_talk_provider_quota_message(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    inputs = iter(["hello", "quit"])
+
+    def raise_quota(_prompt: str, *, timeout: float = 8.0) -> str:
+        del timeout
+        raise ProviderQuotaExceededError("quota")
+
+    client = LLMProviderClient(name="openai", generate=raise_quota)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: client)
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    outputs: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
+
+    talk(provider="openai", seed=11)
+
+    assert any("quota is exceeded" in out for out in outputs)
+
+
+def test_talk_logs_provider_events(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    inputs = iter(["hello", "quit"])
+    events = []
+
+    client = LLMProviderClient(
+        name="openai", generate=lambda _prompt, timeout=8.0: "hello"
+    )
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: client)
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    monkeypatch.setattr("builtins.print", lambda _msg: None)
+    monkeypatch.setattr(
+        "singular.organisms.talk.log_provider_event",
+        lambda **kwargs: events.append(kwargs),
+    )
+
+    talk(provider="openai")
+
+    assert events
+    assert events[0]["provider"] == "openai"
+    assert events[0]["fallback"] is False
+    assert events[0]["error_category"] is None


### PR DESCRIPTION
### Motivation
- Provide a single, well-typed contract for LLM providers to standardize error handling, timeouts and retry behavior. 
- Make `talk` behavior deterministic and unambiguous when providers fail, and record provider telemetry for observability.

### Description
- Introduced a shared provider module with typed exceptions, default timeout and `LLMProviderClient` that applies a bounded retry policy, plus `load_llm_client()` and backward-compatible `load_llm_provider()` (`src/singular/providers/__init__.py`).
- Updated `llm_openai.py` to propagate timeouts and map client exceptions to typed errors (`ProviderMisconfiguredError`, `ProviderTimeoutError`, `ProviderQuotaExceededError`, `ProviderUnavailableError`, `ProviderExecutionError`) and added `MAX_RETRIES` (`src/singular/providers/llm_openai.py`).
- Updated `llm_local.py` to enforce inference timeout using a thread executor, raise typed errors on unavailability/timeouts, and expose `MAX_RETRIES` (`src/singular/providers/llm_local.py`).
- Refactored `talk` to use `LLMProviderClient`, distinguish provider error categories, show clear user-facing fallback messages, and call a new structured provider logger with provider, latency, fallback flag and error category (`src/singular/organisms/talk.py`, `src/singular/runs/logger.py`).
- Added and adapted tests to cover timeout/retry/fallback and logging scenarios (`tests/providers/test_llm_openai.py`, `tests/providers/test_llm_local.py`, `tests/test_talk.py`).

### Testing
- Ran the provider and talk unit tests with `pytest -q tests/providers/test_llm_openai.py tests/providers/test_llm_local.py tests/test_talk.py tests/test_runs_logger.py` and all executed tests passed.
- Test summary: `20 passed, 1 skipped` (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbdd6b57f0832abae1d1db1439c232)