### PR TITLE
Event bus: log handler exceptions and add configurable strict mode

### DIFF
--- a/src/singular/events/bus.py
+++ b/src/singular/events/bus.py
@@ -6,12 +6,14 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 import atexit
+import logging
 import os
 from queue import Empty, Queue
 import threading
 from typing import Any, Callable
 
 EventHandler = Callable[["Event"], None]
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -27,11 +29,12 @@ class Event:
 class EventBus:
     """Simple event bus supporting sync and async dispatch modes."""
 
-    def __init__(self, *, mode: str = "sync") -> None:
+    def __init__(self, *, mode: str = "sync", strict: bool = False) -> None:
         normalized_mode = mode.strip().lower()
         if normalized_mode not in {"sync", "async"}:
             normalized_mode = "sync"
         self.mode = normalized_mode
+        self.strict = strict
         self._subscribers: dict[str, list[EventHandler]] = defaultdict(list)
         self._lock = threading.Lock()
         self._queue: Queue[Event] | None = None
@@ -91,7 +94,13 @@ class EventBus:
             try:
                 handler(event)
             except Exception:
-                continue
+                logger.exception(
+                    "Error while handling event '%s' in handler '%s'",
+                    event.event_type,
+                    getattr(handler, "__name__", repr(handler)),
+                )
+                if self.strict:
+                    raise
 
     def _start_worker(self) -> None:
         if self._queue is None:
@@ -126,11 +135,20 @@ def get_bus_mode_from_env() -> str:
     return os.environ.get("SINGULAR_EVENT_BUS_MODE", "sync").strip().lower()
 
 
+def get_bus_strict_from_env() -> bool:
+    """Read strict event bus mode from configuration environment."""
+
+    value = os.environ.get("SINGULAR_EVENT_BUS_STRICT", "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
 def get_global_event_bus() -> EventBus:
     """Return process-wide event bus configured by environment."""
 
     global _GLOBAL_BUS
     if _GLOBAL_BUS is None:
-        _GLOBAL_BUS = EventBus(mode=get_bus_mode_from_env())
+        _GLOBAL_BUS = EventBus(
+            mode=get_bus_mode_from_env(), strict=get_bus_strict_from_env()
+        )
         atexit.register(_GLOBAL_BUS.shutdown)
     return _GLOBAL_BUS

--- a/tests/test_events_bus.py
+++ b/tests/test_events_bus.py
@@ -1,0 +1,40 @@
+import logging
+
+import pytest
+
+from singular.events.bus import EventBus, Event, get_bus_strict_from_env
+
+
+def test_dispatch_logs_handler_error(caplog: pytest.LogCaptureFixture) -> None:
+    bus = EventBus(mode="sync")
+
+    def failing_handler(event: Event) -> None:
+        raise RuntimeError("boom")
+
+    bus.subscribe("test.event", failing_handler)
+    caplog.set_level(logging.ERROR, logger="singular.events.bus")
+
+    bus.publish("test.event", {"ok": True})
+
+    assert "Error while handling event 'test.event'" in caplog.text
+    assert "failing_handler" in caplog.text
+
+
+def test_dispatch_reraises_in_strict_mode() -> None:
+    bus = EventBus(mode="sync", strict=True)
+
+    def failing_handler(event: Event) -> None:
+        raise ValueError("strict failure")
+
+    bus.subscribe("test.event", failing_handler)
+
+    with pytest.raises(ValueError, match="strict failure"):
+        bus.publish("test.event", {"ok": True})
+
+
+def test_get_bus_strict_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SINGULAR_EVENT_BUS_STRICT", "true")
+    assert get_bus_strict_from_env() is True
+
+    monkeypatch.setenv("SINGULAR_EVENT_BUS_STRICT", "0")
+    assert get_bus_strict_from_env() is False


### PR DESCRIPTION
### Motivation
- Surface and record exceptions raised by event handlers to aid debugging and observability. 
- Provide an optional strict mode that re-raises handler exceptions for fail-fast behavior in dev/test. 

### Description
- Add a module-level logger via `logger = logging.getLogger(__name__)` in `src/singular/events/bus.py`. 
- Update `_dispatch()` to log handler exceptions with the `event_type` and the handler name and to re-raise when an `EventBus(strict=True)` is used. 
- Add a `strict: bool` constructor argument to `EventBus` and a helper `get_bus_strict_from_env()` that parses `SINGULAR_EVENT_BUS_STRICT`, and wire this into the global bus creation in `get_global_event_bus()`. 
- Add `tests/test_events_bus.py` with tests that verify a handler error is logged, strict mode re-raises handler exceptions, and the environment parsing for `SINGULAR_EVENT_BUS_STRICT`. 

### Testing
- Ran `pytest -q tests/test_events_bus.py` which completed successfully with `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc51b53f74832a8a1197dcfc9f354d)