### PR TITLE
Dashboard: incremental tailing of run JSONL + live events queue UI

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -891,6 +891,18 @@ def create_app(
             entries = [line for line in chunk.splitlines() if line.strip()]
             return entries, next_cursor
 
+        def _normalize_stream_event(file: Path, payload: dict[str, object]) -> dict[str, object] | None:
+            event = _event_type(payload)
+            if event is None:
+                return None
+            ts = payload.get("ts")
+            return {
+                "type": "run_event",
+                "run_id": file.stem,
+                "event": event,
+                "ts": ts if isinstance(ts, str) else None,
+            }
+
         try:
             while True:
                 if psyche_path.exists():
@@ -900,27 +912,35 @@ def create_app(
                         data = json.loads(psyche_path.read_text())
                         await ws.send_json({"type": "psyche", "data": data})
 
-                incremental_logs: dict[str, list[str]] = {}
+                incremental_events: list[dict[str, object]] = []
                 if runs_path.exists():
                     current_files: set[str] = set()
                     for file in runs_path.iterdir():
-                        if not file.is_file():
+                        if not file.is_file() or file.suffix != ".jsonl":
                             continue
                         current_files.add(file.name)
                         entries, next_cursor = await asyncio.to_thread(
                             _read_new_entries, file, log_cursors.get(file.name)
                         )
                         log_cursors[file.name] = next_cursor
-                        if entries:
-                            incremental_logs[file.name] = entries
+                        for line in entries:
+                            try:
+                                payload = json.loads(line)
+                            except json.JSONDecodeError:
+                                continue
+                            if not isinstance(payload, dict):
+                                continue
+                            event = _normalize_stream_event(file, payload)
+                            if event is not None:
+                                incremental_events.append(event)
 
                     for name in set(log_cursors) - current_files:
                         del log_cursors[name]
                 else:
                     log_cursors.clear()
 
-                if incremental_logs:
-                    await ws.send_json({"type": "logs", "data": incremental_logs})
+                for event in incremental_events:
+                    await ws.send_json(event)
                 await asyncio.sleep(0.1)
         except WebSocketDisconnect:
             pass
@@ -965,9 +985,18 @@ def create_app(
             "<th><button data-sort='iterations'>Itérations</button></th>"
             "<th>Badges</th>"
             "</tr></thead><tbody id='lives-table-body'></tbody></table></section>"
-            "<section><h2>Actions rapides</h2><pre id='action-result'>Aucune exécution</pre><div style='display:flex;flex-direction:column;gap:8px;max-width:680px;'><label>Token dashboard <input id='action-token' type='password' placeholder='optionnel'/></label><label>Nom de vie (birth/use) <input id='action-life-name' placeholder='New life'/></label><label>Prompt talk <input id='action-prompt' placeholder='Prompt unique'/></label><label>Budget loop (s) <input id='action-budget' type='number' min='0.1' step='0.1' value='1.0'/></label><div style='display:flex;gap:8px;flex-wrap:wrap;'><button id='act-birth'>Birth</button><button id='act-talk'>Talk</button><button id='act-loop'>Loop</button><button id='act-report'>Report</button><button id='act-lives-list'>Lives list</button><button id='act-lives-use'>Lives use</button></div></div></section><h2>Runs</h2><div id='logs'></div>"
+            "<section><h2>Actions rapides</h2><pre id='action-result'>Aucune exécution</pre><div style='display:flex;flex-direction:column;gap:8px;max-width:680px;'><label>Token dashboard <input id='action-token' type='password' placeholder='optionnel'/></label><label>Nom de vie (birth/use) <input id='action-life-name' placeholder='New life'/></label><label>Prompt talk <input id='action-prompt' placeholder='Prompt unique'/></label><label>Budget loop (s) <input id='action-budget' type='number' min='0.1' step='0.1' value='1.0'/></label><div style='display:flex;gap:8px;flex-wrap:wrap;'><button id='act-birth'>Birth</button><button id='act-talk'>Talk</button><button id='act-loop'>Loop</button><button id='act-report'>Report</button><button id='act-lives-list'>Lives list</button><button id='act-lives-use'>Lives use</button></div></div></section>"
+            "<section><h2>Événements live</h2>"
+            "<div style='display:flex;gap:8px;align-items:center;flex-wrap:wrap;'>"
+            "<button id='live-toggle'>Pause</button>"
+            "<label><input id='live-autoscroll' type='checkbox' checked/> Auto-scroll</label>"
+            "<span id='live-status'>Lecture en direct</span>"
+            "</div>"
+            "<pre id='live-events' style='max-height:240px;overflow:auto;border:1px solid #ccc;padding:8px;'></pre>"
+            "</section>"
             "<script>const ws=new WebSocket(`ws://${location.host}/ws`);"
             "const livesTableState={sortBy:'score',sortOrder:'desc'};"
+            "const liveState={paused:false,autoScroll:true,events:[]};"
             "const loadEco=()=>fetch('/ecosystem').then(r=>r.json()).then(d=>{document.getElementById('ecosystem-summary').textContent=JSON.stringify(d.summary,null,2);document.getElementById('organisms').textContent=JSON.stringify(d.organisms,null,2);});"
             "const loadCockpit=()=>fetch('/api/cockpit').then(r=>r.json()).then(d=>{"
             "document.getElementById('cockpit-status').textContent=`Statut global: ${d.global_status}`;"
@@ -994,9 +1023,14 @@ def create_app(
             "for(const button of document.querySelectorAll('#lives-table [data-sort]')){button.onclick=()=>{const next=button.getAttribute('data-sort');if(livesTableState.sortBy===next){livesTableState.sortOrder=livesTableState.sortOrder==='desc'?'asc':'desc';}else{livesTableState.sortBy=next;livesTableState.sortOrder='desc';}loadLivesBoard();};}"
             "document.getElementById('filter-active').onchange=()=>loadLivesBoard();"
             "document.getElementById('filter-degrading').onchange=()=>loadLivesBoard();"
+            "const renderLiveEvents=()=>{const pre=document.getElementById('live-events');const rows=liveState.events.map(item=>`${item.ts||'n/a'} | ${item.run_id||'n/a'} | ${item.event||'unknown'}`);pre.textContent=rows.join('\\n');if(liveState.autoScroll){pre.scrollTop=pre.scrollHeight;}};"
+            "const updateLiveStatus=()=>{document.getElementById('live-status').textContent=liveState.paused?'Pause activée':'Lecture en direct';document.getElementById('live-toggle').textContent=liveState.paused?'Reprendre':'Pause';};"
+            "document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};"
+            "document.getElementById('live-autoscroll').onchange=e=>{liveState.autoScroll=Boolean(e.target.checked);if(liveState.autoScroll){renderLiveEvents();}};"
             "const loadTimeline=()=>fetch('/runs/latest').then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}return fetch(`/api/runs/${meta.run}/timeline?page=1&page_size=120`).then(r=>r.json());}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;btn.style.padding='6px';row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.style.alignSelf='center';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';}});"
             "loadEco();loadCockpit();loadTimeline();loadLivesBoard();setInterval(()=>{loadEco();loadCockpit();loadTimeline();loadLivesBoard();},500);"
-            "ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);}else if(m.type==='logs'){const d=document.getElementById('logs');for(const [n,entries] of Object.entries(m.data)){let pre=document.getElementById(`log-${n}`);if(!pre){pre=document.createElement('pre');pre.id=`log-${n}`;pre.textContent=n+'\n';d.appendChild(pre);}for(const entry of entries){pre.textContent+=entry+'\n';}}}};"
+            "updateLiveStatus();"
+            "ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);return;}if(typeof m.run_id==='string'&&typeof m.event==='string'){liveState.events.push({type:m.type,run_id:m.run_id,event:m.event,ts:m.ts||null});if(!liveState.paused){renderLiveEvents();}}};"
             "</script></body></html>"
         )
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -182,6 +182,9 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Vies · Tableau comparatif" in body
     assert "Actives seulement" in body
     assert "Seulement en dégradation" in body
+    assert "Événements live" in body
+    assert "live-autoscroll" in body
+    assert "live-toggle" in body
 
 
 def test_dashboard_timeline_comparison_and_top_mutations(tmp_path: Path) -> None:
@@ -537,11 +540,14 @@ def test_psyche_missing_returns_404(tmp_path: Path) -> None:
     assert response.status_code == 404
 
 
-def test_websocket_stream_incremental_logs_and_growth_stability(tmp_path: Path) -> None:
+def test_websocket_stream_incremental_events_and_growth_stability(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
-    log_file = runs_dir / "log.txt"
-    log_file.write_text("first\n", encoding="utf-8")
+    run_file = runs_dir / "run-live.jsonl"
+    run_file.write_text(
+        json.dumps({"ts": "2026-04-12T10:00:00", "event": "interaction"}) + "\n",
+        encoding="utf-8",
+    )
     psyche_file = tmp_path / "psyche.json"
     psyche_file.write_text(json.dumps({"mood": "happy"}), encoding="utf-8")
 
@@ -551,22 +557,57 @@ def test_websocket_stream_incremental_logs_and_growth_stability(tmp_path: Path) 
     with client.websocket_connect("/ws") as ws:
         first = _receive_with_timeout(ws)
         second = _receive_with_timeout(ws)
-        received = {first["type"]: first["data"], second["type"]: second["data"]}
-        assert received["psyche"] == {"mood": "happy"}
-        assert received["logs"] == {"log.txt": ["first"]}
+        assert first == {"type": "psyche", "data": {"mood": "happy"}} or second == {
+            "type": "psyche",
+            "data": {"mood": "happy"},
+        }
+        first_event = first if "run_id" in first else second
+        assert first_event == {
+            "type": "run_event",
+            "run_id": "run-live",
+            "event": "interaction",
+            "ts": "2026-04-12T10:00:00",
+        }
 
-        with log_file.open("a", encoding="utf-8") as handle:
-            handle.write("second\n")
-        log_update = _receive_with_timeout(ws)
-        assert log_update["type"] == "logs"
-        assert log_update["data"] == {"log.txt": ["second"]}
+        with run_file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"ts": "2026-04-12T10:00:01", "event": "delay"}) + "\n")
+        update = _receive_with_timeout(ws)
+        assert update == {
+            "type": "run_event",
+            "run_id": "run-live",
+            "event": "delay",
+            "ts": "2026-04-12T10:00:01",
+        }
 
-        with log_file.open("a", encoding="utf-8") as handle:
-            handle.write("third\n")
-            handle.write("fourth\n")
-        growth_update = _receive_with_timeout(ws)
-        assert growth_update["type"] == "logs"
-        assert growth_update["data"] == {"log.txt": ["third", "fourth"]}
+        with run_file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"ts": "2026-04-12T10:00:02", "event": "refuse"}) + "\n")
+            handle.write(
+                json.dumps(
+                    {
+                        "ts": "2026-04-12T10:00:03",
+                        "score_base": 10.0,
+                        "score_new": 9.0,
+                        "accepted": True,
+                    }
+                )
+                + "\n"
+            )
+        growth_first = _receive_with_timeout(ws)
+        growth_second = _receive_with_timeout(ws)
+        assert [growth_first, growth_second] == [
+            {
+                "type": "run_event",
+                "run_id": "run-live",
+                "event": "refuse",
+                "ts": "2026-04-12T10:00:02",
+            },
+            {
+                "type": "run_event",
+                "run_id": "run-live",
+                "event": "mutation",
+                "ts": "2026-04-12T10:00:03",
+            },
+        ]
 
 
 


### PR DESCRIPTION
### Motivation
- Remplacer l’envoi de blocs complets de logs vers le frontend par un suivi incrémental des fichiers `*.jsonl` pour éviter le rejeu et permettre un streaming en temps réel stable.
- Fournir au frontend un format d’événement stable et minimal (`type`, `run_id`, `event`, `ts`) pour simplifier le traitement côté UI.
- Ajouter une file d’événements live avec contrôles pause/reprise et auto-scroll pour visualiser la timeline des événements au fil de l’eau.

### Description
- Implémentation d’un tailing par fichier avec curseurs `(inode, offset)` dans `websocket_endpoint` et lecture uniquement des nouvelles lignes des fichiers `*.jsonl` dans `src/singular/dashboard/__init__.py`.
- Normalisation et émission des nouveaux enregistrements sous la forme `{"type":"run_event","run_id":<file.stem>,"event":<event>,"ts":<ts>}` en lieu et place des anciens blocs de logs.
- Ajout d’une section UI «Événements live» avec une queue en mémoire, bouton `live-toggle` (pause/reprendre) et `live-autoscroll` (auto-scroll) dans la page index HTML/JS intégrée.
- Mise à jour des tests dans `tests/test_dashboard.py` pour vérifier la nouvelle UI et couvrir l’émission incrémentale des événements (y compris détection implicite de `mutation`).

### Testing
- Exécuté `pytest -q tests/test_dashboard.py` et les tests ont réussi : `14 passed` with 1 warning. 
- Les nouveaux cas couvrent l’émission initiale d’un `psyche` puis d’événements `run_event`, l’émission incrémentale à l’append de lignes et la non-régression lors de la croissance des fichiers.
- Aucune régression détectée sur les endpoints existants couverts par ces tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc220c6fe8832aa63299b41c745c19)