### PR TITLE
Ajouter une horloge vitale configurable (config, orchestrateur, docs, tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ le fichier hybride dans `child/`.
    singular birth --name Lumen
    ```
 
+### ⏰ Horloge vitale
+
+L'horloge vitale centralise le rythme du daemon `orchestrate run` et son adaptation en fatigue.
+
+- **Fichier versionné** : `configs/lifecycle.yaml`.
+- **Surcharge CLI** : `singular orchestrate run --lifecycle-config <chemin>`.
+- **Paramètres principaux** :
+  - `cycle.veille_seconds` : durée de veille.
+  - `cycle.sommeil_seconds` : durée de sommeil.
+  - `cycle.introspection_frequency_ticks` : fréquence d'introspection (1 = à chaque passage).
+  - `cycle.mutation_window_seconds` : fenêtre max dédiée à la mutation/tick.
+- **Mapping phase → comportements** :
+  - `cpu_budget_percent` : budget CPU indicatif par phase.
+  - `allowed_actions` : actions autorisées.
+  - `slowdown_on_fatigue` : facteur de ralentissement appliqué en humeur `fatigue`.
+
+Exemple de démarrage:
+
+```bash
+singular orchestrate run --lifecycle-config configs/lifecycle.yaml
+```
+
 ### ⚙️ Fonctionnement interne
 
 **Corps**

--- a/configs/lifecycle.yaml
+++ b/configs/lifecycle.yaml
@@ -1,0 +1,23 @@
+cycle:
+  veille_seconds: 2.0
+  sommeil_seconds: 3.0
+  introspection_frequency_ticks: 1
+  mutation_window_seconds: 0.2
+
+phases:
+  veille:
+    cpu_budget_percent: 30
+    allowed_actions: [perception, resource_scan]
+    slowdown_on_fatigue: 1.1
+  action:
+    cpu_budget_percent: 75
+    allowed_actions: [mutation, evaluation, checkpoint]
+    slowdown_on_fatigue: 1.5
+  introspection:
+    cpu_budget_percent: 40
+    allowed_actions: [self_review, memory_consolidation]
+    slowdown_on_fatigue: 1.2
+  sommeil:
+    cpu_budget_percent: 15
+    allowed_actions: [recovery, cooldown]
+    slowdown_on_fatigue: 1.0

--- a/docs/technical_life_status.md
+++ b/docs/technical_life_status.md
@@ -29,3 +29,34 @@ Le dashboard n'infère plus un statut de vie uniquement à partir des runs:
 1. Il lit d'abord `status` depuis le registre (source de vérité).
 2. Il calcule en parallèle des indicateurs run-level (`extinction_seen_in_runs`, `run_terminated`, `has_recent_activity`).
 3. Si une extinction est détectée dans les runs pour une vie enregistrée, il synchronise le registre via `set_life_status(slug, "extinct")`.
+
+## Horloge vitale (cycles, transitions, priorités)
+
+L'orchestrateur suit les transitions cycliques `veille → action → introspection → sommeil`.
+
+### Paramètres de cycle
+
+Le fichier versionné `configs/lifecycle.yaml` définit:
+
+- `cycle.veille_seconds`
+- `cycle.sommeil_seconds`
+- `cycle.introspection_frequency_ticks`
+- `cycle.mutation_window_seconds`
+
+Les valeurs peuvent être surchargées via `singular orchestrate run --lifecycle-config`.
+
+### Mapping phase → comportements
+
+Chaque phase expose un mapping comportemental:
+
+- `cpu_budget_percent`: budget CPU cible.
+- `allowed_actions`: liste des actions autorisées.
+- `slowdown_on_fatigue`: multiplicateur de ralentissement quand l'humeur est `fatigue`.
+
+En phase `action`, le budget tick effectif est plafonné par la fenêtre de mutation (`mutation_window_seconds`) puis ralenti selon `slowdown_on_fatigue` si fatigue.
+
+### Priorités d'exécution
+
+1. Respect de la fenêtre de mutation.
+2. Respect de la fréquence d'introspection.
+3. Ralentissement adaptatif en fatigue.

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -667,12 +667,17 @@ def main(argv: list[str] | None = None) -> int:
         "run",
         help="Lance le daemon d'orchestration structuré",
     )
-    orchestrate_run.add_argument("--veille-seconds", type=float, default=2.0)
-    orchestrate_run.add_argument("--action-seconds", type=float, default=1.0)
-    orchestrate_run.add_argument("--introspection-seconds", type=float, default=1.0)
-    orchestrate_run.add_argument("--sommeil-seconds", type=float, default=3.0)
-    orchestrate_run.add_argument("--poll-interval", type=float, default=0.3)
-    orchestrate_run.add_argument("--tick-budget", type=float, default=0.2)
+    orchestrate_run.add_argument("--veille-seconds", type=float, default=None)
+    orchestrate_run.add_argument("--action-seconds", type=float, default=None)
+    orchestrate_run.add_argument("--introspection-seconds", type=float, default=None)
+    orchestrate_run.add_argument("--sommeil-seconds", type=float, default=None)
+    orchestrate_run.add_argument("--poll-interval", type=float, default=None)
+    orchestrate_run.add_argument("--tick-budget", type=float, default=None)
+    orchestrate_run.add_argument(
+        "--lifecycle-config",
+        default=None,
+        help="Chemin vers le fichier lifecycle.yaml pour l'horloge vitale",
+    )
     orchestrate_run.add_argument(
         "--dry-run",
         action="store_true",
@@ -1013,6 +1018,7 @@ def main(argv: list[str] | None = None) -> int:
                 sommeil_seconds=args.sommeil_seconds,
                 poll_interval_seconds=args.poll_interval,
                 tick_budget_seconds=args.tick_budget,
+                lifecycle_config_path=args.lifecycle_config,
                 dry_run=args.dry_run,
             )
 

--- a/src/singular/orchestrator/lifecycle_clock.py
+++ b/src/singular/orchestrator/lifecycle_clock.py
@@ -1,0 +1,128 @@
+"""Lifecycle clock configuration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "lifecycle.yaml"
+
+
+@dataclass(frozen=True)
+class CycleParameters:
+    """Durations and frequencies driving the lifecycle clock."""
+
+    veille_seconds: float = 2.0
+    sommeil_seconds: float = 3.0
+    introspection_frequency_ticks: int = 1
+    mutation_window_seconds: float = 0.2
+
+
+@dataclass(frozen=True)
+class PhaseBehavior:
+    """Operational budget and behavior flags for one phase."""
+
+    cpu_budget_percent: float
+    slowdown_on_fatigue: float
+    allowed_actions: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class LifecycleClockConfig:
+    """Complete lifecycle clock config with sane defaults."""
+
+    cycle: CycleParameters = field(default_factory=CycleParameters)
+    phases: dict[str, PhaseBehavior] = field(
+        default_factory=lambda: {
+            "veille": PhaseBehavior(30.0, 1.1, ("perception", "resource_scan")),
+            "action": PhaseBehavior(75.0, 1.5, ("mutation", "evaluation", "checkpoint")),
+            "introspection": PhaseBehavior(40.0, 1.2, ("self_review", "memory_consolidation")),
+            "sommeil": PhaseBehavior(15.0, 1.0, ("recovery", "cooldown")),
+        }
+    )
+
+
+def _parse_scalar(value: str) -> Any:
+    text = value.strip()
+    if text.startswith("[") and text.endswith("]"):
+        inner = text[1:-1].strip()
+        if not inner:
+            return []
+        return [chunk.strip().strip('"').strip("'") for chunk in inner.split(",")]
+    try:
+        return int(text)
+    except ValueError:
+        try:
+            return float(text)
+        except ValueError:
+            return text.strip('"').strip("'")
+
+
+def _load_simple_yaml(path: Path) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    stack: list[tuple[int, dict[str, Any]]] = [(0, data)]
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        key, value = line.strip().split(":", 1)
+        while stack and indent < stack[-1][0]:
+            stack.pop()
+        current = stack[-1][1]
+        if not value.strip():
+            new: dict[str, Any] = {}
+            current[key.strip()] = new
+            stack.append((indent + 2, new))
+            continue
+        current[key.strip()] = _parse_scalar(value)
+    return data
+
+
+def load_lifecycle_clock_config(path: Path | None = None) -> LifecycleClockConfig:
+    """Load lifecycle clock config and merge with defaults."""
+
+    selected = path or DEFAULT_CONFIG_PATH
+    cfg = LifecycleClockConfig()
+    if not selected.exists():
+        return cfg
+
+    raw = _load_simple_yaml(selected)
+    cycle_raw = raw.get("cycle", {})
+    phases_raw = raw.get("phases", {})
+
+    cycle = CycleParameters(
+        veille_seconds=float(cycle_raw.get("veille_seconds", cfg.cycle.veille_seconds)),
+        sommeil_seconds=float(cycle_raw.get("sommeil_seconds", cfg.cycle.sommeil_seconds)),
+        introspection_frequency_ticks=int(
+            cycle_raw.get(
+                "introspection_frequency_ticks",
+                cfg.cycle.introspection_frequency_ticks,
+            )
+        ),
+        mutation_window_seconds=float(
+            cycle_raw.get("mutation_window_seconds", cfg.cycle.mutation_window_seconds)
+        ),
+    )
+
+    phases: dict[str, PhaseBehavior] = {}
+    for name, default in cfg.phases.items():
+        source = phases_raw.get(name, {}) if isinstance(phases_raw, dict) else {}
+        actions = source.get("allowed_actions", list(default.allowed_actions))
+        if isinstance(actions, str):
+            actions = [actions]
+        phases[name] = PhaseBehavior(
+            cpu_budget_percent=float(source.get("cpu_budget_percent", default.cpu_budget_percent)),
+            slowdown_on_fatigue=float(source.get("slowdown_on_fatigue", default.slowdown_on_fatigue)),
+            allowed_actions=tuple(str(item) for item in actions),
+        )
+
+    if cycle.introspection_frequency_ticks <= 0:
+        raise ValueError("introspection_frequency_ticks must be > 0")
+    if cycle.mutation_window_seconds <= 0:
+        raise ValueError("mutation_window_seconds must be > 0")
+
+    return LifecycleClockConfig(cycle=cycle, phases=phases)

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -14,6 +14,10 @@ from typing import Any
 from singular.events import Event, EventBus, get_global_event_bus
 from singular.life.loop import run_tick
 from singular.memory import _atomic_write_text, get_base_dir, get_mem_dir
+from singular.orchestrator.lifecycle_clock import (
+    LifecycleClockConfig,
+    load_lifecycle_clock_config,
+)
 from singular.perception import capture_signals
 from singular.psyche import Psyche
 from singular.resource_manager import ResourceManager
@@ -64,6 +68,9 @@ class OrchestratorConfig:
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     poll_interval_seconds: float = 0.3
     tick_budget_seconds: float = 0.2
+    introspection_frequency_ticks: int = 1
+    mutation_window_seconds: float = 0.2
+    phase_behaviors: dict[str, dict[str, Any]] = field(default_factory=dict)
     dry_run: bool = False
 
 
@@ -92,6 +99,7 @@ class OrchestratorService:
         self._running = False
         self._wake_requested = False
         self._pending_events: list[dict[str, Any]] = []
+        self._tick_count = 0
 
         self._subscribe_external_stimuli()
 
@@ -220,6 +228,15 @@ class OrchestratorService:
         if phase is LifecyclePhase.ACTION:
             self.resource_manager.metabolize()
             mood = self.psyche.update_from_resource_manager(self.resource_manager)
+            behavior = self.config.phase_behaviors.get(phase.value, {})
+            fatigue_slowdown = float(behavior.get("slowdown_on_fatigue", 1.0))
+            cpu_budget_percent = float(behavior.get("cpu_budget_percent", 100.0))
+            tick_budget = min(
+                self.config.tick_budget_seconds,
+                self.config.mutation_window_seconds,
+            )
+            if mood.value == "fatigue":
+                tick_budget *= max(fatigue_slowdown, 1.0)
             if not self.config.dry_run:
                 run_tick(
                     skills_dirs=self.skills_dir,
@@ -227,7 +244,7 @@ class OrchestratorService:
                     run_id="orchestrator",
                     event_bus=self.bus,
                     resource_manager=self.resource_manager,
-                    tick_budget_seconds=self.config.tick_budget_seconds,
+                    tick_budget_seconds=tick_budget,
                 )
             self._push_event(
                 phase,
@@ -235,11 +252,17 @@ class OrchestratorService:
                     "energy": self.resource_manager.energy,
                     "food": self.resource_manager.food,
                     "mood": mood.value,
+                    "cpu_budget_percent": cpu_budget_percent,
+                    "tick_budget_seconds": tick_budget,
+                    "allowed_actions": behavior.get("allowed_actions", []),
                 },
             )
             return
 
         if phase is LifecyclePhase.INTROSPECTION:
+            if self._tick_count % self.config.introspection_frequency_ticks != 0:
+                self._push_event(phase, {"skipped": True, "reason": "frequency_gate"})
+                return
             mood = self.psyche.update_from_resource_manager(self.resource_manager)
             self.psyche.save_state()
             self._push_event(phase, {"mood": mood.value, "energy": self.psyche.energy})
@@ -251,6 +274,7 @@ class OrchestratorService:
         self._push_event(phase, {"energy": self.psyche.energy})
 
     def tick(self) -> LifecyclePhase:
+        self._tick_count += 1
         phase = LifecyclePhase(self.state.current_phase)
         self._run_phase(phase)
 
@@ -291,32 +315,68 @@ class OrchestratorService:
 
 def run_orchestrator_daemon(
     *,
-    veille_seconds: float,
-    action_seconds: float,
-    introspection_seconds: float,
-    sommeil_seconds: float,
-    poll_interval_seconds: float,
-    tick_budget_seconds: float,
+    veille_seconds: float | None,
+    action_seconds: float | None,
+    introspection_seconds: float | None,
+    sommeil_seconds: float | None,
+    poll_interval_seconds: float | None,
+    tick_budget_seconds: float | None,
+    lifecycle_config_path: str | None,
     dry_run: bool,
 ) -> int:
     """CLI entry point for ``singular orchestrate run``."""
 
+    lifecycle_clock: LifecycleClockConfig = load_lifecycle_clock_config(
+        Path(lifecycle_config_path) if lifecycle_config_path else None
+    )
+    resolved_veille = (
+        veille_seconds
+        if veille_seconds is not None
+        else lifecycle_clock.cycle.veille_seconds
+    )
+    resolved_sommeil = (
+        sommeil_seconds
+        if sommeil_seconds is not None
+        else lifecycle_clock.cycle.sommeil_seconds
+    )
+    resolved_introspection = (
+        introspection_seconds
+        if introspection_seconds is not None
+        else 1.0
+    )
+    resolved_action = action_seconds if action_seconds is not None else 1.0
+    resolved_poll = poll_interval_seconds if poll_interval_seconds is not None else 0.3
+    resolved_tick_budget = (
+        tick_budget_seconds
+        if tick_budget_seconds is not None
+        else lifecycle_clock.cycle.mutation_window_seconds
+    )
     service = OrchestratorService(
         config=OrchestratorConfig(
             scheduler=SchedulerConfig(
-                veille_seconds=veille_seconds,
-                action_seconds=action_seconds,
-                introspection_seconds=introspection_seconds,
-                sommeil_seconds=sommeil_seconds,
+                veille_seconds=resolved_veille,
+                action_seconds=resolved_action,
+                introspection_seconds=float(resolved_introspection),
+                sommeil_seconds=resolved_sommeil,
             ),
-            poll_interval_seconds=poll_interval_seconds,
-            tick_budget_seconds=tick_budget_seconds,
+            poll_interval_seconds=resolved_poll,
+            tick_budget_seconds=resolved_tick_budget,
+            introspection_frequency_ticks=lifecycle_clock.cycle.introspection_frequency_ticks,
+            mutation_window_seconds=lifecycle_clock.cycle.mutation_window_seconds,
+            phase_behaviors={
+                phase: {
+                    "cpu_budget_percent": behavior.cpu_budget_percent,
+                    "allowed_actions": list(behavior.allowed_actions),
+                    "slowdown_on_fatigue": behavior.slowdown_on_fatigue,
+                }
+                for phase, behavior in lifecycle_clock.phases.items()
+            },
             dry_run=dry_run,
         )
     )
     print(
         "Orchestrateur démarré "
-        f"(veille={veille_seconds}s, action={action_seconds}s, introspection={introspection_seconds}s, sommeil={sommeil_seconds}s)"
+        f"(veille={resolved_veille}s, action={resolved_action}s, introspection={resolved_introspection}s, sommeil={resolved_sommeil}s)"
     )
     try:
         service.run_forever()

--- a/tests/test_cli_orchestrate.py
+++ b/tests/test_cli_orchestrate.py
@@ -45,4 +45,37 @@ def test_cli_orchestrate_run_dispatches(monkeypatch, tmp_path) -> None:
     assert captured["sommeil_seconds"] == 0.8
     assert captured["poll_interval_seconds"] == 0.1
     assert captured["tick_budget_seconds"] == 0.05
+    assert captured["lifecycle_config_path"] is None
     assert captured["dry_run"] is True
+
+
+def test_cli_orchestrate_run_passes_lifecycle_config_path(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "root"
+    config = tmp_path / "lifecycle.yaml"
+    config.write_text("cycle:\n  veille_seconds: 1.5\n", encoding="utf-8")
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    captured: dict[str, object] = {}
+
+    def fake_run_orchestrator_daemon(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "singular.orchestrator.run_orchestrator_daemon",
+        fake_run_orchestrator_daemon,
+    )
+
+    code = main(
+        [
+            "--root",
+            str(root),
+            "orchestrate",
+            "run",
+            "--lifecycle-config",
+            str(config),
+        ]
+    )
+
+    assert code == 0
+    assert captured["lifecycle_config_path"] == str(config)

--- a/tests/test_lifecycle_clock_config.py
+++ b/tests/test_lifecycle_clock_config.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from singular.orchestrator.lifecycle_clock import load_lifecycle_clock_config
+
+
+def test_load_lifecycle_clock_defaults_when_file_missing(tmp_path: Path) -> None:
+    cfg = load_lifecycle_clock_config(tmp_path / "missing.yaml")
+
+    assert cfg.cycle.veille_seconds == 2.0
+    assert cfg.cycle.sommeil_seconds == 3.0
+    assert cfg.cycle.introspection_frequency_ticks == 1
+    assert cfg.cycle.mutation_window_seconds == 0.2
+    assert cfg.phases["action"].cpu_budget_percent == 75.0
+
+
+def test_load_lifecycle_clock_parses_values(tmp_path: Path) -> None:
+    file_path = tmp_path / "lifecycle.yaml"
+    file_path.write_text(
+        """
+cycle:
+  veille_seconds: 4
+  sommeil_seconds: 8
+  introspection_frequency_ticks: 3
+  mutation_window_seconds: 0.15
+phases:
+  action:
+    cpu_budget_percent: 65
+    slowdown_on_fatigue: 1.8
+    allowed_actions: [mutation, evaluation]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_lifecycle_clock_config(file_path)
+
+    assert cfg.cycle.veille_seconds == 4.0
+    assert cfg.cycle.sommeil_seconds == 8.0
+    assert cfg.cycle.introspection_frequency_ticks == 3
+    assert cfg.cycle.mutation_window_seconds == 0.15
+    assert cfg.phases["action"].allowed_actions == ("mutation", "evaluation")
+    assert cfg.phases["action"].slowdown_on_fatigue == 1.8
+
+
+def test_load_lifecycle_clock_rejects_invalid_frequency(tmp_path: Path) -> None:
+    file_path = tmp_path / "lifecycle.yaml"
+    file_path.write_text(
+        """
+cycle:
+  introspection_frequency_ticks: 0
+""".strip(),
+        encoding="utf-8",
+    )
+
+    try:
+        load_lifecycle_clock_config(file_path)
+    except ValueError as err:
+        assert "introspection_frequency_ticks" in str(err)
+    else:
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
### Motivation

- Centraliser et rendre configurable le rythme du daemon d'orchestration (`veille → action → introspection → sommeil`) et ses adaptations en fatigue via un fichier versionné. 
- Exposer paramètres de cycle (durées, fréquence d'introspection, fenêtre mutation) et un mapping phase→comportements (budgets, actions autorisées, ralentissement). 
- Permettre la surcharge par la CLI et assurer des valeurs par défaut sûres et validées.

### Description

- Ajout de `src/singular/orchestrator/lifecycle_clock.py` pour parser un YAML minimal, fournir des valeurs par défaut et valider les bornes (`introspection_frequency_ticks > 0`, `mutation_window_seconds > 0`).
- Ajout du fichier versionné `configs/lifecycle.yaml` contenant les paramètres de cycle et le mapping des phases vers `cpu_budget_percent`, `allowed_actions` et `slowdown_on_fatigue`.
- Intégration dans l’orchestrateur via `OrchestratorConfig` et `OrchestratorService`: plafonnement du budget de mutation par `mutation_window_seconds`, application d’un ralentissement en cas d’humeur `fatigue`, et gate de fréquence d’introspection pilotée par `introspection_frequency_ticks`.
- Mise à jour de la CLI (`--lifecycle-config`) et adaptation des arguments temporels pour permettre la résolution par fichier ou par flags explicites, plus documentation ajoutée dans `README.md` et `docs/technical_life_status.md`.
- Ajout de tests unitaires `tests/test_lifecycle_clock_config.py` (parsing, valeurs par défaut, validation) et extension de `tests/test_cli_orchestrate.py` pour vérifier le passage du chemin `--lifecycle-config`.

### Testing

- Exécution de l'ensemble ciblé : `pytest -q tests/test_lifecycle_clock_config.py tests/test_cli_orchestrate.py tests/test_orchestrator_service.py` qui a retourné `7 passed` en ~0.54s. 
- Les nouveaux tests vérifient les valeurs par défaut, le parsing de `configs/lifecycle.yaml` et la validation d'une fréquence invalide, ainsi que le routage du paramètre CLI vers l’orchestrateur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc55bdadd4832a9d934c495de98ce7)