### PR TITLE
Introduce versioned EventBus and decouple loop→memory via events

### DIFF
--- a/src/singular/cognition/reflect.py
+++ b/src/singular/cognition/reflect.py
@@ -10,7 +10,9 @@ highest-scoring action according to:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Mapping
+
+from singular.events import EventBus, get_global_event_bus
 
 
 @dataclass(frozen=True)
@@ -61,16 +63,33 @@ def reflect_action(
     long_term_weight: float = 0.6,
     sandbox_weight: float = 0.25,
     resource_weight: float = 0.15,
+    bus: EventBus | None = None,
+    event_context: Mapping[str, Any] | None = None,
 ) -> ReflectionDecision:
     """Select the best action from candidate hypotheses."""
 
     if not hypotheses:
-        return ReflectionDecision(
+        decision = ReflectionDecision(
             action=None,
             decision_reason="no hypothesis available",
             alternative_scores={},
             ranked_actions=[],
         )
+        emitter = bus or get_global_event_bus()
+        emitter.publish(
+            "decision.made",
+            {
+                "decision": {
+                    "action": decision.action,
+                    "decision_reason": decision.decision_reason,
+                    "alternative_scores": decision.alternative_scores,
+                    "ranked_actions": decision.ranked_actions,
+                },
+                "context": dict(event_context or {}),
+            },
+            payload_version=1,
+        )
+        return decision
 
     scores = {
         hyp.action: _hypothesis_score(
@@ -88,9 +107,24 @@ def reflect_action(
         f"(long_term={long_term_weight:.2f}, sandbox={sandbox_weight:.2f}, "
         f"resources={resource_weight:.2f})"
     )
-    return ReflectionDecision(
+    decision = ReflectionDecision(
         action=selected,
         decision_reason=reason,
         alternative_scores=scores,
         ranked_actions=ranked,
     )
+    emitter = bus or get_global_event_bus()
+    emitter.publish(
+        "decision.made",
+        {
+            "decision": {
+                "action": decision.action,
+                "decision_reason": decision.decision_reason,
+                "alternative_scores": decision.alternative_scores,
+                "ranked_actions": decision.ranked_actions,
+            },
+            "context": dict(event_context or {}),
+        },
+        payload_version=1,
+    )
+    return decision

--- a/src/singular/events/__init__.py
+++ b/src/singular/events/__init__.py
@@ -1,0 +1,5 @@
+"""Events infrastructure."""
+
+from .bus import Event, EventBus, get_global_event_bus
+
+__all__ = ["Event", "EventBus", "get_global_event_bus"]

--- a/src/singular/events/bus.py
+++ b/src/singular/events/bus.py
@@ -1,0 +1,136 @@
+"""Internal publish/subscribe event bus with payload versioning."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import atexit
+import os
+from queue import Empty, Queue
+import threading
+from typing import Any, Callable
+
+EventHandler = Callable[["Event"], None]
+
+
+@dataclass(frozen=True)
+class Event:
+    """Event envelope dispatched to subscribers."""
+
+    event_type: str
+    payload: dict[str, Any]
+    payload_version: int = 1
+    emitted_at: str = ""
+
+
+class EventBus:
+    """Simple event bus supporting sync and async dispatch modes."""
+
+    def __init__(self, *, mode: str = "sync") -> None:
+        normalized_mode = mode.strip().lower()
+        if normalized_mode not in {"sync", "async"}:
+            normalized_mode = "sync"
+        self.mode = normalized_mode
+        self._subscribers: dict[str, list[EventHandler]] = defaultdict(list)
+        self._lock = threading.Lock()
+        self._queue: Queue[Event] | None = None
+        self._worker: threading.Thread | None = None
+        self._stop_event: threading.Event | None = None
+        if self.mode == "async":
+            self._start_worker()
+
+    def subscribe(self, event_type: str, handler: EventHandler) -> None:
+        """Register a ``handler`` for ``event_type``."""
+
+        with self._lock:
+            handlers = self._subscribers[event_type]
+            if handler not in handlers:
+                handlers.append(handler)
+
+    def publish(
+        self,
+        event_type: str,
+        payload: dict[str, Any],
+        *,
+        payload_version: int = 1,
+    ) -> None:
+        """Publish one event with an explicit payload schema version."""
+
+        event = Event(
+            event_type=event_type,
+            payload=payload,
+            payload_version=payload_version,
+            emitted_at=datetime.now(timezone.utc).isoformat(),
+        )
+        if self.mode == "async":
+            if self._queue is None:
+                self._start_worker()
+            assert self._queue is not None
+            self._queue.put(event)
+            return
+        self._dispatch(event)
+
+    def shutdown(self, *, timeout: float = 1.0) -> None:
+        """Stop async worker and flush pending events."""
+
+        if self.mode != "async":
+            return
+        if self._stop_event is None or self._queue is None or self._worker is None:
+            return
+        self._stop_event.set()
+        self._queue.put(
+            Event(event_type="__bus.shutdown__", payload={}, payload_version=1)
+        )
+        self._worker.join(timeout=timeout)
+
+    def _dispatch(self, event: Event) -> None:
+        with self._lock:
+            handlers = list(self._subscribers.get(event.event_type, []))
+        for handler in handlers:
+            try:
+                handler(event)
+            except Exception:
+                continue
+
+    def _start_worker(self) -> None:
+        if self._queue is None:
+            self._queue = Queue()
+        if self._stop_event is None:
+            self._stop_event = threading.Event()
+        if self._worker is None or not self._worker.is_alive():
+            self._worker = threading.Thread(target=self._run_worker, daemon=True)
+            self._worker.start()
+
+    def _run_worker(self) -> None:
+        assert self._queue is not None
+        assert self._stop_event is not None
+        while not self._stop_event.is_set():
+            try:
+                event = self._queue.get(timeout=0.1)
+            except Empty:
+                continue
+            if event.event_type == "__bus.shutdown__":
+                self._queue.task_done()
+                break
+            self._dispatch(event)
+            self._queue.task_done()
+
+
+_GLOBAL_BUS: EventBus | None = None
+
+
+def get_bus_mode_from_env() -> str:
+    """Read event bus mode from configuration environment."""
+
+    return os.environ.get("SINGULAR_EVENT_BUS_MODE", "sync").strip().lower()
+
+
+def get_global_event_bus() -> EventBus:
+    """Return process-wide event bus configured by environment."""
+
+    global _GLOBAL_BUS
+    if _GLOBAL_BUS is None:
+        _GLOBAL_BUS = EventBus(mode=get_bus_mode_from_env())
+        atexit.register(_GLOBAL_BUS.shutdown)
+    return _GLOBAL_BUS

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -15,7 +15,8 @@ from pathlib import Path
 from typing import Callable, Dict, Iterable, Mapping
 
 from singular.cognition.reflect import ActionHypothesis, reflect_action
-from singular.memory import add_episode, add_procedural_memory, update_score
+from singular.events import EventBus, get_global_event_bus
+from singular.memory import register_memory_event_handlers
 from singular.psyche import Psyche, Mood
 from singular.runs.logger import RunLogger
 from singular.runs.explain import summarize_mutation
@@ -332,21 +333,7 @@ def log_mutation(
         loop_modifications=loop_modifications,
         health=health,
     )
-    add_procedural_memory(
-        {
-            "event": "loop_mutation",
-            "iteration": iteration,
-            "skill": key,
-            "op": op_name,
-            "accepted": accepted,
-            "score_base": base_score,
-            "score_new": mutated_score,
-            "loop_modifications": loop_modifications,
-            "decision_reason": decision_reason,
-            "alternative_scores": alternative_scores or {},
-            "health": health or {},
-        }
-    )
+
 
 
 def _ast_node_count(tree: ast.AST) -> int:
@@ -484,6 +471,7 @@ def run(
     test_pool: LivingTestPool | None = None,
     robustness_weight: float = 1.0,
     max_test_candidates: int = 3,
+    event_bus: EventBus | None = None,
 ) -> Checkpoint:
     """Run the evolutionary loop for at most ``budget_seconds`` seconds.
 
@@ -520,6 +508,8 @@ def run(
 
     psyche = Psyche.load_state()
     resource_manager = resource_manager or ResourceManager()
+    event_bus = event_bus or get_global_event_bus()
+    register_memory_event_handlers(event_bus)
     start = time.time()
     last_post = 0.0
     initial_freq = max(
@@ -558,11 +548,10 @@ def run(
                 continue
 
             resource_manager.metabolize()
-            signals = capture_signals()
+            signals = capture_signals(bus=event_bus)
             temp = get_temperature()
             signals["temperature"] = temp
             resource_manager.update_from_environment(temp)
-            add_episode({"event": "perception", **signals})
             state.iteration += 1
 
             now = time.time()
@@ -628,7 +617,11 @@ def run(
                         resource_cost=resource_cost,
                     )
                 )
-            reflection = reflect_action(hypotheses)
+            reflection = reflect_action(
+                hypotheses,
+                bus=event_bus,
+                event_context={"iteration": state.iteration, "organism": org_name},
+            )
             op_name = reflection.action or select_operator(operators, stats, policy, rng)
             mutated = apply_mutation(original, operators[op_name], rng)
             org = world.organisms[org_name]
@@ -691,12 +684,6 @@ def run(
                 )
             if accepted:
                 skill_path.write_text(mutated, encoding="utf-8")
-                key = (
-                    f"{org_name}:{skill_path.stem}"
-                    if len(world.organisms) > 1
-                    else skill_path.stem
-                )
-                update_score(key, mutated_score)
                 org.last_score = mutated_score
                 org.energy += 0.2
                 env_artifacts.save_text(f"mutation_{state.iteration}", diff)
@@ -776,6 +763,26 @@ def run(
                 f"{org_name}:{skill_path.stem}"
                 if len(world.organisms) > 1
                 else skill_path.stem
+            )
+            mutation_payload = {
+                "iteration": state.iteration,
+                "skill": key,
+                "op": op_name,
+                "accepted": accepted,
+                "score_base": base_score,
+                "score_new": mutated_score,
+                "loop_modifications": loop_modifications,
+                "decision_reason": reflection.decision_reason,
+                "alternative_scores": reflection.alternative_scores,
+                "health": health_snapshot.to_dict(),
+                "diff": diff,
+                "impacted_file": skill_path.name,
+                "timing_ms": {"base": ms_base, "new": ms_new},
+            }
+            event_bus.publish(
+                "mutation.applied" if accepted else "mutation.rejected",
+                mutation_payload,
+                payload_version=1,
             )
             log_mutation(
                 logger,

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -12,6 +12,7 @@ import json
 import os
 import tempfile
 
+from .events import Event, EventBus
 from .memory_layers import MemoryLayerService, build_backend
 
 _MEMORY_LAYER_SERVICE: MemoryLayerService | None = None
@@ -335,3 +336,52 @@ def write_psyche(state: dict[str, Any], path: Path | str | None = None) -> None:
         path = get_psyche_file()
     path = Path(path)
     _atomic_write_text(path, json.dumps(state))
+
+
+_REGISTERED_MEMORY_BUS_IDS: set[int] = set()
+
+
+def _consolidate_signal_event(event: Event) -> None:
+    payload = event.payload
+    signals = payload.get("signals", {})
+    if isinstance(signals, dict):
+        add_episode({"event": "perception", **signals})
+
+
+def _consolidate_decision_event(event: Event) -> None:
+    payload = event.payload
+    decision = payload.get("decision", {})
+    context = payload.get("context", {})
+    if isinstance(decision, dict):
+        episode = {"event": "decision", **decision}
+        if isinstance(context, dict):
+            episode.update({"context": context})
+        add_episode(episode)
+
+
+def _consolidate_applied_mutation(event: Event) -> None:
+    payload = event.payload
+    key = payload.get("skill")
+    score_new = payload.get("score_new")
+    if isinstance(key, str) and isinstance(score_new, (int, float)):
+        update_score(key, float(score_new))
+    add_procedural_memory({"event": "loop_mutation", **payload, "accepted": True})
+
+
+def _consolidate_rejected_mutation(event: Event) -> None:
+    payload = event.payload
+    add_procedural_memory({"event": "loop_mutation", **payload, "accepted": False})
+
+
+def register_memory_event_handlers(bus: EventBus) -> None:
+    """Subscribe memory consolidation handlers once for the given bus."""
+
+    identity = id(bus)
+    if identity in _REGISTERED_MEMORY_BUS_IDS:
+        return
+
+    bus.subscribe("signal.captured", _consolidate_signal_event)
+    bus.subscribe("decision.made", _consolidate_decision_event)
+    bus.subscribe("mutation.applied", _consolidate_applied_mutation)
+    bus.subscribe("mutation.rejected", _consolidate_rejected_mutation)
+    _REGISTERED_MEMORY_BUS_IDS.add(identity)

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -15,6 +15,8 @@ import time
 from typing import Any, Dict
 from pathlib import Path
 
+from singular.events import EventBus, get_global_event_bus
+
 
 def _read_optional_file() -> Dict[str, Any]:
     """Read data from ``SINGULAR_SENSOR_FILE`` if available."""
@@ -72,8 +74,12 @@ def get_temperature() -> float:
     return random.uniform(-20.0, 40.0)
 
 
-def capture_signals() -> Dict[str, Any]:
-    """Collect sensory signals from virtual and optional real sources."""
+def capture_signals(
+    *,
+    bus: EventBus | None = None,
+    publish_event: bool = True,
+) -> Dict[str, Any]:
+    """Collect sensory signals and optionally publish ``signal.captured``."""
     signals: Dict[str, Any] = {
         "temperature": random.uniform(-20.0, 40.0),
         "is_daytime": 6 <= time.localtime().tm_hour < 18,
@@ -81,4 +87,7 @@ def capture_signals() -> Dict[str, Any]:
     }
     signals.update(_read_optional_file())
     signals.update(_query_optional_weather_api())
+    if publish_event:
+        emitter = bus or get_global_event_bus()
+        emitter.publish("signal.captured", {"signals": dict(signals)}, payload_version=1)
     return signals


### PR DESCRIPTION
### Motivation
- Provide a lightweight publish/subscribe mechanism so subsystems can communicate with looser coupling and allow progressive migration from direct calls to events.
- Enable both a simple synchronous mode and an optional asynchronous worker mode so message dispatch can be toggled via configuration.
- Move perception, cognition and loop outputs into a uniform event stream that memory can consume for consolidation.

### Description
- Add `src/singular/events/bus.py` implementing a small `Event` envelope and `EventBus` with `publish`, `subscribe`, `shutdown`, a process singleton via `get_global_event_bus()` and mode controlled by `SINGULAR_EVENT_BUS_MODE` (`sync` by default, `async` supported). 
- Wire perception to publish `signal.captured` by changing `capture_signals` to accept an optional `bus` and `publish_event` flag and publish the versioned payload. 
- Emit `decision.made` from `reflect_action` (both no-hypothesis and selected-decision paths) and allow `reflect_action` to receive an optional `bus` and `event_context`. 
- Refactor `run()` in `src/singular/life/loop.py` to accept an optional `event_bus`, register memory subscribers via `register_memory_event_handlers`, publish `mutation.applied` / `mutation.rejected` payloads instead of directly calling memory update helpers, and pass `bus`/context into reflection and perception calls. 
- Add memory consolidation handlers and registration helper in `src/singular/memory.py` (`register_memory_event_handlers`) that subscribe to `signal.captured`, `decision.made`, `mutation.applied` and `mutation.rejected` and perform `add_episode`, `add_procedural_memory` and `update_score` where appropriate.

### Testing
- Ran byte-compilation to validate syntax: `python -m compileall -q src/singular/events src/singular/perception.py src/singular/cognition/reflect.py src/singular/memory.py src/singular/life/loop.py` (succeeded).
- Ran targeted pytest: `python -m pytest -q src/singular/life/test_coevolution.py` which executed but reported no tests collected for that path (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3f7d734c832a8e14c377877bb545)