### PR TITLE
Add loop mutation diff metrics and ranked 'Modifications de boucle' report

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -200,6 +200,7 @@ def log_mutation(
     base_score: float,
     mutated_score: float,
     impacted_file: str,
+    loop_modifications: dict[str, int],
 ) -> None:
     """Record mutation outcome and notify observers."""
 
@@ -236,7 +237,76 @@ def log_mutation(
         impacted_file=impacted_file,
         decision_reason=decision_reason,
         human_summary=human_summary,
+        loop_modifications=loop_modifications,
     )
+
+
+def _ast_node_count(tree: ast.AST) -> int:
+    """Return the total number of nodes in ``tree``."""
+
+    return sum(1 for _ in ast.walk(tree))
+
+
+def _function_fingerprints(tree: ast.AST) -> dict[str, str]:
+    """Build stable fingerprints for functions in ``tree``."""
+
+    fingerprints: dict[str, str] = {}
+
+    def visit(node: ast.AST, parents: tuple[str, ...]) -> None:
+        if isinstance(node, ast.ClassDef):
+            next_parents = parents + (node.name,)
+        else:
+            next_parents = parents
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            key = ".".join((*parents, node.name))
+            fingerprints[key] = ast.dump(node, include_attributes=False)
+            next_parents = (*parents, node.name)
+        for child in ast.iter_child_nodes(node):
+            visit(child, next_parents)
+
+    visit(tree, ())
+    return fingerprints
+
+
+def _compute_loop_modifications(original: str, mutated: str) -> dict[str, int]:
+    """Compute mutation diff metrics for loop reporting."""
+
+    diff_lines = list(
+        difflib.unified_diff(
+            original.splitlines(),
+            mutated.splitlines(),
+            fromfile="original",
+            tofile="mutated",
+            lineterm="",
+        )
+    )
+    added = sum(
+        1 for line in diff_lines if line.startswith("+") and not line.startswith("+++")
+    )
+    removed = sum(
+        1 for line in diff_lines if line.startswith("-") and not line.startswith("---")
+    )
+
+    before_tree = ast.parse(original)
+    after_tree = ast.parse(mutated)
+    before_functions = _function_fingerprints(before_tree)
+    after_functions = _function_fingerprints(after_tree)
+
+    changed = {
+        name
+        for name in (before_functions.keys() & after_functions.keys())
+        if before_functions[name] != after_functions[name]
+    }
+    added_functions = after_functions.keys() - before_functions.keys()
+    removed_functions = before_functions.keys() - after_functions.keys()
+
+    return {
+        "lines_added": added,
+        "lines_removed": removed,
+        "functions_modified": len(changed | added_functions | removed_functions),
+        "ast_nodes_before": _ast_node_count(before_tree),
+        "ast_nodes_after": _ast_node_count(after_tree),
+    }
 
 
 def _choose_skill(
@@ -422,6 +492,7 @@ def run(
                     tofile="mutated",
                 )
             )
+            loop_modifications = _compute_loop_modifications(original, mutated)
 
             if diff not in seen_diffs:
                 if hasattr(psyche, "feel"):
@@ -536,6 +607,7 @@ def run(
                 base_score,
                 mutated_score,
                 skill_path.name,
+                loop_modifications,
             )
 
             if hasattr(psyche, "consume"):

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -179,6 +179,7 @@ class RunLogger:
         impacted_file: str | None = None,
         decision_reason: str | None = None,
         human_summary: str | None = None,
+        loop_modifications: dict[str, int] | None = None,
     ) -> None:
         """Append a mutation record to the log file."""
 
@@ -197,6 +198,7 @@ class RunLogger:
             "impacted_file": impacted_file,
             "decision_reason": decision_reason,
             "human_summary": human_summary,
+            "loop_modifications": loop_modifications or {},
         }
         self._write_record(record)
         self._write_event("mutation", record, ts)

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -27,7 +27,7 @@ def load_run_records(
                 event = json.loads(line)
                 payload = event.get("payload", {})
                 if isinstance(payload, dict):
-                    records.append(payload)
+                    records.append({**payload, "_event_type": event.get("event_type")})
         return records
 
     pattern = f"{run_id}-*.jsonl"
@@ -62,8 +62,15 @@ def report(
         print(f"No records for id {run_id}")
         return
 
-    scores = [r.get("score_new", 0.0) for r in records]
-    ops = [r.get("op", "?") for r in records]
+    mutations = [
+        r for r in records if r.get("_event_type") == "mutation" or "op" in r
+    ]
+    if not mutations:
+        print(f"No mutation records for id {run_id}")
+        return
+
+    scores = [r.get("score_new", 0.0) for r in mutations]
+    ops = [r.get("op", "?") for r in mutations]
 
     print(f"Run {run_id}")
     print(f"Generations: {len(scores)}")
@@ -75,6 +82,7 @@ def report(
     print("Operator histogram:")
     for op, count in counter.items():
         print(f"  {op}: {count}")
+    _print_loop_modifications(mutations)
 
     if skills_path is None:
         skills_path = get_skills_file()
@@ -94,3 +102,66 @@ def report(
             print(line)
     else:
         print("No skills recorded.")
+
+
+def _print_loop_modifications(mutations: list[dict[str, Any]]) -> None:
+    """Print ranked mutation-impact metrics for the loop."""
+
+    entries: list[dict[str, Any]] = []
+    for idx, mutation in enumerate(mutations, start=1):
+        metrics = mutation.get("loop_modifications")
+        if not isinstance(metrics, dict) or not metrics:
+            continue
+        lines_added = int(metrics.get("lines_added", 0))
+        lines_removed = int(metrics.get("lines_removed", 0))
+        functions_modified = int(metrics.get("functions_modified", 0))
+        ast_before = int(metrics.get("ast_nodes_before", 0))
+        ast_after = int(metrics.get("ast_nodes_after", 0))
+        entries.append(
+            {
+                "index": idx,
+                "op": mutation.get("op", "?"),
+                "lines_added": lines_added,
+                "lines_removed": lines_removed,
+                "functions_modified": functions_modified,
+                "ast_before": ast_before,
+                "ast_after": ast_after,
+                "line_change": lines_added + lines_removed,
+                "ast_delta": abs(ast_after - ast_before),
+                "profit": float(mutation.get("score_base", 0.0))
+                - float(mutation.get("score_new", 0.0)),
+            }
+        )
+
+    if not entries:
+        return
+
+    print("Modifications de boucle:")
+
+    biggest = sorted(
+        entries,
+        key=lambda e: (e["line_change"], e["ast_delta"], e["functions_modified"]),
+        reverse=True,
+    )
+    print("  Plus gros changement:")
+    for entry in biggest[:3]:
+        print(
+            f"    #{entry['index']} {entry['op']} "
+            f"(lignes +{entry['lines_added']}/-{entry['lines_removed']}, "
+            f"fonctions={entry['functions_modified']}, "
+            f"AST {entry['ast_before']}→{entry['ast_after']})"
+        )
+
+    frequency = Counter(entry["op"] for entry in entries)
+    print("  Plus fréquent:")
+    for op, count in sorted(frequency.items(), key=lambda item: (-item[1], item[0]))[:3]:
+        print(f"    {op}: {count}")
+
+    profitable = sorted(entries, key=lambda e: e["profit"], reverse=True)
+    print("  Plus rentable:")
+    for entry in profitable[:3]:
+        print(
+            f"    #{entry['index']} {entry['op']} "
+            f"(gain={entry['profit']:.4f}, "
+            f"lignes={entry['line_change']}, ASTΔ={entry['ast_delta']})"
+        )

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -17,9 +17,17 @@ def test_report_cli(monkeypatch, tmp_path, capsys):
             "ts": "2026-01-01T00:00:00",
             "payload": {
                 "op": "mutate",
+                "score_base": 2.0,
                 "score_new": 1.0,
                 "human_summary": "op=mutate; fichier=a.py; acceptée; impact: score 2→1; perf ok",
                 "decision_reason": "accepted: score improved",
+                "loop_modifications": {
+                    "lines_added": 3,
+                    "lines_removed": 1,
+                    "functions_modified": 1,
+                    "ast_nodes_before": 20,
+                    "ast_nodes_after": 24,
+                },
             },
         },
         {
@@ -28,9 +36,17 @@ def test_report_cli(monkeypatch, tmp_path, capsys):
             "ts": "2026-01-01T00:00:01",
             "payload": {
                 "op": "crossover",
+                "score_base": 1.0,
                 "score_new": 1.5,
                 "human_summary": "op=crossover; fichier=a.py; rejetée; impact: score 1→1.5; perf slower",
                 "decision_reason": "rejected: score regression",
+                "loop_modifications": {
+                    "lines_added": 1,
+                    "lines_removed": 2,
+                    "functions_modified": 1,
+                    "ast_nodes_before": 24,
+                    "ast_nodes_after": 22,
+                },
             },
         },
     ]
@@ -49,6 +65,7 @@ def test_report_cli(monkeypatch, tmp_path, capsys):
     assert "Generations: 2" in out
     assert "Best score: 1.0" in out
     assert "skillA" in out
+    assert "Modifications de boucle:" in out
 
 
 def test_report_records_include_explanatory_fields(monkeypatch, tmp_path, capsys):
@@ -68,6 +85,7 @@ def test_report_records_include_explanatory_fields(monkeypatch, tmp_path, capsys
                         "ts": "2026-01-01T00:00:00",
                         "payload": {
                             "op": "mutate",
+                            "score_base": 1.0,
                             "score_new": 0.9,
                             "human_summary": "op=mutate; fichier=foo.py; acceptée; impact: score 1.0 → 0.9; perf: plus rapide",
                             "decision_reason": "accepted: score improved",
@@ -89,3 +107,87 @@ def test_report_records_include_explanatory_fields(monkeypatch, tmp_path, capsys
     assert payload["human_summary"]
     assert "op=" in payload["human_summary"]
     assert payload["decision_reason"]
+
+
+def test_report_loop_modifications_ranking(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    run_dir = runs / "run3"
+    run_dir.mkdir()
+    log = run_dir / "events.jsonl"
+    records = [
+        {
+            "version": 1,
+            "event_type": "mutation",
+            "ts": "2026-01-01T00:00:00",
+            "payload": {
+                "op": "mutate",
+                "score_base": 1.0,
+                "score_new": 0.6,
+                "loop_modifications": {
+                    "lines_added": 2,
+                    "lines_removed": 1,
+                    "functions_modified": 1,
+                    "ast_nodes_before": 10,
+                    "ast_nodes_after": 12,
+                },
+            },
+        },
+        {
+            "version": 1,
+            "event_type": "mutation",
+            "ts": "2026-01-01T00:00:01",
+            "payload": {
+                "op": "mutate",
+                "score_base": 0.7,
+                "score_new": 0.2,
+                "loop_modifications": {
+                    "lines_added": 5,
+                    "lines_removed": 4,
+                    "functions_modified": 2,
+                    "ast_nodes_before": 12,
+                    "ast_nodes_after": 18,
+                },
+            },
+        },
+        {
+            "version": 1,
+            "event_type": "mutation",
+            "ts": "2026-01-01T00:00:02",
+            "payload": {
+                "op": "splice",
+                "score_base": 0.2,
+                "score_new": 0.15,
+                "loop_modifications": {
+                    "lines_added": 1,
+                    "lines_removed": 1,
+                    "functions_modified": 1,
+                    "ast_nodes_before": 18,
+                    "ast_nodes_after": 19,
+                },
+            },
+        },
+    ]
+    with log.open("w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+    mem = tmp_path / "mem"
+    mem.mkdir()
+    (mem / "skills.json").write_text(json.dumps({}), encoding="utf-8")
+
+    main(["report", "--id", "run3"])
+    out = capsys.readouterr().out
+    assert "Modifications de boucle:" in out
+    assert "Plus gros changement:" in out
+    assert "Plus fréquent:" in out
+    assert "Plus rentable:" in out
+
+    biggest_section = out.split("Plus gros changement:")[1].split("Plus fréquent:")[0]
+    assert "#2 mutate" in biggest_section.splitlines()[1]
+
+    frequent_section = out.split("Plus fréquent:")[1].split("Plus rentable:")[0]
+    assert "mutate: 2" in frequent_section.splitlines()[1]
+
+    profitable_section = out.split("Plus rentable:")[1]
+    assert "#2 mutate" in profitable_section.splitlines()[1]


### PR DESCRIPTION
### Motivation
- Mesurer l'impact des mutations dans la boucle de vie pour mieux prioriser et expliquer les changements (taille du diff, fonctions touchées, taille AST). 
- Propager ces métriques dans les événements de mutation afin qu'elles soient persistées et exploitables par les outils de reporting.
- Présenter un rapport trié par impact/fréquence/rentabilité pour faciliter l'analyse des mutations.

### Description
- Calcul des métriques de mutation dans `src/singular/life/loop.py` via `
_compute_loop_modifications`, avec helpers `
_function_fingerprints` et `
_ast_node_count`, et calcul des lignes +/-, fonctions modifiées et taille AST avant/après, et appel au moment où le diff est produit.
- Passage des métriques au logger en ajoutant l'argument `loop_modifications` à `log_mutation` et en le transmettant à `RunLogger.log`.
- Extension de `src/singular/runs/logger.py` pour accepter `loop_modifications` et l'embarquer dans le payload d'événement (clé `loop_modifications`).
- Enrichissement de `src/singular/runs/report.py` pour conserver `event_type` lors du chargement des logs, filtrer les enregistrements de mutation et afficher une section `Modifications de boucle` triée en trois vues: `Plus gros changement`, `Plus fréquent` et `Plus rentable` (implémenté dans `_print_loop_modifications`).
- Ajout / mise à jour de tests dans `tests/test_report.py` pour vérifier la présence de la nouvelle section et l'ordre des classements.

### Testing
- Tests automatisés exécutés: `pytest -q tests/test_report.py`.
- Résultat: `3 passed` (tous les tests de rapport concernés ont réussi).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe6ca52ec832a83048cdf6e40df9f)