### PR TITLE
CLI: avertir quand `--root` diffère du registre implicite et afficher le root utilisé sur `birth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ Les sous-commandes qui consultent la mémoire (``talk``, ``run``, ``loop``,
 sélectionnée. Utilisez ``singular lives delete <nom>`` pour supprimer une vie et
 libérer son espace disque.
 
+### Piège courant : changer de root sans le voir
+
+Un cas classique : créer une vie dans le registre implicite, puis lister avec un
+autre root explicite.
+
+```bash
+# Crée la vie dans le root implicite (SINGULAR_ROOT ou ~/.singular)
+singular birth --name "Lumen"
+
+# Liste un autre registre : ici ./lab
+singular lives list --root ./lab
+```
+
+Depuis cette version, Singular affiche un message de contexte quand ``--root``
+diffère du registre implicite précédent :
+
+```text
+Vous utilisez un autre registre de vies: ... (au lieu de ...).
+```
+
+De plus, ``birth`` affiche explicitement le root de registre utilisé pour éviter
+toute ambiguïté.
+
 ## 🧹 Désinstallation
 
 Singular propose une sous-commande pour nettoyer les données stockées dans

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -427,9 +427,37 @@ def _print_table(headers: list[str], rows: list[list[str]]) -> None:
         print(_fmt(row))
 
 
+def _implicit_registry_root_from_env_or_default() -> Path:
+    """Return the implicit registry root used before any ``--root`` override."""
+
+    raw = os.environ.get("SINGULAR_ROOT")
+    if raw:
+        return Path(raw).expanduser()
+    return Path.home() / ".singular"
+
+
+def _print_registry_context_message_if_needed(
+    selected_root: Path | None, *, previous_root: Path
+) -> None:
+    """Inform the user when ``--root`` switches to another registry context."""
+
+    if selected_root is None:
+        return
+
+    active_root = selected_root.expanduser().resolve()
+    if active_root == previous_root:
+        return
+
+    print(
+        "Vous utilisez un autre registre de vies: "
+        f"{active_root} (au lieu de {previous_root})."
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the singular command line interface."""
 
+    implicit_root_before_override = _implicit_registry_root_from_env_or_default().resolve()
     argv_list = list(argv) if argv is not None else None
     _preparse_environment(argv_list)
 
@@ -450,7 +478,10 @@ def main(argv: list[str] | None = None) -> int:
         "--root",
         type=Path,
         default=os.environ.get("SINGULAR_ROOT"),
-        help="Base directory storing lives (env: SINGULAR_ROOT)",
+        help=(
+            "Base directory storing lives (env: SINGULAR_ROOT). "
+            "Un message d'information est affiché si ce root diffère du contexte implicite."
+        ),
     )
     parser.add_argument(
         "--home",
@@ -473,7 +504,10 @@ def main(argv: list[str] | None = None) -> int:
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    birth_parser = subparsers.add_parser("birth", help="Birth a new life")
+    birth_parser = subparsers.add_parser(
+        "birth",
+        help="Birth a new life (affiche aussi le root de registre utilisé)",
+    )
     birth_parser.add_argument(
         "--name",
         default="New life",
@@ -714,6 +748,11 @@ def main(argv: list[str] | None = None) -> int:
                 selected_life = args.talk_life_legacy
         args.life = selected_life if selected_life is not None else args.life
 
+    _print_registry_context_message_if_needed(
+        args.root,
+        previous_root=implicit_root_before_override,
+    )
+
     if args.root:
         os.environ["SINGULAR_ROOT"] = str(args.root)
 
@@ -731,8 +770,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "birth":
         name = args.name or "New life"
         metadata = bootstrap_life(name, seed=args.seed)
+        registry_root = get_registry_root()
         os.environ["SINGULAR_HOME"] = str(metadata.path)
         print(f"Vie créée: {metadata.name} ({metadata.slug}) → {metadata.path}")
+        print(f"Registre de vies utilisé: {registry_root}")
 
     elif args.command == "spawn":
         from .organisms.spawn import spawn

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -147,3 +147,40 @@ def test_status_supports_subcommand_format_and_verbose(
 
     assert captured["verbose"] is True
     assert captured["output_format"] == "table"
+
+
+def test_cli_root_context_message_when_switching_registry_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root_a = tmp_path / "root-a"
+    root_b = tmp_path / "root-b"
+
+    monkeypatch.setenv("SINGULAR_ROOT", str(root_a))
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(["--root", str(root_a), "lives", "list"])
+    first_out = capsys.readouterr().out
+    assert "Vous utilisez un autre registre de vies" not in first_out
+
+    main(["--root", str(root_b), "lives", "list"])
+    second_out = capsys.readouterr().out
+    assert "Vous utilisez un autre registre de vies" in second_out
+    assert str(root_b.resolve()) in second_out
+    assert str(root_a.resolve()) in second_out
+
+
+def test_birth_prints_registry_root_used(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "registry-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(["--root", str(root), "birth", "--name", "Gamma"])
+    out = capsys.readouterr().out
+    assert "Registre de vies utilisé:" in out
+    assert str(root.resolve()) in out


### PR DESCRIPTION
### Motivation

- Réduire les confusions quand on alterne entre un registre implicite (env ou `~/.singular`) et un `--root` explicite en informant l'utilisateur du changement de contexte. 
- Rendre explicite le registre utilisé lors de la création d'une vie pour éviter les erreurs silencieuses liées au mauvais emplacement.

### Description

- Ajout de ` _implicit_registry_root_from_env_or_default()` et ` _print_registry_context_message_if_needed()` dans `src/singular/cli.py` pour calculer le root implicite avant pré-parser et afficher un message informatif quand `--root` diffère de ce contexte implicite. 
- Capture du root implicite avant ` _preparse_environment()` et invocation de la vérification de contexte avant d'écraser `SINGULAR_ROOT`. 
- `birth` affiche désormais explicitement le registre utilisé via `print(f"Registre de vies utilisé: {registry_root}")` en plus du message de vie créée. 
- Mise à jour de l'aide CLI (`--root` et aide de `birth`) pour documenter le comportement contextuel. 
- Documentation `README.md` enrichie avec une section "Piège courant : changer de root sans le voir" et exemple illustrant `birth` sans `--root` vs `lives list --root ...`. 
- Tests ajoutés dans `tests/test_cli_lives.py` pour valider l'affichage du message de contexte lors d'un basculement de root et l'affichage du root utilisé par `birth`.

### Testing

- Exécution des tests ciblés avec `pytest -q tests/test_cli_lives.py`, résultat : `7 passed` (tests verts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc29030c84832aa320d44ecdea4a14)