### PR TITLE
Handle registry loading failures and add tests for malformed registry

### DIFF
--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import shutil
@@ -13,6 +14,8 @@ from typing import Any, Dict
 
 _REGISTRY_DIRNAME = "lives"
 _REGISTRY_FILENAME = "registry.json"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -81,11 +84,14 @@ def load_registry() -> dict[str, Any]:
     """Load the life registry from disk."""
 
     path = _registry_path()
-    if not path.exists():
-        return {"active": None, "lives": {}}
+    default_registry = {"active": None, "lives": {}}
 
-    with path.open(encoding="utf-8") as fh:
-        payload = json.load(fh)
+    try:
+        with path.open(encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        _LOGGER.warning("Failed to load life registry from %s: %s", path, exc)
+        return default_registry
 
     lives_payload = payload.get("lives", {})
     lives: dict[str, LifeMetadata] = {}

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -99,3 +99,44 @@ def test_set_life_status_updates_registry(
 
     registry = load_registry()
     assert registry["lives"][life.slug].status == "extinct"
+
+
+def test_load_registry_returns_default_for_empty_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    registry_path = tmp_path / "lives" / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text("", encoding="utf-8")
+
+    registry = load_registry()
+
+    assert registry == {"active": None, "lives": {}}
+    assert "Failed to load life registry" in caplog.text
+
+
+def test_load_registry_returns_default_for_invalid_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    registry_path = tmp_path / "lives" / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text("{invalid", encoding="utf-8")
+
+    registry = load_registry()
+
+    assert registry == {"active": None, "lives": {}}
+    assert "Failed to load life registry" in caplog.text
+
+
+def test_load_registry_handles_partial_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    registry_path = tmp_path / "lives" / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text('{"active": "missing-slug"}', encoding="utf-8")
+
+    registry = load_registry()
+
+    assert registry == {"active": None, "lives": {}}


### PR DESCRIPTION
### Motivation

- Prevent uncaught errors when reading the lives registry file and provide a safe default if the file is missing or malformed. 
- Improve robustness by logging a warning when registry loading fails so failures are visible during debugging and CI.

### Description

- Add `import logging` and a module logger `_LOGGER = logging.getLogger(__name__)` in `src/singular/lives.py`.
- Update `load_registry()` to wrap JSON file reading in a `try/except` that catches `FileNotFoundError`, `json.JSONDecodeError`, and `OSError`, returns the default payload `{"active": None, "lives": {}}`, and logs a warning with the exception.
- Remove the prior explicit `path.exists()` early-return branch and consolidate the default-return logic into the error handler.
- Add three tests in `tests/test_lives.py` to cover an empty registry file, invalid JSON content, and a partial payload missing a resolvable `active` slug.

### Testing

- Ran `pytest -q tests/test_lives.py` and all tests passed (`8 passed`).
- The new tests assert that `load_registry()` returns `{"active": None, "lives": {}}` for empty/invalid files and that a partial payload with an unresolved `active` results in the same default behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4f4f12f4832a97aac9f12dfe7482)