### PR TITLE
Add sandboxed artifact perception sensors and anti-noise filtering

### DIFF
--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -3,8 +3,11 @@
 This module provides a :func:`capture_signals` function that gathers basic
 sensory inputs.  It includes a few virtual sensors (temperature, a simple
 cycle to indicate day or night, and ambient noise).  Optional connectors can
-supply real-world data by reading from a file or querying a weather API.  Any
-failures in these connectors are ignored so that perception always succeeds.
+supply real-world data by reading from a file or querying a weather API.
+
+The module also exposes sandboxed ``artifact.*`` sensors that inspect local
+project state (modified files, new logs and simple technical debt markers) and
+publishes normalized perception events on the :class:`~singular.events.EventBus`.
 """
 
 from __future__ import annotations
@@ -12,13 +15,15 @@ from __future__ import annotations
 import os
 import random
 import time
-from typing import Any, Dict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from singular.events import EventBus, get_global_event_bus
 
 
-def _read_optional_file() -> Dict[str, Any]:
+def _read_optional_file() -> dict[str, Any]:
     """Read data from ``SINGULAR_SENSOR_FILE`` if available."""
     path = os.getenv("SINGULAR_SENSOR_FILE")
     if not path:
@@ -29,7 +34,7 @@ def _read_optional_file() -> Dict[str, Any]:
         return {}
 
 
-def _query_optional_weather_api() -> Dict[str, Any]:
+def _query_optional_weather_api() -> dict[str, Any]:
     """Query ``SINGULAR_WEATHER_API`` for weather data if possible."""
     url = os.getenv("SINGULAR_WEATHER_API")
     if not url:
@@ -48,6 +53,167 @@ def _query_optional_weather_api() -> Dict[str, Any]:
     except Exception:
         return {}
 
+
+def _resolve_sandbox_root(path: str | Path | None) -> Path:
+    if path is None:
+        path = os.getenv("SINGULAR_SANDBOX_ROOT", "sandbox")
+    candidate = Path(path).resolve()
+    if not candidate.exists() or not candidate.is_dir():
+        return candidate
+    return candidate
+
+
+def _list_sandbox_files(root: Path) -> dict[str, float]:
+    if not root.exists() or not root.is_dir():
+        return {}
+    files: dict[str, float] = {}
+    for p in root.rglob("*"):
+        if p.is_file():
+            files[str(p.relative_to(root))] = p.stat().st_mtime
+    return files
+
+
+def _count_tech_debt(root: Path) -> int:
+    if not root.exists() or not root.is_dir():
+        return 0
+    markers = ("TODO", "FIXME", "HACK")
+    total = 0
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.suffix.lower() not in {".py", ".md", ".txt", ".yml", ".yaml", ".json"}:
+            continue
+        try:
+            content = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        upper = content.upper()
+        for marker in markers:
+            total += upper.count(marker)
+    return total
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class _ArtifactScanState:
+    files_mtime: dict[str, float] = field(default_factory=dict)
+    seen_logs: set[str] = field(default_factory=set)
+
+
+@dataclass
+class PerceptionNoiseFilter:
+    """Simple anti-noise filter using confidence, dedupe and cooldown."""
+
+    confidence_threshold: float = 0.45
+    cooldown_seconds: float = 5.0
+    deduplicate: bool = True
+    _seen_signatures: set[str] = field(default_factory=set)
+    _last_emitted_at: dict[str, float] = field(default_factory=dict)
+
+    def allow(self, event: dict[str, Any]) -> bool:
+        confidence = float(event.get("confidence", 0.0))
+        if confidence < self.confidence_threshold:
+            return False
+
+        event_type = str(event.get("type", ""))
+        now = time.monotonic()
+        last_at = self._last_emitted_at.get(event_type)
+        if last_at is not None and (now - last_at) < self.cooldown_seconds:
+            return False
+
+        signature = str((event_type, event.get("source"), event.get("data")))
+        if self.deduplicate and signature in self._seen_signatures:
+            return False
+
+        self._last_emitted_at[event_type] = now
+        self._seen_signatures.add(signature)
+        return True
+
+
+_ARTIFACT_STATE = _ArtifactScanState()
+_NOISE_FILTER = PerceptionNoiseFilter()
+
+
+def _build_perception_event(
+    *,
+    event_type: str,
+    source: str,
+    confidence: float,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    """Normalized perception event format."""
+
+    return {
+        "type": event_type,
+        "source": source,
+        "confidence": max(0.0, min(1.0, confidence)),
+        "timestamp": _iso_now(),
+        "data": data,
+    }
+
+
+def _collect_artifact_signals(root: Path, state: _ArtifactScanState) -> list[dict[str, Any]]:
+    files_mtime = _list_sandbox_files(root)
+    previous_files = state.files_mtime
+
+    modified_files = sorted(
+        rel
+        for rel, mtime in files_mtime.items()
+        if rel in previous_files and previous_files[rel] != mtime
+    )
+
+    new_logs = sorted(
+        rel
+        for rel in files_mtime
+        if rel.endswith(".log") and rel not in state.seen_logs
+    )
+
+    debt_count = _count_tech_debt(root)
+
+    state.files_mtime = files_mtime
+    state.seen_logs.update(new_logs)
+
+    events: list[dict[str, Any]] = []
+    if modified_files:
+        events.append(
+            _build_perception_event(
+                event_type="artifact.files.modified",
+                source=str(root),
+                confidence=0.95,
+                data={"count": len(modified_files), "files": modified_files},
+            )
+        )
+    if new_logs:
+        events.append(
+            _build_perception_event(
+                event_type="artifact.logs.new",
+                source=str(root),
+                confidence=0.9,
+                data={"count": len(new_logs), "files": new_logs},
+            )
+        )
+    events.append(
+        _build_perception_event(
+            event_type="artifact.tech_debt.simple",
+            source=str(root),
+            confidence=0.6,
+            data={"markers": debt_count},
+        )
+    )
+    return events
+
+
+
+def reset_perception_state() -> None:
+    """Reset in-memory artifact scan and anti-noise state (tests/helpers)."""
+
+    _ARTIFACT_STATE.files_mtime.clear()
+    _ARTIFACT_STATE.seen_logs.clear()
+    _NOISE_FILTER._seen_signatures.clear()
+    _NOISE_FILTER._last_emitted_at.clear()
 
 def get_temperature() -> float:
     """Return the current temperature.
@@ -78,16 +244,34 @@ def capture_signals(
     *,
     bus: EventBus | None = None,
     publish_event: bool = True,
-) -> Dict[str, Any]:
-    """Collect sensory signals and optionally publish ``signal.captured``."""
-    signals: Dict[str, Any] = {
+    sandbox_root: str | Path | None = None,
+    noise_filter: PerceptionNoiseFilter | None = None,
+    artifact_state: _ArtifactScanState | None = None,
+) -> dict[str, Any]:
+    """Collect sensory signals and optionally publish perception events."""
+    signals: dict[str, Any] = {
         "temperature": random.uniform(-20.0, 40.0),
         "is_daytime": 6 <= time.localtime().tm_hour < 18,
         "noise": random.random(),
     }
     signals.update(_read_optional_file())
     signals.update(_query_optional_weather_api())
+
+    root = _resolve_sandbox_root(sandbox_root)
+    state = artifact_state or _ARTIFACT_STATE
+    filter_instance = noise_filter or _NOISE_FILTER
+    artifact_events = _collect_artifact_signals(root, state)
+    filtered_events = [event for event in artifact_events if filter_instance.allow(event)]
+    if filtered_events:
+        signals["artifact_events"] = filtered_events
+
     if publish_event:
         emitter = bus or get_global_event_bus()
         emitter.publish("signal.captured", {"signals": dict(signals)}, payload_version=1)
+        for event in filtered_events:
+            emitter.publish(
+                "artifact.perception",
+                {"version": "1.0", "event": event},
+                payload_version=1,
+            )
     return signals

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,8 @@
+import time
+
 from singular.resource_manager import ResourceManager
 from singular.environment.notifications import auto_post, notify
+from singular.perception import PerceptionNoiseFilter
 
 
 def test_update_from_environment_increases_warmth(tmp_path):
@@ -35,3 +38,34 @@ def test_auto_post_defaults_action_for_warning() -> None:
     assert messages == [
         "[WARNING] baisse continue du health score — action recommandée: réduire exploration"
     ]
+
+
+def test_perception_noise_filter_threshold_dedup_and_cooldown() -> None:
+    noise_filter = PerceptionNoiseFilter(confidence_threshold=0.5, cooldown_seconds=0.1)
+    weak = {
+        "type": "artifact.logs.new",
+        "source": "sandbox",
+        "confidence": 0.1,
+        "data": {"count": 1},
+    }
+    strong = {
+        "type": "artifact.logs.new",
+        "source": "sandbox",
+        "confidence": 0.9,
+        "data": {"count": 1},
+    }
+
+    assert noise_filter.allow(weak) is False
+    assert noise_filter.allow(strong) is True
+    # Dedup: same payload is filtered while still in seen cache.
+    assert noise_filter.allow(strong) is False
+
+    time.sleep(0.11)
+    # New payload after cooldown can pass.
+    new_payload = {
+        "type": "artifact.logs.new",
+        "source": "sandbox",
+        "confidence": 0.9,
+        "data": {"count": 2},
+    }
+    assert noise_filter.allow(new_payload) is True

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -2,33 +2,42 @@ import sys
 import time
 import types
 
-from singular.perception import capture_signals
+from singular.events import EventBus
+from singular.perception import capture_signals, reset_perception_state
 from singular.memory import add_episode, read_episodes
 
 
 def test_capture_and_persist_signals(tmp_path, monkeypatch):
+    reset_perception_state()
     # Prepare optional file sensor
     sensor_file = tmp_path / "sensor.txt"
     sensor_file.write_text("42", encoding="utf-8")
     monkeypatch.setenv("SINGULAR_SENSOR_FILE", str(sensor_file))
 
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    (sandbox / "app.py").write_text("# TODO: cleanup\n", encoding="utf-8")
+    (sandbox / "run.log").write_text("boot\n", encoding="utf-8")
+
     # Capture signals
-    signals = capture_signals()
+    signals = capture_signals(sandbox_root=sandbox)
     assert "temperature" in signals
     assert "is_daytime" in signals
     assert "noise" in signals
     assert signals.get("file") == "42"
+    assert "artifact_events" in signals
 
     # Persist and verify
     episodic = tmp_path / "mem" / "episodic.jsonl"
     add_episode({"event": "perception", **signals}, path=episodic)
     episodes = read_episodes(path=episodic)
     assert episodes[0]["event"] == "perception"
-    for key in ["temperature", "is_daytime", "noise", "file"]:
+    for key in ["temperature", "is_daytime", "noise", "file", "artifact_events"]:
         assert key in episodes[0]
 
 
 def test_weather_api_timeout(monkeypatch):
+    reset_perception_state()
     monkeypatch.setenv("SINGULAR_WEATHER_API", "http://example.com")
     monkeypatch.setenv("SINGULAR_HTTP_TIMEOUT", "0.1")
 
@@ -45,3 +54,36 @@ def test_weather_api_timeout(monkeypatch):
 
     assert duration < 0.5
     assert "weather" not in signals
+
+
+def test_capture_signals_publishes_normalized_artifact_events(tmp_path):
+    reset_perception_state()
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    code = sandbox / "service.py"
+    code.write_text("# FIXME: remove this hack\n", encoding="utf-8")
+    log_file = sandbox / "service.log"
+    log_file.write_text("first\n", encoding="utf-8")
+
+    bus = EventBus(mode="sync")
+    captured = []
+    bus.subscribe("artifact.perception", lambda event: captured.append(event))
+
+    # prime state to allow detecting modifications/new logs during second scan
+    capture_signals(bus=bus, sandbox_root=sandbox)
+    time.sleep(0.02)
+    code.write_text("# FIXME: remove this hack\nprint('ok')\n", encoding="utf-8")
+    signals = capture_signals(bus=bus, sandbox_root=sandbox)
+
+    assert any(evt.payload["event"]["type"] == "artifact.files.modified" for evt in captured)
+    assert any(evt.payload["event"]["type"] == "artifact.logs.new" for evt in captured)
+    assert any(evt.payload["event"]["type"] == "artifact.tech_debt.simple" for evt in captured)
+
+    for event in captured:
+        assert event.payload_version == 1
+        payload = event.payload
+        assert payload["version"] == "1.0"
+        normalized = payload["event"]
+        assert set(normalized) >= {"type", "source", "confidence", "timestamp"}
+
+    assert "artifact_events" in signals


### PR DESCRIPTION
### Motivation
- Fournir des capteurs sandboxés qui exposent l’état local du projet (fichiers, journaux, dette technique) comme signaux de perception normalisés.
- Normaliser le format d’événement de perception pour garantir une charge utile stable et parcourable par les consommateurs d'événements.
- Réduire le bruit des signaux via un filtrage simple (seuils, déduplication, cooldown) afin d'éviter la surcharge d'événements répétés.

### Description
- Ajout de capteurs `artifact.*` dans `src/singular/perception.py` détectant fichiers modifiés (`artifact.files.modified`), nouveaux logs (`artifact.logs.new`) et marqueurs de dette technique (`artifact.tech_debt.simple`).
- Introduction d’un schéma de perception normalisé contenant `type`, `source`, `confidence`, `timestamp` et `data`, construit par `_build_perception_event` et publié sur `EventBus` sous l’événement `artifact.perception` avec `payload = {"version": "1.0", "event": ...}` et `payload_version=1`.
- Implémentation d’un filtre anti-bruit `PerceptionNoiseFilter` (seuil de confiance, déduplication, cooldown) et d’un état d’analyse `_ArtifactScanState`, avec intégration dans `capture_signals` qui accepte désormais `sandbox_root`, `noise_filter` et `artifact_state` et attache `artifact_events` au retour.
- Ajout de `reset_perception_state()` pour réinitialiser l’état en mémoire afin de rendre les tests déterministes et mises à jour des tests en `tests/test_perception.py` et `tests/test_environment.py` pour couvrir la nouvelle fonctionnalité et le filtre.

### Testing
- Exécution des tests ciblés avec `pytest -q tests/test_perception.py tests/test_environment.py tests/test_events_bus.py` réussie.
- Résultat des tests : `11 passed` (tous les tests ciblés ont passé).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccac07924832aa30a43111b2edf04)