### PR TITLE
Dashboard: agréger les runs multi‑vies, exposer le contexte registre/vie et ajouter filtre vie courante

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -11,7 +11,7 @@ import os
 import sys
 from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
-from singular.lives import load_registry, set_life_status
+from singular.lives import get_registry_root, load_registry, set_life_status
 
 from singular.dashboard.actions import DashboardActionService
 from fastapi.responses import HTMLResponse
@@ -29,8 +29,9 @@ def create_app(
     runs_dir: Path | str | None = None, psyche_file: Path | str | None = None
 ) -> FastAPI:
     """Create the dashboard FastAPI application."""
-    base_dir = Path(os.environ.get("SINGULAR_HOME", "."))
-    runs_path = Path(runs_dir) if runs_dir is not None else base_dir / "runs"
+    registry_root = get_registry_root()
+    base_dir = Path(os.environ.get("SINGULAR_HOME", registry_root))
+    runs_path = Path(runs_dir) if runs_dir is not None else None
     psyche_path = (
         Path(psyche_file)
         if psyche_file is not None
@@ -46,27 +47,57 @@ def create_app(
             template = template.replace(key, value)
         return template
 
-    def _load_run_records() -> list[dict[str, object]]:
-        records: list[dict[str, object]] = []
-        if not runs_path.exists():
-            return records
+    def _registry_lives_paths() -> list[Path]:
+        registry = load_registry()
+        raw_lives = registry.get("lives")
+        if not isinstance(raw_lives, dict):
+            return []
+        lives_paths: list[Path] = []
+        for meta in raw_lives.values():
+            path = getattr(meta, "path", None)
+            if isinstance(path, Path):
+                lives_paths.append(path)
+        return lives_paths
 
-        for file in runs_path.iterdir():
-            if not file.is_file() or file.suffix != ".jsonl":
+    def _runs_dirs(current_life_only: bool = False) -> list[Path]:
+        if runs_path is not None:
+            return [runs_path]
+        if current_life_only:
+            return [base_dir / "runs"]
+        dirs: list[Path] = []
+        seen: set[str] = set()
+        for life_dir in _registry_lives_paths():
+            candidate = life_dir / "runs"
+            candidate_key = str(candidate.resolve()) if candidate.exists() else str(candidate)
+            if candidate_key in seen:
                 continue
-            for line in file.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line:
+            seen.add(candidate_key)
+            dirs.append(candidate)
+        if not dirs:
+            dirs.append(base_dir / "runs")
+        return dirs
+
+    def _load_run_records(current_life_only: bool = False) -> list[dict[str, object]]:
+        records: list[dict[str, object]] = []
+        for directory in _runs_dirs(current_life_only=current_life_only):
+            if not directory.exists():
+                continue
+            for file in directory.iterdir():
+                if not file.is_file() or file.suffix != ".jsonl":
                     continue
-                try:
-                    payload = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if not isinstance(payload, dict):
-                    continue
-                if "_run_file" not in payload:
-                    payload["_run_file"] = file.stem
-                records.append(payload)
+                for line in file.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(payload, dict):
+                        continue
+                    if "_run_file" not in payload:
+                        payload["_run_file"] = file.stem
+                    records.append(payload)
         return records
 
     def _is_mutation_record(record: dict[str, object]) -> bool:
@@ -130,10 +161,12 @@ def create_app(
                 return mapped_life
         return "unknown"
 
-    def _compute_ecosystem() -> dict:
+    def _compute_ecosystem(current_life_only: bool = False) -> dict:
         organisms: dict[str, dict[str, object]] = {}
-        if runs_path.exists():
-            for file in runs_path.iterdir():
+        for directory in _runs_dirs(current_life_only=current_life_only):
+            if not directory.exists():
+                continue
+            for file in directory.iterdir():
                 if not file.is_file() or file.suffix != ".jsonl":
                     continue
                 for line in file.read_text(encoding="utf-8").splitlines():
@@ -198,11 +231,16 @@ def create_app(
             },
         }
 
-    def _iter_run_files() -> list[Path]:
-        if not runs_path.exists():
-            return []
+    def _iter_run_files(current_life_only: bool = False) -> list[Path]:
+        files: list[Path] = []
+        for directory in _runs_dirs(current_life_only=current_life_only):
+            if not directory.exists():
+                continue
+            for path in directory.iterdir():
+                if path.is_file() and path.suffix == ".jsonl":
+                    files.append(path)
         return sorted(
-            [path for path in runs_path.iterdir() if path.is_file() and path.suffix == ".jsonl"],
+            files,
             key=lambda path: (path.stat().st_mtime_ns, path.name),
         )
 
@@ -220,8 +258,8 @@ def create_app(
                 records.append(payload)
         return records
 
-    def _latest_run_file() -> Path | None:
-        files = _iter_run_files()
+    def _latest_run_file(current_life_only: bool = False) -> Path | None:
+        files = _iter_run_files(current_life_only=current_life_only)
         if not files:
             return None
 
@@ -337,8 +375,8 @@ def create_app(
             },
         }
 
-    def _summarize_cockpit() -> dict[str, object]:
-        latest = _latest_run_file()
+    def _summarize_cockpit(current_life_only: bool = False) -> dict[str, object]:
+        latest = _latest_run_file(current_life_only=current_life_only)
         if latest is None:
             empty = {
                 "run": None,
@@ -450,12 +488,16 @@ def create_app(
 
 
     @app.get("/logs")
-    def read_logs() -> dict[str, str]:
+    def read_logs(current_life_only: bool = False) -> dict[str, str]:
         logs: dict[str, str] = {}
-        if runs_path.exists():
-            for file in runs_path.iterdir():
+        prefix_paths = runs_path is None
+        for directory in _runs_dirs(current_life_only=current_life_only):
+            if not directory.exists():
+                continue
+            for file in directory.iterdir():
                 if file.is_file():
-                    logs[file.name] = file.read_text()
+                    key = f"{directory.parent.name}/{file.name}" if prefix_paths else file.name
+                    logs[key] = file.read_text()
         return logs
 
     @app.get("/psyche")
@@ -465,20 +507,20 @@ def create_app(
         return json.loads(psyche_path.read_text())
 
     @app.get("/ecosystem")
-    def read_ecosystem() -> dict:
-        return _compute_ecosystem()
+    def read_ecosystem(current_life_only: bool = False) -> dict:
+        return _compute_ecosystem(current_life_only=current_life_only)
 
     @app.get("/alerts")
-    def read_alerts() -> dict[str, object]:
-        latest = _latest_run_file()
+    def read_alerts(current_life_only: bool = False) -> dict[str, object]:
+        latest = _latest_run_file(current_life_only=current_life_only)
         if latest is None:
             return {"run": None, "alerts": []}
         records = _read_jsonl_records(latest)
         return {"run": latest.stem, "alerts": alerts_from_records(records)}
 
     @app.get("/runs/latest")
-    def read_latest_run() -> dict[str, object]:
-        latest = _latest_run_file()
+    def read_latest_run(current_life_only: bool = False) -> dict[str, object]:
+        latest = _latest_run_file(current_life_only=current_life_only)
         if latest is None:
             return {"run": None, "records": []}
         return {"run": latest.stem, "records": _read_jsonl_records(latest)}
@@ -493,9 +535,17 @@ def create_app(
         period_start: str | None = None,
         period_end: str | None = None,
         organism: str | None = None,
+        current_life_only: bool = False,
     ) -> dict[str, object]:
-        run_file = runs_path / f"{run_id}.jsonl"
-        if not run_file.exists():
+        run_file = next(
+            (
+                directory / f"{run_id}.jsonl"
+                for directory in _runs_dirs(current_life_only=current_life_only)
+                if (directory / f"{run_id}.jsonl").exists()
+            ),
+            None,
+        )
+        if run_file is None:
             raise HTTPException(status_code=404, detail=f"run '{run_id}' not found")
 
         all_items: list[dict[str, object]] = []
@@ -557,9 +607,18 @@ def create_app(
         }
 
     @app.get("/api/runs/{run_id}/mutations/{index}")
-    def read_run_mutation(run_id: str, index: int) -> dict[str, object]:
-        run_file = runs_path / f"{run_id}.jsonl"
-        if not run_file.exists():
+    def read_run_mutation(
+        run_id: str, index: int, current_life_only: bool = False
+    ) -> dict[str, object]:
+        run_file = next(
+            (
+                directory / f"{run_id}.jsonl"
+                for directory in _runs_dirs(current_life_only=current_life_only)
+                if (directory / f"{run_id}.jsonl").exists()
+            ),
+            None,
+        )
+        if run_file is None:
             raise HTTPException(status_code=404, detail=f"run '{run_id}' not found")
 
         mutations = [record for record in _read_jsonl_records(run_file) if _is_mutation_record(record)]
@@ -571,8 +630,8 @@ def create_app(
         return _mutation_detail(mutations[index], run_id=run_id, index=index)
 
     @app.get("/runs/latest/summary")
-    def read_latest_run_summary() -> dict[str, object]:
-        latest = _latest_run_file()
+    def read_latest_run_summary(current_life_only: bool = False) -> dict[str, object]:
+        latest = _latest_run_file(current_life_only=current_life_only)
         if latest is None:
             return {"run": None, "summary": None}
 
@@ -612,8 +671,16 @@ def create_app(
         }
 
     @app.get("/api/cockpit")
-    def read_cockpit() -> dict[str, object]:
-        return _summarize_cockpit()
+    def read_cockpit(current_life_only: bool = False) -> dict[str, object]:
+        return _summarize_cockpit(current_life_only=current_life_only)
+
+    @app.get("/dashboard/context")
+    def read_dashboard_context() -> dict[str, object]:
+        return {
+            "singular_root": str(registry_root),
+            "singular_home": str(base_dir),
+            "registry_lives_count": len(_registry_lives_paths()),
+        }
 
     @app.get("/timeline")
     def read_timeline(
@@ -622,8 +689,9 @@ def create_app(
         operator: str | None = None,
         decision: str | None = None,
         impact: str | None = None,
+        current_life_only: bool = False,
     ) -> dict[str, object]:
-        records = _load_run_records()
+        records = _load_run_records(current_life_only=current_life_only)
         items: list[dict[str, object]] = []
 
         for record in records:
@@ -730,7 +798,9 @@ def create_app(
                     return slug, None
         return None, None
 
-    def _aggregate_lives() -> tuple[dict[str, dict[str, object]], dict[str, object]]:
+    def _aggregate_lives(
+        current_life_only: bool = False,
+    ) -> tuple[dict[str, dict[str, object]], dict[str, object]]:
         registry = load_registry()
         active_life = registry.get("active")
         registry_lives = registry.get("lives")
@@ -738,7 +808,7 @@ def create_app(
             registry_lives = {}
         by_life: dict[str, list[dict[str, object]]] = {}
         unattached_runs: dict[str, int] = {}
-        for record in _load_run_records():
+        for record in _load_run_records(current_life_only=current_life_only):
             life_name = _record_life(record)
             if life_name == "unknown":
                 run_id = _record_run_id(record)
@@ -877,8 +947,9 @@ def create_app(
         active_only: bool = False,
         degrading_only: bool = False,
         dead_only: bool = False,
+        current_life_only: bool = False,
     ) -> dict[str, object]:
-        comparison, unattached = _aggregate_lives()
+        comparison, unattached = _aggregate_lives(current_life_only=current_life_only)
         lives_rows = [{"life": name, **payload} for name, payload in comparison.items()]
 
         if active_only:
@@ -925,10 +996,10 @@ def create_app(
         }
 
     @app.get("/mutations/top")
-    def read_top_mutations(limit: int = 3) -> dict[str, object]:
+    def read_top_mutations(limit: int = 3, current_life_only: bool = False) -> dict[str, object]:
         mutations: list[dict[str, object]] = []
         operator_counts: Counter[str] = Counter()
-        for record in _load_run_records():
+        for record in _load_run_records(current_life_only=current_life_only):
             if not _is_mutation_record(record):
                 continue
             operator = record.get("operator", record.get("op"))
@@ -1040,16 +1111,21 @@ def create_app(
                         await ws.send_json({"type": "psyche", "data": data})
 
                 incremental_events: list[dict[str, object]] = []
-                if runs_path.exists():
+                run_directories = _runs_dirs()
+                if run_directories:
                     current_files: set[str] = set()
-                    for file in runs_path.iterdir():
-                        if not file.is_file() or file.suffix != ".jsonl":
+                    for directory in run_directories:
+                        if not directory.exists():
                             continue
-                        current_files.add(file.name)
-                        entries, next_cursor = await asyncio.to_thread(
-                            _read_new_entries, file, log_cursors.get(file.name)
-                        )
-                        log_cursors[file.name] = next_cursor
+                        for file in directory.iterdir():
+                            if not file.is_file() or file.suffix != ".jsonl":
+                                continue
+                            key = f"{directory.parent.name}/{file.name}"
+                            current_files.add(key)
+                            entries, next_cursor = await asyncio.to_thread(
+                                _read_new_entries, file, log_cursors.get(key)
+                            )
+                            log_cursors[key] = next_cursor
                         for line in entries:
                             try:
                                 payload = json.loads(line)

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
+from singular.lives import get_registry_root
+
 
 @dataclass(slots=True)
 class ActionResult:
@@ -31,8 +33,18 @@ class DashboardActionService:
     """Execute controlled dashboard actions with strict validation."""
 
     def __init__(self, *, root: Path | None = None, home: Path | None = None) -> None:
-        self.root = Path(root or os.environ.get("SINGULAR_ROOT", Path.home() / ".singular"))
-        self.home = Path(home or os.environ.get("SINGULAR_HOME", "."))
+        self.root = Path(root) if root is not None else get_registry_root()
+        if home is not None:
+            self.home = Path(home)
+        else:
+            self.home = Path(os.environ.get("SINGULAR_HOME", self.root))
+
+    def _context_payload(self) -> dict[str, str]:
+        current_home = Path(os.environ.get("SINGULAR_HOME", str(self.home)))
+        return {
+            "registry_root": str(self.root),
+            "current_life_home": str(current_home),
+        }
 
     def validate_token(self, token: str | None) -> None:
         expected = os.environ.get("SINGULAR_DASHBOARD_ACTION_TOKEN")
@@ -54,22 +66,27 @@ class DashboardActionService:
             elif action == "lives_use":
                 result = self._lives_use(params)
             else:
-                return ActionResult(
+                payload = ActionResult(
                     ok=False,
                     action=action,
-                    data={},
+                    data=self._context_payload(),
                     log="",
                     error=f"unsupported action: {action}",
                 ).to_payload()
-            return result.to_payload()
+                return payload
+            payload = result.to_payload()
+            payload["context"] = self._context_payload()
+            return payload
         except Exception as exc:  # pragma: no cover - defensive fallback
-            return ActionResult(
+            payload = ActionResult(
                 ok=False,
                 action=action,
-                data={},
+                data=self._context_payload(),
                 log="",
                 error=str(exc),
             ).to_payload()
+            payload["context"] = self._context_payload()
+            return payload
 
     def _capture(self, fn: Callable[[], dict[str, Any]]) -> tuple[dict[str, Any], str]:
         stream = io.StringIO()

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -97,6 +97,12 @@
 
 <section id="parametres">
   <h2>Paramètres</h2>
+  <div class='panel' style='margin-bottom:12px;'>
+    <h3 style='margin-top:0;'>Contexte registre</h3>
+    <div><strong>Registre courant (SINGULAR_ROOT)</strong> : <code id='ctx-root'>n/a</code></div>
+    <div><strong>Vie courante (SINGULAR_HOME)</strong> : <code id='ctx-home'>n/a</code></div>
+    <div><strong>Nombre de vies détectées</strong> : <span id='ctx-lives-count'>0</span></div>
+  </div>
   <h3>État psychique</h3><pre id='psyche'></pre>
   <h3>Organismes (résumé)</h3>
   <ul id='organisms-list'></ul>
@@ -176,10 +182,18 @@
 const ws=new WebSocket(`ws://${location.host}/ws`);
 const livesTableState={sortBy:'score',sortOrder:'desc'};
 const liveState={paused:false,autoScroll:true,events:[]};
+const scopeState={currentLifeOnly:false};
 
 const setStatusTone=(el,tone)=>{el.classList.remove('status-good','status-warn','status-bad');if(tone==='good'){el.classList.add('status-good');}if(tone==='warn'){el.classList.add('status-warn');}if(tone==='bad'){el.classList.add('status-bad');}};
+const withScope=(url)=>{const u=new URL(url,window.location.origin);if(scopeState.currentLifeOnly){u.searchParams.set('current_life_only','true');}return `${u.pathname}${u.search}`;};
 
-const loadEco=()=>Promise.all([fetch('/ecosystem').then(r=>r.json()),fetch('/lives/comparison?sort_by=last_activity&sort_order=desc').then(r=>r.json())]).then(([eco,lives])=>{
+const loadContext=()=>fetch('/dashboard/context').then(r=>r.json()).then(ctx=>{
+  document.getElementById('ctx-root').textContent=ctx.singular_root||'n/a';
+  document.getElementById('ctx-home').textContent=ctx.singular_home||'n/a';
+  document.getElementById('ctx-lives-count').textContent=String(ctx.registry_lives_count||0);
+});
+
+const loadEco=()=>Promise.all([fetch(withScope('/ecosystem')).then(r=>r.json()),fetch(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc')).then(r=>r.json())]).then(([eco,lives])=>{
   const summary=eco.summary||{};
   const total=Number(summary.total_organisms||0);
   const alive=Number(summary.alive_organisms||0);
@@ -211,7 +225,7 @@ const loadEco=()=>Promise.all([fetch('/ecosystem').then(r=>r.json()),fetch('/liv
   document.getElementById('raw-eco-json').textContent=JSON.stringify(eco,null,2);
 });
 
-const loadCockpit=()=>fetch('/api/cockpit').then(r=>r.json()).then(d=>{
+const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=>{
   const statusBox=document.getElementById('cockpit-status');
   statusBox.textContent=`Statut global: ${d.global_status||'unknown'}`;
   if(d.global_status==='stable'){setStatusTone(statusBox,'good');}
@@ -264,7 +278,7 @@ const badge=(label,bg)=>`<span style="display:inline-block;padding:2px 8px;borde
 const renderLivesBuckets=(rows)=>{const activeInRegistry=(rows||[]).filter(row=>row.is_registry_active_life===true);const extinctInRuns=(rows||[]).filter(row=>row.extinction_seen_in_runs===true);const aliveList=document.getElementById('alive-lives');const deadList=document.getElementById('dead-lives');document.getElementById('alive-count').textContent=String(activeInRegistry.length);document.getElementById('dead-count').textContent=String(extinctInRuns.length);aliveList.innerHTML='';deadList.innerHTML='';for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||'n/a';aliveList.appendChild(li);}for(const row of extinctInRuns){const li=document.createElement('li');li.textContent=row.life||'n/a';deadList.appendChild(li);}if(!activeInRegistry.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);}if(!extinctInRuns.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);}};
 const renderLivesTable=(rows)=>{const body=document.getElementById('lives-table-body');body.innerHTML='';for(const row of rows||[]){const tr=document.createElement('tr');const score=row.current_health_score===null||row.current_health_score===undefined?'n/a':Number(row.current_health_score).toFixed(1);const stability=row.stability===null||row.stability===undefined?'n/a':`${(Number(row.stability)*100).toFixed(1)}%`;const lastActivity=row.last_activity||'n/a';let badges='';if(row.selected_life){badges+=badge('Vie sélectionnée','#d1fadf');}else{badges+=badge('Vie non sélectionnée','#fde2e1');}if(row.is_registry_active_life){badges+=badge('Vie active dans le registre','#d1fadf');}else{badges+=badge(`Statut registre: ${row.life_status||'n/a'}`,'#fde2e1');}if(row.run_terminated){badges+=badge('Run terminé','#ffe7c2');}if(row.extinction_seen_in_runs){badges+=badge('Extinction détectée','#fecdca');}if(row.has_recent_activity){badges+=badge('Activité récente','#d9ecff');}if(row.trend==='dégradation'){badges+=badge('dégradation','#ffe7c2');}if((row.alerts_count||0)>0){badges+=badge(`${row.alerts_count} alertes`,'#fecdca');}tr.innerHTML=`<td>${row.life||'n/a'}</td><td>${score}</td><td>${row.trend||'n/a'}</td><td>${stability}</td><td>${lastActivity}</td><td>${row.iterations??0}</td><td>${badges}</td>`;body.appendChild(tr);}if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}};
 const renderUnattachedRuns=(payload)=>{const panel=document.getElementById('unattached-runs-panel');const list=document.getElementById('unattached-runs-list');const runs=(payload?.runs)||[];const runsCount=Number(payload?.runs_count||0);const recordsCount=Number(payload?.records_count||0);document.getElementById('unattached-runs-count').textContent=String(runsCount);document.getElementById('unattached-records-count').textContent=String(recordsCount);list.innerHTML='';if(!runsCount){panel.style.display='none';return;}panel.style.display='block';for(const item of runs){const li=document.createElement('li');li.textContent=`${item.run_id||'unknown'} · ${item.records_count||0} enregistrements`;list.appendChild(li);}};
-const loadLivesBoard=()=>{const q=new URLSearchParams();q.set('sort_by',livesTableState.sortBy);q.set('sort_order',livesTableState.sortOrder);if(document.getElementById('filter-active').checked){q.set('active_only','true');}if(document.getElementById('filter-degrading').checked){q.set('degrading_only','true');}if(document.getElementById('filter-dead').checked){q.set('dead_only','true');}return fetch(`/lives/comparison?${q.toString()}`).then(r=>r.json()).then(d=>{renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})));renderLivesTable(d.table||[]);renderUnattachedRuns(d.unattached_runs);});};
+const loadLivesBoard=()=>{const q=new URLSearchParams();q.set('sort_by',livesTableState.sortBy);q.set('sort_order',livesTableState.sortOrder);if(document.getElementById('filter-active').checked){q.set('active_only','true');}if(document.getElementById('filter-degrading').checked){q.set('degrading_only','true');}if(document.getElementById('filter-dead').checked){q.set('dead_only','true');}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}return fetch(`/lives/comparison?${q.toString()}`).then(r=>r.json()).then(d=>{renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})));renderLivesTable(d.table||[]);renderUnattachedRuns(d.unattached_runs);});};
 for(const button of document.querySelectorAll('#lives-table [data-sort]')){button.onclick=()=>{const next=button.getAttribute('data-sort');if(livesTableState.sortBy===next){livesTableState.sortOrder=livesTableState.sortOrder==='desc'?'asc':'desc';}else{livesTableState.sortBy=next;livesTableState.sortOrder='desc';}loadLivesBoard();};}
 document.getElementById('filter-active').onchange=()=>loadLivesBoard();
 document.getElementById('filter-degrading').onchange=()=>loadLivesBoard();
@@ -273,8 +287,8 @@ const renderLiveEvents=()=>{const pre=document.getElementById('live-events');con
 const updateLiveStatus=()=>{document.getElementById('live-status').textContent=liveState.paused?'Pause activée':'Lecture en direct';document.getElementById('live-toggle').textContent=liveState.paused?'Reprendre':'Pause';};
 document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};
 document.getElementById('live-autoscroll').onchange=e=>{liveState.autoScroll=Boolean(e.target.checked);if(liveState.autoScroll){renderLiveEvents();}};
-const loadTimeline=()=>fetch('/runs/latest').then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}return fetch(`/api/runs/${meta.run}/timeline?page=1&page_size=120`).then(r=>r.json());}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;btn.style.padding='6px';row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.style.alignSelf='center';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';}});
-loadEco();loadCockpit();loadTimeline();loadLivesBoard();setInterval(()=>{loadEco();loadCockpit();loadTimeline();loadLivesBoard();},500);
+const loadTimeline=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=scopeState.currentLifeOnly?'&current_life_only=true':'';return fetch(`/api/runs/${meta.run}/timeline?page=1&page_size=120${q}`).then(r=>r.json());}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;btn.style.padding='6px';row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.style.alignSelf='center';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';}});
+loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();setInterval(()=>{loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();},500);
 updateLiveStatus();
 ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);return;}if(typeof m.run_id==='string'&&typeof m.event==='string'){liveState.events.push({type:m.type,run_id:m.run_id,event:m.event,ts:m.ts||null});if(!liveState.paused){renderLiveEvents();}}};
 </script>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -196,6 +196,9 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "#vies" in body
     assert "#logs-live" in body
     assert "#parametres" in body
+    assert "Registre courant (SINGULAR_ROOT)" in body
+    assert "Vie courante (SINGULAR_HOME)" in body
+    assert "Nombre de vies détectées" in body
 
 
 def test_dashboard_index_renders_main_sections(tmp_path: Path) -> None:
@@ -740,6 +743,9 @@ def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: py
     ok = app._routes["/api/actions/{action}"]("lives_list", token="secret", payload="{}")
     assert ok["ok"] is True
     assert ok["action"] == "lives_list"
+    assert "context" in ok
+    assert "registry_root" in ok["context"]
+    assert "current_life_home" in ok["context"]
 
     with pytest.raises(Exception):
         app._routes["/api/actions/{action}"]("lives_list", token="wrong", payload="{}")
@@ -764,3 +770,119 @@ def test_dashboard_actions_validation_robustness(tmp_path: Path) -> None:
 
     with pytest.raises(Exception):
         route("lives_use", payload=json.dumps({"name": ""}))
+
+
+def test_dashboard_registry_scope_aggregates_multiple_lives_and_can_filter_current_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root_default = tmp_path / "default-root"
+    root_lab = tmp_path / "lab-root"
+    default_alpha = root_default / "lives" / "alpha"
+    default_beta = root_default / "lives" / "beta"
+    lab_gamma = root_lab / "lives" / "gamma"
+    (root_default / "lives").mkdir(parents=True)
+    (root_lab / "lives").mkdir(parents=True)
+    (default_alpha / "runs").mkdir(parents=True)
+    (default_beta / "runs").mkdir(parents=True)
+    (lab_gamma / "runs").mkdir(parents=True)
+
+    (default_alpha / "runs" / "run-a.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-12T08:00:00",
+                "life": "alpha",
+                "op": "flip",
+                "accepted": True,
+                "score_base": 10.0,
+                "score_new": 8.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (default_beta / "runs" / "run-b.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-12T09:00:00",
+                "life": "beta",
+                "op": "swap",
+                "accepted": False,
+                "score_base": 9.0,
+                "score_new": 10.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (lab_gamma / "runs" / "run-c.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-12T10:00:00",
+                "life": "gamma",
+                "op": "noop",
+                "accepted": True,
+                "score_base": 6.0,
+                "score_new": 5.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (root_default / "lives" / "registry.json").write_text(
+        json.dumps(
+            {
+                "active": "alpha",
+                "lives": {
+                    "alpha": {
+                        "name": "Alpha",
+                        "slug": "alpha",
+                        "path": str(default_alpha),
+                        "created_at": "2026-04-12T00:00:00+00:00",
+                        "status": "active",
+                    },
+                    "beta": {
+                        "name": "Beta",
+                        "slug": "beta",
+                        "path": str(default_beta),
+                        "created_at": "2026-04-12T00:05:00+00:00",
+                        "status": "active",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (root_lab / "lives" / "registry.json").write_text(
+        json.dumps(
+            {
+                "active": "gamma",
+                "lives": {
+                    "gamma": {
+                        "name": "Gamma",
+                        "slug": "gamma",
+                        "path": str(lab_gamma),
+                        "created_at": "2026-04-12T00:10:00+00:00",
+                        "status": "active",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("SINGULAR_ROOT", str(root_default))
+    monkeypatch.setenv("SINGULAR_HOME", str(default_alpha))
+
+    app = create_app(psyche_file=tmp_path / "psyche.json")
+    context = app._routes["/dashboard/context"]()
+    assert context["singular_root"] == str(root_default)
+    assert context["singular_home"] == str(default_alpha)
+    assert context["registry_lives_count"] == 2
+
+    timeline_all = app._routes["/timeline"]()
+    assert timeline_all["count"] == 2
+    assert {item["life"] for item in timeline_all["items"]} == {"alpha", "beta"}
+
+    timeline_current = app._routes["/timeline"](current_life_only=True)
+    assert timeline_current["count"] == 1
+    assert timeline_current["items"][0]["life"] == "alpha"


### PR DESCRIPTION
### Motivation
- Le dashboard lisait uniquement `SINGULAR_HOME/runs`, ce qui masquait les runs provenant d’autres vies présentes dans le registre; il faut une vue d’écosystème qui couvre toutes les vies du registre.
- Conserver une option pour limiter la portée à la vie courante est nécessaire pour les cas d’utilisation localisés.
- Les actions du dashboard devaient exposer et utiliser de façon cohérente le contexte de registre/chemin de vie afin d’éviter la confusion entre `SINGULAR_ROOT` et `SINGULAR_HOME`.

### Description
- Remplacement de la lecture mono-répertoire par une agrégation basée sur `load_registry()` en introduisant `_registry_lives_paths()`, `_runs_dirs()` et un `_load_run_records(current_life_only: bool)` qui parcourt `meta.path / runs` pour chaque vie; si `create_app(runs_dir=...)` reçoit un `runs_dir` explicite, ce comportement reste local à ce répertoire.
- Ajout d’un flag optionnel `current_life_only` aux endpoints pertinents (`/timeline`, `/lives/comparison`, `/mutations/top`, `/api/cockpit`, `/runs/latest`, `/api/runs/...`) et adaptation des fonctions internes (`_iter_run_files`, `_latest_run_file`, `_summarize_cockpit`, `_compute_ecosystem`, `_aggregate_lives`) pour respecter ce filtre.
- Harmonisation du service d’actions `DashboardActionService`: utilisation de `get_registry_root()`, détermination de `home` cohérente, introduction de `._context_payload()` et attachement du bloc `context` (`registry_root`, `current_life_home`) aux réponses d’action.
- Websocket streaming adapté pour suivre plusieurs répertoires de runs en utilisant des clés uniques par répertoire (`<registry_folder>/<file>`) et gérer correctement les curseurs de lecture.
- Ajout d’un nouvel endpoint `/dashboard/context` et d’un encart UI dans `dashboard.html` affichant `SINGULAR_ROOT`, `SINGULAR_HOME` et le nombre de vies détectées, plus adaptation du JS pour propager l’option `current_life_only` aux requêtes et charger le contexte.
- Tests étendus/ajoutés dans `tests/test_dashboard.py` pour couvrir l’agrégation multi‑vies, la non‑confusion entre deux racines distinctes (`default` vs `lab`) et le filtrage `current_life_only`; mises à jour de l’UI expectations.

### Testing
- Exécution des tests d’intégration dashboard : `pytest -q tests/test_dashboard.py`, résultat : all tests passed (`17 passed, 1 warning`).
- Les modules modifiés ont été compilés (`python -m py_compile`) pendant la validation sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3a80cecc832aa266021b0bc219ff)