### PR TITLE
Add threshold-based alerts for reevaluation and expose them in dashboard/CLI

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -355,7 +355,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     loop_parser.add_argument("--run-id", default="loop", help="Run identifier")
 
-    subparsers.add_parser("status", help="Show current status")
+    status_parser = subparsers.add_parser("status", help="Show current status")
+    status_parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Display detailed alerts and diagnostics",
+    )
 
     talk_parser = subparsers.add_parser("talk", help="Talk with the system")
     talk_parser.add_argument(
@@ -583,7 +588,7 @@ def main(argv: list[str] | None = None) -> int:
         from .organisms.status import status
 
         _ensure_active_life(resolve_life, args.life)
-        status()
+        status(verbose=args.verbose)
 
     elif args.command == "talk":
         from .organisms.talk import talk

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 
+from singular.schedulers.reevaluation import alerts_from_records
+
 
 def create_app(
     runs_dir: Path | str | None = None, psyche_file: Path | str | None = None
@@ -110,6 +112,36 @@ def create_app(
     @app.get("/ecosystem")
     def read_ecosystem() -> dict:
         return _compute_ecosystem()
+
+    @app.get("/alerts")
+    def read_alerts() -> dict[str, object]:
+        if not runs_path.exists():
+            return {"run": None, "alerts": []}
+
+        files = sorted(
+            [
+                path
+                for path in runs_path.iterdir()
+                if path.is_file() and path.suffix == ".jsonl"
+            ],
+            key=lambda path: path.stat().st_mtime,
+        )
+        if not files:
+            return {"run": None, "alerts": []}
+
+        latest = files[-1]
+        records: list[dict[str, object]] = []
+        for line in latest.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                records.append(payload)
+        return {"run": latest.stem, "alerts": alerts_from_records(records)}
 
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:

--- a/src/singular/environment/notifications.py
+++ b/src/singular/environment/notifications.py
@@ -2,24 +2,52 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Literal
+
+Level = Literal["info", "warning", "critical"]
+
+_ACTION_BY_LEVEL: dict[Level, str] = {
+    "info": "continuer observation",
+    "warning": "réduire exploration",
+    "critical": "changer opérateurs",
+}
 
 
-def notify(message: str, channel: Callable[[str], None] | None = None) -> None:
+def _format_notification(message: str, level: Level, action: str | None = None) -> str:
+    """Build a user-facing notification payload with actionable guidance."""
+
+    recommendation = action or _ACTION_BY_LEVEL[level]
+    return f"[{level.upper()}] {message} — action recommandée: {recommendation}"
+
+
+def notify(
+    message: str,
+    channel: Callable[[str], None] | None = None,
+    *,
+    level: Level = "info",
+    action: str | None = None,
+) -> None:
     """Send *message* through *channel*.
 
     By default messages are printed to standard output. A different callable
     can be provided via *channel* (for example ``logging.getLogger(__name__).info``).
     """
 
-    (channel or print)(message)
+    payload = _format_notification(message=message, level=level, action=action)
+    (channel or print)(payload)
 
 
-def auto_post(channel: Callable[[str], None] | None, message: str) -> None:
+def auto_post(
+    channel: Callable[[str], None] | None,
+    message: str,
+    *,
+    level: Level = "info",
+    action: str | None = None,
+) -> None:
     """Automatically post *message* via *channel*.
 
     This is a thin wrapper over :func:`notify` keeping a channel-first
     signature for convenience when used with partials.
     """
 
-    notify(message, channel=channel)
+    notify(message, channel=channel, level=level, action=action)

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -8,9 +8,10 @@ from pathlib import Path
 from ..life.health import detect_health_state
 from ..psyche import Psyche
 from ..runs.logger import RUNS_DIR
+from ..schedulers.reevaluation import alerts_from_records
 
 
-def status() -> None:
+def status(*, verbose: bool = False) -> None:
     """Display basic metrics and current psyche state."""
 
     runs_dir = Path(RUNS_DIR)
@@ -45,6 +46,18 @@ def status() -> None:
                     "Health score: "
                     f"{health_scores[-1]:.2f}/100 ({state}, fenêtres 10/50)"
                 )
+            if verbose:
+                alerts = alerts_from_records(records)
+                if alerts:
+                    print("Alerts:")
+                    for alert in alerts:
+                        print(
+                            "  - "
+                            f"[{alert['level']}] {alert['message']} "
+                            f"(action: {alert['action']})"
+                        )
+                else:
+                    print("Alerts: none")
         else:
             print(f"Run log {latest.name} is empty.")
     else:

--- a/src/singular/schedulers/reevaluation.py
+++ b/src/singular/schedulers/reevaluation.py
@@ -4,14 +4,127 @@ from __future__ import annotations
 
 import threading
 import time
+from dataclasses import dataclass
+from typing import Iterable
 
 from singular.agents import Agent
+from singular.environment import notifications
 
 
 def reevaluate_goals(agent: Agent) -> None:
     """Trigger the agent to reconsider its current goal."""
 
     agent.choose_goal()
+
+
+@dataclass(frozen=True)
+class Alert:
+    """Alert emitted when reevaluation thresholds are exceeded."""
+
+    kind: str
+    level: notifications.Level
+    message: str
+    action: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "kind": self.kind,
+            "level": self.level,
+            "message": self.message,
+            "action": self.action,
+        }
+
+
+def detect_alerts(
+    *,
+    health_scores: Iterable[float],
+    sandbox_failure_rates: Iterable[float],
+    stagnation_steps: int,
+    decline_window: int = 5,
+    sandbox_window: int = 5,
+    stagnation_threshold: int = 12,
+) -> list[Alert]:
+    """Detect alerts for health decline, sandbox failures and stagnation."""
+
+    alerts: list[Alert] = []
+    health = [float(score) for score in health_scores]
+    sandbox = [float(rate) for rate in sandbox_failure_rates]
+
+    if len(health) >= decline_window:
+        window = health[-decline_window:]
+        if all(curr < prev for prev, curr in zip(window, window[1:])):
+            alerts.append(
+                Alert(
+                    kind="health_decline",
+                    level="warning",
+                    message="baisse continue du health score",
+                    action="réduire exploration",
+                )
+            )
+
+    if len(sandbox) >= sandbox_window * 2:
+        previous = sandbox[-(sandbox_window * 2) : -sandbox_window]
+        recent = sandbox[-sandbox_window:]
+        previous_avg = sum(previous) / len(previous)
+        recent_avg = sum(recent) / len(recent)
+        if recent_avg - previous_avg >= 0.15 and recent_avg >= 0.25:
+            alerts.append(
+                Alert(
+                    kind="sandbox_failures_rising",
+                    level="critical",
+                    message="hausse des échecs sandbox",
+                    action="changer opérateurs",
+                )
+            )
+
+    if stagnation_steps >= stagnation_threshold:
+        alerts.append(
+            Alert(
+                kind="prolonged_stagnation",
+                level="warning",
+                message="stagnation prolongée détectée",
+                action="réduire exploration",
+            )
+        )
+    return alerts
+
+
+def alerts_from_records(
+    records: Iterable[dict[str, object]],
+    *,
+    decline_window: int = 5,
+    sandbox_window: int = 5,
+    stagnation_threshold: int = 12,
+) -> list[dict[str, str]]:
+    """Build alerts from run log records."""
+
+    health_scores: list[float] = []
+    sandbox_failure_rates: list[float] = []
+    stagnation_steps = 0
+    for record in records:
+        health = record.get("health")
+        if isinstance(health, dict):
+            if isinstance(health.get("score"), (int, float)):
+                health_scores.append(float(health["score"]))
+            stability = health.get("sandbox_stability")
+            if isinstance(stability, (int, float)):
+                sandbox_failure_rates.append(1.0 - float(stability))
+
+        accepted = record.get("accepted")
+        if isinstance(accepted, bool):
+            stagnation_steps = 0 if accepted else stagnation_steps + 1
+
+    return [
+        alert.to_dict()
+        for alert in detect_alerts(
+            health_scores=health_scores,
+            sandbox_failure_rates=sandbox_failure_rates,
+            stagnation_steps=stagnation_steps,
+            decline_window=decline_window,
+            sandbox_window=sandbox_window,
+            stagnation_threshold=stagnation_threshold,
+        )
+    ]
 
 
 def start(interval: float, agent: Agent) -> threading.Event:
@@ -27,10 +140,20 @@ def start(interval: float, agent: Agent) -> threading.Event:
     def loop() -> None:
         while not stop_event.is_set():
             reevaluate_goals(agent)
+            if hasattr(agent, "alerts") and isinstance(agent.alerts, list):
+                for alert in agent.alerts:
+                    if isinstance(alert, dict):
+                        level = str(alert.get("level", "info"))
+                        if level in {"info", "warning", "critical"}:
+                            notifications.notify(
+                                str(alert.get("message", "")),
+                                level=level,
+                                action=str(alert.get("action", "")),
+                            )
             time.sleep(interval)
 
     threading.Thread(target=loop, daemon=True).start()
     return stop_event
 
 
-__all__ = ["reevaluate_goals", "start"]
+__all__ = ["Alert", "alerts_from_records", "detect_alerts", "reevaluate_goals", "start"]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -20,6 +20,42 @@ def test_dashboard_endpoints(tmp_path: Path) -> None:
 
     assert client.get("/logs").json() == {"log.txt": "hello"}
     assert client.get("/psyche").json() == data
+    assert client.get("/alerts").json() == {"run": None, "alerts": []}
+
+
+def test_dashboard_alerts_endpoint(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    run_file = runs_dir / "loop.jsonl"
+    lines = []
+    for i in range(12):
+        lines.append(
+            json.dumps(
+                {
+                    "accepted": False,
+                    "health": {
+                        "score": 80.0 - i,
+                        "sandbox_stability": 0.95 - (i * 0.05),
+                    },
+                }
+            )
+        )
+    run_file.write_text("\n".join(lines) + "\n")
+    psyche_file = tmp_path / "psyche.json"
+    psyche_file.write_text(json.dumps({"mood": "focused"}))
+
+    app = create_app(runs_dir=runs_dir, psyche_file=psyche_file)
+    client = TestClient(app)
+
+    response = client.get("/alerts")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["run"] == "loop"
+    assert {item["kind"] for item in payload["alerts"]} == {
+        "health_decline",
+        "sandbox_failures_rising",
+        "prolonged_stagnation",
+    }
 
 
 def test_psyche_missing_returns_404(tmp_path: Path) -> None:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,4 +1,5 @@
 from singular.resource_manager import ResourceManager
+from singular.environment.notifications import auto_post, notify
 
 
 def test_update_from_environment_increases_warmth(tmp_path):
@@ -13,3 +14,24 @@ def test_update_from_environment_decreases_warmth(tmp_path):
     rm = ResourceManager(warmth=50.0, path=path)
     rm.update_from_environment(10.0)
     assert rm.warmth < 50.0
+
+
+def test_notify_supports_levels_and_actions() -> None:
+    messages: list[str] = []
+    notify(
+        "hausse des échecs sandbox",
+        channel=messages.append,
+        level="critical",
+        action="changer opérateurs",
+    )
+    assert messages == [
+        "[CRITICAL] hausse des échecs sandbox — action recommandée: changer opérateurs"
+    ]
+
+
+def test_auto_post_defaults_action_for_warning() -> None:
+    messages: list[str] = []
+    auto_post(messages.append, "baisse continue du health score", level="warning")
+    assert messages == [
+        "[WARNING] baisse continue du health score — action recommandée: réduire exploration"
+    ]

--- a/tests/test_scheduler_reevaluation.py
+++ b/tests/test_scheduler_reevaluation.py
@@ -2,6 +2,7 @@ import time
 
 from singular.agents import Agent
 from singular.schedulers import start
+from singular.schedulers.reevaluation import alerts_from_records, detect_alerts
 
 
 def test_scheduler_triggers_goal_reevaluation():
@@ -19,3 +20,31 @@ def test_scheduler_triggers_goal_reevaluation():
     stop_event.set()
 
     assert calls["count"] > 0
+
+
+def test_detect_alerts_thresholds() -> None:
+    alerts = detect_alerts(
+        health_scores=[80.0, 76.0, 72.0, 68.0, 63.0],
+        sandbox_failure_rates=[0.05, 0.1, 0.15, 0.2, 0.1, 0.2, 0.35, 0.4, 0.45, 0.5],
+        stagnation_steps=12,
+    )
+    kinds = {alert.kind for alert in alerts}
+    assert "health_decline" in kinds
+    assert "sandbox_failures_rising" in kinds
+    assert "prolonged_stagnation" in kinds
+
+
+def test_alerts_from_records_uses_health_and_acceptance() -> None:
+    records = [
+        {
+            "accepted": False,
+            "health": {"score": 70.0 - i, "sandbox_stability": 0.95 - (i * 0.04)},
+        }
+        for i in range(12)
+    ]
+    alerts = alerts_from_records(records)
+    assert {alert["kind"] for alert in alerts} == {
+        "health_decline",
+        "sandbox_failures_rising",
+        "prolonged_stagnation",
+    }

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -34,3 +34,38 @@ def test_status_displays_health_trend(tmp_path, monkeypatch, capsys) -> None:
     out = capsys.readouterr().out
     assert "Health score:" in out
     assert "fenêtres 10/50" in out
+
+
+def test_status_verbose_displays_alerts(tmp_path, monkeypatch, capsys) -> None:
+    run_file = tmp_path / "demo.jsonl"
+    with run_file.open("w", encoding="utf-8") as fh:
+        for i in range(12):
+            record = {
+                "ok": False,
+                "accepted": False,
+                "ms_new": 10.0,
+                "score_new": 1.0,
+                "health": {
+                    "score": 70.0 - i,
+                    "sandbox_stability": 0.95 - (i * 0.05),
+                },
+            }
+            fh.write(json.dumps(record) + "\n")
+
+    class DummyPsyche:
+        last_mood = None
+        curiosity = 0.5
+        patience = 0.5
+        playfulness = 0.5
+        optimism = 0.5
+        resilience = 0.5
+
+    monkeypatch.setattr(status_mod, "RUNS_DIR", tmp_path)
+    monkeypatch.setattr(
+        status_mod.Psyche, "load_state", staticmethod(lambda: DummyPsyche())
+    )
+
+    status_mod.status(verbose=True)
+    out = capsys.readouterr().out
+    assert "Alerts:" in out
+    assert "baisse continue du health score" in out


### PR DESCRIPTION
### Motivation
- Détecter et remonter automatiquement situations critiques observées pendant la boucle d'évolution : baisse continue du `health` score, montée des échecs sandbox et stagnation prolongée.
- Fournir des notifications orientées action (niveaux et recommandations) pour permettre des actions opératoires (p.ex. réduire exploration, changer opérateurs).
- Rendre ces alertes accessibles via l'interface web et la CLI pour faciliter le diagnostic rapide.

### Description
- Ajout d'une détection d'alertes dans `src/singular/schedulers/reevaluation.py` avec `detect_alerts`, `alerts_from_records` et le type `Alert` (détection de `health_decline`, `sandbox_failures_rising`, `prolonged_stagnation`).
- Extension du module de notifications `src/singular/environment/notifications.py` pour supporter des niveaux `info|warning|critical` et messages orientés action via `notify` et `auto_post`.
- Exposition d'un endpoint `GET /alerts` dans `src/singular/dashboard/__init__.py` qui analyse le dernier run `.jsonl` et retourne les alertes détectées.
- Ajout d'un flag CLI `status --verbose` (modifications dans `src/singular/cli.py`) et affichage des alertes dans `src/singular/organisms/status.py` quand `verbose=True`.
- Ajout et adaptation des tests couvrant la logique de seuils et les sorties : `tests/test_scheduler_reevaluation.py`, `tests/test_environment.py`, `tests/test_dashboard.py`, `tests/test_status.py`.

### Testing
- Exécution ciblée des tests affectés : `pytest -q tests/test_scheduler_reevaluation.py tests/test_environment.py tests/test_status.py tests/test_dashboard.py -k 'not websocket_stream'`.
- Résultat des tests automatisés : tous les tests exécutés ont réussi (`13 passed, 1 deselected, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe9ec94ac832ab28040b8221e6f8b)