### PR TITLE
Harden loop scoring against non-finite values

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -6,6 +6,7 @@ import difflib
 import importlib
 import json
 import logging
+import math
 import random
 import time
 import heapq
@@ -201,7 +202,10 @@ def score_code(code: str) -> float:
         result = sandbox.run(code)
     except Exception:
         return float("-inf")
-    return float(result) if isinstance(result, (int, float)) else float("-inf")
+    if not isinstance(result, (int, float)):
+        return float("-inf")
+    score = float(result)
+    return score if math.isfinite(score) else float("-inf")
 
 
 def manage_resources(
@@ -605,7 +609,9 @@ def run(
                 org.energy -= 0.1
 
             stats[op_name]["count"] += 1
-            stats[op_name]["reward"] += base_score - mutated_score
+            reward_delta = base_score - mutated_score
+            if math.isfinite(reward_delta):
+                stats[op_name]["reward"] += reward_delta
             state.stats = stats
 
             # Resource accounting

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -235,6 +235,48 @@ def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
     return tree
 
 
+def _noop_operator(tree: ast.AST, rng=None) -> ast.AST:
+    return tree
+
+
+def test_run_nan_score_does_not_contaminate_stats(tmp_path: Path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = float('nan')", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+
+    state = run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.05,
+        rng=random.Random(0),
+        operators={"noop": _noop_operator},
+    )
+
+    assert state.stats["noop"]["count"] >= 1
+    assert state.stats["noop"]["reward"] == 0.0
+
+
+def test_run_inf_score_does_not_contaminate_stats(tmp_path: Path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = float('inf')", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+
+    state = run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.05,
+        rng=random.Random(0),
+        operators={"noop": _noop_operator},
+    )
+
+    assert state.stats["noop"]["count"] >= 1
+    assert state.stats["noop"]["reward"] == 0.0
+
+
 def test_multi_operator_selection(tmp_path: Path, monkeypatch):
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Prevent `nan`/`inf` values produced by sandboxed skills from polluting operator statistics and scores.
- Ensure the loop treats non-finite execution results as failures rather than propagating invalid numbers into metrics.

### Description
- Import `math` and update `score_code` to return `-inf` for non-numeric results or when `not math.isfinite(score)`, keeping previous behavior for exceptions; this normalizes `nan`/`inf` outputs into the failure sentinel (`-inf`).
- Compute `reward_delta = base_score - mutated_score` and only add it to `stats[op_name]["reward"]` when `math.isfinite(reward_delta)` to avoid `nan` contamination of stats.
- Add tests in `tests/test_loop.py`: a `_noop_operator` and two regression tests `test_run_nan_score_does_not_contaminate_stats` and `test_run_inf_score_does_not_contaminate_stats` that create skills returning `float('nan')` and `float('inf')` and assert `stats["noop"]["reward"] == 0.0` and `count >= 1`.

### Testing
- Ran `pytest -q tests/test_loop.py -k "nan_score or inf_score"` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfe8d65e0832a84605ce8235bd4f7)