### PR TITLE
Add multi-agent protocol, transports, and orchestration scenario

### DIFF
--- a/src/singular/multiagent/__init__.py
+++ b/src/singular/multiagent/__init__.py
@@ -1,0 +1,19 @@
+"""Multi-agent protocol and orchestration utilities."""
+
+from .protocol import (
+    AgentMessage,
+    CollectiveMemory,
+    FileQueueTransport,
+    InMemoryQueueTransport,
+    OrchestrationScenario,
+    resolve_conflicts,
+)
+
+__all__ = [
+    "AgentMessage",
+    "CollectiveMemory",
+    "FileQueueTransport",
+    "InMemoryQueueTransport",
+    "OrchestrationScenario",
+    "resolve_conflicts",
+]

--- a/src/singular/multiagent/protocol.py
+++ b/src/singular/multiagent/protocol.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Protocol
+import json
+import tempfile
+import time
+from collections import defaultdict, deque
+
+
+@dataclass(slots=True)
+class AgentMessage:
+    """Versioned multi-agent message format.
+
+    Version 1 keeps the required fields explicit:
+    ``intent``, ``task``, ``evidence`` and ``confidence``.
+    """
+
+    intent: str
+    task: str
+    evidence: list[str]
+    confidence: float
+    priority: int = 0
+    agent_id: str | None = None
+    version: int = 1
+    created_at: float = field(default_factory=time.time)
+
+    def __post_init__(self) -> None:
+        if self.version != 1:
+            raise ValueError("unsupported message version")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be in [0, 1]")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "intent": self.intent,
+            "task": self.task,
+            "evidence": list(self.evidence),
+            "confidence": self.confidence,
+            "priority": self.priority,
+            "agent_id": self.agent_id,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "AgentMessage":
+        return cls(
+            version=int(payload.get("version", 1)),
+            intent=str(payload["intent"]),
+            task=str(payload["task"]),
+            evidence=[str(item) for item in payload.get("evidence", [])],
+            confidence=float(payload["confidence"]),
+            priority=int(payload.get("priority", 0)),
+            agent_id=(
+                str(payload["agent_id"])
+                if payload.get("agent_id") is not None
+                else None
+            ),
+            created_at=float(payload.get("created_at", time.time())),
+        )
+
+
+class MessageTransport(Protocol):
+    def send(self, message: AgentMessage) -> None: ...
+
+    def receive(self) -> list[AgentMessage]: ...
+
+
+class InMemoryQueueTransport:
+    """Simple local transport backed by an in-memory queue."""
+
+    def __init__(self) -> None:
+        self._queue: deque[AgentMessage] = deque()
+
+    def send(self, message: AgentMessage) -> None:
+        self._queue.append(message)
+
+    def receive(self) -> list[AgentMessage]:
+        messages = list(self._queue)
+        self._queue.clear()
+        return messages
+
+
+class FileQueueTransport:
+    """Simple local transport backed by a JSONL file queue."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+
+    def send(self, message: AgentMessage) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(message.to_dict(), ensure_ascii=False) + "\n"
+        existing = self.path.read_text(encoding="utf-8") if self.path.exists() else ""
+        _atomic_write_text(self.path, existing + line)
+
+    def receive(self) -> list[AgentMessage]:
+        if not self.path.exists():
+            return []
+        payload = self.path.read_text(encoding="utf-8")
+        _atomic_write_text(self.path, "")
+        messages: list[AgentMessage] = []
+        for line in payload.splitlines():
+            if not line.strip():
+                continue
+            messages.append(AgentMessage.from_dict(json.loads(line)))
+        return messages
+
+
+def resolve_conflicts(messages: Iterable[AgentMessage]) -> dict[str, AgentMessage]:
+    """Pick one message per task using priority then confidence."""
+
+    grouped: dict[str, list[AgentMessage]] = defaultdict(list)
+    for message in messages:
+        grouped[message.task].append(message)
+
+    resolved: dict[str, AgentMessage] = {}
+    for task, candidates in grouped.items():
+        resolved[task] = sorted(
+            candidates,
+            key=lambda msg: (-msg.priority, -msg.confidence, msg.created_at),
+        )[0]
+    return resolved
+
+
+class CollectiveMemory:
+    """Optional shared memory, isolated by namespace."""
+
+    def __init__(self, root: Path | str, namespace: str) -> None:
+        self.root = Path(root)
+        self.namespace = namespace
+
+    @property
+    def _path(self) -> Path:
+        return self.root / f"{self.namespace}.jsonl"
+
+    def append(self, record: dict[str, Any]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, ensure_ascii=False) + "\n"
+        existing = self._path.read_text(encoding="utf-8") if self._path.exists() else ""
+        _atomic_write_text(self._path, existing + line)
+
+    def read(self) -> list[dict[str, Any]]:
+        if not self._path.exists():
+            return []
+        out: list[dict[str, Any]] = []
+        for line in self._path.read_text(encoding="utf-8").splitlines():
+            if line.strip():
+                out.append(json.loads(line))
+        return out
+
+
+@dataclass(slots=True)
+class OrchestrationScenario:
+    """Scenario helper for distributing sub-problems and merging outcomes."""
+
+    transport: MessageTransport
+    memory: CollectiveMemory | None = None
+
+    def share_subproblems(
+        self,
+        parent_task: str,
+        subproblems: dict[str, str],
+    ) -> list[AgentMessage]:
+        sent: list[AgentMessage] = []
+        for agent_id, task in subproblems.items():
+            message = AgentMessage(
+                intent="sub_problem",
+                task=task,
+                evidence=[f"parent:{parent_task}"],
+                confidence=1.0,
+                priority=0,
+                agent_id=agent_id,
+            )
+            self.transport.send(message)
+            if self.memory is not None:
+                self.memory.append(
+                    {
+                        "kind": "dispatch",
+                        "agent_id": agent_id,
+                        "task": task,
+                        "parent_task": parent_task,
+                    }
+                )
+            sent.append(message)
+        return sent
+
+    def merge_results(self, results: Iterable[AgentMessage]) -> dict[str, Any]:
+        winners = resolve_conflicts(results)
+        merged = {
+            "tasks": {
+                task: {
+                    "intent": msg.intent,
+                    "agent_id": msg.agent_id,
+                    "confidence": msg.confidence,
+                    "priority": msg.priority,
+                    "evidence": msg.evidence,
+                }
+                for task, msg in winners.items()
+            },
+            "evidence": [
+                evidence
+                for message in winners.values()
+                for evidence in message.evidence
+            ],
+        }
+        if self.memory is not None:
+            self.memory.append({"kind": "merge", "payload": merged})
+        return merged
+
+
+def _atomic_write_text(path: Path, data: str) -> None:
+    tmp = tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    )
+    try:
+        with tmp:
+            tmp.write(data)
+            tmp.flush()
+        Path(tmp.name).replace(path)
+    finally:
+        try:
+            Path(tmp.name).unlink()
+        except FileNotFoundError:
+            pass

--- a/tests/test_multiagent_protocol.py
+++ b/tests/test_multiagent_protocol.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from singular.multiagent import (
+    AgentMessage,
+    CollectiveMemory,
+    FileQueueTransport,
+    InMemoryQueueTransport,
+    OrchestrationScenario,
+    resolve_conflicts,
+)
+
+
+def test_message_is_versioned_and_serializable():
+    message = AgentMessage(
+        intent="answer",
+        task="sum",
+        evidence=["calc:1+1=2"],
+        confidence=0.9,
+        priority=1,
+        agent_id="agent-a",
+    )
+
+    decoded = AgentMessage.from_dict(message.to_dict())
+    assert decoded.version == 1
+    assert decoded.intent == "answer"
+    assert decoded.task == "sum"
+    assert decoded.evidence == ["calc:1+1=2"]
+
+
+def test_transports_queue_and_file(tmp_path):
+    message = AgentMessage(
+        intent="answer",
+        task="part-a",
+        evidence=["ok"],
+        confidence=0.7,
+    )
+
+    memory_transport = InMemoryQueueTransport()
+    memory_transport.send(message)
+    assert [m.task for m in memory_transport.receive()] == ["part-a"]
+    assert memory_transport.receive() == []
+
+    file_transport = FileQueueTransport(tmp_path / "queue" / "messages.jsonl")
+    file_transport.send(message)
+    received = file_transport.receive()
+    assert len(received) == 1
+    assert received[0].task == "part-a"
+    assert file_transport.receive() == []
+
+
+def test_conflict_resolution_by_priority_then_confidence():
+    messages = [
+        AgentMessage(
+            intent="answer",
+            task="part-a",
+            evidence=["low priority"],
+            confidence=0.95,
+            priority=1,
+            agent_id="agent-a",
+        ),
+        AgentMessage(
+            intent="answer",
+            task="part-a",
+            evidence=["high priority"],
+            confidence=0.6,
+            priority=2,
+            agent_id="agent-b",
+        ),
+        AgentMessage(
+            intent="answer",
+            task="part-b",
+            evidence=["best confidence"],
+            confidence=0.8,
+            priority=1,
+            agent_id="agent-c",
+        ),
+    ]
+
+    resolved = resolve_conflicts(messages)
+    assert resolved["part-a"].agent_id == "agent-b"
+    assert resolved["part-b"].agent_id == "agent-c"
+
+
+def test_orchestration_sharing_merge_and_namespaced_memory(tmp_path):
+    transport = InMemoryQueueTransport()
+    alpha_memory = CollectiveMemory(tmp_path / "collective", "alpha")
+    beta_memory = CollectiveMemory(tmp_path / "collective", "beta")
+
+    scenario = OrchestrationScenario(transport=transport, memory=alpha_memory)
+    scenario.share_subproblems(
+        parent_task="global-problem",
+        subproblems={"agent-a": "part-a", "agent-b": "part-b"},
+    )
+
+    dispatched = transport.receive()
+    assert {message.task for message in dispatched} == {"part-a", "part-b"}
+
+    merged = scenario.merge_results(
+        [
+            AgentMessage(
+                intent="answer",
+                task="part-a",
+                evidence=["result-a"],
+                confidence=0.7,
+                priority=1,
+                agent_id="agent-a",
+            ),
+            AgentMessage(
+                intent="answer",
+                task="part-a",
+                evidence=["result-a-alt"],
+                confidence=0.9,
+                priority=1,
+                agent_id="agent-c",
+            ),
+            AgentMessage(
+                intent="answer",
+                task="part-b",
+                evidence=["result-b"],
+                confidence=0.8,
+                priority=1,
+                agent_id="agent-b",
+            ),
+        ]
+    )
+
+    assert merged["tasks"]["part-a"]["agent_id"] == "agent-c"
+    assert merged["tasks"]["part-b"]["agent_id"] == "agent-b"
+    assert "result-b" in merged["evidence"]
+
+    alpha_records = alpha_memory.read()
+    assert any(record["kind"] == "dispatch" for record in alpha_records)
+    assert any(record["kind"] == "merge" for record in alpha_records)
+    assert beta_memory.read() == []


### PR DESCRIPTION
### Motivation
- Introduire un protocole simple et versionné pour l'échange de messages entre agents afin de standardiser `intent`, `task`, `evidence` et `confidence`.
- Fournir des transports locaux légers pour permettre la communication inter-processus via mémoire ou fichier sans dépendances externes.
- Gérer les conflits de réponses multiples sur une même tâche via une stratégie déterministe (priorité, puis confiance).
- Permettre l'orchestration de sous-problèmes avec option de mémoire collective isolée par `namespace` pour traçabilité.

### Description
- Ajout du package `singular.multiagent` exportant `AgentMessage`, `CollectiveMemory`, `FileQueueTransport`, `InMemoryQueueTransport`, `OrchestrationScenario` et `resolve_conflicts` (files: `src/singular/multiagent/__init__.py`, `src/singular/multiagent/protocol.py`).
- Implémentation de `AgentMessage` (version 1) avec validation et sérialisation/désérialisation JSON via `to_dict` / `from_dict`.
- Ajout de `InMemoryQueueTransport` et `FileQueueTransport` pour queue en mémoire et queue JSONL fichier, la version fichier utilisant des écritures atomiques.
- Ajout de la résolution de conflits par tâche (`resolve_conflicts`) triant par `priority`, puis `confidence`, puis `created_at`, et d`'OrchestrationScenario` fournissant `share_subproblems` et `merge_results` qui journalise dans `CollectiveMemory` quand configuré.

### Testing
- Ajout de `tests/test_multiagent_protocol.py` couvrant format versionné, transports mémoire/fichier, résolution de conflits, partage/fusion et isolation de mémoire par namespace.
- Exécution des tests ciblés avec `pytest -q tests/test_multiagent_protocol.py` a réussi avec `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc48ef8a00832a9dd7bc284f50e7f2)