### PR TITLE
Extend governance with mutation quotas, circuit breaker, and global safe-mode

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -501,6 +501,11 @@ def main(argv: list[str] | None = None) -> int:
         default="plain",
         help="Output format for compatible commands",
     )
+    parser.add_argument(
+        "--safe-mode",
+        action="store_true",
+        help="Active un mode global qui bloque les mutations autonomes",
+    )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -871,6 +876,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.seed is not None:
         random.seed(args.seed)
+    if args.safe_mode:
+        os.environ["SINGULAR_SAFE_MODE"] = "1"
 
     if args.command == "birth":
         name = args.name or "New life"
@@ -908,6 +915,7 @@ def main(argv: list[str] | None = None) -> int:
             budget_seconds=args.budget_seconds,
             run_id=args.run_id,
             seed=args.seed,
+            safe_mode=args.safe_mode,
         )
 
     elif args.command == "ecosystem":
@@ -940,6 +948,7 @@ def main(argv: list[str] | None = None) -> int:
             budget_seconds=args.budget_seconds,
             run_id=args.run_id,
             seed=args.seed,
+            safe_mode=args.safe_mode,
         )
 
     elif args.command == "status":
@@ -1047,6 +1056,7 @@ def main(argv: list[str] | None = None) -> int:
                 tick_budget_seconds=args.tick_budget,
                 lifecycle_config_path=args.lifecycle_config,
                 dry_run=args.dry_run,
+                safe_mode=args.safe_mode,
             )
 
     elif args.command == "doctor":

--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from collections import deque
 import logging
 from pathlib import Path
 
@@ -24,6 +26,7 @@ class GovernanceDecision:
     allowed: bool
     reason: str
     corrective_action: str
+    severity: str = "info"
 
 
 class MutationGovernancePolicy:
@@ -42,11 +45,70 @@ class MutationGovernancePolicy:
             "tests",
         ),
         value_weights: ValueWeights | None = None,
+        mutation_quota_per_window: int = 25,
+        mutation_quota_window_seconds: float = 300.0,
+        circuit_breaker_threshold: int = 3,
+        circuit_breaker_window_seconds: float = 180.0,
+        circuit_breaker_cooldown_seconds: float = 300.0,
+        safe_mode: bool = False,
     ) -> None:
         self.modifiable_paths = tuple(p.strip("/") for p in modifiable_paths)
         self.review_required_paths = tuple(p.strip("/") for p in review_required_paths)
         self.forbidden_paths = tuple(p.strip("/") for p in forbidden_paths)
         self.value_weights = (value_weights or ValueWeights()).normalized()
+        self.mutation_quota_per_window = max(int(mutation_quota_per_window), 1)
+        self.mutation_quota_window_seconds = max(float(mutation_quota_window_seconds), 1.0)
+        self.circuit_breaker_threshold = max(int(circuit_breaker_threshold), 1)
+        self.circuit_breaker_window_seconds = max(float(circuit_breaker_window_seconds), 1.0)
+        self.circuit_breaker_cooldown_seconds = max(float(circuit_breaker_cooldown_seconds), 1.0)
+        self.safe_mode = bool(safe_mode)
+        self._mutation_timestamps: deque[datetime] = deque()
+        self._violation_timestamps: deque[datetime] = deque()
+        self._circuit_open_until: datetime | None = None
+
+    @staticmethod
+    def _now() -> datetime:
+        return datetime.now(timezone.utc)
+
+    def mutations_enabled(self) -> bool:
+        if self.safe_mode:
+            return False
+        if self._circuit_open_until is None:
+            return True
+        if self._now() < self._circuit_open_until:
+            return False
+        self._circuit_open_until = None
+        return True
+
+    def mutation_lock_reason(self) -> str | None:
+        if self.safe_mode:
+            return "safe-mode enabled"
+        if self._circuit_open_until is not None and self._now() < self._circuit_open_until:
+            return "circuit-breaker open after repeated violations"
+        return None
+
+    def _prune_history(self) -> None:
+        now = self._now()
+        quota_cutoff = now - timedelta(seconds=self.mutation_quota_window_seconds)
+        while self._mutation_timestamps and self._mutation_timestamps[0] < quota_cutoff:
+            self._mutation_timestamps.popleft()
+        violation_cutoff = now - timedelta(seconds=self.circuit_breaker_window_seconds)
+        while self._violation_timestamps and self._violation_timestamps[0] < violation_cutoff:
+            self._violation_timestamps.popleft()
+
+    def record_violation(self, *, category: str, severity: str = "high") -> None:
+        self._prune_history()
+        now = self._now()
+        self._violation_timestamps.append(now)
+        if len(self._violation_timestamps) >= self.circuit_breaker_threshold:
+            self._circuit_open_until = now + timedelta(seconds=self.circuit_breaker_cooldown_seconds)
+            log.error(
+                "governance circuit breaker opened: category=%s severity=%s threshold=%s cooldown=%ss",
+                category,
+                severity,
+                self.circuit_breaker_threshold,
+                self.circuit_breaker_cooldown_seconds,
+            )
 
     def _relative(self, target: Path, root: Path) -> Path:
         target_resolved = target.resolve()
@@ -64,6 +126,35 @@ class MutationGovernancePolicy:
     def simulate_write(self, target: Path, *, root: Path | None = None) -> GovernanceDecision:
         """Simulate authorization before a filesystem write."""
 
+        self._prune_history()
+        if self.safe_mode:
+            return GovernanceDecision(
+                level=AUTH_BLOCKED,
+                allowed=False,
+                reason="safe-mode blocks all mutation writes",
+                corrective_action="disable safe-mode to resume autonomous mutations",
+                severity="high",
+            )
+        if not self.mutations_enabled():
+            return GovernanceDecision(
+                level=AUTH_BLOCKED,
+                allowed=False,
+                reason="circuit-breaker active after repeated governance/sandbox violations",
+                corrective_action="wait cooldown or reset governance counters",
+                severity="critical",
+            )
+        if len(self._mutation_timestamps) >= self.mutation_quota_per_window:
+            return GovernanceDecision(
+                level=AUTH_BLOCKED,
+                allowed=False,
+                reason=(
+                    "mutation quota exceeded "
+                    f"({self.mutation_quota_per_window}/{self.mutation_quota_window_seconds:.0f}s)"
+                ),
+                corrective_action="wait for quota window reset or reduce mutation frequency",
+                severity="medium",
+            )
+
         if root is None:
             root = target.parent.parent if target.parent.name == "skills" else target.parent
         rel = self._relative(target, root)
@@ -74,6 +165,7 @@ class MutationGovernancePolicy:
                 allowed=False,
                 reason=f"target '{target}' is outside governed root '{root}'",
                 corrective_action="write inside an organism skills/ directory",
+                severity="high",
             )
 
         if self._matches(rel, self.forbidden_paths):
@@ -82,6 +174,7 @@ class MutationGovernancePolicy:
                 allowed=False,
                 reason=f"path '{rel.as_posix()}' is in forbidden zone",
                 corrective_action="choose a path under an allowlisted mutable zone",
+                severity="high",
             )
 
         if self._matches(rel, self.review_required_paths):
@@ -94,12 +187,14 @@ class MutationGovernancePolicy:
                         "by value weights (security-first)"
                     ),
                     corrective_action="request explicit human review before mutating this zone",
+                    severity="critical",
                 )
             return GovernanceDecision(
                 level=AUTH_REVIEW_REQUIRED,
                 allowed=False,
                 reason=f"path '{rel.as_posix()}' requires manual review",
                 corrective_action="request human review or move target to auto-authorized zone",
+                severity="medium",
             )
 
         if self._matches(rel, self.modifiable_paths):
@@ -108,6 +203,7 @@ class MutationGovernancePolicy:
                 allowed=True,
                 reason=f"path '{rel.as_posix()}' is allowlisted for autonomous writes",
                 corrective_action="none",
+                severity="info",
             )
 
         return GovernanceDecision(
@@ -115,6 +211,7 @@ class MutationGovernancePolicy:
             allowed=False,
             reason=f"path '{rel.as_posix()}' is not allowlisted",
             corrective_action="add this zone to policy allowlist after validation",
+            severity="medium",
         )
 
     def enforce_write(self, target: Path, content: str, *, root: Path | None = None) -> GovernanceDecision:
@@ -122,10 +219,12 @@ class MutationGovernancePolicy:
 
         decision = self.simulate_write(target, root=root)
         if not decision.allowed:
+            self.record_violation(category="governance_violation", severity=decision.severity)
             log.warning(
-                "governance blocked write: target=%s level=%s reason=%s corrective_action=%s",
+                "governance blocked write: target=%s level=%s severity=%s reason=%s corrective_action=%s",
                 target,
                 decision.level,
+                decision.severity,
                 decision.reason,
                 decision.corrective_action,
             )
@@ -142,10 +241,13 @@ class MutationGovernancePolicy:
                         "new content appears to truncate existing knowledge"
                     ),
                     corrective_action="retry with a non-destructive mutation or request manual review",
+                    severity="high",
                 )
 
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
+        self._prune_history()
+        self._mutation_timestamps.append(self._now())
         return decision
 
 

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -590,6 +590,16 @@ def run(
                     decision = psyche.irrational_decision(rng)
 
             original = skill_path.read_text(encoding="utf-8")
+            if not governance_policy.mutations_enabled():
+                logger.log_interaction(
+                    "mutation_halted",
+                    organism=org_name,
+                    target=str(skill_path),
+                    severity="critical",
+                    reason=governance_policy.mutation_lock_reason(),
+                    alive=True,
+                )
+                continue
 
             if decision is Psyche.Decision.REFUSE:
                 logger.log_refusal(skill_path.name)
@@ -617,6 +627,7 @@ def run(
                         organism=org_name,
                         target=str(skill_path),
                         level=decision.level,
+                        severity=decision.severity,
                         reason=decision.reason,
                         corrective_action=decision.corrective_action,
                         alive=True,
@@ -832,6 +843,7 @@ def run(
                         organism=org_name,
                         target=str(skill_path),
                         level=decision.level,
+                        severity=decision.severity,
                         reason=decision.reason,
                         corrective_action=decision.corrective_action,
                         alive=True,
@@ -942,6 +954,11 @@ def run(
             sandbox_failure = (
                 base_score == float("-inf") or mutated_score == float("-inf")
             )
+            if sandbox_failure:
+                governance_policy.record_violation(
+                    category="sandbox_violation",
+                    severity="critical",
+                )
             failed = sandbox_failure or (not accepted)
             health_snapshot = health_tracker.update(
                 iteration=state.iteration,

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from singular.events import Event, EventBus, get_global_event_bus
+from singular.governance.policy import MutationGovernancePolicy
 from singular.life.loop import run_tick
 from singular.memory import _atomic_write_text, get_base_dir, get_mem_dir
 from singular.orchestrator.lifecycle_clock import (
@@ -73,6 +74,7 @@ class OrchestratorConfig:
     mutation_window_seconds: float = 0.2
     phase_behaviors: dict[str, dict[str, Any]] = field(default_factory=dict)
     dry_run: bool = False
+    safe_mode: bool = False
 
 
 class OrchestratorService:
@@ -98,6 +100,7 @@ class OrchestratorService:
         self.resource_manager = ResourceManager(path=self.resources_path)
         self.psyche = Psyche.load_state()
         self.quest_runtime = QuestRuntime(base_dir=self.base_dir, mem_dir=self.mem_dir)
+        self.governance_policy = MutationGovernancePolicy(safe_mode=self.config.safe_mode)
         self._running = False
         self._wake_requested = False
         self._pending_events: list[dict[str, Any]] = []
@@ -251,6 +254,7 @@ class OrchestratorService:
                     event_bus=self.bus,
                     resource_manager=self.resource_manager,
                     tick_budget_seconds=tick_budget,
+                    governance_policy=self.governance_policy,
                 )
             quest_outcomes = self.quest_runtime.settle_active(
                 psyche=self.psyche,
@@ -334,6 +338,7 @@ def run_orchestrator_daemon(
     tick_budget_seconds: float | None,
     lifecycle_config_path: str | None,
     dry_run: bool,
+    safe_mode: bool,
 ) -> int:
     """CLI entry point for ``singular orchestrate run``."""
 
@@ -383,6 +388,7 @@ def run_orchestrator_daemon(
                 for phase, behavior in lifecycle_clock.phases.items()
             },
             dry_run=dry_run,
+            safe_mode=safe_mode,
         )
     )
     print(

--- a/src/singular/runs/loop.py
+++ b/src/singular/runs/loop.py
@@ -6,6 +6,7 @@ import random
 from pathlib import Path
 from typing import Iterable, Mapping
 
+from singular.governance.policy import MutationGovernancePolicy
 from singular.life.loop import run
 
 
@@ -17,6 +18,7 @@ def loop(
     budget_seconds: float,
     run_id: str = "loop",
     seed: int | None = None,
+    safe_mode: bool = False,
 ) -> None:
     """Wrapper around :func:`life.loop.run` used by the CLI.
 
@@ -32,4 +34,12 @@ def loop(
         payload: Mapping[str, Path] | Iterable[Path] | Path = skills_dir
     else:
         payload = skills_dirs
-    run(payload, checkpoint, budget_seconds, rng=rng, run_id=run_id)
+    governance_policy = MutationGovernancePolicy(safe_mode=safe_mode)
+    run(
+        payload,
+        checkpoint,
+        budget_seconds,
+        rng=rng,
+        run_id=run_id,
+        governance_policy=governance_policy,
+    )

--- a/tests/test_cli_orchestrate.py
+++ b/tests/test_cli_orchestrate.py
@@ -47,6 +47,7 @@ def test_cli_orchestrate_run_dispatches(monkeypatch, tmp_path) -> None:
     assert captured["tick_budget_seconds"] == 0.05
     assert captured["lifecycle_config_path"] is None
     assert captured["dry_run"] is True
+    assert captured["safe_mode"] is False
 
 
 def test_cli_orchestrate_run_passes_lifecycle_config_path(monkeypatch, tmp_path) -> None:
@@ -79,3 +80,33 @@ def test_cli_orchestrate_run_passes_lifecycle_config_path(monkeypatch, tmp_path)
 
     assert code == 0
     assert captured["lifecycle_config_path"] == str(config)
+    assert captured["safe_mode"] is False
+
+
+def test_cli_orchestrate_run_passes_safe_mode(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "root"
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    captured: dict[str, object] = {}
+
+    def fake_run_orchestrator_daemon(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "singular.orchestrator.run_orchestrator_daemon",
+        fake_run_orchestrator_daemon,
+    )
+
+    code = main(
+        [
+            "--root",
+            str(root),
+            "--safe-mode",
+            "orchestrate",
+            "run",
+        ]
+    )
+
+    assert code == 0
+    assert captured["safe_mode"] is True

--- a/tests/test_values_schema.py
+++ b/tests/test_values_schema.py
@@ -84,6 +84,49 @@ def test_policy_blocks_destructive_overwrite_when_memory_preservation_high(tmp_p
     assert "memory-preservation guard" in decision.reason
 
 
+def test_policy_enforces_mutation_quota(tmp_path: Path) -> None:
+    target = tmp_path / "skills" / "example.py"
+    policy = MutationGovernancePolicy(mutation_quota_per_window=1, mutation_quota_window_seconds=60.0)
+
+    first = policy.enforce_write(target, "result = 1\n", root=tmp_path)
+    second = policy.enforce_write(target, "result = 2\n", root=tmp_path)
+
+    assert first.allowed is True
+    assert second.allowed is False
+    assert "quota exceeded" in second.reason
+    assert second.severity == "medium"
+
+
+def test_policy_opens_circuit_breaker_on_repeated_violations(tmp_path: Path) -> None:
+    target = tmp_path / "skills" / "example.py"
+    forbidden = tmp_path / "src" / "blocked.py"
+    policy = MutationGovernancePolicy(
+        circuit_breaker_threshold=2,
+        circuit_breaker_window_seconds=60.0,
+        circuit_breaker_cooldown_seconds=120.0,
+    )
+
+    policy.enforce_write(forbidden, "x = 1\n", root=tmp_path)
+    policy.enforce_write(forbidden, "x = 2\n", root=tmp_path)
+    decision = policy.enforce_write(target, "result = 42\n", root=tmp_path)
+
+    assert policy.mutations_enabled() is False
+    assert decision.allowed is False
+    assert "circuit-breaker active" in decision.reason
+    assert decision.severity == "critical"
+
+
+def test_policy_safe_mode_blocks_writes(tmp_path: Path) -> None:
+    target = tmp_path / "skills" / "example.py"
+    policy = MutationGovernancePolicy(safe_mode=True)
+
+    decision = policy.enforce_write(target, "result = 1\n", root=tmp_path)
+
+    assert decision.allowed is False
+    assert decision.severity == "high"
+    assert "safe-mode" in decision.reason
+
+
 def test_cli_values_show_json(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys) -> None:
     root = tmp_path / "root"
     monkeypatch.delenv("SINGULAR_ROOT", raising=False)


### PR DESCRIPTION
### Motivation
- Introduire des contrôles cumulés sur les mutations pour limiter le débit de modifications autonomes et pouvoir arrêter automatiquement les mutations en cas d’échecs répétés ou de violations sandbox.
- Fournir des métadonnées de gravité (`severity`) exploitables par le dashboard et permettre un `safe-mode` global pilotable depuis le CLI/orchestrateur.

### Description
- Étend `MutationGovernancePolicy` avec des quotas temporels (`mutation_quota_per_window`, `mutation_quota_window_seconds`), suivi par timestamps et prune history, une logique de `circuit-breaker` (seuil, fenêtre, cooldown) et un flag `safe_mode`, plus des méthodes utilitaires `mutations_enabled()` et `record_violation()`; les décisions portent désormais un champ `severity`.
- `enforce_write` enregistre les violations via `record_violation` et ajoute les timestamps de mutations autorisées pour appliquer la fenêtre de quota.
- Intégration dans la boucle d’évolution : la boucle vérifie `governance_policy.mutations_enabled()` et émet un événement `mutation_halted` lorsque verrouillée, journalise `governance_violation` avec `severity`, et enregistre les échecs sandbox comme violations alimentant le circuit-breaker.
- Expose un flag CLI `--safe-mode` et propage son état aux wrappers et démons concernés (`runs.loop`, `ecosystem run`, `orchestrate run`), et fait en sorte que l’orchestrateur conserve et réutilise une instance de `MutationGovernancePolicy` (incluant `safe_mode`) entre ticks.
- Ajout ou mise à jour de tests ciblés couvrant le quota de mutations, l’ouverture du circuit-breaker, le comportement de `safe_mode` et la propagation du paramètre CLI.

### Testing
- Tests ciblés lancés avec `pytest -q tests/test_values_schema.py tests/test_cli_orchestrate.py tests/test_loop.py -k 'governance_blocks_mutation_write or values_show_json or mutation_quota or circuit_breaker or safe_mode or orchestrate_run'`.
- Résultat des tests : `8 passed, 30 deselected, 7 warnings` (local run shown above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcda2baa88832abdb0477ff04d15c6)