### PR TITLE
Add generation registry, snapshots and atomic rollback CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,20 @@ singular status --verbose --format json
 - `--export evolution.json` écrit un JSON stable (clés triées) sur disque.
 - `--export markdown` imprime un rapport Markdown sur la sortie standard.
 
+### Registre des générations et rollback
+
+Chaque tentative de mutation est journalisée dans `mem/generations.jsonl` avec :
+parent, mutation, score, verdict, hash, raison d’acceptation/rejet, lien run,
+snapshot de skill, et métadonnées de sécurité.
+
+Rollback atomique vers une génération stable :
+
+```bash
+singular rollback --generation 42
+```
+
+Politique de conservation/archivage/purge : `docs/generations_registry.md`.
+
 Schéma JSON (`schema_version: 1`) :
 
 - `context` : métadonnées d'exécution (`run_id`, bornes temporelles, volumes).

--- a/docs/generations_registry.md
+++ b/docs/generations_registry.md
@@ -1,0 +1,37 @@
+# Registre des générations
+
+Le système enregistre chaque tentative de mutation dans `mem/generations.jsonl`.
+
+## Schéma enregistré
+
+Chaque entrée contient :
+
+- `generation_id` et `parent_generation_id`
+- lien au run (`run_id`, `iteration`, `ts`)
+- mutation (`operator`, `diff`)
+- score (`base`, `new`)
+- `verdict` (`accepted`/`rejected`)
+- hash (`parent`, `candidate`)
+- raison de décision (`reason`)
+- métadonnées de sécurité (`security`)
+- snapshot de code (`snapshot`)
+
+Les snapshots sont stockés sous `runs/<run_id>/generations/gen-<id>.py`.
+
+## Rollback atomique
+
+Commande:
+
+```bash
+singular rollback --generation <id>
+```
+
+Le rollback est autorisé uniquement pour une génération stable (`stable=true`, i.e. acceptée),
+et restaure atomiquement le fichier de skill depuis le snapshot.
+
+## Politique de conservation / archivage / purge
+
+- Le registre `mem/generations.jsonl` est conservé comme journal d’audit principal.
+- Les snapshots `runs/<run_id>/generations/` peuvent être archivés après 30 jours.
+- Après vérification d’archivage, les snapshots des générations rejetées peuvent être purgés en priorité.
+- Les générations acceptées gardent au moins un snapshot restaurable par run actif.

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -600,6 +600,15 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Export report to file (.json/.md) or use `markdown` for stdout",
     )
+    rollback_parser = subparsers.add_parser(
+        "rollback", help="Rollback atomique vers une génération stable"
+    )
+    rollback_parser.add_argument(
+        "--generation",
+        type=int,
+        required=True,
+        help="Identifiant de génération à restaurer",
+    )
 
     subparsers.add_parser("dashboard", help="Launch web dashboard")
     quickstart_parser = subparsers.add_parser(
@@ -973,6 +982,20 @@ def main(argv: list[str] | None = None) -> int:
         from .dashboard import run as dashboard_run
 
         dashboard_run()
+    elif args.command == "rollback":
+        from .runs.generations import rollback_generation
+
+        _ensure_active_life(resolve_life, args.life)
+        try:
+            restored = rollback_generation(args.generation)
+        except ValueError as exc:
+            print(f"Rollback impossible: {exc}", file=sys.stderr)
+            return 1
+        print(
+            "Rollback appliqué: "
+            f"generation={restored['generation_id']} "
+            f"target={restored['skill_path']}"
+        )
 
     elif args.command == "quickstart":
         if args.name:

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -10,6 +10,8 @@ import math
 import random
 import time
 import heapq
+import hashlib
+import os
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, Iterable, Mapping
@@ -26,6 +28,7 @@ from singular.memory import register_memory_event_handlers
 from singular.psyche import Psyche, Mood
 from singular.runs.logger import RunLogger
 from singular.runs.explain import summarize_mutation
+from singular.runs.generations import record_generation
 from singular.organisms.spawn import mutation_absurde
 from singular.perception import capture_signals, get_temperature
 from graine.evolver.generate import propose_mutations
@@ -783,6 +786,13 @@ def run(
                 if map_elites
                 else mutated_score <= base_score
             )
+            security_metadata: dict[str, object] = {
+                "governance_checked": False,
+                "allowed": accepted,
+                "level": None,
+                "reason": "score_gate",
+                "corrective_action": None,
+            }
             detection_rate = 0.0
             test_delta = {"added": 0, "removed": 0}
             if coevolve_tests and test_pool is not None:
@@ -808,6 +818,13 @@ def run(
             if accepted:
                 governance_root = skill_path.parent.parent if skill_path.parent.name == "skills" else skill_path.parent
                 decision = governance_policy.enforce_write(skill_path, mutated, root=governance_root)
+                security_metadata = {
+                    "governance_checked": True,
+                    "allowed": decision.allowed,
+                    "level": decision.level,
+                    "reason": decision.reason,
+                    "corrective_action": decision.corrective_action,
+                }
                 if not decision.allowed:
                     accepted = False
                     logger.log_interaction(
@@ -973,6 +990,27 @@ def run(
                 "mutation.applied" if accepted else "mutation.rejected",
                 mutation_payload,
                 payload_version=1,
+            )
+            life_root = Path(os.environ.get("SINGULAR_HOME", ".")).resolve()
+            try:
+                skill_relative_path = str(skill_path.resolve().relative_to(life_root))
+            except ValueError:
+                skill_relative_path = str(skill_path)
+
+            record_generation(
+                run_id=logger.run_id,
+                iteration=state.iteration,
+                skill=key,
+                operator=op_name,
+                mutation_diff=diff,
+                score_base=base_score,
+                score_new=mutated_score,
+                accepted=accepted,
+                reason=reflection.decision_reason,
+                parent_hash=hashlib.sha256(original.encode("utf-8")).hexdigest(),
+                candidate_code=mutated,
+                skill_relative_path=skill_relative_path,
+                security_metadata=security_metadata,
             )
             log_mutation(
                 logger,

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -122,6 +122,7 @@ def ensure_memory_structure(mem_dir: Path | str | None = None) -> None:
     (mem_dir / "profile.json").touch(exist_ok=True)
     (mem_dir / "values.yaml").touch(exist_ok=True)
     (mem_dir / "episodic.jsonl").touch(exist_ok=True)
+    (mem_dir / "generations.jsonl").touch(exist_ok=True)
     (mem_dir / "skills.json").touch(exist_ok=True)
     (mem_dir / "psyche.json").touch(exist_ok=True)
     (mem_dir / "layers").mkdir(parents=True, exist_ok=True)

--- a/src/singular/runs/generations.py
+++ b/src/singular/runs/generations.py
@@ -1,0 +1,168 @@
+"""Generation registry utilities linked to mutation runs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import hashlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def get_base_dir() -> Path:
+    """Return base life directory from environment."""
+
+    return Path(os.environ.get("SINGULAR_HOME", "."))
+
+
+def get_generations_path(base_dir: Path | None = None) -> Path:
+    """Return the generations JSONL registry path."""
+
+    root = Path(base_dir) if base_dir is not None else get_base_dir()
+    return root / "mem" / "generations.jsonl"
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    items: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            items.append(json.loads(line))
+    return items
+
+
+def _next_generation_id(path: Path) -> int:
+    items = _read_jsonl(path)
+    if not items:
+        return 1
+    return int(items[-1].get("generation_id", 0)) + 1
+
+
+def _latest_generation_for_skill(path: Path, *, skill: str) -> dict[str, Any] | None:
+    items = _read_jsonl(path)
+    for entry in reversed(items):
+        if entry.get("skill") == skill:
+            return entry
+    return None
+
+
+def record_generation(
+    *,
+    run_id: str,
+    iteration: int,
+    skill: str,
+    operator: str,
+    mutation_diff: str,
+    score_base: float,
+    score_new: float,
+    accepted: bool,
+    reason: str,
+    parent_hash: str,
+    candidate_code: str,
+    skill_relative_path: str,
+    security_metadata: dict[str, Any],
+    base_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Persist one generation attempt in ``mem/generations.jsonl``."""
+
+    generations_path = get_generations_path(base_dir)
+    generation_id = _next_generation_id(generations_path)
+    parent = _latest_generation_for_skill(generations_path, skill=skill)
+
+    candidate_hash = hashlib.sha256(candidate_code.encode("utf-8")).hexdigest()
+    run_generation_dir = (
+        (Path(base_dir) if base_dir is not None else get_base_dir())
+        / "runs"
+        / run_id
+        / "generations"
+    )
+    run_generation_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = run_generation_dir / f"gen-{generation_id:06d}.py"
+    snapshot_path.write_text(candidate_code, encoding="utf-8")
+
+    payload: dict[str, Any] = {
+        "generation_id": generation_id,
+        "parent_generation_id": parent.get("generation_id") if parent else None,
+        "run_id": run_id,
+        "iteration": iteration,
+        "ts": datetime.utcnow().isoformat(timespec="seconds"),
+        "skill": skill,
+        "skill_path": skill_relative_path,
+        "mutation": {"operator": operator, "diff": mutation_diff},
+        "score": {"base": score_base, "new": score_new},
+        "verdict": "accepted" if accepted else "rejected",
+        "hash": {
+            "parent": parent_hash,
+            "candidate": candidate_hash,
+        },
+        "reason": reason,
+        "security": security_metadata,
+        "snapshot": str(snapshot_path),
+        "stable": accepted,
+    }
+    _append_jsonl(generations_path, payload)
+    return payload
+
+
+def rollback_generation(generation_id: int, *, base_dir: Path | None = None) -> dict[str, Any]:
+    """Atomically rollback the skill file to a stable generation snapshot."""
+
+    root = Path(base_dir) if base_dir is not None else get_base_dir()
+    generations_path = get_generations_path(root)
+    items = _read_jsonl(generations_path)
+    generation = next((item for item in items if item.get("generation_id") == generation_id), None)
+    if generation is None:
+        raise ValueError(f"generation_not_found:{generation_id}")
+    if not generation.get("stable"):
+        raise ValueError(f"generation_not_stable:{generation_id}")
+
+    snapshot = Path(str(generation.get("snapshot", "")))
+    if not snapshot.exists():
+        raise ValueError(f"snapshot_not_found:{snapshot}")
+
+    target = root / str(generation.get("skill_path", ""))
+    if not str(generation.get("skill_path", "")).strip():
+        raise ValueError("generation_missing_skill_path")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    content = snapshot.read_text(encoding="utf-8")
+    fd, tmp_name = tempfile.mkstemp(prefix=target.name, suffix=".tmp", dir=target.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+            tmp.write(content)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_name, target)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+    return {
+        "generation_id": generation_id,
+        "skill_path": str(target),
+        "snapshot": str(snapshot),
+    }
+
+
+def retention_policy_text() -> str:
+    """Return documented retention policy used for generation metadata."""
+
+    return (
+        "Conservation: garder le registre mem/generations.jsonl complet; "
+        "archiver les snapshots runs/<run_id>/generations après 30 jours; "
+        "purger les snapshots des générations rejetées après archivage validé."
+    )

--- a/tests/test_generations_registry.py
+++ b/tests/test_generations_registry.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import singular.cli as cli
+from singular.life import loop as life_loop
+from singular.lives import bootstrap_life
+from singular.runs.generations import get_generations_path, record_generation
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_generation_registry_stays_coherent_with_run_events(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    (skills_dir / "addition.py").write_text(
+        "def run(x:int,y:int)->int:\n    return x+y\n",
+        encoding="utf-8",
+    )
+
+    def noop_operator(tree: ast.AST, rng=None) -> ast.AST:
+        return tree
+
+    checkpoint = tmp_path / "life_checkpoint.json"
+    life_loop.run(
+        skills_dirs=skills_dir,
+        checkpoint_path=checkpoint,
+        budget_seconds=0.2,
+        run_id="gen-coherence",
+        operators={"noop": noop_operator},
+        max_iterations=1,
+    )
+
+    generations = _read_jsonl(get_generations_path(tmp_path))
+    assert len(generations) == 1
+    generation = generations[0]
+    assert generation["run_id"] == "gen-coherence"
+
+    candidate_paths = list(Path.cwd().glob("runs/gen-coherence/events.jsonl"))
+    candidate_paths += list(tmp_path.glob("runs/gen-coherence/events.jsonl"))
+    assert candidate_paths
+    events_path = max(candidate_paths, key=lambda p: p.stat().st_mtime)
+    events = _read_jsonl(events_path)
+    mutation_events = [entry for entry in events if entry.get("event_type") == "mutation"]
+    assert mutation_events
+    mutation_payload = mutation_events[-1]["payload"]
+
+    assert generation["mutation"]["operator"] == mutation_payload["op"]
+    assert generation["score"]["base"] == mutation_payload["score_base"]
+    assert generation["score"]["new"] == mutation_payload["score_new"]
+
+
+def test_cli_rollback_generation_restores_stable_snapshot(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    metadata = bootstrap_life("Rollback Life")
+    monkeypatch.setenv("SINGULAR_HOME", str(metadata.path))
+
+    skill_path = metadata.path / "skills" / "sample.py"
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    generation = record_generation(
+        run_id="rollback-run",
+        iteration=1,
+        skill="sample",
+        operator="noop",
+        mutation_diff="",
+        score_base=1.0,
+        score_new=1.0,
+        accepted=True,
+        reason="accepted: stable",
+        parent_hash="basehash",
+        candidate_code="def f():\n    return 2\n",
+        skill_relative_path="skills/sample.py",
+        security_metadata={"governance_checked": True, "allowed": True},
+        base_dir=metadata.path,
+    )
+
+    skill_path.write_text("def f():\n    return 999\n", encoding="utf-8")
+
+    exit_code = cli.main([
+        "--root",
+        str(tmp_path),
+        "--life",
+        metadata.slug,
+        "rollback",
+        "--generation",
+        str(generation["generation_id"]),
+    ])
+
+    assert exit_code == 0
+    assert "return 2" in skill_path.read_text(encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Provide an audit trail of every mutation attempt and enable safe restoration to a previously accepted generation. 
- Link each generation to run metadata and security/governance checks so rollback decisions are auditable and reproducible.

### Description
- Add `src/singular/runs/generations.py` to record generations into `mem/generations.jsonl` and store per-generation snapshots under `runs/<run_id>/generations/` with hashes and security metadata.
- Wire recording into the life loop by calling `record_generation(...)` for every mutation attempt and capture governance-related `security_metadata` in `src/singular/life/loop.py`.
- Implement atomic rollback in `rollback_generation(...)` (validate stable/accepted state, restore via temp file + `os.replace`) and expose CLI command `singular rollback --generation <id>` in `src/singular/cli.py`.
- Ensure memory bootstrap creates `mem/generations.jsonl` in `src/singular/memory.py`, add docs `docs/generations_registry.md`, update `README.md`, and include tests in `tests/test_generations_registry.py` covering registry↔run coherence and CLI rollback.

### Testing
- Ran the focused test suite: `pytest -q tests/test_generations_registry.py tests/test_loop.py::test_mutation_persistence`, which passed (`3 passed`).
- During development an earlier broader run (`pytest -q tests/test_generations_registry.py tests/test_cli_config.py tests/test_loop.py::test_mutation_persistence`) initially surfaced two failures that were fixed; the final targeted tests above succeeded.
- Tests exercise generation recording, snapshot creation, coherence with `events.jsonl`, and CLI rollback restoration of stable snapshots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd1535d68832a92d0ac3ef345740f)