### PR TITLE
Add composite health scoring and trend reporting

### DIFF
--- a/src/singular/life/health.py
+++ b/src/singular/life/health.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Literal
+
+HealthState = Literal["amélioration", "plateau", "dégradation"]
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+@dataclass
+class HealthSnapshot:
+    iteration: int
+    score: float
+    performance: float
+    acceptance_rate: float
+    sandbox_stability: float
+    energy_resources: float
+    failure_frequency: float
+
+    def to_dict(self) -> dict[str, float | int]:
+        return asdict(self)
+
+
+@dataclass
+class HealthTracker:
+    """Track and compute organism health as a composite score."""
+
+    total_iterations: int = 0
+    accepted_count: int = 0
+    failed_count: int = 0
+    sandbox_failures: int = 0
+    sandbox_checks: int = 0
+    latency_ema_ms: float = 0.0
+    latency_alpha: float = 0.2
+
+    @classmethod
+    def from_state(cls, state: dict[str, float | int] | None) -> HealthTracker:
+        if not isinstance(state, dict):
+            return cls()
+        return cls(
+            total_iterations=int(state.get("total_iterations", 0)),
+            accepted_count=int(state.get("accepted_count", 0)),
+            failed_count=int(state.get("failed_count", 0)),
+            sandbox_failures=int(state.get("sandbox_failures", 0)),
+            sandbox_checks=int(state.get("sandbox_checks", 0)),
+            latency_ema_ms=float(state.get("latency_ema_ms", 0.0)),
+            latency_alpha=float(state.get("latency_alpha", 0.2)),
+        )
+
+    def to_state(self) -> dict[str, float | int]:
+        return {
+            "total_iterations": self.total_iterations,
+            "accepted_count": self.accepted_count,
+            "failed_count": self.failed_count,
+            "sandbox_failures": self.sandbox_failures,
+            "sandbox_checks": self.sandbox_checks,
+            "latency_ema_ms": self.latency_ema_ms,
+            "latency_alpha": self.latency_alpha,
+        }
+
+    def update(
+        self,
+        *,
+        iteration: int,
+        latency_ms: float,
+        accepted: bool,
+        sandbox_failure: bool,
+        energy: float,
+        resources: float,
+        failed: bool,
+    ) -> HealthSnapshot:
+        self.total_iterations += 1
+        self.accepted_count += int(accepted)
+        self.failed_count += int(failed)
+        self.sandbox_failures += int(sandbox_failure)
+        self.sandbox_checks += 1
+        if self.total_iterations == 1:
+            self.latency_ema_ms = max(0.0, float(latency_ms))
+        else:
+            alpha = _clamp(self.latency_alpha)
+            self.latency_ema_ms = (
+                alpha * max(0.0, float(latency_ms))
+                + (1.0 - alpha) * self.latency_ema_ms
+            )
+
+        acceptance_rate = (
+            self.accepted_count / self.total_iterations if self.total_iterations else 0.0
+        )
+        sandbox_stability = 1.0 - (
+            self.sandbox_failures / self.sandbox_checks if self.sandbox_checks else 0.0
+        )
+        failure_frequency = (
+            self.failed_count / self.total_iterations if self.total_iterations else 0.0
+        )
+        # Lower latency is better. 100ms -> 0.5, 900ms -> 0.1.
+        performance = 1.0 / (1.0 + (self.latency_ema_ms / 100.0))
+        energy_norm = _clamp(energy / 5.0)
+        resources_norm = _clamp(resources / 5.0)
+        energy_resources = (energy_norm + resources_norm) / 2.0
+
+        score = composite_score(
+            performance=performance,
+            acceptance_rate=acceptance_rate,
+            sandbox_stability=sandbox_stability,
+            energy_resources=energy_resources,
+            failure_frequency=failure_frequency,
+        )
+        return HealthSnapshot(
+            iteration=iteration,
+            score=score,
+            performance=performance,
+            acceptance_rate=acceptance_rate,
+            sandbox_stability=sandbox_stability,
+            energy_resources=energy_resources,
+            failure_frequency=failure_frequency,
+        )
+
+
+def composite_score(
+    *,
+    performance: float,
+    acceptance_rate: float,
+    sandbox_stability: float,
+    energy_resources: float,
+    failure_frequency: float,
+) -> float:
+    """Compute a weighted health score between 0 and 100."""
+
+    failure_quality = 1.0 - _clamp(failure_frequency)
+    value = (
+        0.25 * _clamp(performance)
+        + 0.20 * _clamp(acceptance_rate)
+        + 0.20 * _clamp(sandbox_stability)
+        + 0.20 * _clamp(energy_resources)
+        + 0.15 * failure_quality
+    )
+    return round(100.0 * value, 4)
+
+
+def detect_health_state(
+    scores: Iterable[float],
+    *,
+    short_window: int = 10,
+    long_window: int = 50,
+    margin: float = 1.0,
+) -> HealthState:
+    """Compare short and long moving windows to infer health trajectory."""
+
+    values = list(scores)
+    if len(values) < max(2, short_window):
+        return "plateau"
+    short_avg = sum(values[-short_window:]) / min(short_window, len(values))
+    long_slice = values[-long_window:] if len(values) >= long_window else values
+    long_avg = sum(long_slice) / len(long_slice)
+    delta = short_avg - long_avg
+    if delta > margin:
+        return "amélioration"
+    if delta < -margin:
+        return "dégradation"
+    return "plateau"

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -27,6 +27,7 @@ from singular.resource_manager import ResourceManager
 
 from . import sandbox
 from .death import DeathMonitor
+from .health import HealthTracker
 from .reproduction import crossover
 from .map_elites import MapElites
 from .test_coevolution import LivingTestPool, propose_test_candidates
@@ -48,6 +49,8 @@ class Checkpoint:
 
     iteration: int = 0
     stats: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    health_history: list[dict[str, float | int]] = field(default_factory=list)
+    health_counters: dict[str, float | int] = field(default_factory=dict)
 
 
 @dataclass
@@ -201,6 +204,7 @@ def log_mutation(
     mutated_score: float,
     impacted_file: str,
     loop_modifications: dict[str, int],
+    health: dict[str, float | int] | None = None,
 ) -> None:
     """Record mutation outcome and notify observers."""
 
@@ -238,6 +242,7 @@ def log_mutation(
         decision_reason=decision_reason,
         human_summary=human_summary,
         loop_modifications=loop_modifications,
+        health=health,
     )
 
 
@@ -405,6 +410,7 @@ def run(
         test_pool = LivingTestPool()
 
     with RunLogger(run_id, psyche=psyche) as logger:
+        health_tracker = HealthTracker.from_state(state.health_counters)
         delayed: list[tuple[float, str, Path]] = []
         while time.time() - start < budget_seconds:
             if getattr(psyche, "sleeping", False) or (
@@ -580,6 +586,22 @@ def run(
                 other.energy -= 0.05
                 other.resources -= 0.02
 
+            sandbox_failure = (
+                base_score == float("-inf") or mutated_score == float("-inf")
+            )
+            failed = sandbox_failure or (not accepted)
+            health_snapshot = health_tracker.update(
+                iteration=state.iteration,
+                latency_ms=ms_new,
+                accepted=accepted,
+                sandbox_failure=sandbox_failure,
+                energy=org.energy,
+                resources=org.resources,
+                failed=failed,
+            )
+            state.health_history.append(health_snapshot.to_dict())
+            state.health_counters = health_tracker.to_state()
+
             logger.log_interaction(
                 INTERACTION_RESOURCE_COMPETITION,
                 organism=org_name,
@@ -608,6 +630,7 @@ def run(
                 mutated_score,
                 skill_path.name,
                 loop_modifications,
+                health=health_snapshot.to_dict(),
             )
 
             if hasattr(psyche, "consume"):

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ..life.health import detect_health_state
 from ..psyche import Psyche
 from ..runs.logger import RUNS_DIR
 
@@ -27,10 +28,23 @@ def status() -> None:
             ms_new = last.get("ms_new")
             ok_count = sum(1 for r in records if r.get("ok"))
             success_rate = ok_count / len(records) * 100
+            mutation_records = [r for r in records if "score_new" in r]
+            health_scores = [
+                float(h["score"])
+                for r in mutation_records
+                for h in [r.get("health", {})]
+                if isinstance(h, dict) and isinstance(h.get("score"), (int, float))
+            ]
+            state = detect_health_state(health_scores, short_window=10, long_window=50)
             print(f"Latest run: {latest.stem}")
             if isinstance(ms_new, (int, float)):
                 print(f"Last execution speed: {ms_new:.2f}ms")
             print(f"Success rate: {success_rate:.0f}%")
+            if health_scores:
+                print(
+                    "Health score: "
+                    f"{health_scores[-1]:.2f}/100 ({state}, fenêtres 10/50)"
+                )
         else:
             print(f"Run log {latest.name} is empty.")
     else:

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -180,6 +180,7 @@ class RunLogger:
         decision_reason: str | None = None,
         human_summary: str | None = None,
         loop_modifications: dict[str, int] | None = None,
+        health: dict[str, float | int] | None = None,
     ) -> None:
         """Append a mutation record to the log file."""
 
@@ -199,6 +200,7 @@ class RunLogger:
             "decision_reason": decision_reason,
             "human_summary": human_summary,
             "loop_modifications": loop_modifications or {},
+            "health": health or {},
         }
         self._write_record(record)
         self._write_event("mutation", record, ts)

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -8,6 +8,7 @@ import json
 from typing import Any
 
 from .logger import RUNS_DIR
+from ..life.health import detect_health_state
 from ..memory import read_skills, get_skills_file
 
 
@@ -77,6 +78,18 @@ def report(
     print(f"Final score: {scores[-1]}")
     # Lower scores indicate better performance.
     print(f"Best score: {min(scores)}")
+    health_scores = [
+        float(h["score"])
+        for r in mutations
+        for h in [r.get("health", {})]
+        if isinstance(h, dict) and isinstance(h.get("score"), (int, float))
+    ]
+    if health_scores:
+        health_state = detect_health_state(health_scores, short_window=10, long_window=50)
+        print(
+            "Health: "
+            f"{health_scores[-1]:.2f}/100 ({health_state}, comparaison fenêtres 10/50)"
+        )
 
     counter = Counter(ops)
     print("Operator histogram:")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from singular.life.health import HealthTracker, detect_health_state
+from singular.runs import report as report_mod
+
+
+def test_health_tracker_progression() -> None:
+    tracker = HealthTracker()
+    scores: list[float] = []
+    for i in range(1, 31):
+        snap = tracker.update(
+            iteration=i,
+            latency_ms=350.0,
+            accepted=False,
+            sandbox_failure=True,
+            energy=1.0,
+            resources=1.0,
+            failed=True,
+        )
+        scores.append(snap.score)
+    for i in range(31, 91):
+        snap = tracker.update(
+            iteration=i,
+            latency_ms=25.0,
+            accepted=True,
+            sandbox_failure=False,
+            energy=4.5,
+            resources=4.2,
+            failed=False,
+        )
+        scores.append(snap.score)
+
+    assert scores[-1] > 70.0
+    assert detect_health_state(scores, short_window=10, long_window=50) == "amélioration"
+
+
+def test_health_tracker_regression() -> None:
+    tracker = HealthTracker()
+    scores: list[float] = []
+    for i in range(1, 51):
+        scores.append(
+            tracker.update(
+                iteration=i,
+                latency_ms=30.0,
+                accepted=True,
+                sandbox_failure=False,
+                energy=4.0,
+                resources=4.0,
+                failed=False,
+            ).score
+        )
+    for i in range(51, 101):
+        scores.append(
+            tracker.update(
+                iteration=i,
+                latency_ms=900.0,
+                accepted=False,
+                sandbox_failure=True,
+                energy=0.2,
+                resources=0.1,
+                failed=True,
+            ).score
+        )
+
+    assert scores[-1] < scores[49]
+    assert detect_health_state(scores, short_window=10, long_window=50) == "dégradation"
+
+
+def test_report_prints_health_state(tmp_path: Path, capsys) -> None:
+    runs_dir = tmp_path / "runs"
+    run_id = "demo"
+    event_path = runs_dir / run_id / "events.jsonl"
+    event_path.parent.mkdir(parents=True, exist_ok=True)
+    for i in range(60):
+        payload = {
+            "op": "inc",
+            "score_base": 2.0,
+            "score_new": 1.0,
+            "health": {"score": 40.0 + i},
+        }
+        event = {"event_type": "mutation", "payload": payload}
+        with event_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event) + "\n")
+
+    report_mod.report(run_id, runs_dir=runs_dir, skills_path=tmp_path / "skills.json")
+    out = capsys.readouterr().out
+    assert "Health:" in out
+    assert "amélioration" in out

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+
+import singular.organisms.status as status_mod
+
+
+def test_status_displays_health_trend(tmp_path, monkeypatch, capsys) -> None:
+    run_file = tmp_path / "demo.jsonl"
+    with run_file.open("w", encoding="utf-8") as fh:
+        for i in range(60):
+            record = {
+                "ok": True,
+                "ms_new": 10.0 + i,
+                "score_new": 1.0,
+                "health": {"score": 30.0 + i},
+            }
+            fh.write(json.dumps(record) + "\n")
+
+    class DummyPsyche:
+        last_mood = None
+        curiosity = 0.5
+        patience = 0.5
+        playfulness = 0.5
+        optimism = 0.5
+        resilience = 0.5
+
+    monkeypatch.setattr(status_mod, "RUNS_DIR", tmp_path)
+    monkeypatch.setattr(
+        status_mod.Psyche, "load_state", staticmethod(lambda: DummyPsyche())
+    )
+
+    status_mod.status()
+    out = capsys.readouterr().out
+    assert "Health score:" in out
+    assert "fenêtres 10/50" in out


### PR DESCRIPTION
### Motivation
- Provide a single composite health metric that captures execution performance, acceptance rate, sandbox stability, energy/resources and failure frequency so loop health can be monitored over time.
- Make health available to logging and CLI/reporting so users can see whether the organism is improving, plateauing or degrading using rolling-window comparisons.

### Description
- Add `src/singular/life/health.py` implementing `HealthTracker`, `HealthSnapshot`, `composite_score` and `detect_health_state` (sliding-window comparison, French labels `amélioration`/`plateau`/`dégradation`).
- Update `src/singular/life/loop.py` to maintain a `health_tracker` initialized from checkpoint, append `health_history` and persist `health_counters` in the checkpoint, and attach a `health` snapshot to mutation logs.
- Extend `src/singular/runs/logger.py` to include a `health` field in mutation records and write it into `events.jsonl` for downstream tools.
- Add health reporting to `src/singular/organisms/status.py` and `src/singular/runs/report.py` that compute and print the current health score and trend using the 10/50 windows.
- Add tests `tests/test_health.py` and `tests/test_status.py` that exercise progression and regression scenarios and verify CLI/report output contains health/trend info.

### Testing
- Ran the new unit tests with `pytest -q tests/test_health.py tests/test_status.py` and they passed (`4 passed`).
- The tests validate health progression, regression and that `report`/`status` include the health score and 10/50-window trend label.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe82a4664832a86a80abd2cc5b1ad)