### PR TITLE
Add consciousness reflection logs and dashboard timeline filters

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -276,6 +276,24 @@ def create_app(
             key=lambda path: (path.stat().st_mtime_ns, _latest_ts_in_file(path), path.name),
         )
 
+    def _resolve_run_file(run_id: str, current_life_only: bool = False) -> Path | None:
+        return next(
+            (
+                directory / f"{run_id}.jsonl"
+                for directory in _runs_dirs(current_life_only=current_life_only)
+                if (directory / f"{run_id}.jsonl").exists()
+            ),
+            None,
+        )
+
+    def _resolve_consciousness_path(run_id: str, current_life_only: bool = False) -> Path | None:
+        raw_run_id = run_id.rsplit("-", 1)[0]
+        for directory in _runs_dirs(current_life_only=current_life_only):
+            candidate = directory / raw_run_id / "consciousness.jsonl"
+            if candidate.exists():
+                return candidate
+        return None
+
     def _parse_ts(value: object) -> datetime | None:
         if not isinstance(value, str):
             return None
@@ -537,14 +555,7 @@ def create_app(
         organism: str | None = None,
         current_life_only: bool = False,
     ) -> dict[str, object]:
-        run_file = next(
-            (
-                directory / f"{run_id}.jsonl"
-                for directory in _runs_dirs(current_life_only=current_life_only)
-                if (directory / f"{run_id}.jsonl").exists()
-            ),
-            None,
-        )
+        run_file = _resolve_run_file(run_id, current_life_only=current_life_only)
         if run_file is None:
             raise HTTPException(status_code=404, detail=f"run '{run_id}' not found")
 
@@ -606,18 +617,63 @@ def create_app(
             "items": items,
         }
 
+    @app.get("/api/runs/{run_id}/consciousness")
+    def read_run_consciousness(
+        run_id: str,
+        objective: str | None = None,
+        mood: str | None = None,
+        success: str | None = None,
+        current_life_only: bool = False,
+    ) -> dict[str, object]:
+        consciousness_file = _resolve_consciousness_path(
+            run_id, current_life_only=current_life_only
+        )
+        if consciousness_file is None:
+            raise HTTPException(
+                status_code=404, detail=f"consciousness timeline for run '{run_id}' not found"
+            )
+
+        success_filter: bool | None = None
+        if isinstance(success, str):
+            lowered = success.strip().lower()
+            if lowered in {"true", "1", "yes", "success"}:
+                success_filter = True
+            elif lowered in {"false", "0", "no", "failure"}:
+                success_filter = False
+
+        items: list[dict[str, object]] = []
+        for line in consciousness_file.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(record, dict):
+                continue
+            if objective and record.get("objective") != objective:
+                continue
+            emotional = record.get("emotional_state")
+            record_mood = emotional.get("mood") if isinstance(emotional, dict) else None
+            if mood and record_mood != mood:
+                continue
+            if success_filter is not None and record.get("success") is not success_filter:
+                continue
+            items.append(record)
+
+        items.sort(key=lambda item: str(item.get("ts", "")))
+        return {
+            "run_id": run_id,
+            "filters": {"objective": objective, "mood": mood, "success": success},
+            "count": len(items),
+            "items": items,
+        }
+
     @app.get("/api/runs/{run_id}/mutations/{index}")
     def read_run_mutation(
         run_id: str, index: int, current_life_only: bool = False
     ) -> dict[str, object]:
-        run_file = next(
-            (
-                directory / f"{run_id}.jsonl"
-                for directory in _runs_dirs(current_life_only=current_life_only)
-                if (directory / f"{run_id}.jsonl").exists()
-            ),
-            None,
-        )
+        run_file = _resolve_run_file(run_id, current_life_only=current_life_only)
         if run_file is None:
             raise HTTPException(status_code=404, detail=f"run '{run_id}' not found")
 

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -117,6 +117,32 @@
   <pre id='timeline-diff' style='padding:12px;border:1px solid #ccc;'></pre>
 </section>
 
+<section id="reflections-section">
+  <h2>Timeline des réflexions</h2>
+  <div style='display:flex;gap:8px;flex-wrap:wrap;align-items:center;'>
+    <label>Objectif
+      <select id='reflection-objective'>
+        <option value=''>Tous</option>
+        <option value='coherence'>coherence</option>
+        <option value='robustesse'>robustesse</option>
+        <option value='efficacite'>efficacite</option>
+        <option value='exploration'>exploration</option>
+      </select>
+    </label>
+    <label>Humeur <input id='reflection-mood' placeholder='ex: curious'/></label>
+    <label>Réussite
+      <select id='reflection-success'>
+        <option value=''>Toutes</option>
+        <option value='true'>Succès</option>
+        <option value='false'>Échec</option>
+      </select>
+    </label>
+    <button id='reflection-apply'>Appliquer filtres</button>
+  </div>
+  <div id='reflections-timeline' style='display:flex;gap:8px;overflow:auto;white-space:nowrap;margin-top:8px;'></div>
+  <pre id='reflections-detail' style='margin-top:8px;'></pre>
+</section>
+
 <section id="vies"><h2>Vies · Tableau comparatif</h2>
   <div style='display:flex;gap:12px;align-items:center;flex-wrap:wrap;'>
     <label><input id='filter-active' type='checkbox'/> Statut registre: active</label>
@@ -288,7 +314,10 @@ const updateLiveStatus=()=>{document.getElementById('live-status').textContent=l
 document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};
 document.getElementById('live-autoscroll').onchange=e=>{liveState.autoScroll=Boolean(e.target.checked);if(liveState.autoScroll){renderLiveEvents();}};
 const loadTimeline=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=scopeState.currentLifeOnly?'&current_life_only=true':'';return fetch(`/api/runs/${meta.run}/timeline?page=1&page_size=120${q}`).then(r=>r.json());}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;btn.style.padding='6px';row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.style.alignSelf='center';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';}});
+const loadReflections=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=new URLSearchParams();const objective=document.getElementById('reflection-objective').value;const mood=document.getElementById('reflection-mood').value;const success=document.getElementById('reflection-success').value;if(objective){q.set('objective',objective);}if(mood){q.set('mood',mood);}if(success){q.set('success',success);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}const suffix=q.toString()?`?${q.toString()}`:'';return fetch(`/api/runs/${meta.run}/consciousness${suffix}`).then(r=>r.ok?r.json():{run_id:meta.run,items:[]});}).then(data=>{const wrap=document.getElementById('reflections-timeline');const detail=document.getElementById('reflections-detail');wrap.innerHTML='';for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');const mood=item.emotional_state?.mood||'n/a';const objective=item.objective||'n/a';btn.textContent=`${item.ts||'n/a'} · ${objective} · ${mood}`;btn.style.padding='6px';btn.onclick=()=>{detail.textContent=JSON.stringify(item,null,2);};row.appendChild(btn);wrap.appendChild(row);}if(!(data.items||[]).length){detail.textContent='Aucune réflexion disponible pour ces filtres.';}});
+document.getElementById('reflection-apply').onclick=()=>loadReflections();
 loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();setInterval(()=>{loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();},500);
+loadReflections();setInterval(()=>{loadReflections();},800);
 updateLiveStatus();
 ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);return;}if(typeof m.run_id==='string'&&typeof m.event==='string'){liveState.events.push({type:m.type,run_id:m.run_id,event:m.event,ts:m.ts||null});if(!liveState.paused){renderLiveEvents();}}};
 </script>

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -736,6 +736,38 @@ def run(
             else:
                 org.energy -= 0.1
 
+            objective_weights = asdict(goal_weights)
+            dominant_objective = max(
+                objective_weights,
+                key=lambda objective_name: objective_weights[objective_name],
+            )
+            mood_value = getattr(getattr(psyche, "last_mood", None), "value", None)
+            if mood_value is None:
+                raw_mood = getattr(psyche, "last_mood", None)
+                mood_value = str(raw_mood) if raw_mood is not None else None
+            logger.log_consciousness(
+                perception_summary=(
+                    f"temp={temp:.2f}, baseline_failure_risk={baseline_failure_risk:.3f}, "
+                    f"resource_energy={resource_manager.energy:.2f}"
+                ),
+                evaluated_hypotheses=[
+                    {
+                        "action": hypothesis.action,
+                        "long_term": hypothesis.long_term,
+                        "sandbox_risk": hypothesis.sandbox_risk,
+                        "resource_cost": hypothesis.resource_cost,
+                        "score": reflection.alternative_scores.get(hypothesis.action),
+                    }
+                    for hypothesis in weighted_hypotheses
+                ],
+                final_choice=op_name,
+                justification=reflection.decision_reason,
+                objective=dominant_objective,
+                mood=mood_value,
+                energy=float(getattr(psyche, "energy", resource_manager.energy)),
+                success=accepted,
+            )
+
             stats[op_name]["count"] += 1
             reward_delta = base_score - mutated_score
             if math.isfinite(reward_delta):

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -130,6 +130,8 @@ class RunLogger:
         self.run_dir.mkdir(parents=True, exist_ok=True)
         self.events_path = self.run_dir / "events.jsonl"
         self._events_file = self.events_path.open("a", encoding="utf-8")
+        self.consciousness_path = self.run_dir / "consciousness.jsonl"
+        self._consciousness_file = self.consciousness_path.open("a", encoding="utf-8")
 
         # Resume from existing temporary file if present
         tmp_pattern = f"{self.run_id}-*.jsonl.tmp"
@@ -164,6 +166,39 @@ class RunLogger:
         self._events_file.write(json.dumps(event) + "\n")
         self._events_file.flush()
         os.fsync(self._events_file.fileno())
+
+    def log_consciousness(
+        self,
+        *,
+        perception_summary: str,
+        evaluated_hypotheses: list[dict[str, Any]],
+        final_choice: str | None,
+        justification: str,
+        objective: str | None = None,
+        mood: str | None = None,
+        energy: float | None = None,
+        success: bool | None = None,
+    ) -> None:
+        """Record a reflection event in ``runs/<run_id>/consciousness.jsonl``."""
+
+        ts = datetime.utcnow().isoformat(timespec="seconds")
+        record: dict[str, Any] = {
+            "ts": ts,
+            "event": "consciousness",
+            "perception_summary": perception_summary,
+            "evaluated_hypotheses": evaluated_hypotheses,
+            "final_choice": final_choice,
+            "justification": justification,
+            "objective": objective,
+            "emotional_state": {
+                "mood": mood,
+                "energy": energy,
+            },
+            "success": success,
+        }
+        self._consciousness_file.write(json.dumps(record) + "\n")
+        self._consciousness_file.flush()
+        os.fsync(self._consciousness_file.fileno())
 
     def log(
         self,
@@ -315,6 +350,10 @@ class RunLogger:
 
     def close(self) -> None:
         """Flush and finalize the log files atomically."""
+        if not self._consciousness_file.closed:
+            self._consciousness_file.flush()
+            os.fsync(self._consciousness_file.fileno())
+            self._consciousness_file.close()
         if not self._events_file.closed:
             self._events_file.flush()
             os.fsync(self._events_file.fileno())

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -193,6 +193,8 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Navigation" in body
     assert "#cockpit" in body
     assert "#timeline-section" in body
+    assert "Timeline des réflexions" in body
+    assert "reflection-objective" in body
     assert "#vies" in body
     assert "#logs-live" in body
     assert "#parametres" in body
@@ -207,6 +209,7 @@ def test_dashboard_index_renders_main_sections(tmp_path: Path) -> None:
 
     assert "<section id=\"cockpit\">" in body
     assert "<section id=\"timeline-section\">" in body
+    assert "<section id=\"reflections-section\">" in body
     assert "<section id=\"vies\">" in body
     assert "<section id=\"logs-live\">" in body
     assert "<section id=\"parametres\">" in body
@@ -301,6 +304,51 @@ def test_dashboard_timeline_comparison_and_top_mutations(tmp_path: Path) -> None
     assert top_payload["most_risky"][0]["life"] == "life-a"
     assert top_payload["most_risky"][0]["impact_delta"] == -1.0
     assert top_payload["most_frequent"][0] == {"operator": "flip", "count": 2}
+
+
+def test_dashboard_consciousness_endpoint_filters(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    run_file = runs_dir / "mind-20260412101010.jsonl"
+    run_file.write_text(json.dumps({"event": "start"}) + "\n", encoding="utf-8")
+
+    run_dir = runs_dir / "mind"
+    run_dir.mkdir()
+    (run_dir / "consciousness.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-04-12T10:10:10",
+                        "objective": "coherence",
+                        "success": True,
+                        "emotional_state": {"mood": "focused"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-04-12T10:11:10",
+                        "objective": "exploration",
+                        "success": False,
+                        "emotional_state": {"mood": "fatigue"},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    payload = app._routes["/api/runs/{run_id}/consciousness"](
+        run_id="mind-20260412101010",
+        objective="coherence",
+        success="true",
+        mood="focused",
+    )
+
+    assert payload["count"] == 1
+    assert payload["items"][0]["objective"] == "coherence"
 
 
 def test_dashboard_lives_comparison_excludes_runs_without_explicit_life(tmp_path: Path) -> None:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -475,6 +475,9 @@ def test_angry_increases_proposals(tmp_path: Path, monkeypatch):
         def log_death(self, *a, **k):
             pass
 
+        def log_consciousness(self, *a, **k):
+            pass
+
     skill_dir = tmp_path / "skills"
     skill_dir.mkdir()
     checkpoint = tmp_path / "ckpt.json"
@@ -519,6 +522,9 @@ def test_fatigue_reduces_proposals(tmp_path: Path, monkeypatch):
             pass
 
         def log_death(self, *a, **k):
+            pass
+
+        def log_consciousness(self, *a, **k):
             pass
 
     skill_dir = tmp_path / "skills"

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -88,6 +88,28 @@ def test_log_test_coevolution(tmp_path: Path) -> None:
     assert record["regression_detection_rate"] == 0.5
 
 
+def test_log_consciousness_file(tmp_path: Path) -> None:
+    logger = RunLogger("mind", root=tmp_path)
+    logger.log_consciousness(
+        perception_summary="temperature stable",
+        evaluated_hypotheses=[{"action": "flip", "score": 0.2}],
+        final_choice="flip",
+        justification="best weighted score",
+        objective="coherence",
+        mood="focused",
+        energy=77.0,
+        success=True,
+    )
+    logger.close()
+
+    consciousness_path = tmp_path / "mind" / "consciousness.jsonl"
+    assert consciousness_path.exists()
+    payload = json.loads(consciousness_path.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["event"] == "consciousness"
+    assert payload["objective"] == "coherence"
+    assert payload["success"] is True
+
+
 def test_human_summary_quality_minimum() -> None:
     summary = summarize_mutation(
         operator="arith",


### PR DESCRIPTION
### Motivation
- Capture structured "reflection" events (perception summary, evaluated hypotheses, final choice + justification, emotional/energy state, success) for each run to aid observability and post-mortem analysis.
- Surface those reflections in the dashboard so operators can filter and inspect the agent’s decisions by objective, mood and success.

### Description
- Add `RunLogger.log_consciousness` which writes structured reflection records to `runs/<run_id>/consciousness.jsonl` and ensure file is flushed/fsynced and closed; see `src/singular/runs/logger.py`.
- Wire reflection emission from the life loop so a consciousness record is logged after mutation evaluation, including perception summary, evaluated hypotheses, chosen operator, decision justification, dominant objective, mood/energy and success flag (`src/singular/life/loop.py`).
- Extend dashboard backend with run-file resolution and a new endpoint `GET /api/runs/{run_id}/consciousness` supporting `objective`, `mood` and `success` filters (`src/singular/dashboard/__init__.py`).
- Add a frontend section to the dashboard template to show a "Timeline des réflexions" with interactive filters and detail view (`src/singular/dashboard/templates/dashboard.html`).
- Add and update tests to cover the new logger and dashboard behavior and adapt test doubles that mock the logger to accept `log_consciousness` (`tests/test_runs_logger.py`, `tests/test_dashboard.py`, `tests/test_loop.py`).

### Testing
- Ran `pytest -q tests/test_runs_logger.py tests/test_dashboard.py`; all tests in those suites passed (23 passed, 0 failed).
- During development an earlier run `pytest -q tests/test_runs_logger.py tests/test_dashboard.py tests/test_loop.py` revealed failures (6 failing) which were fixed by adding the new API wiring and adapting test doubles; the failing tests were addressed and subsequent focused test runs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc44df8a18832abcb24377b5904005)