### PR TITLE
Add health_history retention with periodic aggregation

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -82,6 +82,52 @@ INTERACTION_EXTINCTION = "extinction"
 
 
 CHECKPOINT_VERSION = 1
+HEALTH_HISTORY_FINE_WINDOW = 500
+HEALTH_HISTORY_AGGREGATE_EVERY = 10
+
+
+def _aggregate_health_bucket(
+    bucket: list[dict[str, float | int]],
+) -> dict[str, float | int]:
+    """Aggregate a bucket of health snapshots into one representative point."""
+
+    if not bucket:
+        return {}
+
+    keys = bucket[0].keys()
+    aggregated: dict[str, float | int] = {}
+    for key in keys:
+        if key == "iteration":
+            aggregated[key] = int(bucket[-1].get("iteration", 0))
+            continue
+        values = [float(point.get(key, 0.0)) for point in bucket]
+        aggregated[key] = sum(values) / len(values)
+    return aggregated
+
+
+def _retain_health_history(
+    history: list[dict[str, float | int]],
+    *,
+    fine_window: int = HEALTH_HISTORY_FINE_WINDOW,
+    aggregate_every: int = HEALTH_HISTORY_AGGREGATE_EVERY,
+) -> list[dict[str, float | int]]:
+    """Retain recent detailed points and periodically aggregate older samples."""
+
+    if fine_window <= 0:
+        fine_window = 1
+    if aggregate_every <= 1:
+        aggregate_every = 1
+    if len(history) <= fine_window:
+        return list(history)
+
+    older = history[:-fine_window]
+    recent = history[-fine_window:]
+    retained: list[dict[str, float | int]] = []
+    for start in range(0, len(older), aggregate_every):
+        bucket = older[start : start + aggregate_every]
+        retained.append(_aggregate_health_bucket(bucket))
+    retained.extend(recent)
+    return retained
 
 
 def _migrate_checkpoint_data(data: Mapping[str, object]) -> dict[str, object]:
@@ -437,6 +483,7 @@ def run(
 
     rng = rng or random.Random()
     state = load_checkpoint(checkpoint_path)
+    state.health_history = _retain_health_history(state.health_history)
 
     organisms_input = _normalize_organism_inputs(skills_dirs)
 
@@ -664,6 +711,7 @@ def run(
                 failed=failed,
             )
             state.health_history.append(health_snapshot.to_dict())
+            state.health_history = _retain_health_history(state.health_history)
             state.health_counters = health_tracker.to_state()
 
             logger.log_interaction(

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from singular.life.health import HealthTracker, detect_health_state
+from singular.life.loop import _retain_health_history
 from singular.runs import report as report_mod
 
 
@@ -89,3 +90,25 @@ def test_report_prints_health_state(tmp_path: Path, capsys) -> None:
     out = capsys.readouterr().out
     assert "Health:" in out
     assert "amélioration" in out
+
+
+def test_detect_health_state_with_retained_history_keeps_trend() -> None:
+    history = [
+        {
+            "iteration": i,
+            "score": 20.0 + (i * 0.2),
+            "performance": 0.7,
+            "acceptance_rate": 0.7,
+            "sandbox_stability": 0.95,
+            "energy_resources": 0.8,
+            "failure_frequency": 0.1,
+        }
+        for i in range(1, 1601)
+    ]
+
+    retained = _retain_health_history(history, fine_window=500, aggregate_every=10)
+
+    assert len(retained) == 610
+    assert detect_health_state(
+        [point["score"] for point in retained], short_window=20, long_window=100
+    ) == "amélioration"

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -14,6 +14,7 @@ sys.path.append(str(root_dir / "src"))
 
 import singular.life.loop as life_loop  # noqa: E402
 from singular.life.loop import run, load_checkpoint  # noqa: E402
+from singular.life.health import detect_health_state  # noqa: E402
 from singular.life.test_coevolution import LivingTestPool, TestCandidate  # noqa: E402
 from singular.resource_manager import ResourceManager  # noqa: E402
 from singular.psyche import Psyche, Mood  # noqa: E402
@@ -217,6 +218,61 @@ def test_run_with_legacy_checkpoint_continues_without_crash(tmp_path: Path):
     assert state.version == life_loop.CHECKPOINT_VERSION
     assert saved["version"] == life_loop.CHECKPOINT_VERSION
     assert saved["iteration"] >= 2
+
+
+def test_health_history_retention_bounds_size() -> None:
+    history = [
+        {
+            "iteration": i,
+            "score": float(i),
+            "performance": float(i) / 10.0,
+            "acceptance_rate": 0.5,
+            "sandbox_stability": 1.0,
+            "energy_resources": 0.7,
+            "failure_frequency": 0.1,
+        }
+        for i in range(1, 1001)
+    ]
+
+    retained = life_loop._retain_health_history(
+        history,
+        fine_window=50,
+        aggregate_every=10,
+    )
+
+    expected_older = (1000 - 50) // 10
+    assert len(retained) == expected_older + 50
+    assert [point["iteration"] for point in retained[-50:]] == list(range(951, 1001))
+
+
+def test_health_history_retention_preserves_trend_signal() -> None:
+    history = [
+        {
+            "iteration": i,
+            "score": float(i) / 2.0,
+            "performance": 0.8,
+            "acceptance_rate": 0.8,
+            "sandbox_stability": 1.0,
+            "energy_resources": 0.9,
+            "failure_frequency": 0.0,
+        }
+        for i in range(1, 1201)
+    ]
+    original_scores = [point["score"] for point in history]
+
+    retained = life_loop._retain_health_history(
+        history,
+        fine_window=200,
+        aggregate_every=10,
+    )
+    retained_scores = [point["score"] for point in retained]
+
+    assert detect_health_state(original_scores, short_window=20, long_window=100) == (
+        "amélioration"
+    )
+    assert detect_health_state(retained_scores, short_window=20, long_window=100) == (
+        "amélioration"
+    )
 
 
 def _inc2_operator(tree: ast.AST, rng=None) -> ast.AST:


### PR DESCRIPTION
### Motivation
- Prevent unbounded growth of `Checkpoint.health_history` during long runs by keeping recent high-resolution samples and compacting older data.
- Preserve the overall health trend signal while reducing storage by aggregating older snapshots into periodic buckets.

### Description
- Add retention configuration constants `HEALTH_HISTORY_FINE_WINDOW` and `HEALTH_HISTORY_AGGREGATE_EVERY` and two helpers: `_aggregate_health_bucket` and `_retain_health_history` in `src/singular/life/loop.py` to compute bucket averages and retain a fine window plus aggregated older buckets.
- Compact loaded checkpoints immediately by calling `state.health_history = _retain_health_history(state.health_history)` after `load_checkpoint` in `run` so existing checkpoints are shrunk on load.
- Apply retention after each appended health snapshot in the main loop by calling `_retain_health_history` after `state.health_history.append(...)` to control growth continuously.
- Ensure aggregated points use the last iteration of the bucket for the `iteration` field and average numeric metrics for other keys.
- Add unit tests: `tests/test_loop.py` includes `test_health_history_retention_bounds_size` and `test_health_history_retention_preserves_trend_signal`, and `tests/test_health.py` includes `test_detect_health_state_with_retained_history_keeps_trend` to verify size bounds and trend preservation.

### Testing
- Ran `pytest -q tests/test_health.py tests/test_loop.py`, all tests passed (`30 passed`) with warnings unrelated to the changes.
- Retention behavior and trend-preservation tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc02ec2414832abfa6a08781eda16d)