### PR TITLE
Add Bayesian belief store with decay, operator biasing, and CLI audit/reset

### DIFF
--- a/src/singular/beliefs/__init__.py
+++ b/src/singular/beliefs/__init__.py
@@ -1,0 +1,5 @@
+"""Belief storage and scoring helpers."""
+
+from .store import BeliefRecord, BeliefStore
+
+__all__ = ["BeliefRecord", "BeliefStore"]

--- a/src/singular/beliefs/store.py
+++ b/src/singular/beliefs/store.py
@@ -1,0 +1,180 @@
+"""Persistent belief store with Bayesian updates and temporal forgetting."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+import math
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Iterable
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_datetime(value: str | None) -> datetime:
+    if not value:
+        return _utcnow()
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return _utcnow()
+
+
+@dataclass
+class BeliefRecord:
+    """Belief entry attached to a hypothesis."""
+
+    hypothesis: str
+    confidence: float
+    evidence: str
+    updated_at: str
+    alpha: float = 1.0
+    beta: float = 1.0
+    score_ema: float = 0.0
+    runs: int = 0
+
+
+class BeliefStore:
+    """Store beliefs and update them after each mutation run."""
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        *,
+        prior_alpha: float = 1.0,
+        prior_beta: float = 1.0,
+        decay_per_day: float = 0.03,
+    ) -> None:
+        base = Path(os.environ.get("SINGULAR_HOME", "."))
+        self.path = path or (base / "mem" / "beliefs.json")
+        self.prior_alpha = float(prior_alpha)
+        self.prior_beta = float(prior_beta)
+        self.decay_per_day = max(0.0, float(decay_per_day))
+        self._beliefs = self._load()
+
+    def _load(self) -> dict[str, BeliefRecord]:
+        if not self.path.exists():
+            return {}
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(payload, dict):
+            return {}
+        beliefs: dict[str, BeliefRecord] = {}
+        for key, value in payload.items():
+            if not isinstance(key, str) or not isinstance(value, dict):
+                continue
+            beliefs[key] = BeliefRecord(
+                hypothesis=key,
+                confidence=float(value.get("confidence", 0.5)),
+                evidence=str(value.get("evidence", "")),
+                updated_at=str(value.get("updated_at", _utcnow().isoformat())),
+                alpha=float(value.get("alpha", self.prior_alpha)),
+                beta=float(value.get("beta", self.prior_beta)),
+                score_ema=float(value.get("score_ema", 0.0)),
+                runs=int(value.get("runs", 0)),
+            )
+        return beliefs
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {key: asdict(value) for key, value in self._beliefs.items()}
+        tmp = tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", dir=self.path.parent, delete=False
+        )
+        try:
+            with tmp:
+                tmp.write(json.dumps(payload, ensure_ascii=False, indent=2))
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp.name, self.path)
+        finally:
+            try:
+                os.unlink(tmp.name)
+            except FileNotFoundError:
+                pass
+
+    def list_beliefs(self) -> list[BeliefRecord]:
+        return sorted(self._beliefs.values(), key=lambda item: item.confidence, reverse=True)
+
+    def get_confidence(self, hypothesis: str, default: float = 0.5) -> float:
+        if hypothesis in self._beliefs:
+            return self._beliefs[hypothesis].confidence
+        return default
+
+    def _apply_decay(self, record: BeliefRecord, now: datetime) -> None:
+        updated_at = _parse_datetime(record.updated_at)
+        delta_days = max(0.0, (now - updated_at).total_seconds() / 86400.0)
+        if delta_days <= 0.0 or self.decay_per_day <= 0.0:
+            return
+        retention = math.exp(-self.decay_per_day * delta_days)
+        record.alpha = self.prior_alpha + (record.alpha - self.prior_alpha) * retention
+        record.beta = self.prior_beta + (record.beta - self.prior_beta) * retention
+
+    def update_after_run(
+        self,
+        hypothesis: str,
+        *,
+        success: bool,
+        evidence: str,
+        reward_delta: float = 0.0,
+        when: datetime | None = None,
+    ) -> BeliefRecord:
+        now = when or _utcnow()
+        record = self._beliefs.get(hypothesis) or BeliefRecord(
+            hypothesis=hypothesis,
+            confidence=0.5,
+            evidence="",
+            updated_at=now.isoformat(),
+            alpha=self.prior_alpha,
+            beta=self.prior_beta,
+            score_ema=0.0,
+            runs=0,
+        )
+        self._apply_decay(record, now)
+        if success:
+            record.alpha += 1.0
+        else:
+            record.beta += 1.0
+        record.runs += 1
+        record.score_ema = (record.score_ema * 0.8) + (float(reward_delta) * 0.2)
+        record.confidence = record.alpha / max(record.alpha + record.beta, 1e-9)
+        record.updated_at = now.isoformat()
+        record.evidence = evidence
+        self._beliefs[hypothesis] = record
+        self._save()
+        return record
+
+    def reset(self, *, hypothesis: str | None = None, prefix: str | None = None) -> int:
+        if hypothesis:
+            deleted = int(self._beliefs.pop(hypothesis, None) is not None)
+            self._save()
+            return deleted
+        if prefix:
+            keys = [key for key in self._beliefs if key.startswith(prefix)]
+            for key in keys:
+                self._beliefs.pop(key, None)
+            self._save()
+            return len(keys)
+        count = len(self._beliefs)
+        self._beliefs = {}
+        self._save()
+        return count
+
+    def operator_preference_bias(self, operator_names: Iterable[str]) -> dict[str, float]:
+        biases: dict[str, float] = {}
+        for name in operator_names:
+            hypothesis = f"operator:{name}"
+            record = self._beliefs.get(hypothesis)
+            if record is None:
+                biases[name] = 0.0
+                continue
+            confidence_shift = record.confidence - 0.5
+            biases[name] = (confidence_shift * 0.4) + max(-0.2, min(0.2, record.score_ema))
+        return biases

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -729,6 +729,31 @@ def main(argv: list[str] | None = None) -> int:
     ecosystem_run.add_argument("--budget-seconds", type=float, required=True)
     ecosystem_run.add_argument("--run-id", default="ecosystem", help="Run identifier")
 
+    beliefs_parser = subparsers.add_parser("beliefs", help="Audit and reset beliefs")
+    beliefs_subparsers = beliefs_parser.add_subparsers(
+        dest="beliefs_command", required=True
+    )
+    beliefs_audit = beliefs_subparsers.add_parser(
+        "audit", help="Inspect current beliefs"
+    )
+    beliefs_audit.add_argument(
+        "--limit",
+        type=int,
+        default=25,
+        help="Maximum number of beliefs to display",
+    )
+    beliefs_reset = beliefs_subparsers.add_parser(
+        "reset", help="Reset beliefs (targeted or all)"
+    )
+    reset_mode = beliefs_reset.add_mutually_exclusive_group(required=True)
+    reset_mode.add_argument("--hypothesis", default=None, help="Exact hypothesis key")
+    reset_mode.add_argument("--prefix", default=None, help="Delete by key prefix")
+    reset_mode.add_argument(
+        "--all",
+        action="store_true",
+        help="Delete all beliefs",
+    )
+
     uninstall_parser = subparsers.add_parser(
         "uninstall", help="Remove Singular data from SINGULAR_ROOT"
     )
@@ -1072,6 +1097,61 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Données Singular supprimées sous: {root}")
         else:
             print(f"Artefacts globaux supprimés sous: {root} (mem/, runs/)")
+
+    elif args.command == "beliefs":
+        if args.life is not None:
+            _ensure_active_life(resolve_life, args.life)
+        elif "SINGULAR_HOME" not in os.environ:
+            _ensure_active_life(resolve_life, args.life)
+        from .beliefs.store import BeliefStore
+
+        store = BeliefStore()
+        if args.beliefs_command == "audit":
+            beliefs = store.list_beliefs()[: max(0, args.limit)]
+            rows = [
+                [
+                    belief.hypothesis,
+                    f"{belief.confidence:.3f}",
+                    str(belief.runs),
+                    belief.updated_at,
+                    belief.evidence,
+                ]
+                for belief in beliefs
+            ]
+            if args.output_format == "json":
+                print(
+                    json.dumps(
+                        {"beliefs": [belief.__dict__ for belief in beliefs]},
+                        ensure_ascii=False,
+                    )
+                )
+            elif args.output_format == "table":
+                if rows:
+                    _print_table(
+                        ["Hypothesis", "Confidence", "Runs", "Updated", "Evidence"],
+                        rows,
+                    )
+                else:
+                    print("Aucune croyance enregistrée.")
+            else:
+                if not beliefs:
+                    print("Aucune croyance enregistrée.")
+                for belief in beliefs:
+                    print(
+                        f"- {belief.hypothesis}: conf={belief.confidence:.3f} "
+                        f"runs={belief.runs} updated={belief.updated_at} "
+                        f"evidence={belief.evidence}"
+                    )
+        elif args.beliefs_command == "reset":
+            if args.hypothesis:
+                deleted = store.reset(hypothesis=args.hypothesis)
+                print(f"Croyances supprimées (hypothesis): {deleted}")
+            elif args.prefix:
+                deleted = store.reset(prefix=args.prefix)
+                print(f"Croyances supprimées (prefix): {deleted}")
+            else:
+                deleted = store.reset()
+                print(f"Croyances supprimées (all): {deleted}")
 
     else:  # pragma: no cover - defensive programming
         raise SystemExit(f"Commande inconnue: {args.command}")

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterable, Mapping
 
 from singular.cognition.reflect import ActionHypothesis, reflect_action
+from singular.beliefs.store import BeliefStore
 from singular.events import EventBus, get_global_event_bus
 from singular.memory import register_memory_event_handlers
 from singular.psyche import Psyche, Mood
@@ -510,6 +511,7 @@ def run(
         stats.setdefault(name, {"count": 0, "reward": 0.0})
 
     psyche = Psyche.load_state()
+    belief_store = BeliefStore()
     resource_manager = resource_manager or ResourceManager()
     event_bus = event_bus or get_global_event_bus()
     register_memory_event_handlers(event_bus)
@@ -655,12 +657,17 @@ def run(
                 sandbox_weight=goal_weights.robustesse,
                 resource_weight=goal_weights.efficacite,
             )
+            belief_bias = belief_store.operator_preference_bias(operators.keys())
+            combined_bias = intrinsic_goals.influence_operator_scores(stats)
+            for operator_name, extra_bias in belief_bias.items():
+                combined_bias[operator_name] = combined_bias.get(operator_name, 0.0) + extra_bias
+
             op_name = reflection.action or select_operator(
                 operators,
                 stats,
                 policy,
                 rng,
-                objective_bias=intrinsic_goals.influence_operator_scores(stats),
+                objective_bias=combined_bias,
             )
             mutated = apply_mutation(original, operators[op_name], rng)
             org = world.organisms[org_name]
@@ -733,6 +740,12 @@ def run(
             reward_delta = base_score - mutated_score
             if math.isfinite(reward_delta):
                 stats[op_name]["reward"] += reward_delta
+            belief_store.update_after_run(
+                f"operator:{op_name}",
+                success=accepted,
+                evidence=f"accepted={accepted};base={base_score:.6f};new={mutated_score:.6f}",
+                reward_delta=reward_delta if math.isfinite(reward_delta) else 0.0,
+            )
             state.stats = stats
 
             # Resource accounting

--- a/src/singular/runs/run.py
+++ b/src/singular/runs/run.py
@@ -6,6 +6,7 @@ import ast
 import difflib
 import random
 
+from singular.beliefs.store import BeliefStore
 from singular.life.operators import const_tune, deadcode_elim, eq_rewrite_reduce_sum
 from singular.life.score import score
 from graine.evolver.generate import propose_mutations
@@ -87,6 +88,12 @@ def run(seed: int | None = None) -> str:
     }
 
     psyche.process_run_record(record)
+    BeliefStore().update_after_run(
+        f"operator:{op_name}",
+        success=bool(record["improved"]),
+        evidence=f"improved={record['improved']};base={base_score:.6f};new={mutated_score:.6f}",
+        reward_delta=base_score - mutated_score,
+    )
     add_episode(
         {
             "event": "mutation",

--- a/tests/test_beliefs_store.py
+++ b/tests/test_beliefs_store.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from singular.beliefs.store import BeliefStore
+from singular.life.loop import select_operator
+
+
+def test_belief_store_updates_and_resets(tmp_path: Path) -> None:
+    path = tmp_path / "beliefs.json"
+    store = BeliefStore(path=path)
+
+    rec1 = store.update_after_run(
+        "operator:eq_rewrite_reduce_sum",
+        success=True,
+        evidence="accepted",
+        reward_delta=0.12,
+    )
+    assert rec1.confidence > 0.5
+    assert path.exists()
+
+    rec2 = store.update_after_run(
+        "operator:eq_rewrite_reduce_sum",
+        success=False,
+        evidence="rejected",
+        reward_delta=-0.05,
+    )
+    assert rec2.runs == 2
+
+    deleted = store.reset(hypothesis="operator:eq_rewrite_reduce_sum")
+    assert deleted == 1
+    assert store.list_beliefs() == []
+
+
+def test_beliefs_bias_guides_operator_selection(tmp_path: Path) -> None:
+    store = BeliefStore(path=tmp_path / "beliefs.json")
+    for _ in range(5):
+        store.update_after_run(
+            "operator:preferred",
+            success=True,
+            evidence="ok",
+            reward_delta=0.2,
+        )
+    for _ in range(5):
+        store.update_after_run(
+            "operator:other",
+            success=False,
+            evidence="ko",
+            reward_delta=-0.2,
+        )
+
+    operators = {"preferred": lambda tree: tree, "other": lambda tree: tree}
+    stats = {
+        "preferred": {"count": 10, "reward": 0.0},
+        "other": {"count": 10, "reward": 0.0},
+    }
+    selected = select_operator(
+        operators,
+        stats,
+        policy="stochastic",
+        rng=__import__("random").Random(0),
+        objective_bias=store.operator_preference_bias(operators.keys()),
+    )
+    assert selected == "preferred"
+
+
+def test_beliefs_file_is_json_serializable(tmp_path: Path) -> None:
+    path = tmp_path / "beliefs.json"
+    store = BeliefStore(path=path)
+    store.update_after_run("operator:demo", success=True, evidence="ok")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert "operator:demo" in payload

--- a/tests/test_cli_beliefs.py
+++ b/tests/test_cli_beliefs.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+
+import singular.cli as cli
+from singular.beliefs.store import BeliefStore
+
+
+def test_cli_beliefs_audit_and_reset(tmp_path, capsys) -> None:
+    life_dir = tmp_path / "life"
+    store = BeliefStore(path=life_dir / "mem" / "beliefs.json")
+    store.update_after_run("operator:demo", success=True, evidence="accepted")
+
+    assert cli.main(["--home", str(life_dir), "beliefs", "audit"]) == 0
+    out = capsys.readouterr().out
+    assert "operator:demo" in out
+
+    assert (
+        cli.main(
+            [
+                "--home",
+                str(life_dir),
+                "--format",
+                "json",
+                "beliefs",
+                "reset",
+                "--hypothesis",
+                "operator:demo",
+            ]
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    assert "supprimées" in out
+
+    payload = json.loads((life_dir / "mem" / "beliefs.json").read_text(encoding="utf-8"))
+    assert payload == {}

--- a/thinking/reasoner.py
+++ b/thinking/reasoner.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Mapping
 
+from singular.beliefs.store import BeliefStore
+
 
 def evaluate_actions(agent: Any, options: Iterable[Any]) -> Any:
     """Return the action that best aligns with the agent's motivations.
@@ -22,14 +24,20 @@ def evaluate_actions(agent: Any, options: Iterable[Any]) -> Any:
     """
 
     motivations: Mapping[str, float] = getattr(agent, "motivations", {})
+    beliefs = BeliefStore()
     best_option: Any | None = None
     best_score = float("-inf")
 
     for option in options:
         outcomes: Mapping[str, float] = getattr(option, "outcomes", option)
+        hypothesis = getattr(option, "hypothesis", None) or getattr(option, "action", None)
+        if hypothesis is None:
+            hypothesis = str(getattr(option, "name", "generic"))
+        belief_confidence = beliefs.get_confidence(f"action:{hypothesis}", default=0.5)
         score = 0.0
         for name, weight in motivations.items():
             score += weight * outcomes.get(name, 0.0)
+        score *= 0.5 + belief_confidence
         if score > best_score:
             best_score = score
             best_option = option


### PR DESCRIPTION
### Motivation

- Persist a simple hypothesis/belief model (hypothesis, confidence, evidence, updated date) to let the system learn which operators/actions are effective.  
- Update beliefs after each mutation/run using a Bayesian-style posterior (alpha/beta) and a simple EMA score to summarize reward.  
- Allow beliefs to fade over time (exponential decay) and expose audit/reset tooling to inspect or clear learned preferences.

### Description

- Add a new package `src/singular/beliefs` providing `BeliefRecord` and `BeliefStore` which persist to `$SINGULAR_HOME/mem/beliefs.json`, support `update_after_run`, exponential time decay, EMA scoring and `operator_preference_bias` extraction.  
- Wire beliefs into reasoning by loading `BeliefStore` in `thinking/reasoner.py` and scaling action scores by the stored confidence.  
- Integrate beliefs into the evolutionary loop and run paths by loading `BeliefStore` in `src/singular/life/loop.py` and `src/singular/runs/run.py`, folding operator biases into `select_operator` and updating beliefs after each operator attempt.  
- Add CLI commands under `singular beliefs` to `audit` (with `--limit`) and `reset` (by `--hypothesis`, `--prefix`, or `--all`) and include tests covering store behavior, operator-bias influence, and CLI audit/reset flow.

### Testing

- Ran `pytest -q tests/test_beliefs_store.py tests/test_cli_beliefs.py tests/test_loop.py::test_mutation_persistence` and the tests completed successfully.  
- The focused test run reported all tests passed (`5 passed` for the set executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc41caf0b0832a84d75ced8643e8e4)