### PR TITLE
Add subcommand `--format` for status/report and default to latest run for `report`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ pip install -e .[yaml,dashboard,viz]
 singular birth --name Lumen
 singular talk
 singular loop --budget-seconds 10
-singular report
+singular status --format table
+singular report --format plain
 singular dashboard
 ```
 
@@ -264,7 +265,7 @@ SINGULAR_HOME=/chemin/personnel singular birth
 singular --home /chemin/personnel birth
 
 # Ajuster la rétention des journaux
-SINGULAR_RUNS_KEEP=50 singular report
+SINGULAR_RUNS_KEEP=50 singular report --format json
 
 # Utiliser l'API OpenAI
 OPENAI_API_KEY=sk-... singular talk --prompt "Salut"
@@ -272,11 +273,20 @@ OPENAI_API_KEY=sk-... singular talk --prompt "Salut"
 
 ### Audit et export
 
-La commande `report` peut produire un export structuré pour archivage ou intégration CI :
+La commande `report` peut produire un export structuré pour archivage ou intégration CI.
+Règle de sélection du run :
+
+- si `--id` est fourni, ce run exact est utilisé ;
+- si `--id` est absent, `report` prend automatiquement le run le plus récent.
+
+Exemples :
 
 ```bash
 singular report --id run1 --export evolution.json
 singular report --id run1 --export markdown
+singular report --format table
+singular report --format json
+singular status --verbose --format json
 ```
 
 - `--export evolution.json` écrit un JSON stable (clés triées) sur disque.

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -285,6 +285,35 @@ def _ensure_active_life(
     return life_dir
 
 
+def _resolve_latest_run_id(runs_root: Path | None = None) -> str | None:
+    """Return the most recent run identifier from ``runs/``."""
+
+    base = Path(runs_root or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs")
+    if not base.exists():
+        return None
+
+    latest: tuple[float, str] | None = None
+
+    for run_dir in base.iterdir():
+        if not run_dir.is_dir():
+            continue
+        events_path = run_dir / "events.jsonl"
+        if not events_path.exists():
+            continue
+        candidate = (events_path.stat().st_mtime, run_dir.name)
+        if latest is None or candidate[0] > latest[0]:
+            latest = candidate
+
+    for legacy_log in base.glob("*.jsonl"):
+        stem = legacy_log.stem
+        run_id = stem.rsplit("-", 1)[0] if "-" in stem else stem
+        candidate = (legacy_log.stat().st_mtime, run_id)
+        if latest is None or candidate[0] > latest[0]:
+            latest = candidate
+
+    return latest[1] if latest is not None else None
+
+
 def _can_prompt() -> bool:
     """Return True when guided prompts can safely run."""
 
@@ -408,6 +437,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Display detailed alerts and diagnostics",
     )
+    status_parser.add_argument(
+        "--format",
+        dest="status_output_format",
+        choices=("table", "json", "plain"),
+        default=None,
+        help="Output format for the status command",
+    )
 
     talk_parser = subparsers.add_parser("talk", help="Talk with the system")
     talk_parser.add_argument(
@@ -432,7 +468,14 @@ def main(argv: list[str] | None = None) -> int:
     report_parser = subparsers.add_parser(
         "report", help="Summarize performance from a run"
     )
-    report_parser.add_argument("--id", required=True, help="Run identifier")
+    report_parser.add_argument("--id", required=False, default=None, help="Run identifier")
+    report_parser.add_argument(
+        "--format",
+        dest="report_output_format",
+        choices=("table", "json", "plain"),
+        default=None,
+        help="Output format for the report command",
+    )
     report_parser.add_argument(
         "--export",
         default=None,
@@ -654,7 +697,8 @@ def main(argv: list[str] | None = None) -> int:
         from .organisms.status import status
 
         _ensure_active_life(resolve_life, args.life)
-        status(verbose=args.verbose, output_format=args.output_format)
+        status_format = args.status_output_format or args.output_format
+        status(verbose=args.verbose, output_format=status_format)
 
     elif args.command == "talk":
         from .organisms.talk import talk
@@ -677,7 +721,12 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "report":
         from .runs.report import report
 
-        report(run_id=args.id, output_format=args.output_format, export=args.export)
+        run_id = args.id or _resolve_latest_run_id()
+        if run_id is None:
+            print("No run log found. Use `singular report --id <run_id>`.")
+            return 1
+        report_format = args.report_output_format or args.output_format
+        report(run_id=run_id, output_format=report_format, export=args.export)
 
     elif args.command == "dashboard":
         _ensure_active_life(resolve_life, args.life)

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -125,3 +125,25 @@ def test_lives_list_supports_json_format(
     assert payload["active"]
     assert len(payload["lives"]) == 2
     assert {"Alpha", "Beta"} == {item["name"] for item in payload["lives"]}
+
+
+def test_status_supports_subcommand_format_and_verbose(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "status-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    captured: dict[str, object] = {}
+
+    def fake_status(*, verbose: bool = False, output_format: str = "plain") -> None:
+        captured["verbose"] = verbose
+        captured["output_format"] = output_format
+
+    monkeypatch.setattr("singular.organisms.status.status", fake_status)
+    main(["--root", str(root), "status", "--verbose", "--format", "table"])
+
+    assert captured["verbose"] is True
+    assert captured["output_format"] == "table"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from singular.cli import main
 
@@ -330,3 +331,79 @@ def test_report_export_markdown_stdout(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "# Run report `run6`" in out
     assert "## Timeline des mutations" in out
+
+
+def test_report_defaults_to_latest_run_when_id_missing(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    runs = tmp_path / "runs"
+    runs.mkdir()
+
+    run_old = runs / "run-old"
+    run_old.mkdir()
+    old_log = run_old / "events.jsonl"
+    old_log.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "event_type": "mutation",
+                "ts": "2026-01-01T00:00:00",
+                "payload": {"op": "mutate", "score_base": 2.0, "score_new": 1.8},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run_new = runs / "run-new"
+    run_new.mkdir()
+    new_log = run_new / "events.jsonl"
+    new_log.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "event_type": "mutation",
+                "ts": "2026-01-01T00:00:01",
+                "payload": {"op": "splice", "score_base": 1.8, "score_new": 1.2},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    os.utime(old_log, (1, 1))
+    os.utime(new_log, (2, 2))
+
+    mem = tmp_path / "mem"
+    mem.mkdir()
+    (mem / "skills.json").write_text("{}", encoding="utf-8")
+
+    main(["report"])
+    out = capsys.readouterr().out
+    assert "Run run-new" in out
+
+
+def test_report_supports_subcommand_format_option(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    run_dir = runs / "run-json"
+    run_dir.mkdir()
+    (run_dir / "events.jsonl").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "event_type": "mutation",
+                "ts": "2026-01-01T00:00:00",
+                "payload": {"op": "mutate", "score_base": 1.0, "score_new": 0.5},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    mem = tmp_path / "mem"
+    mem.mkdir()
+    (mem / "skills.json").write_text("{}", encoding="utf-8")
+
+    main(["report", "--id", "run-json", "--format", "json"])
+    out = capsys.readouterr().out.strip()
+    payload = json.loads(out)
+    assert payload["context"]["run_id"] == "run-json"


### PR DESCRIPTION
### Motivation
- Improve CLI ergonomics so `status` and `report` can accept a `--format` directly on the subcommand for natural syntax. 
- Make `report` more convenient in interactive workflows by using the most recent run when `--id` is omitted. 
- Keep backward compatibility: preserve the global `--format` option but let subcommand-level formats take precedence.

### Description
- Added `_resolve_latest_run_id` to `src/singular/cli.py` to detect the most recent run from both directory-based logs (`runs/<run_id>/events.jsonl`) and legacy flat logs (`runs/<run_id>-<timestamp>.jsonl`).
- Made `report`'s `--id` optional and apply the rule "use `--id` if provided, otherwise use the most recent run"; when no runs exist a clear message is printed and the CLI returns with status `1`.
- Added subcommand-level `--format` flags: `status --format` (`status_output_format`) and `report --format` (`report_output_format`), and updated dispatch so these override the global `--format` when present.
- Updated `README.md` quickstart and examples to reflect the actual CLI syntax and documented the run selection rule; added/adjusted tests to cover the new behaviors.

### Testing
- Added tests in `tests/test_report.py` to assert that `report` defaults to the latest run when `--id` is missing and to verify `report --format json` output. 
- Added a test in `tests/test_cli_lives.py` to assert `status --verbose --format table` is passed correctly to the implementation. 
- Ran `pytest -q tests/test_report.py tests/test_cli_lives.py` and got `13 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0072f948832a85eb279ff30c5220)