### PR TITLE
Detect and handle collisions in _normalize_organism_inputs and add tests

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -336,9 +336,33 @@ def _normalize_organism_inputs(skills_dirs: OrganismInputs) -> Dict[str, Path]:
     if isinstance(skills_dirs, Path):
         return {skills_dirs.name: skills_dirs}
     if isinstance(skills_dirs, Mapping):
-        return {str(name): Path(path) for name, path in skills_dirs.items()}
+        normalized: Dict[str, Path] = {}
+        for raw_name, raw_path in skills_dirs.items():
+            name = str(raw_name)
+            path = Path(raw_path)
+            if name in normalized and normalized[name] != path:
+                raise ValueError(
+                    "organism key collision for "
+                    f"'{name}': {normalized[name]} conflicts with {path}"
+                )
+            normalized[name] = path
+        return normalized
+
     paths = [Path(path) for path in skills_dirs]
-    return {path.name: path for path in paths}
+    normalized_paths: Dict[str, Path] = {}
+    name_counts: Dict[str, int] = {}
+
+    for path in paths:
+        base_name = path.name
+        next_index = name_counts.get(base_name, 1)
+        unique_name = base_name if next_index == 1 else f"{base_name}#{next_index}"
+        while unique_name in normalized_paths:
+            next_index += 1
+            unique_name = f"{base_name}#{next_index}"
+        normalized_paths[unique_name] = path
+        name_counts[base_name] = next_index + 1
+
+    return normalized_paths
 
 
 def run(

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -111,3 +111,39 @@ def test_multi_organism_events_and_dashboard(tmp_path: Path, monkeypatch) -> Non
     ecosystem = client.get("/ecosystem").json()
     assert "org1" in ecosystem["organisms"]
     assert ecosystem["summary"]["total_organisms"] >= 1
+
+
+def test_normalize_organism_inputs_iterable_auto_renames_collisions(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "set_a" / "skills"
+    second = tmp_path / "set_b" / "skills"
+    third = tmp_path / "set_c" / "skills"
+
+    normalized = life_loop._normalize_organism_inputs([first, second, third])
+
+    assert list(normalized.keys()) == ["skills", "skills#2", "skills#3"]
+    assert normalized["skills"] == first
+    assert normalized["skills#2"] == second
+    assert normalized["skills#3"] == third
+
+
+def test_normalize_organism_inputs_mapping_collision_raises_clear_error(
+    tmp_path: Path,
+) -> None:
+    one = tmp_path / "org_one"
+    two = tmp_path / "org_two"
+
+    # str(1) and "1" normalize to the same organism key.
+    mapping = {1: one, "1": two}
+
+    try:
+        life_loop._normalize_organism_inputs(mapping)
+    except ValueError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("Expected ValueError for key collision")
+
+    assert "organism key collision for '1'" in message
+    assert str(one) in message
+    assert str(two) in message


### PR DESCRIPTION
### Motivation
- Inputs to the evolutionary loop can be provided as a `Mapping[str, Path]` or an `Iterable[Path]`, and basename collisions or key normalization can produce ambiguous organism names at runtime.
- The normalization function should fail fast with a clear error for conflicting mapping keys and provide a deterministic renaming strategy for iterable inputs to avoid silent overwrites.

### Description
- Update `_normalize_organism_inputs` in `src/singular/life/loop.py` to raise `ValueError` when two mapping entries normalize to the same string key but point to different paths, and include the conflicting key and both paths in the error message.
- Implement deterministic stable naming for `Iterable[Path]` inputs by using the directory basename and suffixing collisions with `#2`, `#3`, ... (e.g. `skills`, `skills#2`, `skills#3`) while avoiding secondary collisions.
- Add tests in `tests/test_multi_organisms.py` that verify iterable auto-renaming behavior and that mapping key collisions raise a readable `ValueError` containing the key and involved paths.

### Testing
- Ran `pytest -q tests/test_multi_organisms.py`, which completed successfully with all tests passing (`4 passed`) and only non-failing warnings observed.
- The new tests validate both the auto-rename behavior for iterable inputs and the explicit `ValueError` for mapping collisions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf4dbccf8832aac98a8576cb26ba3)