### PR TITLE
Normalize belief timestamp parsing to UTC

### DIFF
--- a/src/singular/beliefs/store.py
+++ b/src/singular/beliefs/store.py
@@ -20,9 +20,12 @@ def _parse_datetime(value: str | None) -> datetime:
     if not value:
         return _utcnow()
     try:
-        return datetime.fromisoformat(value)
+        parsed = datetime.fromisoformat(value)
     except ValueError:
         return _utcnow()
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 @dataclass

--- a/tests/test_beliefs_store.py
+++ b/tests/test_beliefs_store.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
-from singular.beliefs.store import BeliefStore
+from singular.beliefs.store import BeliefStore, _parse_datetime
 from singular.life.loop import select_operator
 
 
@@ -71,3 +72,21 @@ def test_beliefs_file_is_json_serializable(tmp_path: Path) -> None:
     store.update_after_run("operator:demo", success=True, evidence="ok")
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert "operator:demo" in payload
+
+
+def test_parse_datetime_normalizes_naive_updated_at_to_utc() -> None:
+    parsed = _parse_datetime("2026-04-13T10:30:00")
+    assert parsed == datetime(2026, 4, 13, 10, 30, tzinfo=timezone.utc)
+
+
+def test_parse_datetime_converts_tz_updated_at_to_utc() -> None:
+    parsed = _parse_datetime("2026-04-13T10:30:00+02:00")
+    assert parsed == datetime(2026, 4, 13, 8, 30, tzinfo=timezone.utc)
+
+
+def test_parse_datetime_uses_safe_fallback_for_corrupted_value(
+    monkeypatch,
+) -> None:
+    fallback = datetime(2026, 4, 13, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("singular.beliefs.store._utcnow", lambda: fallback)
+    assert _parse_datetime("not-a-date") == fallback


### PR DESCRIPTION
### Motivation
- Les dates stockées dans les enregistrements de croyance doivent être normalisées en UTC pour assurer des calculs temporels cohérents (décroissance, retention, etc.).
- Le comportement précédent laissait passer des datetimes naïfs ou avec fuseaux différents sans normalisation explicite.
- Il faut conserver un mécanisme de secours sûr en cas de parsing invalide pour éviter des erreurs runtime.

### Description
- Mise à jour de la fonction `_parse_datetime()` pour convertir toute date en timezone-aware UTC en affectant `timezone.utc` aux datetimes naïfs et en appelant `astimezone(timezone.utc)` pour les datetimes avec offset.
- Les valeurs corrompues continuent de retomber sur le fallback `_utcnow()` pour un comportement sûr.
- Ajout de trois tests dans `tests/test_beliefs_store.py` qui vérifient la normalisation d'un `updated_at` sans timezone, la conversion d'un `updated_at` avec offset, et le fallback pour une valeur corrompue.

### Testing
- Exécution de `pytest -q tests/test_beliefs_store.py` qui a réussi avec `6 passed`.
- Les nouveaux tests ciblés passent et couvrent les cas naïf, avec offset et corrompu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4eb4db04832a86e889470f4759af)