### PR TITLE
Harden checkpoint loading with schema version migration

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -47,6 +47,7 @@ SLEEP_TICKS = 5
 class Checkpoint:
     """Simple persistent state for the evolutionary loop."""
 
+    version: int = 1
     iteration: int = 0
     stats: Dict[str, Dict[str, float]] = field(default_factory=dict)
     health_history: list[dict[str, float | int]] = field(default_factory=list)
@@ -79,16 +80,49 @@ INTERACTION_CROSSOVER = "crossover"
 INTERACTION_EXTINCTION = "extinction"
 
 
+CHECKPOINT_VERSION = 1
+
+
+def _migrate_checkpoint_data(data: Mapping[str, object]) -> dict[str, object]:
+    """Migrate checkpoint payload to the current schema version."""
+
+    migrated = dict(data)
+    version = migrated.get("version")
+    if not isinstance(version, int):
+        version = 0
+
+    if version < 1:
+        migrated["version"] = 1
+        version = 1
+
+    # Keep final payload aligned with current application schema.
+    migrated["version"] = CHECKPOINT_VERSION
+    return migrated
+
+
+def _checkpoint_from_data(data: Mapping[str, object]) -> Checkpoint:
+    """Build a :class:`Checkpoint` from raw persisted data safely."""
+
+    migrated = _migrate_checkpoint_data(data)
+    defaults = asdict(Checkpoint())
+    payload = {**defaults, **migrated}
+    allowed_keys = set(Checkpoint.__dataclass_fields__)
+    filtered_payload = {key: value for key, value in payload.items() if key in allowed_keys}
+    return Checkpoint(**filtered_payload)
+
+
 def load_checkpoint(path: Path) -> Checkpoint:
     """Load checkpoint state from *path* if it exists."""
 
     if path.exists():
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
+        except (OSError, TypeError, json.JSONDecodeError) as exc:
             log.warning("failed to load checkpoint from %s: %s", path, exc)
         else:
-            return Checkpoint(**data)
+            if isinstance(data, Mapping):
+                return _checkpoint_from_data(data)
+            log.warning("failed to load checkpoint from %s: root must be an object", path)
     return Checkpoint()
 
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -161,6 +161,64 @@ def test_corrupted_checkpoint(tmp_path: Path, caplog):
     )
 
 
+def test_load_checkpoint_migrates_old_schema(tmp_path: Path):
+    ckpt = tmp_path / "ckpt.json"
+    ckpt.write_text(json.dumps({"iteration": 7}), encoding="utf-8")
+
+    state = load_checkpoint(ckpt)
+
+    assert state.version == life_loop.CHECKPOINT_VERSION
+    assert state.iteration == 7
+    assert state.stats == {}
+    assert state.health_history == []
+    assert state.health_counters == {}
+
+
+def test_load_checkpoint_ignores_extra_keys(tmp_path: Path):
+    ckpt = tmp_path / "ckpt.json"
+    ckpt.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "iteration": 3,
+                "stats": {},
+                "health_history": [],
+                "health_counters": {},
+                "unexpected": "drop-me",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state = load_checkpoint(ckpt)
+
+    assert state.version == life_loop.CHECKPOINT_VERSION
+    assert state.iteration == 3
+    assert not hasattr(state, "unexpected")
+
+
+def test_run_with_legacy_checkpoint_continues_without_crash(tmp_path: Path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = 1", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+    checkpoint.write_text(json.dumps({"iteration": 2}), encoding="utf-8")
+
+    state = run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.05,
+        rng=random.Random(0),
+        operators={"dec": _dec_operator},
+    )
+
+    saved = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert state.version == life_loop.CHECKPOINT_VERSION
+    assert saved["version"] == life_loop.CHECKPOINT_VERSION
+    assert saved["iteration"] >= 2
+
+
 def _inc2_operator(tree: ast.AST, rng=None) -> ast.AST:
     for node in ast.walk(tree):
         if isinstance(node, ast.Constant) and isinstance(node.value, int):


### PR DESCRIPTION
### Motivation

- Ensure persisted loop state is robust to schema changes and corrupted files by explicitly versioning checkpoints and applying safe hydration before constructing `Checkpoint` objects.

### Description

- Add a `version` field to `Checkpoint` and a `CHECKPOINT_VERSION` constant to represent the current persisted schema.
- Implement `_migrate_checkpoint_data` to normalize older payloads to the current version and `_checkpoint_from_data` to apply defaults and filter unknown keys before instantiating `Checkpoint`.
- Harden `load_checkpoint` to handle malformed JSON/root types and return a safe default while logging warnings.
- Add tests in `tests/test_loop.py` covering legacy schema migration, filtering of extra keys, corrupted checkpoint fallback, and that `run` continues with a legacy checkpoint without crashing.

### Testing

- Ran `pytest -q tests/test_loop.py -k "checkpoint or legacy"`; the targeted tests completed successfully (`5 passed, 17 deselected`, with warnings unrelated to the changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf58a3ff0832ab7b247c156600d8f)