### PR TITLE
Add secured dashboard quick actions service and UI

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -11,6 +11,8 @@ import os
 import sys
 from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+
+from singular.dashboard.actions import DashboardActionService
 from fastapi.responses import HTMLResponse
 
 from singular.schedulers.reevaluation import alerts_from_records
@@ -34,6 +36,7 @@ def create_app(
         else base_dir / "mem" / "psyche.json"
     )
     app = FastAPI()
+    actions = DashboardActionService(home=base_dir)
 
     def _load_run_records() -> list[dict[str, object]]:
         records: list[dict[str, object]] = []
@@ -748,6 +751,28 @@ def create_app(
             "most_frequent": frequent,
         }
 
+    @app.get("/api/actions/{action}")
+    def run_action(action: str, token: str | None = None, payload: str | None = None) -> dict[str, object]:
+        try:
+            actions.validate_token(token)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+        params: dict[str, object] = {}
+        if payload:
+            try:
+                candidate = json.loads(payload)
+            except json.JSONDecodeError as exc:
+                raise HTTPException(status_code=400, detail="payload must be valid JSON") from exc
+            if not isinstance(candidate, dict):
+                raise HTTPException(status_code=400, detail="payload must be an object")
+            params = candidate
+
+        result = actions.execute(action, params)
+        if not result.get("ok"):
+            raise HTTPException(status_code=400, detail=str(result.get("error") or "action failed"))
+        return result
+
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:
         await ws.accept()
@@ -831,7 +856,7 @@ def create_app(
             "<p id='timeline-summary'>Cliquez sur un événement de mutation.</p>"
             "<pre id='timeline-impact'></pre>"
             "<pre id='timeline-diff' style='padding:12px;border:1px solid #ccc;'></pre>"
-            "<h2>Runs</h2><div id='logs'></div>"
+            "<section><h2>Actions rapides</h2><pre id='action-result'>Aucune exécution</pre><div style='display:flex;flex-direction:column;gap:8px;max-width:680px;'><label>Token dashboard <input id='action-token' type='password' placeholder='optionnel'/></label><label>Nom de vie (birth/use) <input id='action-life-name' placeholder='New life'/></label><label>Prompt talk <input id='action-prompt' placeholder='Prompt unique'/></label><label>Budget loop (s) <input id='action-budget' type='number' min='0.1' step='0.1' value='1.0'/></label><div style='display:flex;gap:8px;flex-wrap:wrap;'><button id='act-birth'>Birth</button><button id='act-talk'>Talk</button><button id='act-loop'>Loop</button><button id='act-report'>Report</button><button id='act-lives-list'>Lives list</button><button id='act-lives-use'>Lives use</button></div></div></section><h2>Runs</h2><div id='logs'></div>"
             "<script>const ws=new WebSocket(`ws://${location.host}/ws`);"
             "const loadEco=()=>fetch('/ecosystem').then(r=>r.json()).then(d=>{document.getElementById('ecosystem-summary').textContent=JSON.stringify(d.summary,null,2);document.getElementById('organisms').textContent=JSON.stringify(d.organisms,null,2);});"
             "const loadCockpit=()=>fetch('/api/cockpit').then(r=>r.json()).then(d=>{"
@@ -846,6 +871,13 @@ def create_app(
             "});"
             "const paintDiff=(raw)=>{const escaped=String(raw||'').replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');return escaped.split('\\n').map(line=>{if(line.startsWith('+')){return `<span style=\"color:#0a7f2e;\">${line}</span>`;}if(line.startsWith('-')){return `<span style=\"color:#b42318;\">${line}</span>`;}if(line.startsWith('@@')){return `<span style=\"color:#175cd3;\">${line}</span>`;}return line;}).join('\\n');};"
             "const showMutationDetail=(runId,index)=>fetch(`/api/runs/${runId}/mutations/${index}`).then(r=>r.json()).then(d=>{document.getElementById('timeline-summary').textContent=d.human_summary||d.decision_reason||'Aucun résumé disponible.';document.getElementById('timeline-impact').textContent=JSON.stringify(d.impact,null,2);document.getElementById('timeline-diff').innerHTML=paintDiff(d.diff)||'Aucun diff.';});"
+            "const runAction=(action,payload)=>{const token=document.getElementById('action-token')?.value||'';const q=new URLSearchParams();if(token){q.set('token',token);}if(payload){q.set('payload',JSON.stringify(payload));}return fetch(`/api/actions/${action}?${q.toString()}`).then(async r=>{if(!r.ok){throw new Error(`HTTP ${r.status}`);}return r.json();}).then(data=>{document.getElementById('action-result').textContent=JSON.stringify(data,null,2);loadEco();loadCockpit();loadTimeline();}).catch(err=>{document.getElementById('action-result').textContent=`Erreur action ${action}: ${err.message}`;});};"
+            "document.getElementById('act-birth').onclick=()=>runAction('birth',{name:document.getElementById('action-life-name').value||'New life'});"
+            "document.getElementById('act-talk').onclick=()=>runAction('talk',{prompt:document.getElementById('action-prompt').value||''});"
+            "document.getElementById('act-loop').onclick=()=>runAction('loop',{budget_seconds:Number(document.getElementById('action-budget').value||0)});"
+            "document.getElementById('act-report').onclick=()=>runAction('report',{});"
+            "document.getElementById('act-lives-list').onclick=()=>runAction('lives_list',{});"
+            "document.getElementById('act-lives-use').onclick=()=>runAction('lives_use',{name:document.getElementById('action-life-name').value||''});"
             "const loadTimeline=()=>fetch('/runs/latest').then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}return fetch(`/api/runs/${meta.run}/timeline?page=1&page_size=120`).then(r=>r.json());}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;btn.style.padding='6px';row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.style.alignSelf='center';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';}});"
             "loadEco();loadCockpit();loadTimeline();setInterval(()=>{loadEco();loadCockpit();loadTimeline();},500);"
             "ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);}else if(m.type==='logs'){const d=document.getElementById('logs');for(const [n,entries] of Object.entries(m.data)){let pre=document.getElementById(`log-${n}`);if(!pre){pre=document.createElement('pre');pre.id=`log-${n}`;pre.textContent=n+'\n';d.appendChild(pre);}for(const entry of entries){pre.textContent+=entry+'\n';}}}};"

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from contextlib import redirect_stdout
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass(slots=True)
+class ActionResult:
+    ok: bool
+    action: str
+    data: dict[str, Any]
+    log: str
+    error: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "action": self.action,
+            "data": self.data,
+            "log": self.log,
+            "error": self.error,
+        }
+
+
+class DashboardActionService:
+    """Execute controlled dashboard actions with strict validation."""
+
+    def __init__(self, *, root: Path | None = None, home: Path | None = None) -> None:
+        self.root = Path(root or os.environ.get("SINGULAR_ROOT", Path.home() / ".singular"))
+        self.home = Path(home or os.environ.get("SINGULAR_HOME", "."))
+
+    def validate_token(self, token: str | None) -> None:
+        expected = os.environ.get("SINGULAR_DASHBOARD_ACTION_TOKEN")
+        if expected and token != expected:
+            raise PermissionError("invalid action token")
+
+    def execute(self, action: str, params: dict[str, Any]) -> dict[str, Any]:
+        try:
+            if action == "birth":
+                result = self._birth(params)
+            elif action == "talk":
+                result = self._talk(params)
+            elif action == "loop":
+                result = self._loop(params)
+            elif action == "report":
+                result = self._report(params)
+            elif action == "lives_list":
+                result = self._lives_list(params)
+            elif action == "lives_use":
+                result = self._lives_use(params)
+            else:
+                return ActionResult(
+                    ok=False,
+                    action=action,
+                    data={},
+                    log="",
+                    error=f"unsupported action: {action}",
+                ).to_payload()
+            return result.to_payload()
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            return ActionResult(
+                ok=False,
+                action=action,
+                data={},
+                log="",
+                error=str(exc),
+            ).to_payload()
+
+    def _capture(self, fn: Callable[[], dict[str, Any]]) -> tuple[dict[str, Any], str]:
+        stream = io.StringIO()
+        with redirect_stdout(stream):
+            data = fn()
+        log = stream.getvalue().strip()
+        if len(log) > 1200:
+            log = f"{log[:1200]}..."
+        return data, log
+
+    @staticmethod
+    def _require_non_empty_text(value: Any, *, field: str, max_len: int) -> str:
+        if not isinstance(value, str):
+            raise ValueError(f"{field} must be a string")
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError(f"{field} cannot be empty")
+        if len(normalized) > max_len:
+            raise ValueError(f"{field} too long (max {max_len})")
+        return normalized
+
+    @staticmethod
+    def _require_float(value: Any, *, field: str, min_value: float, max_value: float) -> float:
+        if not isinstance(value, (int, float)):
+            raise ValueError(f"{field} must be a number")
+        float_value = float(value)
+        if float_value < min_value or float_value > max_value:
+            raise ValueError(f"{field} must be between {min_value} and {max_value}")
+        return float_value
+
+    def _birth(self, params: dict[str, Any]) -> ActionResult:
+        name = self._require_non_empty_text(params.get("name", "New life"), field="name", max_len=80)
+        seed = params.get("seed")
+        if seed is not None and not isinstance(seed, int):
+            raise ValueError("seed must be an integer")
+
+        from singular.lives import bootstrap_life
+
+        def _run() -> dict[str, Any]:
+            meta = bootstrap_life(name, seed=seed)
+            os.environ["SINGULAR_HOME"] = str(meta.path)
+            return {
+                "name": meta.name,
+                "slug": meta.slug,
+                "path": str(meta.path),
+            }
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="birth", data=data, log=log)
+
+    def _talk(self, params: dict[str, Any]) -> ActionResult:
+        prompt = self._require_non_empty_text(params.get("prompt"), field="prompt", max_len=400)
+        provider = params.get("provider")
+        if provider is not None:
+            provider = self._require_non_empty_text(provider, field="provider", max_len=40)
+        seed = params.get("seed")
+        if seed is not None and not isinstance(seed, int):
+            raise ValueError("seed must be an integer")
+
+        from singular.lives import resolve_life
+        from singular.organisms.talk import talk
+
+        life = resolve_life(None)
+        if life is None:
+            raise ValueError("no active life")
+        os.environ["SINGULAR_HOME"] = str(life)
+
+        def _run() -> dict[str, Any]:
+            talk(provider=provider, seed=seed, prompt=prompt)
+            return {"life": str(life), "prompt": prompt}
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="talk", data=data, log=log)
+
+    def _loop(self, params: dict[str, Any]) -> ActionResult:
+        budget = self._require_float(
+            params.get("budget_seconds"), field="budget_seconds", min_value=0.1, max_value=3600.0
+        )
+        run_id = self._require_non_empty_text(params.get("run_id", "loop"), field="run_id", max_len=64)
+        seed = params.get("seed")
+        if seed is not None and not isinstance(seed, int):
+            raise ValueError("seed must be an integer")
+
+        from singular.lives import resolve_life
+        from singular.runs.loop import loop
+
+        life = resolve_life(None)
+        if life is None:
+            raise ValueError("no active life")
+        os.environ["SINGULAR_HOME"] = str(life)
+        checkpoint = Path(life) / "life_checkpoint.json"
+        skills_dir = Path(life) / "skills"
+
+        def _run() -> dict[str, Any]:
+            loop(
+                skills_dir=skills_dir,
+                checkpoint=checkpoint,
+                budget_seconds=budget,
+                run_id=run_id,
+                seed=seed,
+            )
+            return {"run_id": run_id, "budget_seconds": budget}
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="loop", data=data, log=log)
+
+    def _report(self, params: dict[str, Any]) -> ActionResult:
+        run_id = params.get("run_id")
+        if run_id is not None:
+            run_id = self._require_non_empty_text(run_id, field="run_id", max_len=120)
+
+        from singular.cli import _resolve_latest_run_id
+        from singular.runs.report import report
+
+        if run_id is None:
+            run_id = _resolve_latest_run_id()
+        if run_id is None:
+            raise ValueError("no run available")
+
+        def _run() -> dict[str, Any]:
+            report(run_id=run_id, output_format="json")
+            return {"run_id": run_id}
+
+        data, log = self._capture(_run)
+        parsed: dict[str, Any] | None = None
+        try:
+            parsed = json.loads(log)
+        except json.JSONDecodeError:
+            parsed = None
+        if parsed is not None:
+            data["report"] = parsed
+        return ActionResult(ok=True, action="report", data=data, log=log)
+
+    def _lives_list(self, params: dict[str, Any]) -> ActionResult:
+        if params:
+            raise ValueError("lives_list does not accept parameters")
+        from singular.lives import load_registry
+
+        def _run() -> dict[str, Any]:
+            registry = load_registry()
+            active = registry.get("active")
+            items = []
+            for slug, meta in sorted(registry.get("lives", {}).items()):
+                items.append(
+                    {
+                        "slug": slug,
+                        "name": meta.name,
+                        "path": str(meta.path),
+                        "active": slug == active,
+                    }
+                )
+            return {"active": active, "lives": items}
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="lives_list", data=data, log=log)
+
+    def _lives_use(self, params: dict[str, Any]) -> ActionResult:
+        name = self._require_non_empty_text(params.get("name"), field="name", max_len=80)
+        from singular.lives import resolve_life
+
+        def _run() -> dict[str, Any]:
+            life = resolve_life(name)
+            if life is None:
+                raise ValueError(f"unknown life: {name}")
+            os.environ["SINGULAR_HOME"] = str(life)
+            return {"name": name, "path": str(life)}
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="lives_use", data=data, log=log)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -504,3 +504,41 @@ def test_run_requires_uvicorn(
 
     captured = capsys.readouterr()
     assert "pip install uvicorn" in captured.err
+
+
+def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SINGULAR_DASHBOARD_ACTION_TOKEN", "secret")
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+
+    body = client.get("/").json()
+    assert "Actions rapides" in body
+    assert "action-result" in body
+
+    ok = app._routes["/api/actions/{action}"]("lives_list", token="secret", payload="{}")
+    assert ok["ok"] is True
+    assert ok["action"] == "lives_list"
+
+    with pytest.raises(Exception):
+        app._routes["/api/actions/{action}"]("lives_list", token="wrong", payload="{}")
+
+
+def test_dashboard_actions_validation_robustness(tmp_path: Path) -> None:
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+
+    route = app._routes["/api/actions/{action}"]
+
+    with pytest.raises(Exception):
+        route("unknown", payload="{}")
+
+    with pytest.raises(Exception):
+        route("lives_list", payload="[]")
+
+    with pytest.raises(Exception):
+        route("talk", payload=json.dumps({"prompt": "   "}))
+
+    with pytest.raises(Exception):
+        route("loop", payload=json.dumps({"budget_seconds": -1}))
+
+    with pytest.raises(Exception):
+        route("lives_use", payload=json.dumps({"name": ""}))


### PR DESCRIPTION
### Motivation
- Fournir des endpoints backend sécurisés pour déclencher des actions contrôlées (`birth`, `talk`, `loop`, `report`, `lives list/use`) et centraliser la logique d'exécution loin du rendu HTML/JS.
- Encapsuler l'exécution et la validation stricte des paramètres pour éviter des usages abusifs et rendre les retours consommables par l'interface.
- Offrir une interface utilisateur minimale «Actions rapides» permettant de lancer ces actions et d'afficher un retour concis (succès/erreur/log).

### Description
- Ajout d'un service `DashboardActionService` dans `src/singular/dashboard/actions.py` qui implémente les actions contrôlées et la validation stricte des entrées, et renvoie des payloads structurés via `ActionResult` (`ok`, `action`, `data`, `log`, `error`).
- Intégration d'un endpoint backend `GET /api/actions/{action}` dans `create_app` avec validation optionnelle du token via l'env var `SINGULAR_DASHBOARD_ACTION_TOKEN`, décodage JSON strict du paramètre `payload` et renvoi d'erreurs HTTP 4xx claires en cas d'échec.
- Extension du dashboard HTML/JS pour ajouter un panneau «Actions rapides» contenant les boutons `Birth`, `Talk`, `Loop`, `Report`, `Lives list`, `Lives use` et la logique `runAction` qui appelle l'endpoint et met à jour `action-result` puis rafraîchit les vues.
- Ajout de tests dans `tests/test_dashboard.py` couvrant l'exposition UI, l'appel d'endpoint, la validation des tokens et des cas d'entrées malformées ou invalides.

### Testing
- Tests unitaires exécutés: `pytest -q tests/test_dashboard.py`.
- Résultat: la suite ciblée a réussi (`13 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1d08602c832aa8962bf952fa9d60)