### PR TITLE
Harden sandbox result retrieval and add regression coverage

### DIFF
--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -6,6 +6,7 @@ import ast
 import logging
 import multiprocessing
 import os
+import queue as queue_module
 import sys
 import tempfile
 from types import ModuleType
@@ -121,10 +122,18 @@ def run(code: str, timeout: float = 1.5, memory_limit: int = 256 * 1024 * 1024) 
         proc.terminate()
         proc.join()
         raise TimeoutError("sandbox execution timed out")
+    queue_timeout = max(0.05, timeout)
+    try:
+        out = queue.get(timeout=queue_timeout)
+    except queue_module.Empty as exc:
+        if proc.exitcode not in (0, None):
+            raise SandboxError(
+                f"sandbox worker exited without payload (exit code {proc.exitcode})"
+            ) from exc
+        raise SandboxError(
+            "sandbox worker finished without returning a payload"
+        ) from exc
 
-    if not queue.empty():
-        out = queue.get()
-        if isinstance(out, Exception):
-            raise out
-        return out
-    return None
+    if isinstance(out, Exception):
+        raise out
+    return out

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -70,7 +70,7 @@ def test_run_windows_cleanup_guard(monkeypatch, caplog):
         def put(self, value):
             self._items.append(value)
 
-        def get(self):
+        def get(self, timeout=None):
             return self._items.pop(0)
 
         def empty(self):
@@ -91,6 +91,7 @@ def test_run_windows_cleanup_guard(monkeypatch, caplog):
     def fake_chdir(path):
         chdir_calls.append(path)
         if len(chdir_calls) == 2:
+            real_chdir(path)
             raise OSError("simulated windows cleanup lock")
         return real_chdir(path)
 
@@ -101,3 +102,59 @@ def test_run_windows_cleanup_guard(monkeypatch, caplog):
     assert len(chdir_calls) == 2
     assert "failed to restore cwd during sandbox cleanup" in caplog.text
 
+
+def test_run_consecutive_calls_do_not_return_none_with_unreliable_empty_check(monkeypatch):
+    import singular.life.sandbox as sandbox_module
+
+    class InlineProcess:
+        def __init__(self, target, args):
+            self._target = target
+            self._args = args
+            self._alive = False
+            self.exitcode = None
+
+        def start(self):
+            self._alive = True
+            self._target(*self._args)
+            self._alive = False
+            self.exitcode = 0
+
+        def join(self, _timeout=None):
+            return None
+
+        def is_alive(self):
+            return self._alive
+
+        def terminate(self):
+            self._alive = False
+            self.exitcode = -15
+
+    class FlakyEmptyQueue:
+        def __init__(self):
+            self._items = []
+            self._empty_checks = 0
+
+        def put(self, value):
+            self._items.append(value)
+
+        def get(self, timeout=None):
+            assert timeout is not None
+            return self._items.pop(0)
+
+        def empty(self):
+            self._empty_checks += 1
+            if self._empty_checks == 1:
+                return True
+            return not self._items
+
+    class InlineContext:
+        def Queue(self):
+            return FlakyEmptyQueue()
+
+        def Process(self, target, args):
+            return InlineProcess(target, args)
+
+    monkeypatch.setattr(sandbox_module.multiprocessing, "get_context", lambda _name: InlineContext())
+
+    for _ in range(20):
+        assert sandbox_module.run("result = 42") == 42


### PR DESCRIPTION
### Motivation
- The previous `if not queue.empty(): queue.get()` pattern is race-prone with `multiprocessing.Queue` and could intermittently return `None` instead of the worker payload. 
- The change makes failure modes explicit and debuggable by surfacing clear errors when the worker exits without sending a payload. 

### Description
- Replaced the post-`join()` readiness check with a blocking `queue.get(timeout=...)` and imported `queue` as `queue_module` in `src/singular/life/sandbox.py`. 
- Added explicit `SandboxError` paths for `queue.Empty` where the worker exited with a non-zero `exitcode` or finished without returning a payload, and preserved re-raising serialized exceptions from the worker. 
- Added a targeted non-regression test `test_run_consecutive_calls_do_not_return_none_with_unreliable_empty_check` in `tests/test_sandbox.py` that simulates a queue whose `empty()` is unreliable and validates consecutive runs never return `None`. 
- Adjusted existing inline test doubles to accept `get(timeout=...)` and made a small fix to the simulated `chdir` behavior to keep the cleanup guard test stable. 

### Testing
- Ran `pytest -q tests/test_sandbox.py`, and all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4e2c6a30832ab90bf67b1d8b5a8c)