### PR TITLE
Add layered memory module with local backend and retention

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -14,7 +14,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, Iterable, Mapping
 
-from singular.memory import add_episode, update_score
+from singular.memory import add_episode, add_procedural_memory, update_score
 from singular.psyche import Psyche, Mood
 from singular.runs.logger import RunLogger
 from singular.runs.explain import summarize_mutation
@@ -327,6 +327,19 @@ def log_mutation(
         human_summary=human_summary,
         loop_modifications=loop_modifications,
         health=health,
+    )
+    add_procedural_memory(
+        {
+            "event": "loop_mutation",
+            "iteration": iteration,
+            "skill": key,
+            "op": op_name,
+            "accepted": accepted,
+            "score_base": base_score,
+            "score_new": mutated_score,
+            "loop_modifications": loop_modifications,
+            "health": health or {},
+        }
     )
 
 

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -12,6 +12,10 @@ import json
 import os
 import tempfile
 
+from .memory_layers import MemoryLayerService, build_backend
+
+_MEMORY_LAYER_SERVICE: MemoryLayerService | None = None
+
 
 def get_base_dir() -> Path:
     """Return the base directory for persistent files."""
@@ -21,6 +25,12 @@ def get_base_dir() -> Path:
 def get_mem_dir() -> Path:
     """Return the base memory directory."""
     return get_base_dir() / "mem"
+
+
+def get_memory_layers_dir() -> Path:
+    """Return the directory containing layered memory storage."""
+
+    return get_mem_dir() / "layers"
 
 
 def get_profile_file() -> Path:
@@ -83,6 +93,18 @@ def ensure_memory_structure(mem_dir: Path | str | None = None) -> None:
     (mem_dir / "episodic.jsonl").touch(exist_ok=True)
     (mem_dir / "skills.json").touch(exist_ok=True)
     (mem_dir / "psyche.json").touch(exist_ok=True)
+    (mem_dir / "layers").mkdir(parents=True, exist_ok=True)
+
+
+def get_memory_layer_service() -> MemoryLayerService:
+    """Return the singleton memory layer service."""
+
+    global _MEMORY_LAYER_SERVICE
+    if _MEMORY_LAYER_SERVICE is None:
+        _MEMORY_LAYER_SERVICE = MemoryLayerService(
+            build_backend(root=get_memory_layers_dir())
+        )
+    return _MEMORY_LAYER_SERVICE
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +231,21 @@ def add_episode(
     path = Path(path)
     existing = path.read_text(encoding="utf-8") if path.exists() else ""
     _atomic_write_text(path, existing + json.dumps(episode) + "\n")
+    try:
+        get_memory_layer_service().ingest_episode(episode)
+    except Exception:
+        # Layered memory is best effort to preserve compatibility.
+        pass
+
+
+def add_procedural_memory(result: dict[str, Any]) -> None:
+    """Store mutation/run outcomes into procedural memory."""
+
+    try:
+        get_memory_layer_service().ingest_mutation_result(result)
+    except Exception:
+        # Layered memory is best effort to preserve compatibility.
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/src/singular/memory_layers/__init__.py
+++ b/src/singular/memory_layers/__init__.py
@@ -1,0 +1,12 @@
+from .base import MemoryBackend, MemoryRecord
+from .local_json import LocalJsonMemoryBackend
+from .service import MemoryLayerService
+from .vector_adapter import build_backend
+
+__all__ = [
+    "MemoryBackend",
+    "MemoryRecord",
+    "LocalJsonMemoryBackend",
+    "MemoryLayerService",
+    "build_backend",
+]

--- a/src/singular/memory_layers/base.py
+++ b/src/singular/memory_layers/base.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass
+class MemoryRecord:
+    """Generic memory record stored by backends."""
+
+    id: str
+    text: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    score: float = 0.0
+
+
+class MemoryBackend(Protocol):
+    """Storage/search contract for memory layers."""
+
+    def put(self, layer: str, record: MemoryRecord) -> None:
+        """Persist a memory record in *layer*."""
+
+    def search(self, layer: str, query: str, limit: int = 5) -> list[MemoryRecord]:
+        """Return top matching records for *query*."""
+
+    def delete(self, layer: str, record_id: str) -> bool:
+        """Delete one record by id and return whether it existed."""

--- a/src/singular/memory_layers/local_json.py
+++ b/src/singular/memory_layers/local_json.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+import json
+import math
+import re
+
+from .base import MemoryBackend, MemoryRecord
+
+_TOKEN_RE = re.compile(r"[a-zA-Z0-9_]+")
+
+
+class LocalJsonMemoryBackend(MemoryBackend):
+    """Simple local backend based on JSONL files and lexical similarity."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _layer_path(self, layer: str) -> Path:
+        return self.root / f"{layer}.jsonl"
+
+    def _read_layer(self, layer: str) -> list[MemoryRecord]:
+        path = self._layer_path(layer)
+        if not path.exists():
+            return []
+        records: list[MemoryRecord] = []
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                payload = json.loads(line)
+                records.append(
+                    MemoryRecord(
+                        id=str(payload.get("id", "")),
+                        text=str(payload.get("text", "")),
+                        metadata=dict(payload.get("metadata", {})),
+                    )
+                )
+        return records
+
+    def _write_layer(self, layer: str, records: list[MemoryRecord]) -> None:
+        path = self._layer_path(layer)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            for rec in records:
+                handle.write(
+                    json.dumps(
+                        {"id": rec.id, "text": rec.text, "metadata": rec.metadata}
+                    )
+                    + "\n"
+                )
+
+    def put(self, layer: str, record: MemoryRecord) -> None:
+        records = [r for r in self._read_layer(layer) if r.id != record.id]
+        records.append(record)
+        self._write_layer(layer, records)
+
+    def search(self, layer: str, query: str, limit: int = 5) -> list[MemoryRecord]:
+        query_vec = _vectorize(query)
+        scored: list[MemoryRecord] = []
+        for rec in self._read_layer(layer):
+            rec.score = _cosine(query_vec, _vectorize(rec.text))
+            scored.append(rec)
+        scored.sort(key=lambda item: item.score, reverse=True)
+        return scored[: max(0, limit)]
+
+    def delete(self, layer: str, record_id: str) -> bool:
+        records = self._read_layer(layer)
+        filtered = [rec for rec in records if rec.id != record_id]
+        self._write_layer(layer, filtered)
+        return len(filtered) != len(records)
+
+
+def _vectorize(text: str) -> Counter[str]:
+    return Counter(token.lower() for token in _TOKEN_RE.findall(text))
+
+
+def _cosine(a: Counter[str], b: Counter[str]) -> float:
+    if not a or not b:
+        return 0.0
+    dot = sum(a[k] * b[k] for k in a.keys() & b.keys())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)

--- a/src/singular/memory_layers/service.py
+++ b/src/singular/memory_layers/service.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from .base import MemoryBackend, MemoryRecord
+
+_SHORT_TERM_LAYER = "short_term"
+_LONG_TERM_LAYER = "long_term"
+_SEMANTIC_LAYER = "semantic"
+_PROCEDURAL_LAYER = "procedural"
+
+
+class MemoryLayerService:
+    """High-level memory orchestration with retention and consolidation."""
+
+    def __init__(
+        self,
+        backend: MemoryBackend,
+        *,
+        short_term_window: int = 200,
+        consolidate_every: int = 25,
+    ) -> None:
+        self.backend = backend
+        self.short_term_window = max(1, short_term_window)
+        self.consolidate_every = max(1, consolidate_every)
+        self._episodes_since_consolidation = 0
+
+    def ingest_episode(self, episode: dict[str, Any]) -> None:
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        record = MemoryRecord(
+            id=_stable_id("episode", episode, now),
+            text=_episode_text(episode),
+            metadata={"kind": "episode", "ts": now, **episode},
+        )
+        self.backend.put(_SHORT_TERM_LAYER, record)
+        self._episodes_since_consolidation += 1
+        self._enforce_short_term_window()
+        self._extract_semantic_facts(episode, now)
+        if self._episodes_since_consolidation >= self.consolidate_every:
+            self.consolidate()
+            self._episodes_since_consolidation = 0
+
+    def ingest_mutation_result(self, result: dict[str, Any]) -> None:
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        text = (
+            f"Mutation skill={result.get('skill')} op={result.get('op')} "
+            f"ok={result.get('ok')} score_new={result.get('score_new')}"
+        )
+        record = MemoryRecord(
+            id=_stable_id("mutation", result, now),
+            text=text,
+            metadata={"kind": "mutation", "ts": now, **result},
+        )
+        self.backend.put(_PROCEDURAL_LAYER, record)
+
+    def consolidate(self) -> None:
+        recent = self.backend.search(_SHORT_TERM_LAYER, query="", limit=10000)
+        for rec in recent:
+            long_rec = MemoryRecord(
+                id=f"ltm-{rec.id}",
+                text=rec.text,
+                metadata={**rec.metadata, "consolidated": True},
+            )
+            self.backend.put(_LONG_TERM_LAYER, long_rec)
+
+    def _enforce_short_term_window(self) -> None:
+        records = self.backend.search(_SHORT_TERM_LAYER, query="", limit=100000)
+        if len(records) <= self.short_term_window:
+            return
+        # backend.search sorts by score; for empty query scores are 0 => stable order by file order.
+        overflow = len(records) - self.short_term_window
+        for rec in records[:overflow]:
+            self.backend.delete(_SHORT_TERM_LAYER, rec.id)
+
+    def _extract_semantic_facts(self, episode: dict[str, Any], ts: str) -> None:
+        for key in ("user_fact", "user_facts", "preference", "preferences"):
+            value = episode.get(key)
+            if value is None:
+                continue
+            if isinstance(value, list):
+                values = [str(item) for item in value]
+            else:
+                values = [str(value)]
+            for item in values:
+                self.backend.put(
+                    _SEMANTIC_LAYER,
+                    MemoryRecord(
+                        id=_stable_id("semantic", {"key": key, "value": item}, ts),
+                        text=item,
+                        metadata={"kind": "semantic", "category": key, "ts": ts},
+                    ),
+                )
+
+
+def _episode_text(episode: dict[str, Any]) -> str:
+    if "summary" in episode:
+        return str(episode["summary"])
+    if "event" in episode:
+        return f"event={episode['event']} payload={json.dumps(episode, ensure_ascii=False)}"
+    return json.dumps(episode, ensure_ascii=False)
+
+
+def _stable_id(prefix: str, payload: dict[str, Any], ts: str) -> str:
+    digest = hashlib.sha1(
+        json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"{prefix}-{ts}-{digest}"

--- a/src/singular/memory_layers/vector_adapter.py
+++ b/src/singular/memory_layers/vector_adapter.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+import logging
+import os
+
+from .base import MemoryBackend
+from .local_json import LocalJsonMemoryBackend
+
+log = logging.getLogger(__name__)
+
+
+def build_backend(*, root: Path | str | None = None) -> MemoryBackend:
+    """Build a memory backend from env config.
+
+    SINGULAR_MEMORY_BACKEND=local|chroma|pinecone
+    """
+
+    backend = os.environ.get("SINGULAR_MEMORY_BACKEND", "local").strip().lower()
+    root_path = Path(root) if root is not None else Path(
+        os.environ.get("SINGULAR_HOME", ".")
+    ) / "mem" / "layers"
+
+    if backend == "local":
+        return LocalJsonMemoryBackend(root_path)
+
+    if backend == "chroma":
+        try:
+            import chromadb  # type: ignore  # noqa: F401
+        except ImportError:
+            log.warning("chroma backend requested but chromadb is missing, fallback local")
+            return LocalJsonMemoryBackend(root_path)
+
+    if backend == "pinecone":
+        try:
+            import pinecone  # type: ignore  # noqa: F401
+        except ImportError:
+            log.warning("pinecone backend requested but pinecone is missing, fallback local")
+            return LocalJsonMemoryBackend(root_path)
+
+    # Adapter stub: until full API wiring, fallback to the local implementation.
+    return LocalJsonMemoryBackend(root_path)

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -11,7 +11,7 @@ import os
 from typing import Any
 
 from ..psyche import Psyche
-from ..memory import add_episode
+from ..memory import add_episode, add_procedural_memory
 from typing import Callable, Dict
 
 # Base directory for persistent files
@@ -211,6 +211,7 @@ class RunLogger:
         add_episode(
             {"event": "mutation", "mood": mood_val, **record}, mood_styles=mood_styles
         )
+        add_procedural_memory(record)
 
     def log_death(self, reason: str, **info: Any) -> None:
         """Record a death event with optional additional information."""

--- a/tests/test_memory_layers.py
+++ b/tests/test_memory_layers.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+
+from singular.memory_layers import LocalJsonMemoryBackend, MemoryLayerService
+
+
+def test_local_backend_put_search_delete(tmp_path):
+    backend = LocalJsonMemoryBackend(tmp_path / "layers")
+    from singular.memory_layers.base import MemoryRecord
+
+    backend.put("short_term", MemoryRecord(id="1", text="likes python", metadata={}))
+    backend.put("short_term", MemoryRecord(id="2", text="likes rust", metadata={}))
+
+    res = backend.search("short_term", "python", limit=1)
+    assert len(res) == 1
+    assert res[0].id == "1"
+
+    assert backend.delete("short_term", "1") is True
+    assert backend.delete("short_term", "404") is False
+
+
+def test_service_retention_and_consolidation(tmp_path):
+    backend = LocalJsonMemoryBackend(tmp_path / "layers")
+    service = MemoryLayerService(backend, short_term_window=2, consolidate_every=2)
+
+    service.ingest_episode({"event": "a", "summary": "alpha"})
+    service.ingest_episode({"event": "b", "summary": "beta"})
+    service.ingest_episode({"event": "c", "summary": "gamma"})
+
+    short_path = tmp_path / "layers" / "short_term.jsonl"
+    long_path = tmp_path / "layers" / "long_term.jsonl"
+
+    short_lines = [line for line in short_path.read_text(encoding="utf-8").splitlines() if line]
+    assert len(short_lines) == 2
+
+    long_lines = [line for line in long_path.read_text(encoding="utf-8").splitlines() if line]
+    assert len(long_lines) >= 2
+
+
+def test_add_episode_enriches_semantic_memory(tmp_path, monkeypatch):
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+
+    from singular.memory import add_episode, get_memory_layers_dir
+
+    add_episode(
+        {
+            "event": "user_profile",
+            "user_facts": ["lives in paris"],
+            "preferences": ["coffee"],
+        }
+    )
+
+    semantic_path = get_memory_layers_dir() / "semantic.jsonl"
+    lines = [json.loads(line) for line in semantic_path.read_text(encoding="utf-8").splitlines()]
+    texts = [entry["text"] for entry in lines]
+    assert "lives in paris" in texts
+    assert "coffee" in texts


### PR DESCRIPTION
### Motivation
- Introduce a layered memory system to support semantic, episodic and procedural memories with a clear backend interface for future vector DB integrations.  
- Provide a startup-friendly local backend so memory features work without extra dependencies.  
- Feed procedural memory from existing mutation/run workflows so long-running behavior and results can be consolidated and queried later.  

### Description
- Added a new package `src/singular/memory_layers` containing the `MemoryBackend`/`MemoryRecord` contract, `LocalJsonMemoryBackend`, a `build_backend` adapter, and the `MemoryLayerService` that implements short-term retention, semantic extraction and periodic consolidation to long-term memory.  
- Wired a singleton layered service into `src/singular/memory.py` by adding `get_memory_layer_service()`, calling ingestion from `add_episode`, and exposing `add_procedural_memory()` as a best-effort helper.  
- Pushed procedural records from runtime paths by calling `add_procedural_memory` from `runs/logger.py` (`RunLogger.log`) and from `life/loop.py` (`log_mutation`) so mutation results are recorded into the procedural layer.  
- Added tests `tests/test_memory_layers.py` validating `LocalJsonMemoryBackend` `put/search/delete`, short-term retention/consolidation behavior, and semantic enrichment via `add_episode`.  

### Testing
- Ran `pytest -q tests/test_memory_layers.py tests/test_memory.py tests/test_runs_logger.py tests/test_loop.py` and the test set passed (39 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3415b3a4832a838b1df5b5f9e0f6)