### PR TITLE
Add `talk` subcommand `--life`/`--live` aliases, deprecation warning and life-like unknown-arg suggestion

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -7,6 +7,7 @@ import getpass
 import json
 import os
 import random
+import re
 import sys
 import sysconfig
 from importlib.metadata import PackageNotFoundError, version
@@ -14,6 +15,78 @@ from pathlib import Path
 from typing import Any, Callable
 
 __all__ = ["main"]
+
+
+def _extract_talk_life_alias(argv: list[str] | None) -> str | None:
+    """Extract ``talk --life/--live`` value from raw argv when present."""
+
+    if not argv:
+        return None
+
+    try:
+        talk_index = argv.index("talk")
+    except ValueError:
+        return None
+
+    tokens = argv[talk_index + 1 :]
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"--life", "--live"} and index + 1 < len(tokens):
+            return tokens[index + 1]
+        if token.startswith("--life="):
+            return token.split("=", 1)[1]
+        if token.startswith("--live="):
+            return token.split("=", 1)[1]
+        index += 1
+    return None
+
+
+def _build_life_suggestion_message(unknown: str) -> str | None:
+    """Return a targeted suggestion when an unknown argument looks like a life slug."""
+
+    if not unknown.startswith("--"):
+        return None
+    candidate = unknown[2:].strip()
+    if not re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9_-]*", candidate):
+        return None
+    return (
+        f"Argument inconnu `{unknown}`. "
+        "Si c'est un nom de vie, utilisez explicitement : "
+        "`singular --life <slug> talk` "
+        "ou `singular --root <root> --life <slug> talk`."
+    )
+
+
+def _suggest_life_flag_for_unknown_args(argv: list[str] | None) -> str | None:
+    """Inspect argv and suggest ``--life`` when unknown options look like slugs."""
+
+    if not argv:
+        return None
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--seed")
+    parser.add_argument("--root")
+    parser.add_argument("--home")
+    parser.add_argument("--life")
+    parser.add_argument("--format")
+    subparsers = parser.add_subparsers(dest="command")
+    talk_parser = subparsers.add_parser("talk", add_help=False)
+    talk_parser.add_argument("--provider")
+    talk_parser.add_argument("--prompt")
+    talk_parser.add_argument("--life")
+    talk_parser.add_argument("--live")
+
+    try:
+        _, unknown = parser.parse_known_args(argv)
+    except SystemExit:
+        return None
+
+    for token in unknown:
+        message = _build_life_suggestion_message(token)
+        if message is not None:
+            return message
+    return None
 
 def _looks_like_dev_repo_root(path: Path) -> bool:
     """Heuristic to detect a development repository root."""
@@ -258,7 +331,7 @@ def _preparse_environment(argv: list[str] | None) -> argparse.Namespace:
 
     from . import lives as life_module
 
-    life_name = args.life
+    life_name = _extract_talk_life_alias(argv) or args.life
     needs_resolution = life_name is not None or (
         args.home is None and "SINGULAR_HOME" not in os.environ
     )
@@ -456,6 +529,18 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="If provided, generate a single response to the prompt and exit",
     )
+    talk_parser.add_argument(
+        "--life",
+        dest="talk_life",
+        default=None,
+        help="Life slug/name for `talk` (prioritaire sur l'option globale)",
+    )
+    talk_parser.add_argument(
+        "--live",
+        dest="talk_life_legacy",
+        default=None,
+        help="Alias de compatibilité déprécié pour `talk --life`",
+    )
 
     quest_parser = subparsers.add_parser(
         "quest", help="Generate a skill from a specification"
@@ -596,7 +681,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Allow purge even if root looks like a development repository",
     )
 
-    args = parser.parse_args(argv_list)
+    try:
+        args = parser.parse_args(argv_list)
+    except SystemExit as exc:
+        if exc.code == 2:
+            suggestion = _suggest_life_flag_for_unknown_args(argv_list)
+            if suggestion is not None:
+                print(suggestion, file=sys.stderr)
+        raise
 
     if args.command == "loop":
         if args.budget_seconds is None and args.ticks is not None:
@@ -610,6 +702,17 @@ def main(argv: list[str] | None = None) -> int:
                 "argument requis: --budget-seconds "
                 "(exemple: `singular loop --budget-seconds 10`)."
             )
+
+    if args.command == "talk":
+        selected_life = args.talk_life
+        if args.talk_life_legacy is not None:
+            print(
+                "⚠️ `talk --live` est déprécié. Utilisez `talk --life`.",
+                file=sys.stderr,
+            )
+            if selected_life is None:
+                selected_life = args.talk_life_legacy
+        args.life = selected_life if selected_life is not None else args.life
 
     if args.root:
         os.environ["SINGULAR_ROOT"] = str(args.root)

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -1,6 +1,10 @@
 import random
+import os
+
+import pytest
 
 from singular.cli import main
+from singular.lives import load_registry
 from singular.memory import read_episodes
 from singular.organisms.talk import _default_reply, talk
 from singular.providers import (
@@ -208,3 +212,68 @@ def test_talk_logs_provider_events(monkeypatch, tmp_path):
     assert events[0]["provider"] == "openai"
     assert events[0]["fallback"] is False
     assert events[0]["error_category"] is None
+
+
+def test_talk_subcommand_life_argument_has_priority(monkeypatch, tmp_path):
+    root = tmp_path / "world"
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+    alpha_slug = load_registry()["active"]
+    assert isinstance(alpha_slug, str)
+    main(["--root", str(root), "lives", "create", "--name", "Beta"])
+
+    captured: dict[str, str] = {}
+
+    def fake_talk(*, provider=None, seed=None, prompt=None):
+        del provider, seed, prompt
+        captured["home"] = os.environ.get("SINGULAR_HOME", "")
+
+    monkeypatch.setattr("singular.organisms.talk.talk", fake_talk)
+    main(
+        [
+            "--root",
+            str(root),
+            "--life",
+            "beta",
+            "talk",
+            "--life",
+            alpha_slug,
+            "--prompt",
+            "bonjour",
+        ]
+    )
+
+    assert captured["home"].endswith(alpha_slug)
+
+
+def test_talk_live_alias_prints_deprecation_warning(
+    monkeypatch, tmp_path, capsys: pytest.CaptureFixture[str]
+):
+    root = tmp_path / "world"
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    monkeypatch.setattr(
+        "singular.organisms.talk.talk",
+        lambda *, provider=None, seed=None, prompt=None: None,
+    )
+    main(["--root", str(root), "talk", "--live", "alpha", "--prompt", "bonjour"])
+
+    stderr = capsys.readouterr().err
+    assert "déprécié" in stderr
+    assert "talk --life" in stderr
+
+
+def test_unknown_argument_that_looks_like_life_suggests_life_flag(
+    capsys: pytest.CaptureFixture[str],
+):
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--lumen", "talk"])
+
+    assert excinfo.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "singular --life <slug> talk" in stderr
+    assert "singular --root <root> --life <slug> talk" in stderr


### PR DESCRIPTION
### Motivation
- Faciliter l'activation d'une vie pour la sous-commande `talk` via un alias local et fournir une rétrocompatibilité pour les utilisateurs utilisant `--live`.
- Prioriser explicitement l'argument fourni à la sous-commande `talk` sur l'option globale `--life` pour éviter des ambiguïtés entre options globales et locales.
- Améliorer l'expérience utilisateur lors d'erreurs de parsing quand un argument inconnu ressemble à un slug de vie en suggérant la commande correcte.

### Description
- Ajout des helpers `
_extract_talk_life_alias`, `
_build_life_suggestion_message` et `
_suggest_life_flag_for_unknown_args` dans `src/singular/cli.py` pour extraire un `--life`/`--live` passé après `talk` et générer une suggestion ciblée.
- Mise à jour de `_preparse_environment` pour prendre en compte un `talk --life/--live` présent dans `argv` lors de la résolution précoce de la vie active.
- Ajout d'options locales à la sous-commande `talk`: `--life` (dest `talk_life`) et `--live` (dest `talk_life_legacy`) et logique qui priorise la valeur fournie à la sous-commande sur l'option globale.
- Affichage d'un message de dépréciation clair sur `stderr` lorsque `talk --live` est utilisé et adoption de sa valeur uniquement si `--life` local est absent.
- Amélioration du parsing principal pour intercepter `SystemExit` de parsing (`exit code 2`) et afficher la suggestion explicite invitant à utiliser `singular --life <slug> talk` ou `singular --root <root> --life <slug> talk` quand un argument inconnu ressemble à un nom de vie.
- Tests ajoutés/mis à jour dans `tests/test_talk.py` couvrant la priorité de l'argument `talk --life`, l'affichage du warning de dépréciation pour `--live`, et la suggestion d'usage sur un argument inconnu ressemblant à une vie.

### Testing
- Exécution des tests ciblés avec `pytest -q tests/test_talk.py tests/test_cli_lives.py` a réussi avec `17 passed`.
- Modifications apportées aux fichiers `src/singular/cli.py` et `tests/test_talk.py` et vérifiées via la suite de tests listée ci‑dessus.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc25ba7474832a84c52971c2198b52)