### PR TITLE
Add context-aware meta-learning memory for operator selection

### DIFF
--- a/src/singular/beliefs/meta_learning.py
+++ b/src/singular/beliefs/meta_learning.py
@@ -1,0 +1,135 @@
+"""Meta-learning utilities to transform run outcomes into actionable beliefs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .store import BeliefStore
+
+
+@dataclass(frozen=True)
+class RunFeatures:
+    """Compact representation of context extracted from a mutation run."""
+
+    operator: str
+    failure_type: str
+    environment_signal: str
+    mood: str
+    outcome: str
+
+    def context_key(self) -> str:
+        return (
+            f"failure={self.failure_type}|env={self.environment_signal}|"
+            f"mood={self.mood}|outcome={self.outcome}"
+        )
+
+
+@dataclass(frozen=True)
+class StrategyRecommendation:
+    """Operator recommendation inferred from past runs under similar contexts."""
+
+    operator: str
+    confidence: float
+    context_key: str
+
+
+def extract_run_features(
+    *,
+    operator: str,
+    accepted: bool,
+    base_score: float,
+    mutated_score: float,
+    temperature: float,
+    mood: str | None,
+) -> RunFeatures:
+    """Extract stable run features for context-conditioned memory."""
+
+    if mutated_score == float("-inf"):
+        failure_type = "sandbox_error"
+    elif not accepted:
+        failure_type = "rejected"
+    elif mutated_score < base_score:
+        failure_type = "improved"
+    else:
+        failure_type = "neutral"
+
+    if temperature <= 5.0:
+        environment_signal = "cold"
+    elif temperature >= 30.0:
+        environment_signal = "hot"
+    else:
+        environment_signal = "stable"
+
+    outcome = "success" if accepted else "failure"
+    normalized_mood = (mood or "unknown").strip().lower() or "unknown"
+
+    return RunFeatures(
+        operator=operator,
+        failure_type=failure_type,
+        environment_signal=environment_signal,
+        mood=normalized_mood,
+        outcome=outcome,
+    )
+
+
+def register_run_result(
+    store: BeliefStore,
+    features: RunFeatures,
+    *,
+    reward_delta: float,
+) -> None:
+    """Persist probabilistic context -> strategy knowledge."""
+
+    context = features.context_key()
+    success = features.outcome == "success"
+    evidence = (
+        f"operator={features.operator};failure={features.failure_type};"
+        f"env={features.environment_signal};mood={features.mood};"
+        f"outcome={features.outcome};reward={reward_delta:.6f}"
+    )
+    store.update_probabilistic_rule(
+        context_key=context,
+        strategy=features.operator,
+        success=success,
+        evidence=evidence,
+        reward_delta=reward_delta,
+    )
+    anticipated_context = (
+        f"failure=anticipated|env={features.environment_signal}|"
+        f"mood={features.mood}|outcome={features.outcome}"
+    )
+    store.update_probabilistic_rule(
+        context_key=anticipated_context,
+        strategy=features.operator,
+        success=success,
+        evidence=evidence,
+        reward_delta=reward_delta,
+    )
+
+
+def recommend_strategy(
+    store: BeliefStore,
+    *,
+    failure_type: str,
+    environment_signal: str,
+    mood: str | None,
+    outcome_hint: str,
+    candidates: Iterable[str],
+) -> StrategyRecommendation | None:
+    """Return the highest-confidence strategy for the current context."""
+
+    normalized_mood = (mood or "unknown").strip().lower() or "unknown"
+    context_key = (
+        f"failure={failure_type}|env={environment_signal}|"
+        f"mood={normalized_mood}|outcome={outcome_hint}"
+    )
+    ranked = store.recommend_strategies(context_key=context_key, candidates=candidates)
+    if not ranked:
+        return None
+    best_operator, confidence = ranked[0]
+    return StrategyRecommendation(
+        operator=best_operator,
+        confidence=confidence,
+        context_key=context_key,
+    )

--- a/src/singular/beliefs/store.py
+++ b/src/singular/beliefs/store.py
@@ -52,12 +52,14 @@ class BeliefStore:
         prior_alpha: float = 1.0,
         prior_beta: float = 1.0,
         decay_per_day: float = 0.03,
+        ttl_days: float = 45.0,
     ) -> None:
         base = Path(os.environ.get("SINGULAR_HOME", "."))
         self.path = path or (base / "mem" / "beliefs.json")
         self.prior_alpha = float(prior_alpha)
         self.prior_beta = float(prior_beta)
         self.decay_per_day = max(0.0, float(decay_per_day))
+        self.ttl_days = max(0.0, float(ttl_days))
         self._beliefs = self._load()
 
     def _load(self) -> dict[str, BeliefRecord]:
@@ -120,6 +122,29 @@ class BeliefStore:
         record.alpha = self.prior_alpha + (record.alpha - self.prior_alpha) * retention
         record.beta = self.prior_beta + (record.beta - self.prior_beta) * retention
 
+    def _is_stale(self, record: BeliefRecord, now: datetime) -> bool:
+        if self.ttl_days <= 0.0:
+            return False
+        age_days = max(0.0, (now - _parse_datetime(record.updated_at)).total_seconds() / 86400.0)
+        near_prior = abs(record.alpha - self.prior_alpha) < 0.02 and abs(record.beta - self.prior_beta) < 0.02
+        return age_days >= self.ttl_days and near_prior
+
+    def forget_stale(self, *, when: datetime | None = None) -> int:
+        now = when or _utcnow()
+        removed = 0
+        for key in list(self._beliefs):
+            record = self._beliefs[key]
+            self._apply_decay(record, now)
+            if self._is_stale(record, now):
+                self._beliefs.pop(key, None)
+                removed += 1
+            else:
+                record.confidence = record.alpha / max(record.alpha + record.beta, 1e-9)
+                record.updated_at = now.isoformat()
+        if removed:
+            self._save()
+        return removed
+
     def update_after_run(
         self,
         hypothesis: str,
@@ -181,3 +206,47 @@ class BeliefStore:
             confidence_shift = record.confidence - 0.5
             biases[name] = (confidence_shift * 0.4) + max(-0.2, min(0.2, record.score_ema))
         return biases
+
+    def update_probabilistic_rule(
+        self,
+        *,
+        context_key: str,
+        strategy: str,
+        success: bool,
+        evidence: str,
+        reward_delta: float = 0.0,
+        when: datetime | None = None,
+    ) -> BeliefRecord:
+        rule_hypothesis = f"strategy:{context_key}->{strategy}"
+        return self.update_after_run(
+            rule_hypothesis,
+            success=success,
+            evidence=evidence,
+            reward_delta=reward_delta,
+            when=when,
+        )
+
+    def recommend_strategies(
+        self,
+        *,
+        context_key: str,
+        candidates: Iterable[str],
+    ) -> list[tuple[str, float]]:
+        now = _utcnow()
+        ranked: list[tuple[str, float]] = []
+        for name in candidates:
+            hypothesis = f"strategy:{context_key}->{name}"
+            record = self._beliefs.get(hypothesis)
+            if record is None:
+                continue
+            self._apply_decay(record, now)
+            record.confidence = record.alpha / max(record.alpha + record.beta, 1e-9)
+            record.updated_at = now.isoformat()
+            if self._is_stale(record, now):
+                self._beliefs.pop(hypothesis, None)
+                continue
+            ranked.append((name, record.confidence))
+        if ranked:
+            self._save()
+        ranked.sort(key=lambda item: item[1], reverse=True)
+        return ranked

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -16,6 +16,11 @@ from typing import Callable, Dict, Iterable, Mapping
 
 from singular.cognition.reflect import ActionHypothesis, reflect_action
 from singular.beliefs.store import BeliefStore
+from singular.beliefs.meta_learning import (
+    extract_run_features,
+    recommend_strategy,
+    register_run_result,
+)
 from singular.events import EventBus, get_global_event_bus
 from singular.memory import register_memory_event_handlers
 from singular.psyche import Psyche, Mood
@@ -684,13 +689,48 @@ def run(
             for operator_name, extra_bias in belief_bias.items():
                 combined_bias[operator_name] = combined_bias.get(operator_name, 0.0) + extra_bias
 
-            op_name = reflection.action or select_operator(
-                operators,
-                stats,
-                policy,
-                rng,
-                objective_bias=combined_bias,
+            mood_label = getattr(getattr(psyche, "last_mood", None), "value", None)
+            if mood_label is None and getattr(psyche, "last_mood", None) is not None:
+                mood_label = str(getattr(psyche, "last_mood"))
+            predicted_failure = (
+                "hot"
+                if temp >= 30.0
+                else "cold"
+                if temp <= 5.0
+                else "stable"
             )
+            meta_recommendation = None
+            if policy != "analyze":
+                meta_recommendation = recommend_strategy(
+                    belief_store,
+                    failure_type="anticipated",
+                    environment_signal=predicted_failure,
+                    mood=mood_label,
+                    outcome_hint="success",
+                    candidates=operators.keys(),
+                )
+            if policy == "analyze":
+                op_name = select_operator(
+                    operators,
+                    stats,
+                    policy,
+                    rng,
+                    objective_bias=combined_bias,
+                )
+            elif (
+                reflection.action is None
+                and meta_recommendation is not None
+                and meta_recommendation.confidence >= 0.55
+            ):
+                op_name = meta_recommendation.operator
+            else:
+                op_name = reflection.action or select_operator(
+                    operators,
+                    stats,
+                    policy,
+                    rng,
+                    objective_bias=combined_bias,
+                )
             mutated = apply_mutation(original, operators[op_name], rng)
             org = world.organisms[org_name]
 
@@ -815,6 +855,20 @@ def run(
                 evidence=f"accepted={accepted};base={base_score:.6f};new={mutated_score:.6f}",
                 reward_delta=reward_delta if math.isfinite(reward_delta) else 0.0,
             )
+            run_features = extract_run_features(
+                operator=op_name,
+                accepted=accepted,
+                base_score=base_score,
+                mutated_score=mutated_score,
+                temperature=temp,
+                mood=mood_value,
+            )
+            register_run_result(
+                belief_store,
+                run_features,
+                reward_delta=reward_delta if math.isfinite(reward_delta) else 0.0,
+            )
+            belief_store.forget_stale()
             state.stats = stats
 
             # Resource accounting

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from singular.beliefs.meta_learning import (
+    extract_run_features,
+    recommend_strategy,
+    register_run_result,
+)
+from singular.beliefs.store import BeliefStore
+
+
+def test_meta_learning_converges_to_best_operator(tmp_path: Path) -> None:
+    store = BeliefStore(path=tmp_path / "beliefs.json")
+    for _ in range(8):
+        register_run_result(
+            store,
+            extract_run_features(
+                operator="eq_rewrite_reduce_sum",
+                accepted=True,
+                base_score=1.0,
+                mutated_score=0.8,
+                temperature=20.0,
+                mood="curious",
+            ),
+            reward_delta=0.2,
+        )
+    for _ in range(8):
+        register_run_result(
+            store,
+            extract_run_features(
+                operator="deadcode_elim",
+                accepted=False,
+                base_score=1.0,
+                mutated_score=1.4,
+                temperature=20.0,
+                mood="curious",
+            ),
+            reward_delta=-0.4,
+        )
+
+    recommendation = recommend_strategy(
+        store,
+        failure_type="anticipated",
+        environment_signal="stable",
+        mood="curious",
+        outcome_hint="success",
+        candidates=["eq_rewrite_reduce_sum", "deadcode_elim"],
+    )
+    assert recommendation is not None
+    assert recommendation.operator == "eq_rewrite_reduce_sum"
+    assert recommendation.confidence > 0.7
+
+
+def test_meta_learning_diverges_when_context_changes(tmp_path: Path) -> None:
+    store = BeliefStore(path=tmp_path / "beliefs.json")
+    for _ in range(6):
+        register_run_result(
+            store,
+            extract_run_features(
+                operator="const_tune",
+                accepted=True,
+                base_score=1.2,
+                mutated_score=1.0,
+                temperature=33.0,
+                mood="fatigue",
+            ),
+            reward_delta=0.2,
+        )
+    for _ in range(6):
+        register_run_result(
+            store,
+            extract_run_features(
+                operator="eq_rewrite_reduce_sum",
+                accepted=True,
+                base_score=1.2,
+                mutated_score=0.9,
+                temperature=10.0,
+                mood="neutre",
+            ),
+            reward_delta=0.3,
+        )
+
+    hot = recommend_strategy(
+        store,
+        failure_type="anticipated",
+        environment_signal="hot",
+        mood="fatigue",
+        outcome_hint="success",
+        candidates=["const_tune", "eq_rewrite_reduce_sum"],
+    )
+    stable = recommend_strategy(
+        store,
+        failure_type="anticipated",
+        environment_signal="stable",
+        mood="neutre",
+        outcome_hint="success",
+        candidates=["const_tune", "eq_rewrite_reduce_sum"],
+    )
+
+    assert hot is not None and stable is not None
+    assert hot.operator == "const_tune"
+    assert stable.operator == "eq_rewrite_reduce_sum"
+
+
+def test_forgetting_progressively_removes_stale_rules(tmp_path: Path) -> None:
+    store = BeliefStore(path=tmp_path / "beliefs.json", decay_per_day=1.2, ttl_days=1)
+    anchor = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    store.update_probabilistic_rule(
+        context_key="failure=rejected|env=stable|mood=neutre|outcome=failure",
+        strategy="deadcode_elim",
+        success=False,
+        evidence="old",
+        reward_delta=-0.2,
+        when=anchor,
+    )
+
+    removed = store.forget_stale(when=anchor + timedelta(days=4))
+    assert removed == 1


### PR DESCRIPTION
### Motivation
- Convert raw run outcomes into context-conditioned, actionable knowledge to bias operator selection (context: operator, failure type, environment signal, mood, outcome). 
- Avoid fossilization of learned rules by introducing progressive forgetting and temporal decay. 
- Use aggregated run experience to recommend strategies before falling back to the existing bandit `select_operator` policy.

### Description
- Added `src/singular/beliefs/meta_learning.py` with `RunFeatures`, `StrategyRecommendation`, `extract_run_features`, `register_run_result` and `recommend_strategy` to extract features from runs and persist/retrieve context→strategy rules. 
- Extended `src/singular/beliefs/store.py` with `ttl_days`, `forget_stale()`, `update_probabilistic_rule()` and `recommend_strategies()` and integrated decay-aware stale-pruning to implement TTL/forgetting. 
- Integrated meta-learning into the life loop (`src/singular/life/loop.py`) to: query `recommend_strategy` (when `policy != 'analyze'`) before falling back to `select_operator`, register contextual run outcomes after each mutation via `register_run_result`, and call `forget_stale()` to prune stale rules. 
- Added unit tests `tests/test_meta_learning.py` that verify convergence/divergence of preferences across contexts and the progressive forgetting behavior.

### Testing
- Ran `pytest -q tests/test_beliefs_store.py tests/test_meta_learning.py` and all tests passed. 
- Ran `pytest -q tests/test_loop.py::test_bandit_persistence_and_exploitation` and the targeted bandit persistence/exploitation test passed. 
- Ran the combined targeted test set `pytest -q tests/test_beliefs_store.py tests/test_meta_learning.py tests/test_loop.py::test_bandit_persistence_and_exploitation` and all included tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5717fa88832abed610d98115d667)