### PR TITLE
Safe JSONL append with file locking for episodic and multi-agent logs

### DIFF
--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -12,6 +12,11 @@ import json
 import os
 import tempfile
 
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
 from .events import Event, EventBus
 from .memory_layers import MemoryLayerService, build_backend
 
@@ -81,6 +86,31 @@ def _atomic_write_text(path: Path, data: str) -> None:
             os.unlink(tmp.name)
         except FileNotFoundError:
             pass
+
+
+def _append_jsonl_line(path: Path, payload: dict[str, Any]) -> None:
+    """Safely append one JSON line with cross-platform file locking."""
+
+    _ensure_dir(path)
+    line = json.dumps(payload, ensure_ascii=False) + "\n"
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            with path.open("a", encoding="utf-8") as file:
+                file.write(line)
+                file.flush()
+                os.fsync(file.fileno())
+        finally:
+            if os.name == "nt":
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def ensure_memory_structure(mem_dir: Path | str | None = None) -> None:
@@ -230,8 +260,7 @@ def add_episode(
     if path is None:
         path = get_episodic_file()
     path = Path(path)
-    existing = path.read_text(encoding="utf-8") if path.exists() else ""
-    _atomic_write_text(path, existing + json.dumps(episode) + "\n")
+    _append_jsonl_line(path, episode)
     try:
         get_memory_layer_service().ingest_episode(episode)
     except Exception:

--- a/src/singular/multiagent/protocol.py
+++ b/src/singular/multiagent/protocol.py
@@ -4,9 +4,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Protocol
 import json
+import os
 import tempfile
 import time
 from collections import defaultdict, deque
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
 
 
 @dataclass(slots=True)
@@ -90,10 +96,7 @@ class FileQueueTransport:
         self.path = Path(path)
 
     def send(self, message: AgentMessage) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(message.to_dict(), ensure_ascii=False) + "\n"
-        existing = self.path.read_text(encoding="utf-8") if self.path.exists() else ""
-        _atomic_write_text(self.path, existing + line)
+        _append_jsonl_line(self.path, message.to_dict())
 
     def receive(self) -> list[AgentMessage]:
         if not self.path.exists():
@@ -136,10 +139,7 @@ class CollectiveMemory:
         return self.root / f"{self.namespace}.jsonl"
 
     def append(self, record: dict[str, Any]) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(record, ensure_ascii=False) + "\n"
-        existing = self._path.read_text(encoding="utf-8") if self._path.exists() else ""
-        _atomic_write_text(self._path, existing + line)
+        _append_jsonl_line(self._path, record)
 
     def read(self) -> list[dict[str, Any]]:
         if not self._path.exists():
@@ -224,3 +224,26 @@ def _atomic_write_text(path: Path, data: str) -> None:
             Path(tmp.name).unlink()
         except FileNotFoundError:
             pass
+
+
+def _append_jsonl_line(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(payload, ensure_ascii=False) + "\n"
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            with path.open("a", encoding="utf-8") as file:
+                file.write(line)
+                file.flush()
+                os.fsync(file.fileno())
+        finally:
+            if os.name == "nt":
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -24,19 +24,21 @@ def test_write_profile_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert json.loads(profile_path.read_text(encoding="utf-8")) == {"old": 1}
 
 
-def test_add_episode_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_add_episode_uses_append_path_not_snapshot_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     episode_path = tmp_path / "mem" / "episodic.jsonl"
     episode_path.parent.mkdir(parents=True, exist_ok=True)
     episode_path.write_text(json.dumps({"event": "old"}) + "\n", encoding="utf-8")
 
     monkeypatch.setattr(memory.os, "replace", failing_replace)
 
-    with pytest.raises(RuntimeError):
-        memory.add_episode({"event": "new"}, path=episode_path)
+    memory.add_episode({"event": "new"}, path=episode_path)
 
     lines = episode_path.read_text(encoding="utf-8").splitlines()
-    assert len(lines) == 1
+    assert len(lines) == 2
     assert json.loads(lines[0]) == {"event": "old"}
+    assert json.loads(lines[1]) == {"event": "new"}
 
 
 def test_resource_manager_save_atomic(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import json
+import multiprocessing as mp
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from typing import Any
@@ -7,6 +9,11 @@ from typing import Any
 from singular.memory import add_episode, update_trait, update_score, update_note
 import singular.memory as memory
 from singular.organisms.birth import birth
+
+
+def _append_episode_worker(path: str, start: int, count: int) -> None:
+    for idx in range(start, start + count):
+        add_episode({"event": "mp", "id": idx}, path=Path(path))
 
 
 def test_birth_creates_memory_files(tmp_path: Path) -> None:
@@ -46,6 +53,44 @@ def test_add_episode(tmp_path: Path) -> None:
     lines = episode_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     assert json.loads(lines[0]) == {"event": "test"}
+
+
+def test_add_episode_concurrent_threads(tmp_path: Path) -> None:
+    episode_path = tmp_path / "mem" / "episodic.jsonl"
+    total = 80
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for idx in range(total):
+            pool.submit(add_episode, {"event": "thread", "id": idx}, episode_path)
+
+    lines = episode_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == total
+    ids = {json.loads(line)["id"] for line in lines}
+    assert ids == set(range(total))
+
+
+def test_add_episode_concurrent_processes(tmp_path: Path) -> None:
+    episode_path = tmp_path / "mem" / "episodic.jsonl"
+    proc_count = 4
+    per_proc = 20
+    processes = [
+        mp.Process(
+            target=_append_episode_worker,
+            args=(str(episode_path), proc_idx * per_proc, per_proc),
+        )
+        for proc_idx in range(proc_count)
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    lines = episode_path.read_text(encoding="utf-8").splitlines()
+    expected = proc_count * per_proc
+    assert len(lines) == expected
+    ids = {json.loads(line)["id"] for line in lines}
+    assert ids == set(range(expected))
 
 
 def test_update_trait_score_and_note(tmp_path: Path) -> None:

--- a/tests/test_multiagent_protocol.py
+++ b/tests/test_multiagent_protocol.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+import json
+import multiprocessing as mp
+from pathlib import Path
+
 from singular.multiagent import (
     AgentMessage,
     CollectiveMemory,
@@ -8,6 +13,25 @@ from singular.multiagent import (
     OrchestrationScenario,
     resolve_conflicts,
 )
+
+
+def _send_messages_worker(path: str, start: int, count: int) -> None:
+    transport = FileQueueTransport(Path(path))
+    for idx in range(start, start + count):
+        transport.send(
+            AgentMessage(
+                intent="answer",
+                task=f"part-{idx}",
+                evidence=["mp"],
+                confidence=0.9,
+            )
+        )
+
+
+def _append_collective_worker(root: str, namespace: str, start: int, count: int) -> None:
+    memory = CollectiveMemory(Path(root), namespace)
+    for idx in range(start, start + count):
+        memory.append({"kind": "mp", "id": idx})
 
 
 def test_message_is_versioned_and_serializable():
@@ -132,3 +156,66 @@ def test_orchestration_sharing_merge_and_namespaced_memory(tmp_path):
     assert any(record["kind"] == "dispatch" for record in alpha_records)
     assert any(record["kind"] == "merge" for record in alpha_records)
     assert beta_memory.read() == []
+
+
+def test_file_queue_transport_concurrent_threads_and_processes(tmp_path):
+    queue_path = tmp_path / "queue" / "messages.jsonl"
+    transport = FileQueueTransport(queue_path)
+    thread_count = 40
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for idx in range(thread_count):
+            pool.submit(
+                transport.send,
+                AgentMessage(
+                    intent="answer",
+                    task=f"thread-{idx}",
+                    evidence=["thread"],
+                    confidence=0.7,
+                ),
+            )
+
+    processes = [
+        mp.Process(
+            target=_send_messages_worker,
+            args=(str(queue_path), proc_idx * 15, 15),
+        )
+        for proc_idx in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    lines = queue_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == thread_count + 30
+    assert all(line.strip() for line in lines)
+    parsed = [json.loads(line) for line in lines]
+    assert len(parsed) == thread_count + 30
+
+
+def test_collective_memory_concurrent_threads_and_processes(tmp_path):
+    root = tmp_path / "collective"
+    memory = CollectiveMemory(root, "alpha")
+    thread_count = 30
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        for idx in range(thread_count):
+            pool.submit(memory.append, {"kind": "thread", "id": idx})
+
+    processes = [
+        mp.Process(
+            target=_append_collective_worker,
+            args=(str(root), "alpha", proc_idx * 10, 10),
+        )
+        for proc_idx in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    records = memory.read()
+    assert len(records) == thread_count + 20
+    ids = {record["id"] for record in records}
+    assert set(range(thread_count)).issubset(ids)


### PR DESCRIPTION
### Motivation

- Ensure JSONL appends do not lose lines under concurrent writers (threads or processes) for episodic and multi-agent logs. 
- Avoid using snapshot/replace semantics for append-only logs but keep atomic snapshot writes for full-file updates.

### Description

- Add a helper ` _append_jsonl_line` that appends a single JSON line using `open(..., "a")` + `flush()` + `os.fsync()` and a sidecar `.lock` file for cross-platform locking (`fcntl.flock` on POSIX, `msvcrt.locking` on Windows). 
- Switch `add_episode`, `FileQueueTransport.send`, and `CollectiveMemory.append` to use ` _append_jsonl_line` instead of building a snapshot and calling the atomic replace path. 
- Preserve ` _atomic_write_text` for snapshot-style writes (full-file replace) used elsewhere (e.g., clearing queues via `receive`, profile/skills writes). 
- Update tests: adjust the atomicity test to reflect append semantics and add lightweight concurrency tests (multi-thread + multi-process) covering `add_episode`, `FileQueueTransport.send`, and `CollectiveMemory.append` to assert no lines are lost and JSON parses correctly.

### Testing

- Ran `pytest -q tests/test_atomic_writes.py tests/test_memory.py tests/test_multiagent_protocol.py` and all tests passed. 
- Test run reported: `17 passed` (concurrency and atomicity tests included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc50f667fc832a8fd4a8aa65a6ea78)