### PR TITLE
Add hierarchical goal policy and psyche-driven objective arbitration

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -675,18 +675,31 @@ def run(
                 )
                 for entry in adjusted_hypotheses
             ]
+            psyche_axes = getattr(psyche, "weighted_objective_axes", lambda: {})()
             reflection = reflect_action(
                 weighted_hypotheses,
                 bus=event_bus,
                 event_context={"iteration": state.iteration, "organism": org_name},
-                long_term_weight=goal_weights.coherence,
-                sandbox_weight=goal_weights.robustesse,
-                resource_weight=goal_weights.efficacite,
+                long_term_weight=(
+                    goal_weights.coherence
+                    + (psyche_axes.get("long_term", 0.0) * 0.4)
+                ),
+                sandbox_weight=(
+                    goal_weights.robustesse
+                    + (psyche_axes.get("sandbox", 0.0) * 0.4)
+                ),
+                resource_weight=(
+                    goal_weights.efficacite
+                    + (psyche_axes.get("resource", 0.0) * 0.4)
+                ),
             )
             score_by_index = {index: score for index, _, score in reflection.alternative_scores}
             belief_bias = belief_store.operator_preference_bias(operators.keys())
             combined_bias = intrinsic_goals.influence_operator_scores(stats)
+            psyche_bias = getattr(psyche, "operator_bias", lambda names: {})(list(operators.keys()))
             for operator_name, extra_bias in belief_bias.items():
+                combined_bias[operator_name] = combined_bias.get(operator_name, 0.0) + extra_bias
+            for operator_name, extra_bias in psyche_bias.items():
                 combined_bias[operator_name] = combined_bias.get(operator_name, 0.0) + extra_bias
 
             mood_label = getattr(getattr(psyche, "last_mood", None), "value", None)

--- a/src/singular/motivation.py
+++ b/src/singular/motivation.py
@@ -1,17 +1,54 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
 class Objective:
-    """Simple structure describing an objective with a weight and reward."""
+    """Structure describing an objective and its policy/arbitration metadata."""
 
     name: str
     weight: float = 1.0
     reward: float = 0.0
+    parent: str | None = None
+    horizon_ticks: int | None = None
+    policy: GoalPolicy = field(default_factory=lambda: GoalPolicy())
 
     def apply_delta(self, delta: float) -> None:
         """Adjust weight by ``delta`` and accumulate reward."""
         self.weight += delta
         self.reward += delta
+
+    def arbitration_score(self) -> float:
+        """Return a normalized policy score in ``[0, 1]``."""
+        return self.policy.arbitration_score()
+
+
+@dataclass(frozen=True)
+class GoalPolicy:
+    """Policy describing how a goal should be prioritized.
+
+    Parameters are expected in the ``[0, 1]`` range:
+    - ``besoin``: intrinsic need pressure.
+    - ``priorite``: strategic priority.
+    - ``urgence``: temporal urgency.
+    - ``alignement_valeurs``: value alignment consistency.
+    """
+
+    besoin: float = 0.5
+    priorite: float = 0.5
+    urgence: float = 0.5
+    alignement_valeurs: float = 0.5
+
+    def arbitration_score(self) -> float:
+        """Aggregate policy dimensions into one arbitration scalar."""
+        return (
+            0.35 * _clamp(self.besoin)
+            + 0.25 * _clamp(self.priorite)
+            + 0.25 * _clamp(self.urgence)
+            + 0.15 * _clamp(self.alignement_valeurs)
+        )
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -9,7 +9,7 @@ import random
 from enum import Enum
 
 from .memory import read_psyche, write_psyche
-from .motivation import Objective
+from .motivation import GoalPolicy, Objective
 from .resource_manager import ResourceManager
 
 
@@ -86,6 +86,8 @@ class Psyche:
     energy: float = 100.0
     sleeping: bool = False
     objectives: Dict[str, Objective] = field(default_factory=dict)
+    schema_version: int = field(default=2, init=False)
+    mood_history: list[str] = field(default_factory=list)
 
     # ``last_mood`` is updated every time :meth:`feel` is called and can be
     # queried by other subsystems (interaction and mutation policies).
@@ -284,6 +286,9 @@ class Psyche:
         if mood not in self._MOOD_EFFECTS:
             mood = Mood.NEUTRAL
         self.last_mood = mood
+        self.mood_history.append(mood.value)
+        if len(self.mood_history) > 256:
+            self.mood_history = self.mood_history[-256:]
 
         for attr, delta in self._MOOD_EFFECTS[mood].items():
             value = getattr(self, attr)
@@ -300,9 +305,107 @@ class Psyche:
         return mood
 
     def adjust_objectives(self) -> None:
-        """Clamp objective weights to the ``[0, 1]`` range."""
-        for obj in self.objectives.values():
-            obj.weight = _clamp(obj.weight)
+        """Clamp and rebalance objective weights for arbitration."""
+        modulation = self.goal_modulation_profile()
+        for name, obj in self.objectives.items():
+            horizon_boost = 0.0
+            if obj.horizon_ticks is not None:
+                horizon_boost = 0.15 if obj.horizon_ticks <= 10 else -0.05
+            parent_boost = 0.0
+            if obj.parent and obj.parent in self.objectives:
+                parent_boost = self.objectives[obj.parent].weight * 0.1
+            policy_signal = obj.arbitration_score()
+            obj.weight = _clamp(
+                obj.weight * modulation
+                + horizon_boost
+                + parent_boost
+                + (policy_signal - 0.5) * 0.2
+            )
+
+    def goal_modulation_profile(self) -> float:
+        """Return a modulation factor derived from mood and recent history."""
+        mood = self.last_mood or Mood.NEUTRAL
+        mood_factor = {
+            Mood.PROUD: 1.08,
+            Mood.CURIOUS: 1.05,
+            Mood.PLEASURE: 1.06,
+            Mood.FRUSTRATED: 0.92,
+            Mood.ANXIOUS: 0.95,
+            Mood.PAIN: 0.9,
+            Mood.FATIGUE: 0.88,
+        }.get(mood, 1.0)
+        if not self.objectives:
+            return mood_factor
+        reward_signal = sum(obj.reward for obj in self.objectives.values()) / max(
+            len(self.objectives), 1
+        )
+        reward_factor = 1.0 + max(-0.1, min(0.1, reward_signal * 0.05))
+        return max(0.7, min(1.3, mood_factor * reward_factor))
+
+    def objective_weights(self) -> Dict[str, float]:
+        """Return normalized objective weights after modulation."""
+        self.adjust_objectives()
+        if not self.objectives:
+            return {}
+        total = sum(max(0.0, obj.weight) for obj in self.objectives.values())
+        if total <= 0:
+            total = float(len(self.objectives))
+        return {
+            name: max(0.0, obj.weight) / total for name, obj in self.objectives.items()
+        }
+
+    def weighted_objective_axes(self) -> dict[str, float]:
+        """Map objective policies to reflection axes."""
+        if not self.objectives:
+            return {"long_term": 0.33, "sandbox": 0.33, "resource": 0.34}
+        normalized = self.objective_weights()
+        long_term = 0.0
+        sandbox = 0.0
+        resource = 0.0
+        for name, obj in self.objectives.items():
+            w = normalized.get(name, 0.0)
+            policy = obj.policy
+            long_term += w * (0.6 * policy.priorite + 0.4 * policy.alignement_valeurs)
+            sandbox += w * (0.7 * policy.urgence + 0.3 * policy.besoin)
+            resource += w * (0.6 * policy.besoin + 0.4 * (1.0 - policy.urgence))
+        total = long_term + sandbox + resource
+        if total <= 0.0:
+            return {"long_term": 0.33, "sandbox": 0.33, "resource": 0.34}
+        return {
+            "long_term": long_term / total,
+            "sandbox": sandbox / total,
+            "resource": resource / total,
+        }
+
+    def operator_bias(self, operator_names: list[str]) -> Dict[str, float]:
+        """Return operator bias from objective hierarchy and horizon pressure."""
+        if not operator_names:
+            return {}
+        weights = self.objective_weights()
+        if not weights:
+            return {}
+        horizon_pressure = sum(
+            1.0
+            for obj in self.objectives.values()
+            if obj.horizon_ticks is not None and obj.horizon_ticks <= 10
+        ) / max(1, len(self.objectives))
+        ordered = list(operator_names)
+        midpoint = max(1, len(ordered) - 1)
+        biases: Dict[str, float] = {}
+        ambition = sum(
+            weights.get(name, 0.0) * obj.policy.priorite
+            for name, obj in self.objectives.items()
+        )
+        urgency = sum(
+            weights.get(name, 0.0) * obj.policy.urgence
+            for name, obj in self.objectives.items()
+        )
+        for index, name in enumerate(ordered):
+            exploit_index = 1.0 - (index / midpoint)
+            biases[name] = (ambition * exploit_index * 0.2) + (
+                urgency * horizon_pressure * (1.0 - exploit_index) * 0.2
+            )
+        return biases
 
     # Exposed helpers -----------------------------------------------------
     def interaction_policy(self) -> str:
@@ -358,6 +461,7 @@ class Psyche:
     def save_state(self, path: Path | str | None = None) -> None:
         """Persist current psyche state to disk."""
         state: Dict[str, Any] = {
+            "schema_version": self.schema_version,
             "curiosity": self.curiosity,
             "patience": self.patience,
             "playfulness": self.playfulness,
@@ -365,10 +469,22 @@ class Psyche:
             "resilience": self.resilience,
             "energy": self.energy,
             "last_mood": self.last_mood.value if self.last_mood else None,
+            "mood_history": list(self.mood_history),
         }
         if self.objectives:
             state["objectives"] = {
-                name: {"weight": obj.weight, "reward": obj.reward}
+                name: {
+                    "weight": obj.weight,
+                    "reward": obj.reward,
+                    "parent": obj.parent,
+                    "horizon_ticks": obj.horizon_ticks,
+                    "policy": {
+                        "besoin": obj.policy.besoin,
+                        "priorite": obj.policy.priorite,
+                        "urgence": obj.policy.urgence,
+                        "alignement_valeurs": obj.policy.alignement_valeurs,
+                    },
+                }
                 for name, obj in self.objectives.items()
             }
         if path is None:
@@ -383,6 +499,25 @@ class Psyche:
             data = read_psyche()
         else:
             data = read_psyche(Path(path))
+        objectives_payload = data.get("objectives", {})
+        if not isinstance(objectives_payload, dict):
+            objectives_payload = {}
+        mood_history = data.get("mood_history", [])
+        schema_version = int(data.get("schema_version", 1))
+        if not isinstance(mood_history, list):
+            mood_history = []
+
+        def _policy_from(payload: dict[str, Any]) -> GoalPolicy:
+            policy_payload = payload.get("policy")
+            if not isinstance(policy_payload, dict):
+                policy_payload = {}
+            return GoalPolicy(
+                besoin=float(policy_payload.get("besoin", 0.5)),
+                priorite=float(policy_payload.get("priorite", 0.5)),
+                urgence=float(policy_payload.get("urgence", 0.5)),
+                alignement_valeurs=float(policy_payload.get("alignement_valeurs", 0.5)),
+            )
+
         psyche = cls(
             curiosity=data.get("curiosity", 0.5),
             patience=data.get("patience", 0.5),
@@ -392,13 +527,19 @@ class Psyche:
             energy=data.get("energy", 100.0),
             objectives={
                 name: Objective(
-                    name,
-                    obj.get("weight", 1.0),
-                    obj.get("reward", 0.0),
+                    name=name,
+                    weight=float(obj.get("weight", 1.0)),
+                    reward=float(obj.get("reward", 0.0)),
+                    parent=obj.get("parent"),
+                    horizon_ticks=obj.get("horizon_ticks"),
+                    policy=_policy_from(obj),
                 )
-                for name, obj in data.get("objectives", {}).items()
+                for name, obj in objectives_payload.items()
+                if isinstance(obj, dict)
             },
+            mood_history=[str(entry) for entry in mood_history[-256:]],
         )
         mood_val = data.get("last_mood")
         psyche.last_mood = Mood(mood_val) if mood_val else None
+        psyche.schema_version = max(2, schema_version)
         return psyche

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,5 +1,5 @@
 from singular.psyche import Psyche, Mood
-from singular.motivation import Objective
+from singular.motivation import GoalPolicy, Objective
 
 
 def test_curiosity_increases():
@@ -18,3 +18,9 @@ def test_objective_weights_adapt():
     psyche.feel(Mood.PAIN)
     decreased = psyche.objectives["goal"].weight
     assert decreased < increased
+
+
+def test_goal_policy_arbitration_bounds() -> None:
+    policy = GoalPolicy(besoin=1.0, priorite=0.8, urgence=0.6, alignement_valeurs=0.9)
+    score = policy.arbitration_score()
+    assert 0.0 <= score <= 1.0

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from singular.psyche import Psyche, Mood
 from singular.resource_manager import ResourceManager
+from singular.motivation import GoalPolicy, Objective
 
 
 def test_feel_updates_traits_and_last_mood() -> None:
@@ -88,3 +89,50 @@ def test_resource_manager_influences_mood(tmp_path: Path) -> None:
     mood = psyche.update_from_resource_manager(rm)
     assert mood is Mood.LONELY
     assert psyche.last_mood is Mood.LONELY
+
+
+def test_objective_policy_persistence_and_schema(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "psyche.json"
+    psyche = Psyche(
+        objectives={
+            "survie": Objective(
+                "survie",
+                weight=0.7,
+                parent=None,
+                horizon_ticks=4,
+                policy=GoalPolicy(besoin=0.9, priorite=0.8, urgence=1.0, alignement_valeurs=0.7),
+            )
+        }
+    )
+    psyche.feel(Mood.PROUD)
+    psyche.save_state(path)
+
+    loaded = Psyche.load_state(path)
+    assert loaded.schema_version >= 2
+    assert loaded.mood_history
+    assert loaded.objectives["survie"].horizon_ticks == 4
+    assert loaded.objectives["survie"].policy.urgence == 1.0
+
+
+def test_weighted_axes_and_operator_bias() -> None:
+    psyche = Psyche(
+        objectives={
+            "root": Objective(
+                "root",
+                weight=1.0,
+                policy=GoalPolicy(besoin=0.6, priorite=0.9, urgence=0.2, alignement_valeurs=0.9),
+            ),
+            "urgent": Objective(
+                "urgent",
+                weight=0.5,
+                parent="root",
+                horizon_ticks=3,
+                policy=GoalPolicy(besoin=0.9, priorite=0.5, urgence=1.0, alignement_valeurs=0.4),
+            ),
+        }
+    )
+    axes = psyche.weighted_objective_axes()
+    assert set(axes) == {"long_term", "sandbox", "resource"}
+    assert abs(sum(axes.values()) - 1.0) < 1e-6
+    biases = psyche.operator_bias(["op_a", "op_b", "op_c"])
+    assert set(biases) == {"op_a", "op_b", "op_c"}


### PR DESCRIPTION
### Motivation
- Support hierarchical multi-objective goals with temporal horizons and per-goal arbitration metadata so decision-making can prioritise needs, urgency and value alignment. 
- Let the agent `Psyche` modulate objective weights dynamically from mood and recent history to influence reflection and operator selection. 
- Surface objective-driven signals into the evolutionary loop so `reflect_action` and operator selection can incorporate psyche-driven long-term/sandbox/resource axes. 
- Provide robust persistence for psyche state and objective policies with a `schema_version` to enable future migration.

### Description
- Add `GoalPolicy` dataclass with dimensions `besoin`, `priorite`, `urgence`, and `alignement_valeurs` and an `arbitration_score` aggregator. 
- Extend `Objective` to include `parent`, `horizon_ticks`, and a `policy` field, and expose `arbitration_score()`; move small clamp helper into `motivation`. 
- Enhance `Psyche` with `schema_version` and `mood_history`, plus new methods `goal_modulation_profile`, `adjust_objectives` (rebalance/clamp with hierarchy and horizon boosts), `objective_weights`, `weighted_objective_axes`, and `operator_bias` to compute reflection axes and per-operator biases derived from goals. 
- Update persistence in `Psyche.save_state`/`load_state` to serialize/deserialize objectives and policy fields robustly and remain backward compatible. 
- Integrate psyche outputs into the life loop by mixing `weighted_objective_axes` with `IntrinsicGoals` when calling `reflect_action`, and merge `psyche.operator_bias(...)` into `combined_bias` used by the selector. 
- Add unit tests for `GoalPolicy` scoring, psyche persistence/schema, weighted axes and operator bias behaviour, and extend existing objective tests.

### Testing
- Ran `pytest -q tests/test_objectives.py tests/test_psyche.py` and both test modules passed (`10 passed`).
- Running a larger invocation including `tests/test_loop.py` (`pytest -q tests/test_objectives.py tests/test_psyche.py tests/test_loop.py -q`) produced failures in `tests/test_loop.py::test_log_and_memory_update`, `tests/test_loop.py::test_irrational_refusal`, `tests/test_loop.py::test_irrational_delay`, and `tests/test_loop.py::test_irrational_curiosity` due to an `AttributeError` arising from tests that monkeypatch a missing `life_loop.update_score` symbol (this appears unrelated to the changes in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc393b6a4832aab24a3e39b7374e8)