### PR TITLE
Add environment-triggered quest runtime with status/dashboard exposure

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -38,6 +38,7 @@ def create_app(
         if psyche_file is not None
         else base_dir / "mem" / "psyche.json"
     )
+    quests_path = base_dir / "mem" / "quests_state.json"
     app = FastAPI()
     actions = DashboardActionService(home=base_dir)
     templates_dir = Path(__file__).parent / "templates"
@@ -528,6 +529,21 @@ def create_app(
         if not psyche_path.exists():
             raise HTTPException(status_code=404, detail="psyche.json not found")
         return json.loads(psyche_path.read_text())
+
+
+    @app.get("/quests")
+    def read_quests() -> dict:
+        if not quests_path.exists():
+            return {"active": [], "completed": []}
+        try:
+            data = json.loads(quests_path.read_text())
+        except json.JSONDecodeError:
+            return {"active": [], "completed": []}
+        if not isinstance(data, dict):
+            return {"active": [], "completed": []}
+        active = data.get("active") if isinstance(data.get("active"), list) else []
+        completed = data.get("completed") if isinstance(data.get("completed"), list) else []
+        return {"active": active, "completed": completed[-20:]}
 
     @app.get("/ecosystem")
     def read_ecosystem(current_life_only: bool = False) -> dict:
@@ -1131,6 +1147,7 @@ def create_app(
     async def websocket_endpoint(ws: WebSocket) -> None:
         await ws.accept()
         last_psyche_mtime_ns: int | None = None
+        last_quests_mtime_ns: int | None = None
         log_cursors: dict[str, _LogCursor] = {}
 
         def _read_new_entries(file: Path, cursor: _LogCursor | None) -> tuple[list[str], _LogCursor]:
@@ -1170,6 +1187,13 @@ def create_app(
                         last_psyche_mtime_ns = mtime_ns
                         data = json.loads(psyche_path.read_text())
                         await ws.send_json({"type": "psyche", "data": data})
+
+                if quests_path.exists():
+                    mtime_ns = quests_path.stat().st_mtime_ns
+                    if mtime_ns != last_quests_mtime_ns:
+                        last_quests_mtime_ns = mtime_ns
+                        data = json.loads(quests_path.read_text())
+                        await ws.send_json({"type": "quests", "data": data})
 
                 incremental_events: list[dict[str, object]] = []
                 run_directories = _runs_dirs()

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -113,6 +113,9 @@
     <div><strong>Nombre de vies détectées</strong> : <span id='ctx-lives-count'>0</span></div>
   </div>
   <h3>État psychique</h3><pre id='psyche'></pre>
+  <h3>Quêtes</h3><pre id='quests'>
+{"active":[],"completed":[]}
+</pre>
   <h3>Organismes (résumé)</h3>
   <ul id='organisms-list'></ul>
 </section>
@@ -260,6 +263,8 @@ const loadEco=()=>Promise.all([fetch(withScope('/ecosystem')).then(r=>r.json()),
   document.getElementById('raw-eco-json').textContent=JSON.stringify(eco,null,2);
 });
 
+
+const loadQuests=()=>fetch('/quests').then(r=>r.json()).then(data=>{document.getElementById('quests').textContent=JSON.stringify(data,null,2);});
 const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=>{
   const statusBox=document.getElementById('cockpit-status');
   statusBox.textContent=`Statut global: ${d.global_status||'unknown'}`;
@@ -334,10 +339,10 @@ document.getElementById('live-autoscroll').onchange=e=>{liveState.autoScroll=Boo
 const loadTimeline=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=scopeState.currentLifeOnly?'&current_life_only=true':'';return fetch(`/api/runs/${meta.run}/timeline?page=1&page_size=120${q}`).then(r=>r.json());}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;btn.style.padding='6px';row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.style.alignSelf='center';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';}});
 const loadReflections=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=new URLSearchParams();const objective=document.getElementById('reflection-objective').value;const mood=document.getElementById('reflection-mood').value;const success=document.getElementById('reflection-success').value;if(objective){q.set('objective',objective);}if(mood){q.set('mood',mood);}if(success){q.set('success',success);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}const suffix=q.toString()?`?${q.toString()}`:'';return fetch(`/api/runs/${meta.run}/consciousness${suffix}`).then(r=>r.ok?r.json():{run_id:meta.run,items:[]});}).then(data=>{const wrap=document.getElementById('reflections-timeline');const detail=document.getElementById('reflections-detail');wrap.innerHTML='';for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');const mood=item.emotional_state?.mood||'n/a';const objective=item.objective||'n/a';btn.textContent=`${item.ts||'n/a'} · ${objective} · ${mood}`;btn.style.padding='6px';btn.onclick=()=>{detail.textContent=JSON.stringify(item,null,2);};row.appendChild(btn);wrap.appendChild(row);}if(!(data.items||[]).length){detail.textContent='Aucune réflexion disponible pour ces filtres.';}});
 document.getElementById('reflection-apply').onclick=()=>loadReflections();
-loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();setInterval(()=>{loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();},500);
+loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();loadQuests();setInterval(()=>{loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();loadQuests();},500);
 loadReflections();setInterval(()=>{loadReflections();},800);
 updateLiveStatus();
-ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);return;}if(typeof m.run_id==='string'&&typeof m.event==='string'){liveState.events.push({type:m.type,run_id:m.run_id,event:m.event,ts:m.ts||null});if(!liveState.paused){renderLiveEvents();}}};
+ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);return;}if(m.type==='quests'){document.getElementById('quests').textContent=JSON.stringify(m.data,null,2);return;}if(typeof m.run_id==='string'&&typeof m.event==='string'){liveState.events.push({type:m.type,run_id:m.run_id,event:m.event,ts:m.ts||null});if(!liveState.paused){renderLiveEvents();}}};
 </script>
 </body>
 </html>

--- a/src/singular/life/quest.py
+++ b/src/singular/life/quest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List
 import json
@@ -37,31 +37,15 @@ class Spec:
     signature: str
     examples: List[Example]
     constraints: Constraints
+    triggers: list[dict[str, Any]] = field(default_factory=list)
+    reward: dict[str, Any] = field(default_factory=dict)
+    penalty: dict[str, Any] = field(default_factory=dict)
+    cooldown: int = 0
+    success: dict[str, Any] = field(default_factory=dict)
 
 
 def load(path: Path) -> Spec:
-    """Parse *path* as a JSON spec and return a :class:`Spec`.
-
-    The expected format is::
-
-        {
-            "name": "skill_name",
-            "signature": "skill(arg1, arg2)",
-            "examples": [
-                {"input": [..], "output": ..},
-                ...,
-            ],
-            "constraints": {
-                "pure": true,
-                "no_import": true,
-                "time_ms_max": 1000
-            }
-        }
-
-    Each example's ``input`` may be a single value or a list of positional
-    arguments.  The ``constraints`` object is mandatory and must request pure
-    operation, disallow imports and specify a positive ``time_ms_max`` value.
-    """
+    """Parse *path* as a JSON spec and return a :class:`Spec`."""
 
     data = json.loads(path.read_text(encoding="utf-8"))
 
@@ -107,8 +91,39 @@ def load(path: Path) -> Spec:
             "'constraints.time_ms_max' must be a positive integer"
         )
 
+    triggers = data.get("triggers", [])
+    if not isinstance(triggers, list):
+        raise SpecValidationError("'triggers' must be a list")
+    for idx, trigger in enumerate(triggers):
+        if not isinstance(trigger, dict):
+            raise SpecValidationError(f"trigger {idx} must be an object")
+
+    reward = data.get("reward", {})
+    if not isinstance(reward, dict):
+        raise SpecValidationError("'reward' must be an object")
+
+    penalty = data.get("penalty", {})
+    if not isinstance(penalty, dict):
+        raise SpecValidationError("'penalty' must be an object")
+
+    cooldown = data.get("cooldown", 0)
+    if not isinstance(cooldown, int) or cooldown < 0:
+        raise SpecValidationError("'cooldown' must be a non-negative integer")
+
+    success = data.get("success", {})
+    if not isinstance(success, dict):
+        raise SpecValidationError("'success' must be an object")
+
     constraints = Constraints(pure=True, no_import=True, time_ms_max=time_ms_max)
 
     return Spec(
-        name=name, signature=signature, examples=examples, constraints=constraints
+        name=name,
+        signature=signature,
+        examples=examples,
+        constraints=constraints,
+        triggers=triggers,
+        reward=reward,
+        penalty=penalty,
+        cooldown=cooldown,
+        success=success,
     )

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -21,6 +21,7 @@ from singular.orchestrator.lifecycle_clock import (
 from singular.perception import capture_signals
 from singular.psyche import Psyche
 from singular.resource_manager import ResourceManager
+from singular.quests import QuestRuntime
 
 
 class LifecyclePhase(Enum):
@@ -96,6 +97,7 @@ class OrchestratorService:
         self.state = self._load_state()
         self.resource_manager = ResourceManager(path=self.resources_path)
         self.psyche = Psyche.load_state()
+        self.quest_runtime = QuestRuntime(base_dir=self.base_dir, mem_dir=self.mem_dir)
         self._running = False
         self._wake_requested = False
         self._pending_events: list[dict[str, Any]] = []
@@ -222,7 +224,11 @@ class OrchestratorService:
     def _run_phase(self, phase: LifecyclePhase) -> None:
         if phase is LifecyclePhase.VEILLE:
             signals = capture_signals(bus=self.bus)
-            self._push_event(phase, {"signals": list(signals.keys())})
+            activated = self.quest_runtime.evaluate_triggers(signals)
+            self._push_event(
+                phase,
+                {"signals": list(signals.keys()), "quests_triggered": activated},
+            )
             return
 
         if phase is LifecyclePhase.ACTION:
@@ -246,6 +252,10 @@ class OrchestratorService:
                     resource_manager=self.resource_manager,
                     tick_budget_seconds=tick_budget,
                 )
+            quest_outcomes = self.quest_runtime.settle_active(
+                psyche=self.psyche,
+                resource_manager=self.resource_manager,
+            )
             self._push_event(
                 phase,
                 {
@@ -255,6 +265,7 @@ class OrchestratorService:
                     "cpu_budget_percent": cpu_budget_percent,
                     "tick_budget_seconds": tick_budget,
                     "allowed_actions": behavior.get("allowed_actions", []),
+                    "quests": quest_outcomes,
                 },
             )
             return

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from ..life.health import detect_health_state
 from ..metrics.autonomy import compute_autonomy_metrics
 from ..psyche import Psyche
+from ..memory import get_mem_dir
 from ..runs.logger import RUNS_DIR
 from ..schedulers.reevaluation import alerts_from_records
 
@@ -41,6 +42,22 @@ def _fmt_number(value: object, unit: str = "") -> str:
         return f"{float(value):.2f}{unit}"
     return "-"
 
+
+
+def _read_quest_status() -> dict[str, object]:
+    path = get_mem_dir() / "quests_state.json"
+    if not path.exists():
+        return {"active": [], "completed": []}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"active": [], "completed": []}
+    if not isinstance(payload, dict):
+        return {"active": [], "completed": []}
+    active = payload.get("active") if isinstance(payload.get("active"), list) else []
+    completed = payload.get("completed") if isinstance(payload.get("completed"), list) else []
+    return {"active": active, "completed": completed[-20:]}
+
 def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     """Display basic metrics and current psyche state."""
 
@@ -55,6 +72,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "mood": None,
         "traits": {},
         "autonomy_metrics": {},
+        "quests": {"active": [], "completed": []},
     }
     runs_dir = Path(RUNS_DIR)
     files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
@@ -113,6 +131,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     psyche = Psyche.load_state()
     mood = psyche.last_mood.value if psyche.last_mood else "neutral"
     payload["mood"] = mood
+    payload["quests"] = _read_quest_status()
     payload["traits"] = {
         "curiosity": round(psyche.curiosity, 2),
         "patience": round(psyche.patience, 2),
@@ -158,6 +177,8 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             ["Latence perception→action", _fmt_number(autonomy.get("perception_to_action_latency_ms"), " ms")],
             ["Coût ressources par gain", _fmt_number(autonomy.get("resource_cost_per_gain"))],
             ["Mood", str(payload.get("mood"))],
+            ["Quêtes actives", str(len((payload.get("quests") or {}).get("active", [])))],
+            ["Quêtes terminées", str(len((payload.get("quests") or {}).get("completed", [])))],
         ]
         _print_table(["Metric", "Value"], run_rows)
         if verbose:
@@ -216,6 +237,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                 print("Alerts: none")
 
     print(f"Mood: {payload['mood']}")
+    quests = payload.get("quests") if isinstance(payload.get("quests"), dict) else {"active": [], "completed": []}
+    print(f"Quêtes actives: {len(quests.get("active", []))}")
+    print(f"Quêtes terminées: {len(quests.get("completed", []))}")
     print("Traits:")
     for trait, value in payload["traits"].items():
         print(f"  {trait}: {value:.2f}")

--- a/src/singular/quests.py
+++ b/src/singular/quests.py
@@ -1,0 +1,316 @@
+"""Runtime quest orchestration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from singular.life.quest import Spec, load as load_spec
+from singular.memory import _atomic_write_text, add_episode, get_mem_dir
+from singular.psyche import Mood, Psyche
+from singular.resource_manager import ResourceManager
+
+
+@dataclass
+class QuestRecord:
+    name: str
+    status: str
+    started_at: str
+    completed_at: str | None = None
+    reason: str | None = None
+
+
+@dataclass
+class QuestRuntimeState:
+    active: list[QuestRecord] = field(default_factory=list)
+    completed: list[QuestRecord] = field(default_factory=list)
+    cooldowns: dict[str, str] = field(default_factory=dict)
+
+
+class QuestRuntime:
+    """Load quest specs, trigger them from perception signals and apply outcomes."""
+
+    def __init__(self, *, base_dir: Path, mem_dir: Path | None = None) -> None:
+        self.base_dir = base_dir
+        self.mem_dir = mem_dir or get_mem_dir()
+        self.quests_dir = self.base_dir / "quests"
+        self.state_path = self.mem_dir / "quests_state.json"
+        self.state = self._load_state()
+
+    def _now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _load_state(self) -> QuestRuntimeState:
+        if not self.state_path.exists():
+            return QuestRuntimeState()
+        try:
+            raw = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return QuestRuntimeState()
+        if not isinstance(raw, dict):
+            return QuestRuntimeState()
+
+        def _records(items: Any) -> list[QuestRecord]:
+            out: list[QuestRecord] = []
+            if not isinstance(items, list):
+                return out
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                name = item.get("name")
+                status = item.get("status")
+                started_at = item.get("started_at")
+                if not all(isinstance(v, str) and v for v in (name, status, started_at)):
+                    continue
+                out.append(
+                    QuestRecord(
+                        name=name,
+                        status=status,
+                        started_at=started_at,
+                        completed_at=item.get("completed_at") if isinstance(item.get("completed_at"), str) else None,
+                        reason=item.get("reason") if isinstance(item.get("reason"), str) else None,
+                    )
+                )
+            return out
+
+        cooldowns: dict[str, str] = {}
+        raw_cooldowns = raw.get("cooldowns", {})
+        if isinstance(raw_cooldowns, dict):
+            for key, value in raw_cooldowns.items():
+                if isinstance(key, str) and isinstance(value, str):
+                    cooldowns[key] = value
+        return QuestRuntimeState(
+            active=_records(raw.get("active", [])),
+            completed=_records(raw.get("completed", [])),
+            cooldowns=cooldowns,
+        )
+
+    def _save_state(self) -> None:
+        payload = {
+            "active": [asdict(item) for item in self.state.active],
+            "completed": [asdict(item) for item in self.state.completed[-200:]],
+            "cooldowns": self.state.cooldowns,
+            "updated_at": self._now().isoformat(),
+        }
+        _atomic_write_text(self.state_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    def _load_specs(self) -> list[Spec]:
+        if not self.quests_dir.exists():
+            return []
+        specs: list[Spec] = []
+        for path in sorted(self.quests_dir.glob("*.json")):
+            try:
+                specs.append(load_spec(path))
+            except Exception:
+                continue
+        return specs
+
+    def _parse_iso(self, value: str) -> datetime | None:
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+
+    def _is_on_cooldown(self, spec: Spec) -> bool:
+        expires = self.state.cooldowns.get(spec.name)
+        if not expires:
+            return False
+        parsed = self._parse_iso(expires)
+        return bool(parsed and parsed > self._now())
+
+    def _signal_matches(self, trigger: dict[str, Any], signals: dict[str, Any]) -> bool:
+        signal_key = trigger.get("signal")
+        if not isinstance(signal_key, str) or not signal_key:
+            return False
+        if signal_key == "artifact.event_type":
+            expected = trigger.get("equals")
+            if not isinstance(expected, str):
+                return False
+            events = signals.get("artifact_events")
+            if not isinstance(events, list):
+                return False
+            for event in events:
+                if isinstance(event, dict) and event.get("type") == expected:
+                    return True
+            return False
+
+        value = signals.get(signal_key)
+        if "equals" in trigger:
+            return value == trigger.get("equals")
+        if "gte" in trigger and isinstance(value, (int, float)):
+            return float(value) >= float(trigger["gte"])
+        if "lte" in trigger and isinstance(value, (int, float)):
+            return float(value) <= float(trigger["lte"])
+        if "contains" in trigger:
+            needle = trigger.get("contains")
+            return isinstance(value, str) and isinstance(needle, str) and needle in value
+        return False
+
+    def evaluate_triggers(self, signals: dict[str, Any]) -> list[str]:
+        activated: list[str] = []
+        active_names = {item.name for item in self.state.active}
+        for spec in self._load_specs():
+            if spec.name in active_names or self._is_on_cooldown(spec):
+                continue
+            if not spec.triggers:
+                continue
+            if all(self._signal_matches(trigger, signals) for trigger in spec.triggers):
+                self.state.active.append(
+                    QuestRecord(
+                        name=spec.name,
+                        status="active",
+                        started_at=self._now().isoformat(),
+                    )
+                )
+                add_episode(
+                    {
+                        "event": "quest_triggered",
+                        "quest": spec.name,
+                        "triggers": spec.triggers,
+                    }
+                )
+                activated.append(spec.name)
+        if activated:
+            self._save_state()
+        return activated
+
+    def _resource_criteria_met(self, criteria: dict[str, Any], rm: ResourceManager) -> bool:
+        rules = criteria.get("resource_min")
+        if not isinstance(rules, dict):
+            return True
+        for key, minimum in rules.items():
+            if not isinstance(key, str) or not isinstance(minimum, (int, float)):
+                return False
+            value = getattr(rm, key, None)
+            if not isinstance(value, (int, float)) or float(value) < float(minimum):
+                return False
+        return True
+
+    def _to_mood(self, raw: Any) -> Mood:
+        if isinstance(raw, str):
+            try:
+                return Mood(raw)
+            except ValueError:
+                return Mood.NEUTRAL
+        return Mood.NEUTRAL
+
+    def _apply_effects(
+        self,
+        *,
+        spec: Spec,
+        effect: dict[str, Any],
+        outcome: str,
+        psyche: Psyche,
+        resource_manager: ResourceManager,
+    ) -> None:
+        rm_delta = effect.get("resource_delta")
+        if isinstance(rm_delta, dict):
+            for key, delta in rm_delta.items():
+                if not isinstance(key, str) or not isinstance(delta, (int, float)):
+                    continue
+                current = getattr(resource_manager, key, None)
+                if isinstance(current, (int, float)):
+                    setattr(resource_manager, key, float(current) + float(delta))
+            resource_manager._clamp()
+            resource_manager._save()
+
+        mood = self._to_mood(effect.get("mood"))
+        psyche.feel(mood)
+        energy_delta = effect.get("psyche_energy")
+        if isinstance(energy_delta, (int, float)):
+            if energy_delta >= 0:
+                psyche.gain(float(energy_delta))
+            else:
+                psyche.consume(abs(float(energy_delta)))
+        psyche.save_state()
+
+        add_episode(
+            {
+                "event": "quest_resolved",
+                "quest": spec.name,
+                "outcome": outcome,
+                "reward": spec.reward,
+                "penalty": spec.penalty,
+                "cooldown": spec.cooldown,
+            }
+        )
+
+    def settle_active(self, *, psyche: Psyche, resource_manager: ResourceManager) -> dict[str, list[str]]:
+        specs = {spec.name: spec for spec in self._load_specs()}
+        next_active: list[QuestRecord] = []
+        successes: list[str] = []
+        failures: list[str] = []
+
+        for record in self.state.active:
+            spec = specs.get(record.name)
+            if spec is None:
+                continue
+            criteria = spec.success
+            success = self._resource_criteria_met(criteria, resource_manager)
+            timeout = criteria.get("timeout_seconds") if isinstance(criteria, dict) else None
+            timed_out = False
+            if isinstance(timeout, (int, float)):
+                started = self._parse_iso(record.started_at)
+                if started is not None and (self._now() - started).total_seconds() > float(timeout):
+                    timed_out = True
+
+            if success:
+                self._apply_effects(
+                    spec=spec,
+                    effect=spec.reward,
+                    outcome="success",
+                    psyche=psyche,
+                    resource_manager=resource_manager,
+                )
+                self.state.completed.append(
+                    QuestRecord(
+                        name=spec.name,
+                        status="success",
+                        started_at=record.started_at,
+                        completed_at=self._now().isoformat(),
+                    )
+                )
+                self.state.cooldowns[spec.name] = (
+                    self._now() + timedelta(seconds=spec.cooldown)
+                ).isoformat()
+                successes.append(spec.name)
+                continue
+
+            if timed_out:
+                self._apply_effects(
+                    spec=spec,
+                    effect=spec.penalty,
+                    outcome="failure",
+                    psyche=psyche,
+                    resource_manager=resource_manager,
+                )
+                self.state.completed.append(
+                    QuestRecord(
+                        name=spec.name,
+                        status="failure",
+                        started_at=record.started_at,
+                        completed_at=self._now().isoformat(),
+                        reason="timeout",
+                    )
+                )
+                self.state.cooldowns[spec.name] = (
+                    self._now() + timedelta(seconds=spec.cooldown)
+                ).isoformat()
+                failures.append(spec.name)
+                continue
+
+            next_active.append(record)
+
+        self.state.active = next_active
+        if successes or failures:
+            self._save_state()
+        return {"successes": successes, "failures": failures}
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "active": [asdict(item) for item in self.state.active],
+            "completed": [asdict(item) for item in self.state.completed[-20:]],
+        }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -15,7 +15,7 @@ def _receive_with_timeout(ws: TestClient._WSConnection, timeout: float = 2.0) ->
         raise AssertionError("timed out waiting for websocket message") from exc
 
 
-def test_dashboard_endpoints(tmp_path: Path) -> None:
+def test_dashboard_endpoints(tmp_path: Path, monkeypatch) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
     (runs_dir / "log.txt").write_text("hello")
@@ -23,12 +23,38 @@ def test_dashboard_endpoints(tmp_path: Path) -> None:
     data = {"mood": "happy"}
     psyche_file.write_text(json.dumps(data))
 
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     app = create_app(runs_dir=runs_dir, psyche_file=psyche_file)
     client = TestClient(app)
 
     assert client.get("/logs").json() == {"log.txt": "hello"}
     assert client.get("/psyche").json() == data
     assert client.get("/alerts").json() == {"run": None, "alerts": []}
+
+
+def test_dashboard_quests_endpoint(tmp_path: Path, monkeypatch) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    psyche_file = tmp_path / "psyche.json"
+    psyche_file.write_text(json.dumps({"mood": "curious"}))
+
+    mem_dir = tmp_path / "mem"
+    mem_dir.mkdir()
+    quests_state = {
+        "active": [{"name": "q1", "status": "active", "started_at": "2026-01-01T00:00:00+00:00"}],
+        "completed": [{"name": "q0", "status": "success", "started_at": "2026-01-01T00:00:00+00:00", "completed_at": "2026-01-01T00:01:00+00:00"}],
+    }
+    (mem_dir / "quests_state.json").write_text(json.dumps(quests_state), encoding="utf-8")
+
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    app = create_app(runs_dir=runs_dir, psyche_file=psyche_file)
+    client = TestClient(app)
+
+    response = client.get("/quests")
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["active"]) == 1
+    assert len(payload["completed"]) == 1
 
 
 def test_dashboard_alerts_endpoint(tmp_path: Path) -> None:
@@ -205,6 +231,7 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Registre courant (SINGULAR_ROOT)" in body
     assert "Vie courante (SINGULAR_HOME)" in body
     assert "Nombre de vies détectées" in body
+    assert "Quêtes" in body
 
 
 def test_dashboard_index_renders_main_sections(tmp_path: Path) -> None:

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -52,3 +52,43 @@ def test_orchestrator_detects_external_stimulus(monkeypatch, tmp_path: Path) -> 
     assert service._external_stimulus_detected() is True
     (life / "runs" / "x.jsonl").write_text("{}\n", encoding="utf-8")
     assert service._external_stimulus_detected() is True
+
+
+def test_orchestrator_triggers_and_settles_quest(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "quests").mkdir(parents=True)
+    (life / "quests" / "repair.json").write_text(
+        """
+{
+  "name": "repair",
+  "signature": "repair(x)",
+  "examples": [{"input": [1], "output": 1}],
+  "constraints": {"pure": true, "no_import": true, "time_ms_max": 10},
+  "triggers": [{"signal": "noise", "gte": 0.5}],
+  "reward": {"mood": "pleasure", "resource_delta": {"food": 1}},
+  "penalty": {"mood": "pain"},
+  "cooldown": 30,
+  "success": {"resource_min": {"energy": 0}}
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+    monkeypatch.setattr(
+        "singular.orchestrator.service.capture_signals",
+        lambda bus: {"noise": 0.8, "artifact_events": []},
+    )
+
+    bus = EventBus()
+    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=bus)
+
+    service.tick()  # VEILLE -> trigger
+    service.tick()  # ACTION -> resolve
+
+    quests_path = life / "mem" / "quests_state.json"
+    assert quests_path.exists()
+    payload = quests_path.read_text(encoding="utf-8")
+    assert '"repair"' in payload
+    assert '"success"' in payload

--- a/tests/test_quest.py
+++ b/tests/test_quest.py
@@ -17,6 +17,33 @@ def test_load_valid_spec(tmp_path):
     assert spec.name == "adder"
     assert spec.signature == "adder(a, b)"
     assert spec.constraints.time_ms_max == 50
+    assert spec.triggers == []
+    assert spec.reward == {}
+    assert spec.penalty == {}
+    assert spec.cooldown == 0
+
+
+def test_load_extended_quest_fields(tmp_path):
+    spec_data = {
+        "name": "repair_loop",
+        "signature": "repair_loop(x)",
+        "examples": [{"input": [1], "output": 1}],
+        "constraints": {"pure": True, "no_import": True, "time_ms_max": 25},
+        "triggers": [{"signal": "noise", "gte": 0.5}],
+        "reward": {"mood": "pleasure", "resource_delta": {"food": 2}},
+        "penalty": {"mood": "pain", "resource_delta": {"energy": -1}},
+        "cooldown": 60,
+        "success": {"resource_min": {"energy": 80}},
+    }
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(spec_data), encoding="utf-8")
+
+    spec = quest.load(path)
+
+    assert spec.triggers == [{"signal": "noise", "gte": 0.5}]
+    assert spec.reward["mood"] == "pleasure"
+    assert spec.penalty["mood"] == "pain"
+    assert spec.cooldown == 60
 
 
 @pytest.mark.parametrize(

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -110,3 +110,36 @@ def test_status_filters_non_mutation_records_for_success_rate(
     assert payload["success_rate"] == 50.0
     assert "autonomy_metrics" in payload
     assert "proactive_initiative_rate" in payload["autonomy_metrics"]
+
+
+def test_status_exposes_quest_counts(tmp_path, monkeypatch, capsys) -> None:
+    mem_dir = tmp_path / "mem"
+    mem_dir.mkdir()
+    (mem_dir / "quests_state.json").write_text(
+        json.dumps(
+            {
+                "active": [{"name": "q1", "status": "active", "started_at": "2026-01-01T00:00:00+00:00"}],
+                "completed": [{"name": "q0", "status": "success", "started_at": "2026-01-01T00:00:00+00:00", "completed_at": "2026-01-01T00:01:00+00:00"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class DummyPsyche:
+        last_mood = None
+        curiosity = 0.5
+        patience = 0.5
+        playfulness = 0.5
+        optimism = 0.5
+        resilience = 0.5
+
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(
+        status_mod.Psyche, "load_state", staticmethod(lambda: DummyPsyche())
+    )
+
+    status_mod.status(output_format="json")
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["quests"]["active"]) == 1
+    assert len(payload["quests"]["completed"]) == 1


### PR DESCRIPTION
### Motivation
- Étendre le format de spécification de quête pour définir déclencheurs environnementaux, critères de succès et effets (récompense/pénalité/cooldown). 
- Permettre le déclenchement automatique des quêtes depuis l’orchestrateur en réponse aux signaux perçus et appliquer leurs effets sur l’état interne. 
- Rendre l’état des quêtes visible via la commande `status` et le tableau de bord pour supervision et debugging.

### Description
- Le chargeur de spec a été étendu (`src/singular/life/quest.py`) pour accepter et valider les champs `triggers`, `reward`, `penalty`, `cooldown` et un bloc `success` de critères. 
- Nouveau runtime `QuestRuntime` (`src/singular/quests.py`) qui charge les specs depuis `quests/*.json`, évalue les triggers par rapport aux signaux, active/termine les quêtes, gère les cooldowns et persiste l’état; il émet aussi des épisodes mémoire (`quest_triggered` / `quest_resolved`) et applique les effets sur `Psyche` et `ResourceManager`. 
- Intégration dans l’orchestrateur (`src/singular/orchestrator/service.py`) : la phase `VEILLE` évalue les triggers via `capture_signals` et la phase `ACTION` appelle `settle_active` pour résoudre les quêtes actives et appliquer les effets. 
- Exposition de l’état des quêtes : nouvel endpoint `/quests` et push websocket `type: "quests"` dans le dashboard (`src/singular/dashboard/__init__.py`) et rendu UI dans le template (`src/singular/dashboard/templates/dashboard.html`); la sortie CLI `status` inclut désormais le comptage des quêtes actives/terminées (`src/singular/organisms/status.py`). 
- Tests ajoutés/ajustés pour couvrir le parsing étendu, le déclenchement/résolution dans l’orchestrateur et l’exposition via `status` et l’endpoint dashboard (`tests/test_quest.py`, `tests/test_orchestrator_service.py`, `tests/test_status.py`, `tests/test_dashboard.py`).

### Testing
- Tests exécutés : `pytest -q tests/test_quest.py tests/test_orchestrator_service.py tests/test_status.py tests/test_dashboard.py`.
- Résultat : tous les tests ciblés sont passés (`31 passed, 1 warning`).
- Les changements ont été vérifiés localement en lançant la suite ciblée et en inspectant les fichiers d’état persistés (`mem/quests_state.json`) et les payloads retournés par `/quests` et le websocket.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccf0e17b4832ab3174f3ce706994e)