### PR TITLE
Add lifecycle orchestrator daemon and tickable mutation API

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -655,6 +655,29 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Détecte et émet les événements sans persister l'inbox",
     )
+    orchestrate_parser = subparsers.add_parser(
+        "orchestrate",
+        help="Pilote un cycle structuré (veille/action/introspection/sommeil)",
+    )
+    orchestrate_subparsers = orchestrate_parser.add_subparsers(
+        dest="orchestrate_command",
+        required=True,
+    )
+    orchestrate_run = orchestrate_subparsers.add_parser(
+        "run",
+        help="Lance le daemon d'orchestration structuré",
+    )
+    orchestrate_run.add_argument("--veille-seconds", type=float, default=2.0)
+    orchestrate_run.add_argument("--action-seconds", type=float, default=1.0)
+    orchestrate_run.add_argument("--introspection-seconds", type=float, default=1.0)
+    orchestrate_run.add_argument("--sommeil-seconds", type=float, default=3.0)
+    orchestrate_run.add_argument("--poll-interval", type=float, default=0.3)
+    orchestrate_run.add_argument("--tick-budget", type=float, default=0.2)
+    orchestrate_run.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Active les phases sans exécuter la mutation",
+    )
     doctor_parser = subparsers.add_parser(
         "doctor", help="Diagnose CLI installation and PATH"
     )
@@ -978,6 +1001,20 @@ def main(argv: list[str] | None = None) -> int:
             dry_run=args.dry_run,
             watch_dir=args.watch_dir,
         )
+    elif args.command == "orchestrate":
+        _ensure_active_life(resolve_life, args.life)
+        if args.orchestrate_command == "run":
+            from .orchestrator import run_orchestrator_daemon
+
+            return run_orchestrator_daemon(
+                veille_seconds=args.veille_seconds,
+                action_seconds=args.action_seconds,
+                introspection_seconds=args.introspection_seconds,
+                sommeil_seconds=args.sommeil_seconds,
+                poll_interval_seconds=args.poll_interval,
+                tick_budget_seconds=args.tick_budget,
+                dry_run=args.dry_run,
+            )
 
     elif args.command == "doctor":
         _doctor(fix=args.fix)

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -479,6 +479,7 @@ def run(
     max_test_candidates: int = 3,
     event_bus: EventBus | None = None,
     governance_policy: MutationGovernancePolicy | None = None,
+    max_iterations: int | None = None,
 ) -> Checkpoint:
     """Run the evolutionary loop for at most ``budget_seconds`` seconds.
 
@@ -540,7 +541,10 @@ def run(
     with RunLogger(run_id, psyche=psyche) as logger:
         health_tracker = HealthTracker.from_state(state.health_counters)
         delayed: list[tuple[float, str, Path]] = []
+        tick_count = 0
         while time.time() - start < budget_seconds:
+            if max_iterations is not None and tick_count >= max_iterations:
+                break
             if getattr(psyche, "sleeping", False) or (
                 hasattr(psyche, "energy")
                 and getattr(psyche, "energy") < SLEEP_THRESHOLD
@@ -555,6 +559,7 @@ def run(
                     setattr(psyche, "sleeping", False)
                 if hasattr(psyche, "save_state"):
                     psyche.save_state()
+                tick_count += 1
                 continue
 
             resource_manager.metabolize()
@@ -939,6 +944,7 @@ def run(
                 del world.organisms[org_name]
                 if not world.organisms:
                     break
+                tick_count += 1
                 continue
 
             # Remove organisms with depleted stores
@@ -989,8 +995,52 @@ def run(
                         child_skills_dir=str(child_dir),
                         alive=True,
                     )
+            tick_count += 1
 
     return state
+
+
+def run_tick(
+    skills_dirs: OrganismInputs,
+    checkpoint_path: Path,
+    rng: random.Random | None = None,
+    run_id: str = "loop",
+    operators: Dict[str, Callable[[ast.AST], ast.AST]] | None = None,
+    mortality: DeathMonitor | None = None,
+    world: WorldState | None = None,
+    map_elites: MapElites | None = None,
+    resource_manager: ResourceManager | None = None,
+    test_runner: Callable[[], int] | None = None,
+    coevolve_tests: bool = False,
+    test_pool: LivingTestPool | None = None,
+    robustness_weight: float = 1.0,
+    max_test_candidates: int = 3,
+    event_bus: EventBus | None = None,
+    governance_policy: MutationGovernancePolicy | None = None,
+    tick_budget_seconds: float = 0.2,
+) -> Checkpoint:
+    """Execute one mutation tick and persist checkpoint state."""
+
+    return run(
+        skills_dirs=skills_dirs,
+        checkpoint_path=checkpoint_path,
+        budget_seconds=max(tick_budget_seconds, 0.01),
+        rng=rng,
+        run_id=run_id,
+        operators=operators,
+        mortality=mortality,
+        world=world,
+        map_elites=map_elites,
+        resource_manager=resource_manager,
+        test_runner=test_runner,
+        coevolve_tests=coevolve_tests,
+        test_pool=test_pool,
+        robustness_weight=robustness_weight,
+        max_test_candidates=max_test_candidates,
+        event_bus=event_bus,
+        governance_policy=governance_policy,
+        max_iterations=1,
+    )
 
 
 def main(argv: list[str] | None = None) -> None:  # pragma: no cover - CLI wrapper

--- a/src/singular/orchestrator/__init__.py
+++ b/src/singular/orchestrator/__init__.py
@@ -1,0 +1,17 @@
+"""Orchestrator package."""
+
+from .service import (
+    LifecyclePhase,
+    OrchestratorConfig,
+    OrchestratorService,
+    SchedulerConfig,
+    run_orchestrator_daemon,
+)
+
+__all__ = [
+    "LifecyclePhase",
+    "OrchestratorConfig",
+    "OrchestratorService",
+    "SchedulerConfig",
+    "run_orchestrator_daemon",
+]

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -1,0 +1,326 @@
+"""Structured orchestration daemon for life ticks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+import json
+import signal
+import time
+from pathlib import Path
+from typing import Any
+
+from singular.events import Event, EventBus, get_global_event_bus
+from singular.life.loop import run_tick
+from singular.memory import _atomic_write_text, get_base_dir, get_mem_dir
+from singular.perception import capture_signals
+from singular.psyche import Psyche
+from singular.resource_manager import ResourceManager
+
+
+class LifecyclePhase(Enum):
+    """High-level phase used by the orchestration loop."""
+
+    VEILLE = "veille"
+    ACTION = "action"
+    INTROSPECTION = "introspection"
+    SOMMEIL = "sommeil"
+
+
+@dataclass
+class SchedulerConfig:
+    """Durations (in seconds) for each lifecycle phase."""
+
+    veille_seconds: float = 2.0
+    action_seconds: float = 1.0
+    introspection_seconds: float = 1.0
+    sommeil_seconds: float = 3.0
+
+    def duration_for(self, phase: LifecyclePhase) -> float:
+        return {
+            LifecyclePhase.VEILLE: self.veille_seconds,
+            LifecyclePhase.ACTION: self.action_seconds,
+            LifecyclePhase.INTROSPECTION: self.introspection_seconds,
+            LifecyclePhase.SOMMEIL: self.sommeil_seconds,
+        }[phase]
+
+
+@dataclass
+class OrchestratorState:
+    """Persisted daemon state to support resume/restart."""
+
+    current_phase: str = LifecyclePhase.VEILLE.value
+    next_wakeup_at: str | None = None
+    last_events: list[dict[str, Any]] = field(default_factory=list)
+    last_run_mtime: float | None = None
+    last_watch_mtime: float | None = None
+
+
+@dataclass
+class OrchestratorConfig:
+    """Runtime configuration for the orchestrator daemon."""
+
+    scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
+    poll_interval_seconds: float = 0.3
+    tick_budget_seconds: float = 0.2
+    dry_run: bool = False
+
+
+class OrchestratorService:
+    """Drive structured ticks across perception/metabolism/cognition/mutation/sleep."""
+
+    def __init__(
+        self,
+        *,
+        config: OrchestratorConfig,
+        bus: EventBus | None = None,
+        base_dir: Path | None = None,
+    ) -> None:
+        self.config = config
+        self.bus = bus or get_global_event_bus()
+        self.base_dir = base_dir or get_base_dir()
+        self.mem_dir = get_mem_dir()
+        self.state_path = self.mem_dir / "orchestrator_state.json"
+        self.checkpoint_path = self.base_dir / "life_checkpoint.json"
+        self.skills_dir = self.base_dir / "skills"
+        self.resources_path = self.base_dir / "resources.json"
+
+        self.state = self._load_state()
+        self.resource_manager = ResourceManager(path=self.resources_path)
+        self.psyche = Psyche.load_state()
+        self._running = False
+        self._wake_requested = False
+        self._pending_events: list[dict[str, Any]] = []
+
+        self._subscribe_external_stimuli()
+
+    def _subscribe_external_stimuli(self) -> None:
+        for event_type in (
+            "watch.significant_change",
+            "mutation.applied",
+            "mutation.rejected",
+            "signal.captured",
+        ):
+            self.bus.subscribe(event_type, self._on_external_event)
+
+    def _on_external_event(self, event: Event) -> None:
+        self._wake_requested = True
+        self._pending_events.append(
+            {
+                "event_type": event.event_type,
+                "emitted_at": event.emitted_at,
+            }
+        )
+        self._pending_events = self._pending_events[-50:]
+
+    def _load_state(self) -> OrchestratorState:
+        if not self.state_path.exists():
+            return OrchestratorState()
+        try:
+            raw = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return OrchestratorState()
+        if not isinstance(raw, dict):
+            return OrchestratorState()
+        return OrchestratorState(
+            current_phase=str(raw.get("current_phase", LifecyclePhase.VEILLE.value)),
+            next_wakeup_at=raw.get("next_wakeup_at"),
+            last_events=list(raw.get("last_events", [])),
+            last_run_mtime=raw.get("last_run_mtime"),
+            last_watch_mtime=raw.get("last_watch_mtime"),
+        )
+
+    def _save_state(self) -> None:
+        payload = {
+            "current_phase": self.state.current_phase,
+            "next_wakeup_at": self.state.next_wakeup_at,
+            "last_events": self.state.last_events[-100:],
+            "last_run_mtime": self.state.last_run_mtime,
+            "last_watch_mtime": self.state.last_watch_mtime,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        _atomic_write_text(self.state_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    def _next_phase(self, phase: LifecyclePhase) -> LifecyclePhase:
+        order = [
+            LifecyclePhase.VEILLE,
+            LifecyclePhase.ACTION,
+            LifecyclePhase.INTROSPECTION,
+            LifecyclePhase.SOMMEIL,
+        ]
+        index = order.index(phase)
+        return order[(index + 1) % len(order)]
+
+    def _push_event(self, phase: LifecyclePhase, details: dict[str, Any]) -> None:
+        self.state.last_events.append(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "phase": phase.value,
+                "details": details,
+            }
+        )
+        self.state.last_events = self.state.last_events[-100:]
+
+    def _runs_mtime(self) -> float | None:
+        runs_dir = self.base_dir / "runs"
+        if not runs_dir.exists():
+            return None
+        mtimes = [entry.stat().st_mtime for entry in runs_dir.rglob("*.jsonl")]
+        return max(mtimes, default=None)
+
+    def _watch_mtime(self) -> float | None:
+        candidates = [
+            self.base_dir / "runs",
+            self.base_dir / "skills",
+            self.mem_dir / "inbox.json",
+        ]
+        latest: float | None = None
+        for item in candidates:
+            if not item.exists():
+                continue
+            try:
+                current = item.stat().st_mtime
+            except OSError:
+                continue
+            if latest is None or current > latest:
+                latest = current
+        return latest
+
+    def _external_stimulus_detected(self) -> bool:
+        latest_run = self._runs_mtime()
+        latest_watch = self._watch_mtime()
+
+        run_changed = (
+            latest_run is not None
+            and (
+                self.state.last_run_mtime is None
+                or latest_run > self.state.last_run_mtime
+            )
+        )
+        watch_changed = (
+            latest_watch is not None
+            and (
+                self.state.last_watch_mtime is None
+                or latest_watch > self.state.last_watch_mtime
+            )
+        )
+
+        self.state.last_run_mtime = latest_run
+        self.state.last_watch_mtime = latest_watch
+
+        return self._wake_requested or run_changed or watch_changed
+
+    def _run_phase(self, phase: LifecyclePhase) -> None:
+        if phase is LifecyclePhase.VEILLE:
+            signals = capture_signals(bus=self.bus)
+            self._push_event(phase, {"signals": list(signals.keys())})
+            return
+
+        if phase is LifecyclePhase.ACTION:
+            self.resource_manager.metabolize()
+            mood = self.psyche.update_from_resource_manager(self.resource_manager)
+            if not self.config.dry_run:
+                run_tick(
+                    skills_dirs=self.skills_dir,
+                    checkpoint_path=self.checkpoint_path,
+                    run_id="orchestrator",
+                    event_bus=self.bus,
+                    resource_manager=self.resource_manager,
+                    tick_budget_seconds=self.config.tick_budget_seconds,
+                )
+            self._push_event(
+                phase,
+                {
+                    "energy": self.resource_manager.energy,
+                    "food": self.resource_manager.food,
+                    "mood": mood.value,
+                },
+            )
+            return
+
+        if phase is LifecyclePhase.INTROSPECTION:
+            mood = self.psyche.update_from_resource_manager(self.resource_manager)
+            self.psyche.save_state()
+            self._push_event(phase, {"mood": mood.value, "energy": self.psyche.energy})
+            return
+
+        self.psyche.sleep_tick()
+        self.psyche.sleeping = True
+        self.psyche.save_state()
+        self._push_event(phase, {"energy": self.psyche.energy})
+
+    def tick(self) -> LifecyclePhase:
+        phase = LifecyclePhase(self.state.current_phase)
+        self._run_phase(phase)
+
+        self.state.last_events.extend(self._pending_events)
+        self.state.last_events = self.state.last_events[-100:]
+        self._pending_events = []
+        self._wake_requested = False
+
+        next_phase = self._next_phase(phase)
+        self.state.current_phase = next_phase.value
+        wakeup_at = datetime.now(timezone.utc) + timedelta(
+            seconds=max(self.config.scheduler.duration_for(next_phase), 0.1)
+        )
+        self.state.next_wakeup_at = wakeup_at.isoformat()
+        self._save_state()
+        return next_phase
+
+    def run_forever(self) -> None:
+        self._running = True
+
+        def _handle_signal(_signum: int, _frame: Any) -> None:
+            self._running = False
+
+        previous_int = signal.signal(signal.SIGINT, _handle_signal)
+        previous_term = signal.signal(signal.SIGTERM, _handle_signal)
+
+        try:
+            while self._running:
+                self.tick()
+                if self._external_stimulus_detected():
+                    continue
+                time.sleep(max(self.config.poll_interval_seconds, 0.05))
+        finally:
+            signal.signal(signal.SIGINT, previous_int)
+            signal.signal(signal.SIGTERM, previous_term)
+            self._save_state()
+
+
+def run_orchestrator_daemon(
+    *,
+    veille_seconds: float,
+    action_seconds: float,
+    introspection_seconds: float,
+    sommeil_seconds: float,
+    poll_interval_seconds: float,
+    tick_budget_seconds: float,
+    dry_run: bool,
+) -> int:
+    """CLI entry point for ``singular orchestrate run``."""
+
+    service = OrchestratorService(
+        config=OrchestratorConfig(
+            scheduler=SchedulerConfig(
+                veille_seconds=veille_seconds,
+                action_seconds=action_seconds,
+                introspection_seconds=introspection_seconds,
+                sommeil_seconds=sommeil_seconds,
+            ),
+            poll_interval_seconds=poll_interval_seconds,
+            tick_budget_seconds=tick_budget_seconds,
+            dry_run=dry_run,
+        )
+    )
+    print(
+        "Orchestrateur démarré "
+        f"(veille={veille_seconds}s, action={action_seconds}s, introspection={introspection_seconds}s, sommeil={sommeil_seconds}s)"
+    )
+    try:
+        service.run_forever()
+    except KeyboardInterrupt:
+        pass
+    print("Orchestrateur arrêté proprement.")
+    return 0

--- a/tests/test_cli_orchestrate.py
+++ b/tests/test_cli_orchestrate.py
@@ -1,0 +1,48 @@
+from singular.cli import main
+
+
+def test_cli_orchestrate_run_dispatches(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "root"
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    captured: dict[str, object] = {}
+
+    def fake_run_orchestrator_daemon(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "singular.orchestrator.run_orchestrator_daemon",
+        fake_run_orchestrator_daemon,
+    )
+
+    code = main(
+        [
+            "--root",
+            str(root),
+            "orchestrate",
+            "run",
+            "--veille-seconds",
+            "0.5",
+            "--action-seconds",
+            "0.3",
+            "--introspection-seconds",
+            "0.2",
+            "--sommeil-seconds",
+            "0.8",
+            "--poll-interval",
+            "0.1",
+            "--tick-budget",
+            "0.05",
+            "--dry-run",
+        ]
+    )
+
+    assert code == 0
+    assert captured["veille_seconds"] == 0.5
+    assert captured["action_seconds"] == 0.3
+    assert captured["introspection_seconds"] == 0.2
+    assert captured["sommeil_seconds"] == 0.8
+    assert captured["poll_interval_seconds"] == 0.1
+    assert captured["tick_budget_seconds"] == 0.05
+    assert captured["dry_run"] is True

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from singular.events import EventBus
+from singular.orchestrator.service import (
+    LifecyclePhase,
+    OrchestratorConfig,
+    OrchestratorService,
+    SchedulerConfig,
+)
+
+
+def test_orchestrator_tick_persists_state(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "skills" / "a.py").write_text("result = 1", encoding="utf-8")
+
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+
+    bus = EventBus()
+    service = OrchestratorService(
+        config=OrchestratorConfig(
+            scheduler=SchedulerConfig(
+                veille_seconds=0.1,
+                action_seconds=0.1,
+                introspection_seconds=0.1,
+                sommeil_seconds=0.1,
+            ),
+            dry_run=True,
+        ),
+        bus=bus,
+    )
+
+    next_phase = service.tick()
+
+    assert next_phase == LifecyclePhase.ACTION
+    state_path = life / "mem" / "orchestrator_state.json"
+    assert state_path.exists()
+    payload = state_path.read_text(encoding="utf-8")
+    assert "current_phase" in payload
+
+
+def test_orchestrator_detects_external_stimulus(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "runs").mkdir(parents=True)
+
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+
+    bus = EventBus()
+    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=bus)
+
+    assert service._external_stimulus_detected() is True
+    (life / "runs" / "x.jsonl").write_text("{}\n", encoding="utf-8")
+    assert service._external_stimulus_detected() is True


### PR DESCRIPTION
### Motivation

- Replace the simple watch loop with a structured tick-based orchestrator that runs distinct lifecycle phases (veille/action/introspection/sommeil) to coordinate perception, metabolism, cognition, mutation and sleep. 
- Provide deterministic, configurable phase scheduling and the ability to wake the orchestrator from external stimuli (file/runs changes and event bus). 
- Allow safe daemon mode with persisted orchestration state so the service can stop and resume cleanly.

### Description

- Add a new orchestration service at `src/singular/orchestrator/service.py` providing `LifecyclePhase`, `SchedulerConfig`, `OrchestratorConfig`, `OrchestratorState` and `OrchestratorService` that manage phase execution, persistence to `mem/orchestrator_state.json`, external stimulus detection and clean SIGINT/SIGTERM shutdown. 
- Wire existing subsystems into phases: `capture_signals` during `veille`, `ResourceManager` and `Psyche` updates and a tick-based mutation call during `action`, `psyche.save_state()` during `introspection`, and `psyche.sleep_tick()` during `sommeil`. 
- Extract a tickable mutation API from `src/singular/life/loop.py` by adding optional `max_iterations` to `run(...)` and a `run_tick(...)` helper that executes a single mutation tick (used by the orchestrator). 
- Add CLI integration (`singular orchestrate run`) and package exports in `src/singular/orchestrator/__init__.py`, plus tests covering orchestrator state persistence, external stimulus detection and CLI dispatch.

### Testing

- Ran unit tests covering the new orchestrator and CLI: `pytest -q tests/test_orchestrator_service.py` and `pytest -q tests/test_cli_orchestrate.py`, both succeeded. 
- Ran a targeted test set including related watch and sleep tests: `pytest -q tests/test_cli_watch.py tests/test_sleep_cycle.py tests/test_orchestrator_service.py tests/test_cli_orchestrate.py` and all tests passed (6 passed, 1 warning). 
- Created new tests `tests/test_orchestrator_service.py` and `tests/test_cli_orchestrate.py` to validate state persistence, stimulus detection and CLI dispatch behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc52c3797c832a9870ea07cb36859e)