### PR TITLE
Add autonomy metrics to status and dashboard

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from singular.lives import get_registry_root, load_registry, set_life_status
+from singular.metrics.autonomy import compute_autonomy_metrics
 
 from singular.dashboard.actions import DashboardActionService
 from fastapi.responses import HTMLResponse
@@ -409,6 +410,7 @@ def create_app(
                     "Vérifier la collecte des métriques",
                 ],
                 "global_status": "unknown",
+                "autonomy_metrics": {},
             }
             return empty
 
@@ -492,6 +494,8 @@ def create_app(
         else:
             global_status = "stable"
 
+        autonomy_metrics = compute_autonomy_metrics(records)
+
         return {
             "run": latest.stem,
             "health_score": health_score,
@@ -502,6 +506,7 @@ def create_app(
             "next_action": next_action,
             "suggested_actions": suggested_actions,
             "global_status": global_status,
+            "autonomy_metrics": autonomy_metrics,
         }
 
 

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -67,6 +67,15 @@
     <div class='card'><div class='card-label'>Prochaine action</div><div id='kpi-next-action' class='card-value'>n/a</div></div>
   </div>
 
+  <h3>Métriques d’autonomie</h3>
+  <div class='cards-grid'>
+    <div class='card'><div class='card-label'>Taux d’initiatives proactives</div><div id='kpi-autonomy-proactive' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label'>Stabilité long terme</div><div id='kpi-autonomy-stability' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label'>Qualité décisions (accept./régr.)</div><div id='kpi-autonomy-decision' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label'>Latence perception→action</div><div id='kpi-autonomy-latency' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label'>Coût ressources par gain</div><div id='kpi-autonomy-cost' class='card-value'>n/a</div></div>
+  </div>
+
   <div class='panel'>
     <h3 style='margin-top:0;'>Synthèse des vies</h3>
     <div class='cards-grid'>
@@ -262,12 +271,21 @@ const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=
   const trend=d.trend||'n/a';
   const accepted=d.accepted_mutation_rate===null?'n/a':`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
   const alertsCount=(d.critical_alerts||[]).length;
+  const autonomy=d.autonomy_metrics||{};
+  const decisionQuality=autonomy.decision_quality||{};
+  const fmtPct=(value)=>value===null||value===undefined?'n/a':`${(Number(value)*100).toFixed(1)}%`;
+  const fmtNum=(value,suffix='')=>value===null||value===undefined?'n/a':`${Number(value).toFixed(2)}${suffix}`;
 
   document.getElementById('kpi-health').textContent=healthValue;
   document.getElementById('kpi-trend').textContent=trend;
   document.getElementById('kpi-accepted').textContent=accepted;
   document.getElementById('kpi-alerts').textContent=String(alertsCount);
   document.getElementById('kpi-next-action').textContent=d.next_action||'n/a';
+  document.getElementById('kpi-autonomy-proactive').textContent=fmtPct(autonomy.proactive_initiative_rate);
+  document.getElementById('kpi-autonomy-stability').textContent=fmtPct(autonomy.long_term_stability);
+  document.getElementById('kpi-autonomy-decision').textContent=`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`;
+  document.getElementById('kpi-autonomy-latency').textContent=fmtNum(autonomy.perception_to_action_latency_ms,' ms');
+  document.getElementById('kpi-autonomy-cost').textContent=fmtNum(autonomy.resource_cost_per_gain);
   setStatusTone(document.getElementById('kpi-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
 
   const notable=d.last_notable_mutation;

--- a/src/singular/metrics/__init__.py
+++ b/src/singular/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Metrics utilities for singular."""
+
+from .autonomy import compute_autonomy_metrics
+
+__all__ = ["compute_autonomy_metrics"]

--- a/src/singular/metrics/autonomy.py
+++ b/src/singular/metrics/autonomy.py
@@ -1,0 +1,165 @@
+"""Autonomy metrics computed from run records."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from statistics import mean
+from typing import Any
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value
+    if value.endswith("Z"):
+        normalized = value[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def _is_action_record(record: dict[str, Any]) -> bool:
+    event = record.get("event")
+    if event in {"mutation", "interaction", "refuse", "delay", "test_coevolution"}:
+        return True
+    return any(key in record for key in ("op", "operator", "score_new"))
+
+
+def _is_proactive_record(record: dict[str, Any]) -> bool:
+    proactive = record.get("proactive")
+    if isinstance(proactive, bool):
+        return proactive
+    event = record.get("event")
+    return event in {"mutation", "interaction", "test_coevolution"} or "score_new" in record
+
+
+def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float | dict[str, float] | None]:
+    """Compute autonomy-oriented metrics from run records."""
+
+    action_records = [record for record in records if _is_action_record(record)]
+    proactive_records = [record for record in action_records if _is_proactive_record(record)]
+    proactive_rate = (
+        len(proactive_records) / len(action_records) if action_records else None
+    )
+
+    health_scores = [
+        score
+        for record in records
+        for health in [record.get("health")]
+        if isinstance(health, dict)
+        for score in [_as_float(health.get("score"))]
+        if score is not None
+    ]
+    score_series = [
+        score
+        for record in records
+        for score in [_as_float(record.get("score_new"))]
+        if score is not None
+    ]
+    reference = score_series if score_series else health_scores
+    long_term_stability = None
+    if len(reference) >= 2:
+        deltas = [abs(reference[idx] - reference[idx - 1]) for idx in range(1, len(reference))]
+        avg_delta = mean(deltas) if deltas else 0.0
+        long_term_stability = max(0.0, min(1.0, 1.0 - (avg_delta / 10.0)))
+
+    accepted = 0
+    regressive = 0
+    decisions = 0
+    positive_gain = 0
+    total_gain = 0.0
+    for record in action_records:
+        accepted_value = record.get("accepted")
+        if not isinstance(accepted_value, bool):
+            accepted_value = record.get("ok")
+
+        score_base = _as_float(record.get("score_base"))
+        score_new = _as_float(record.get("score_new"))
+        gain = None
+        if score_base is not None and score_new is not None:
+            gain = score_base - score_new
+            total_gain += gain
+            if gain > 0:
+                positive_gain += 1
+
+        if isinstance(accepted_value, bool):
+            decisions += 1
+            if accepted_value:
+                accepted += 1
+            if gain is not None and gain < 0:
+                regressive += 1
+
+    acceptance_rate = accepted / decisions if decisions else None
+    regression_rate = regressive / decisions if decisions else None
+
+    latencies_ms: list[float] = []
+    last_perception_ts: datetime | None = None
+    for record in records:
+        if record.get("event") == "consciousness":
+            parsed = _parse_ts(record.get("ts"))
+            if parsed is not None:
+                last_perception_ts = parsed
+            continue
+
+        direct_latency = _as_float(record.get("perception_to_action_ms"))
+        if direct_latency is not None:
+            latencies_ms.append(direct_latency)
+            continue
+
+        if _is_action_record(record) and last_perception_ts is not None:
+            action_ts = _parse_ts(record.get("ts"))
+            if action_ts is not None:
+                delta_ms = (action_ts - last_perception_ts).total_seconds() * 1000.0
+                if delta_ms >= 0:
+                    latencies_ms.append(delta_ms)
+                    continue
+
+        runtime_latency = _as_float(record.get("ms_new"))
+        if runtime_latency is not None and _is_action_record(record):
+            latencies_ms.append(runtime_latency)
+
+    perception_to_action_latency_ms = mean(latencies_ms) if latencies_ms else None
+
+    resource_costs: list[float] = []
+    total_positive_gain = 0.0
+    for record in action_records:
+        cost = _as_float(record.get("resource_cost"))
+        if cost is None:
+            metrics = record.get("mutation_metrics")
+            if isinstance(metrics, dict):
+                cost = _as_float(metrics.get("resource_cost"))
+        if cost is None:
+            cost = _as_float(record.get("ms_new"))
+        if cost is not None:
+            resource_costs.append(cost)
+
+        score_base = _as_float(record.get("score_base"))
+        score_new = _as_float(record.get("score_new"))
+        if score_base is not None and score_new is not None and score_base > score_new:
+            total_positive_gain += score_base - score_new
+
+    resource_cost_per_gain = None
+    if resource_costs and total_positive_gain > 0:
+        resource_cost_per_gain = sum(resource_costs) / total_positive_gain
+
+    return {
+        "proactive_initiative_rate": proactive_rate,
+        "long_term_stability": long_term_stability,
+        "decision_quality": {
+            "acceptance_rate": acceptance_rate,
+            "regression_rate": regression_rate,
+            "improvement_hit_rate": (
+                positive_gain / len(action_records) if action_records else None
+            ),
+        },
+        "perception_to_action_latency_ms": perception_to_action_latency_ms,
+        "resource_cost_per_gain": resource_cost_per_gain,
+        "mean_score_gain": (total_gain / len(action_records) if action_records else None),
+    }

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from ..life.health import detect_health_state
+from ..metrics.autonomy import compute_autonomy_metrics
 from ..psyche import Psyche
 from ..runs.logger import RUNS_DIR
 from ..schedulers.reevaluation import alerts_from_records
@@ -26,6 +27,20 @@ def _print_table(headers: list[str], rows: list[list[str]]) -> None:
         print(_fmt(row))
 
 
+
+
+
+def _fmt_ratio(value: object) -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value) * 100:.1f}%"
+    return "-"
+
+
+def _fmt_number(value: object, unit: str = "") -> str:
+    if isinstance(value, (int, float)):
+        return f"{float(value):.2f}{unit}"
+    return "-"
+
 def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     """Display basic metrics and current psyche state."""
 
@@ -39,6 +54,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "alerts": [],
         "mood": None,
         "traits": {},
+        "autonomy_metrics": {},
     }
     runs_dir = Path(RUNS_DIR)
     files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
@@ -88,6 +104,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                     "trend": state,
                     "window": "10/50",
                 }
+            payload["autonomy_metrics"] = compute_autonomy_metrics(records)
             if verbose:
                 alerts = alerts_from_records(records)
                 payload["alerts"] = alerts
@@ -109,6 +126,8 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         return
 
     if output_format == "table":
+        autonomy = payload.get("autonomy_metrics") if isinstance(payload.get("autonomy_metrics"), dict) else {}
+        decision_quality = autonomy.get("decision_quality") if isinstance(autonomy.get("decision_quality"), dict) else {}
         run_rows = [
             ["Latest run", str(payload.get("latest_run") or "-")],
             ["Last execution speed", f"{payload['last_execution_ms']}ms" if payload.get("last_execution_ms") is not None else "-"],
@@ -130,6 +149,14 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                     else "-"
                 ),
             ],
+            ["Taux d’initiatives proactives", _fmt_ratio(autonomy.get("proactive_initiative_rate"))],
+            ["Stabilité long terme", _fmt_ratio(autonomy.get("long_term_stability"))],
+            [
+                "Qualité décisions (acceptation/régression)",
+                f"{_fmt_ratio(decision_quality.get('acceptance_rate'))} / {_fmt_ratio(decision_quality.get('regression_rate'))}",
+            ],
+            ["Latence perception→action", _fmt_number(autonomy.get("perception_to_action_latency_ms"), " ms")],
+            ["Coût ressources par gain", _fmt_number(autonomy.get("resource_cost_per_gain"))],
             ["Mood", str(payload.get("mood"))],
         ]
         _print_table(["Metric", "Value"], run_rows)
@@ -160,6 +187,16 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         if payload.get("mutation_success_rate") is not None:
             print(f"Mutation success rate: {payload['mutation_success_rate']:.0f}%")
         print(f"Mutation count: {payload['mutation_count']}")
+        autonomy = payload.get("autonomy_metrics") if isinstance(payload.get("autonomy_metrics"), dict) else {}
+        decision_quality = autonomy.get("decision_quality") if isinstance(autonomy.get("decision_quality"), dict) else {}
+        print(f"Taux d’initiatives proactives: {_fmt_ratio(autonomy.get('proactive_initiative_rate'))}")
+        print(f"Stabilité long terme: {_fmt_ratio(autonomy.get('long_term_stability'))}")
+        print(
+            "Qualité décisions (acceptation/régression): "
+            f"{_fmt_ratio(decision_quality.get('acceptance_rate'))} / {_fmt_ratio(decision_quality.get('regression_rate'))}"
+        )
+        print(f"Latence perception→action: {_fmt_number(autonomy.get('perception_to_action_latency_ms'), ' ms')}")
+        print(f"Coût ressources par gain: {_fmt_number(autonomy.get('resource_cost_per_gain'))}")
         health = payload.get("health")
         if isinstance(health, dict):
             print(

--- a/tests/test_autonomy_metrics.py
+++ b/tests/test_autonomy_metrics.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from singular.metrics.autonomy import compute_autonomy_metrics
+
+
+def test_compute_autonomy_metrics_core_indicators() -> None:
+    records = [
+        {
+            "ts": "2026-04-12T10:00:00",
+            "event": "consciousness",
+        },
+        {
+            "ts": "2026-04-12T10:00:01",
+            "event": "mutation",
+            "accepted": True,
+            "score_base": 10.0,
+            "score_new": 8.0,
+            "resource_cost": 2.0,
+        },
+        {
+            "ts": "2026-04-12T10:00:03",
+            "event": "mutation",
+            "accepted": False,
+            "score_base": 8.0,
+            "score_new": 9.0,
+            "resource_cost": 1.0,
+        },
+        {
+            "ts": "2026-04-12T10:00:05",
+            "event": "delay",
+            "ms_new": 4.0,
+        },
+    ]
+
+    metrics = compute_autonomy_metrics(records)
+
+    assert metrics["proactive_initiative_rate"] == 2 / 3
+    assert isinstance(metrics["long_term_stability"], float)
+    assert metrics["perception_to_action_latency_ms"] == 3000.0
+    assert metrics["resource_cost_per_gain"] == 3.5
+
+    quality = metrics["decision_quality"]
+    assert isinstance(quality, dict)
+    assert quality["acceptance_rate"] == 0.5
+    assert quality["regression_rate"] == 0.5

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -164,6 +164,8 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert "health_score" in payload
     assert "accepted_mutation_rate" in payload
     assert "last_notable_mutation" in payload
+    assert "autonomy_metrics" in payload
+    assert "proactive_initiative_rate" in payload["autonomy_metrics"]
 
 
 def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
@@ -175,6 +177,8 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     body = response.json()
     assert "Cockpit" in body
     assert "Prochaine action" in body
+    assert "Métriques d’autonomie" in body
+    assert "Taux d’initiatives proactives" in body
     assert "/api/cockpit" in body
     assert "Timeline des événements" in body
     assert "timeline-diff" in body

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -108,3 +108,5 @@ def test_status_filters_non_mutation_records_for_success_rate(
     assert payload["mutation_count"] == 3
     assert payload["mutation_success_rate"] == 50.0
     assert payload["success_rate"] == 50.0
+    assert "autonomy_metrics" in payload
+    assert "proactive_initiative_rate" in payload["autonomy_metrics"]


### PR DESCRIPTION
### Motivation
- Provide autonomy-oriented KPIs derived from run logs to monitor agent initiative, decision quality, stability, latency and resource efficiency.
- Surface these indicators both in the CLI `status` output and in the web dashboard cockpit so operators can track autonomy signals alongside health metrics.

### Description
- Add a new metrics module `src/singular/metrics/autonomy.py` implementing `compute_autonomy_metrics(records)` to compute: proactive initiative rate, long-term stability, decision quality (acceptance/regression), perception→action latency, and resource cost per gain.
- Export the metric function via `src/singular/metrics/__init__.py` and call it from `status` and dashboard code paths to include `autonomy_metrics` in payloads.
- Integrate metrics into CLI `status` output (JSON/table/plain) by adding formatted display helpers and rows for the autonomy KPIs in `src/singular/organisms/status.py`.
- Include autonomy data in the cockpit payload (`/api/cockpit`) and render a dedicated "Métriques d’autonomie" card grid in `src/singular/dashboard/templates/dashboard.html` with JS hydration from `/api/cockpit`.
- Add unit tests `tests/test_autonomy_metrics.py` and update `tests/test_status.py` and `tests/test_dashboard.py` to assert presence and basic correctness of autonomy metrics.

### Testing
- Ran `pytest -q tests/test_autonomy_metrics.py tests/test_status.py tests/test_dashboard.py` and the test suite for those targets passed: `22 passed, 1 warning`.
- The dashboard endpoints used in tests were exercised via the FastAPI test client to validate `/api/cockpit` schema and HTML template content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc49db3644832a960383d0474daa47)