### PR TITLE
Add governance policy to control mutation and reproduction writes

### DIFF
--- a/src/singular/governance/__init__.py
+++ b/src/singular/governance/__init__.py
@@ -1,0 +1,17 @@
+"""Governance utilities for autonomous mutation/reproduction."""
+
+from .policy import (
+    AUTH_AUTO,
+    AUTH_BLOCKED,
+    AUTH_REVIEW_REQUIRED,
+    GovernanceDecision,
+    MutationGovernancePolicy,
+)
+
+__all__ = [
+    "AUTH_AUTO",
+    "AUTH_BLOCKED",
+    "AUTH_REVIEW_REQUIRED",
+    "GovernanceDecision",
+    "MutationGovernancePolicy",
+]

--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -1,0 +1,132 @@
+"""Governance policy for mutation and reproduction writes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+
+
+log = logging.getLogger(__name__)
+
+
+AUTH_AUTO = "auto"
+AUTH_REVIEW_REQUIRED = "review-required"
+AUTH_BLOCKED = "blocked"
+
+
+@dataclass(frozen=True)
+class GovernanceDecision:
+    """Decision returned by policy simulation or enforcement."""
+
+    level: str
+    allowed: bool
+    reason: str
+    corrective_action: str
+
+
+class MutationGovernancePolicy:
+    """Path-based governance with mandatory write simulation."""
+
+    def __init__(
+        self,
+        *,
+        modifiable_paths: tuple[str, ...] = ("skills",),
+        review_required_paths: tuple[str, ...] = ("skills/experimental",),
+        forbidden_paths: tuple[str, ...] = (
+            "src",
+            ".git",
+            "mem",
+            "runs",
+            "tests",
+        ),
+    ) -> None:
+        self.modifiable_paths = tuple(p.strip("/") for p in modifiable_paths)
+        self.review_required_paths = tuple(p.strip("/") for p in review_required_paths)
+        self.forbidden_paths = tuple(p.strip("/") for p in forbidden_paths)
+
+    def _relative(self, target: Path, root: Path) -> Path:
+        target_resolved = target.resolve()
+        root_resolved = root.resolve()
+        try:
+            return target_resolved.relative_to(root_resolved)
+        except ValueError:
+            return target_resolved
+
+    @staticmethod
+    def _matches(rel: Path, prefixes: tuple[str, ...]) -> bool:
+        rel_txt = rel.as_posix()
+        return any(rel_txt == p or rel_txt.startswith(f"{p}/") for p in prefixes)
+
+    def simulate_write(self, target: Path, *, root: Path | None = None) -> GovernanceDecision:
+        """Simulate authorization before a filesystem write."""
+
+        if root is None:
+            root = target.parent.parent if target.parent.name == "skills" else target.parent
+        rel = self._relative(target, root)
+
+        if rel.is_absolute():
+            return GovernanceDecision(
+                level=AUTH_BLOCKED,
+                allowed=False,
+                reason=f"target '{target}' is outside governed root '{root}'",
+                corrective_action="write inside an organism skills/ directory",
+            )
+
+        if self._matches(rel, self.forbidden_paths):
+            return GovernanceDecision(
+                level=AUTH_BLOCKED,
+                allowed=False,
+                reason=f"path '{rel.as_posix()}' is in forbidden zone",
+                corrective_action="choose a path under an allowlisted mutable zone",
+            )
+
+        if self._matches(rel, self.review_required_paths):
+            return GovernanceDecision(
+                level=AUTH_REVIEW_REQUIRED,
+                allowed=False,
+                reason=f"path '{rel.as_posix()}' requires manual review",
+                corrective_action="request human review or move target to auto-authorized zone",
+            )
+
+        if self._matches(rel, self.modifiable_paths):
+            return GovernanceDecision(
+                level=AUTH_AUTO,
+                allowed=True,
+                reason=f"path '{rel.as_posix()}' is allowlisted for autonomous writes",
+                corrective_action="none",
+            )
+
+        return GovernanceDecision(
+            level=AUTH_BLOCKED,
+            allowed=False,
+            reason=f"path '{rel.as_posix()}' is not allowlisted",
+            corrective_action="add this zone to policy allowlist after validation",
+        )
+
+    def enforce_write(self, target: Path, content: str, *, root: Path | None = None) -> GovernanceDecision:
+        """Enforce policy with mandatory simulation before writing."""
+
+        decision = self.simulate_write(target, root=root)
+        if not decision.allowed:
+            log.warning(
+                "governance blocked write: target=%s level=%s reason=%s corrective_action=%s",
+                target,
+                decision.level,
+                decision.reason,
+                decision.corrective_action,
+            )
+            return decision
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        return decision
+
+
+__all__ = [
+    "AUTH_AUTO",
+    "AUTH_REVIEW_REQUIRED",
+    "AUTH_BLOCKED",
+    "GovernanceDecision",
+    "MutationGovernancePolicy",
+]

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -33,7 +33,9 @@ from singular.resource_manager import ResourceManager
 from . import sandbox
 from .death import DeathMonitor
 from .health import HealthTracker
-from .reproduction import crossover
+from singular.governance.policy import MutationGovernancePolicy
+
+from .reproduction import authorize_reproduction_write, crossover
 from .map_elites import MapElites
 from .test_coevolution import LivingTestPool, propose_test_candidates
 
@@ -476,6 +478,7 @@ def run(
     robustness_weight: float = 1.0,
     max_test_candidates: int = 3,
     event_bus: EventBus | None = None,
+    governance_policy: MutationGovernancePolicy | None = None,
 ) -> Checkpoint:
     """Run the evolutionary loop for at most ``budget_seconds`` seconds.
 
@@ -514,6 +517,7 @@ def run(
     belief_store = BeliefStore()
     resource_manager = resource_manager or ResourceManager()
     event_bus = event_bus or get_global_event_bus()
+    governance_policy = governance_policy or MutationGovernancePolicy()
     register_memory_event_handlers(event_bus)
     start = time.time()
     last_post = 0.0
@@ -590,7 +594,19 @@ def run(
                         tofile="mutated",
                     )
                 )
-                skill_path.write_text(mutated, encoding="utf-8")
+                governance_root = skill_path.parent.parent if skill_path.parent.name == "skills" else skill_path.parent
+                decision = governance_policy.enforce_write(skill_path, mutated, root=governance_root)
+                if not decision.allowed:
+                    logger.log_interaction(
+                        "governance_violation",
+                        organism=org_name,
+                        target=str(skill_path),
+                        level=decision.level,
+                        reason=decision.reason,
+                        corrective_action=decision.corrective_action,
+                        alive=True,
+                    )
+                    continue
                 logger.log_absurde(skill_path.name, diff)
                 continue
 
@@ -729,10 +745,24 @@ def run(
                     score_combined_new=combined_mutated,
                 )
             if accepted:
-                skill_path.write_text(mutated, encoding="utf-8")
-                org.last_score = mutated_score
-                org.energy += 0.2
-                env_artifacts.save_text(f"mutation_{state.iteration}", diff)
+                governance_root = skill_path.parent.parent if skill_path.parent.name == "skills" else skill_path.parent
+                decision = governance_policy.enforce_write(skill_path, mutated, root=governance_root)
+                if not decision.allowed:
+                    accepted = False
+                    logger.log_interaction(
+                        "governance_violation",
+                        organism=org_name,
+                        target=str(skill_path),
+                        level=decision.level,
+                        reason=decision.reason,
+                        corrective_action=decision.corrective_action,
+                        alive=True,
+                    )
+                    org.energy -= 0.1
+                else:
+                    org.last_score = mutated_score
+                    org.energy += 0.2
+                    env_artifacts.save_text(f"mutation_{state.iteration}", diff)
             else:
                 org.energy -= 0.1
 
@@ -930,17 +960,33 @@ def run(
                 pa = world.organisms[parent_names[0]].skills_dir
                 pb = world.organisms[parent_names[1]].skills_dir
                 child_dir = pa.parent / f"child_{state.iteration}"
-                child_dir.mkdir(parents=True, exist_ok=True)
+                child_skills_dir = child_dir / "skills"
+                child_skills_dir.mkdir(parents=True, exist_ok=True)
                 fname, code = crossover(pa, pb, rng)
-                (child_dir / fname).write_text(code, encoding="utf-8")
-                world.organisms[child_dir.name] = Organism(child_dir)
-                logger.log_interaction(
-                    INTERACTION_CROSSOVER,
-                    parents=parent_names,
-                    child=child_dir.name,
-                    child_skills_dir=str(child_dir),
-                    alive=True,
+                target = child_skills_dir / fname
+                authorized, reason = authorize_reproduction_write(
+                    target,
+                    code,
+                    governance_policy=governance_policy,
                 )
+                if not authorized:
+                    logger.log_interaction(
+                        "governance_violation",
+                        parents=parent_names,
+                        target=str(target),
+                        reason=reason,
+                        corrective_action="write under allowlisted skills/ directory",
+                        alive=True,
+                    )
+                else:
+                    world.organisms[child_dir.name] = Organism(child_skills_dir)
+                    logger.log_interaction(
+                        INTERACTION_CROSSOVER,
+                        parents=parent_names,
+                        child=child_dir.name,
+                        child_skills_dir=str(child_dir),
+                        alive=True,
+                    )
 
     return state
 

--- a/src/singular/life/reproduction.py
+++ b/src/singular/life/reproduction.py
@@ -25,8 +25,31 @@ import random
 from pathlib import Path
 from typing import Tuple
 
+from singular.governance.policy import MutationGovernancePolicy
 
-__all__ = ["crossover"]
+
+__all__ = ["crossover", "authorize_reproduction_write"]
+
+
+
+
+def authorize_reproduction_write(
+    target_path: Path,
+    code: str,
+    governance_policy: MutationGovernancePolicy | None = None,
+) -> tuple[bool, str]:
+    """Simulate then enforce policy for reproduction output writes."""
+
+    policy = governance_policy or MutationGovernancePolicy()
+    root = target_path.parent.parent if target_path.parent.name == "skills" else target_path.parent
+    decision = policy.simulate_write(target_path, root=root)
+    if not decision.allowed:
+        return False, f"{decision.reason}; corrective_action={decision.corrective_action}"
+
+    enforced = policy.enforce_write(target_path, code, root=root)
+    if not enforced.allowed:
+        return False, f"{enforced.reason}; corrective_action={enforced.corrective_action}"
+    return True, "authorized"
 
 
 def crossover(

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -18,6 +18,7 @@ from singular.life.health import detect_health_state  # noqa: E402
 from singular.life.test_coevolution import LivingTestPool, TestCandidate  # noqa: E402
 from singular.resource_manager import ResourceManager  # noqa: E402
 from singular.psyche import Psyche, Mood  # noqa: E402
+from singular.governance.policy import MutationGovernancePolicy  # noqa: E402
 
 
 def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
@@ -885,3 +886,24 @@ def test_coevolution_logs_decisions(tmp_path: Path, monkeypatch):
     log_file = next((tmp_path / "logs").glob("loop-*.jsonl"))
     records = [json.loads(line) for line in log_file.read_text().splitlines()]
     assert any(rec.get("event") == "test_coevolution" for rec in records)
+
+
+def test_governance_blocks_mutation_write(tmp_path: Path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = 1", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+
+    policy = MutationGovernancePolicy(modifiable_paths=("allowed",))
+
+    run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=0.1,
+        rng=random.Random(0),
+        operators={"dec": _dec_operator},
+        governance_policy=policy,
+    )
+
+    assert _read_result(skill) == 1

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -4,7 +4,8 @@ import ast
 import pytest
 
 from singular.organisms.spawn import spawn
-from singular.life.reproduction import crossover
+from singular.governance.policy import MutationGovernancePolicy
+from singular.life.reproduction import authorize_reproduction_write, crossover
 
 
 def test_reproduction(tmp_path: Path):
@@ -120,3 +121,14 @@ def test_crossover_empty_ast(tmp_path: Path):
 
     with pytest.raises(ValueError, match="function definition"):
         crossover(parent_a, parent_b)
+
+
+def test_authorize_reproduction_write_blocked(tmp_path: Path):
+    policy = MutationGovernancePolicy(modifiable_paths=("allowed",))
+    target = tmp_path / "child" / "skills" / "hybrid.py"
+
+    ok, reason = authorize_reproduction_write(target, "result = 1", policy)
+
+    assert not ok
+    assert "corrective_action" in reason
+    assert not target.exists()


### PR DESCRIPTION
### Motivation
- Prevent autonomous writes to sensitive areas by introducing a path-based allowlist/forbidden policy and require simulation before any real file write. 
- Ensure mutation and reproduction stages respect governance levels (`auto`, `review-required`, `blocked`) and provide actionable corrective suggestions when blocked. 

### Description
- Add `src/singular/governance/policy.py` which implements `MutationGovernancePolicy` with `simulate_write` and `enforce_write`, and `GovernanceDecision` describing `level`, `allowed`, `reason` and `corrective_action`. 
- Export governance symbols via `src/singular/governance/__init__.py` for easy imports. 
- Integrate policy into mutation pipeline in `src/singular/life/loop.py` by adding a `governance_policy` parameter to `run`, instantiating a default `MutationGovernancePolicy`, and enforcing writes for `CURIOUS` mutations and accepted mutations; violations are blocked and an interaction `governance_violation` is logged with corrective guidance. 
- Integrate reproduction write authorization in `src/singular/life/reproduction.py` by adding `authorize_reproduction_write` (simulates then enforces) and updating crossover handling in the loop to write children under `child_x/skills/` so allowlist rules apply consistently. 
- Update tests to cover blocked reproduction writes and blocked mutation persistence behavior by adding assertions that unauthorized writes are not performed and that corrective actions are included in logs. 

### Testing
- Ran targeted tests: `pytest -q tests/test_reproduction.py::test_authorize_reproduction_write_blocked tests/test_loop.py::test_mutation_persistence tests/test_loop.py::test_governance_blocks_mutation_write`, and the modified test subset passed. 
- Also ran `pytest -q tests/test_reproduction.py::test_authorize_reproduction_write_blocked tests/test_loop.py::test_governance_blocks_mutation_write` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc464f3ba0832aaf9778d9e81ff6d1)