### PR TITLE
Add 'dead only' filter and alive/dead buckets to dashboard

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -773,6 +773,7 @@ def create_app(
         sort_order: str = "desc",
         active_only: bool = False,
         degrading_only: bool = False,
+        dead_only: bool = False,
     ) -> dict[str, object]:
         comparison = _aggregate_lives()
         lives_rows = [{"life": name, **payload} for name, payload in comparison.items()]
@@ -781,6 +782,8 @@ def create_app(
             lives_rows = [row for row in lives_rows if row.get("active") is True]
         if degrading_only:
             lives_rows = [row for row in lives_rows if row.get("trend") == "dégradation"]
+        if dead_only:
+            lives_rows = [row for row in lives_rows if row.get("alive") is False]
 
         sort_key_map: dict[str, str] = {
             "life": "life",
@@ -809,6 +812,7 @@ def create_app(
                 "sort_order": "desc" if reverse else "asc",
                 "active_only": active_only,
                 "degrading_only": degrading_only,
+                "dead_only": dead_only,
             },
         }
 

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -46,6 +46,17 @@
   <div style='display:flex;gap:12px;align-items:center;flex-wrap:wrap;'>
     <label><input id='filter-active' type='checkbox'/> Actives seulement</label>
     <label><input id='filter-degrading' type='checkbox'/> Seulement en dégradation</label>
+    <label><input id='filter-dead' type='checkbox'/> Morts seulement</label>
+  </div>
+  <div style='display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-top:8px;'>
+    <div style='border:1px solid #ddd;border-radius:8px;padding:8px;'>
+      <strong>Vies vivantes (<span id='alive-count'>0</span>)</strong>
+      <ul id='alive-lives' style='margin:8px 0 0 18px;padding:0;'></ul>
+    </div>
+    <div style='border:1px solid #ddd;border-radius:8px;padding:8px;'>
+      <strong>Vies mortes (<span id='dead-count'>0</span>)</strong>
+      <ul id='dead-lives' style='margin:8px 0 0 18px;padding:0;'></ul>
+    </div>
   </div>
   <table id='lives-table' border='1' cellspacing='0' cellpadding='6' style='margin-top:8px;border-collapse:collapse;width:100%;'>
     <thead><tr>
@@ -107,11 +118,13 @@ document.getElementById('act-report').onclick=()=>runAction('report',{});
 document.getElementById('act-lives-list').onclick=()=>runAction('lives_list',{});
 document.getElementById('act-lives-use').onclick=()=>runAction('lives_use',{name:document.getElementById('action-life-name').value||''});
 const badge=(label,bg)=>`<span style="display:inline-block;padding:2px 8px;border-radius:999px;background:${bg};margin-right:4px;">${label}</span>`;
+const renderLivesBuckets=(rows)=>{const alive=(rows||[]).filter(row=>row.alive===true);const dead=(rows||[]).filter(row=>row.alive===false);const aliveList=document.getElementById('alive-lives');const deadList=document.getElementById('dead-lives');document.getElementById('alive-count').textContent=String(alive.length);document.getElementById('dead-count').textContent=String(dead.length);aliveList.innerHTML='';deadList.innerHTML='';for(const row of alive){const li=document.createElement('li');li.textContent=row.life||'n/a';aliveList.appendChild(li);}for(const row of dead){const li=document.createElement('li');li.textContent=row.life||'n/a';deadList.appendChild(li);}if(!alive.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);}if(!dead.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);}};
 const renderLivesTable=(rows)=>{const body=document.getElementById('lives-table-body');body.innerHTML='';for(const row of rows||[]){const tr=document.createElement('tr');const score=row.current_health_score===null||row.current_health_score===undefined?'n/a':Number(row.current_health_score).toFixed(1);const stability=row.stability===null||row.stability===undefined?'n/a':`${(Number(row.stability)*100).toFixed(1)}%`;const lastActivity=row.last_activity||'n/a';let badges='';if(row.selected){badges+=badge('Sélectionnée','#d1fadf');}else{badges+=badge('Non sélectionnée','#fde2e1');}if(row.alive){badges+=badge('Vivante','#d1fadf');}else{badges+=badge('Morte','#fde2e1');}if(row.trend==='dégradation'){badges+=badge('dégradation','#ffe7c2');}if((row.alerts_count||0)>0){badges+=badge(`${row.alerts_count} alertes`,'#fecdca');}tr.innerHTML=`<td>${row.life||'n/a'}</td><td>${score}</td><td>${row.trend||'n/a'}</td><td>${stability}</td><td>${lastActivity}</td><td>${row.iterations??0}</td><td>${badges}</td>`;body.appendChild(tr);}if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}};
-const loadLivesBoard=()=>{const q=new URLSearchParams();q.set('sort_by',livesTableState.sortBy);q.set('sort_order',livesTableState.sortOrder);if(document.getElementById('filter-active').checked){q.set('active_only','true');}if(document.getElementById('filter-degrading').checked){q.set('degrading_only','true');}return fetch(`/lives/comparison?${q.toString()}`).then(r=>r.json()).then(d=>renderLivesTable(d.table||[]));};
+const loadLivesBoard=()=>{const q=new URLSearchParams();q.set('sort_by',livesTableState.sortBy);q.set('sort_order',livesTableState.sortOrder);if(document.getElementById('filter-active').checked){q.set('active_only','true');}if(document.getElementById('filter-degrading').checked){q.set('degrading_only','true');}if(document.getElementById('filter-dead').checked){q.set('dead_only','true');}return fetch(`/lives/comparison?${q.toString()}`).then(r=>r.json()).then(d=>{renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})));renderLivesTable(d.table||[]);});};
 for(const button of document.querySelectorAll('#lives-table [data-sort]')){button.onclick=()=>{const next=button.getAttribute('data-sort');if(livesTableState.sortBy===next){livesTableState.sortOrder=livesTableState.sortOrder==='desc'?'asc':'desc';}else{livesTableState.sortBy=next;livesTableState.sortOrder='desc';}loadLivesBoard();};}
 document.getElementById('filter-active').onchange=()=>loadLivesBoard();
 document.getElementById('filter-degrading').onchange=()=>loadLivesBoard();
+document.getElementById('filter-dead').onchange=()=>loadLivesBoard();
 const renderLiveEvents=()=>{const pre=document.getElementById('live-events');const rows=liveState.events.map(item=>`${item.ts||'n/a'} | ${item.run_id||'n/a'} | ${item.event||'unknown'}`);pre.textContent=rows.join('\n');if(liveState.autoScroll){pre.scrollTop=pre.scrollHeight;}};
 const updateLiveStatus=()=>{document.getElementById('live-status').textContent=liveState.paused?'Pause activée':'Lecture en direct';document.getElementById('live-toggle').textContent=liveState.paused?'Reprendre':'Pause';};
 document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -568,6 +568,9 @@ def test_lives_comparison_table_aggregation_filters_and_sorting(
     degrading_only = route(degrading_only=True)["table"]
     assert [row["life"] for row in degrading_only] == ["life-a"]
 
+    dead_only = route(dead_only=True)["table"]
+    assert [row["life"] for row in dead_only] == ["life-b"]
+
     by_life_asc = route(sort_by="life", sort_order="asc")["table"]
     assert [row["life"] for row in by_life_asc] == ["life-a", "life-b", "life-c"]
 


### PR DESCRIPTION
### Motivation

- Make it easy to see which lives are dead vs alive directly in the dashboard UI.
- Reuse the existing `/lives/comparison` payload for new UI buckets without adding a new endpoint.
- Support server-side filtering for "dead only" so clients can request only dead lives when needed.

### Description

- Added a `dead_only: bool` parameter to the `read_lives_comparison` handler to filter rows where `alive is False`, and exposed the flag in the returned `filters` map (file: `src/singular/dashboard/__init__.py`).
- Updated the dashboard template `src/singular/dashboard/templates/dashboard.html` to add a `Morts seulement` checkbox and two visible buckets with counters and lists: `Vies vivantes` and `Vies mortes`.
- Implemented `renderLivesBuckets` client-side and wired it into `loadLivesBoard` so the UI reuses the `/lives/comparison` response to populate the two lists and to send the `dead_only` query parameter when the checkbox is checked.
- Added a test assertion in `tests/test_dashboard.py` to cover the new `dead_only` filter behavior (mirrors existing `active_only`/`degrading_only` coverage).

### Testing

- Ran `pytest -q tests/test_dashboard.py::test_lives_comparison_table_aggregation_filters_and_sorting` and it passed (`1 passed`).
- Ran the full dashboard test file `pytest -q tests/test_dashboard.py` and it passed (`15 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3085d924832aa71152c309abfa30)