### PR TITLE
Formalise le cycle vital, enrichit status/dashboard et ajoute commandes d’accompagnement

### DIFF
--- a/docs/vital_lifecycle_rules.md
+++ b/docs/vital_lifecycle_rules.md
@@ -1,0 +1,66 @@
+# Spécification métier — cycle vital déterministe
+
+Cette spécification formalise des règles **déterministes** (seuils fixes) et **observables** (causes explicitement remontées) pour:
+
+- âge,
+- déclin,
+- extinction,
+- reproduction.
+
+## Variables observables
+
+- `age`: nombre de mutations observées sur la vie.
+- `current_health`: dernier `health.score` connu.
+- `failure_rate`: part des mutations échouées (`accepted/ok == false`).
+- `failure_streak`: plus longue série continue d’échecs.
+- `extinction_seen`: présence d’un événement `event == "death"` dans les runs.
+- `registry_status`: statut actuel du registre (`active` ou `extinct`).
+
+## Seuils (version 1)
+
+- `decline_age = 50`
+- `terminal_age = 120`
+- `terminal_health = 25.0`
+- `high_failure_rate = 0.60`
+- `terminal_failure_streak = 5`
+- `reproduction_age_window = [3, 80]`
+
+## États et transitions
+
+Ordre de priorité des transitions:
+
+1. **Extinction** (`state=extinct`)
+   - si `extinction_seen == true` **ou** `registry_status == "extinct"`.
+2. **Terminal** (`state=terminal`)
+   - si `age >= terminal_age`
+   - ou `current_health <= terminal_health`
+   - ou `failure_streak >= terminal_failure_streak`.
+3. **Déclin** (`state=declining`)
+   - si `age >= decline_age`
+   - ou `failure_rate >= high_failure_rate`.
+4. **Mature** (`state=mature`) sinon.
+
+## Risque et indicateurs dérivés
+
+- `risk_level=low` pour `mature`.
+- `risk_level=medium` pour `declining`.
+- `risk_level=high` pour `terminal` et `extinct`.
+- `terminal=true` pour `terminal` et `extinct`, sinon `false`.
+- `causes`: liste des causes observées (ex: `high_failure_rate`, `critical_health_score`).
+
+## Éligibilité reproduction
+
+`reproduction_eligible=true` si et seulement si:
+
+- état ∈ `{mature, declining}`,
+- `age` dans `[3, 80]`,
+- `failure_rate < 0.60` (si disponible),
+- `current_health > 25.0` (si disponible).
+
+Sinon `false`.
+
+## Exceptions
+
+- Si aucune donnée de santé n’est disponible, on n’applique pas la règle `current_health`.
+- Si aucune donnée de réussite/échec n’est disponible, on n’applique pas la règle `failure_rate`.
+- L’extinction observée domine toujours les autres états.

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -462,10 +462,13 @@ def main(argv: list[str] | None = None) -> int:
     _preparse_environment(argv_list)
 
     from .lives import (
+        archive_life,
         bootstrap_life,
+        clone_life,
         delete_life,
         get_registry_root,
         load_registry,
+        memorialize_life,
         resolve_life,
         uninstall_singular,
     )
@@ -743,6 +746,24 @@ def main(argv: list[str] | None = None) -> int:
         "delete", help="Delete a life and its data"
     )
     lives_delete.add_argument("name", help="Slug or name of the life to delete")
+    lives_archive = lives_subparsers.add_parser(
+        "archive", help="Archive a life (status extinct) with guided next steps"
+    )
+    lives_archive.add_argument("name", help="Slug or name of the life to archive")
+    lives_memorial = lives_subparsers.add_parser(
+        "memorial", help="Write a memorial message for a life"
+    )
+    lives_memorial.add_argument("name", help="Slug or name of the life")
+    lives_memorial.add_argument(
+        "--message",
+        default="Merci pour ce cycle de vie.",
+        help="Message à inscrire dans le mémorial",
+    )
+    lives_clone = lives_subparsers.add_parser(
+        "clone", help="Clone a life to a new life with guided next steps"
+    )
+    lives_clone.add_argument("name", help="Slug or name of the source life")
+    lives_clone.add_argument("--new-name", default=None, help="Nom de la nouvelle vie")
 
     values_parser = subparsers.add_parser("values", help="Inspecter les poids de valeurs")
     values_subparsers = values_parser.add_subparsers(dest="values_command", required=True)
@@ -1136,6 +1157,28 @@ def main(argv: list[str] | None = None) -> int:
                 os.environ["SINGULAR_HOME"] = str(next_life)
             else:
                 os.environ.pop("SINGULAR_HOME", None)
+        elif args.lives_command == "archive":
+            try:
+                metadata = archive_life(args.name)
+            except KeyError as exc:
+                raise SystemExit(f"Vie introuvable: {args.name}") from exc
+            print(f"Vie archivée: {metadata.name} ({metadata.slug}) → statut={metadata.status}")
+            print("Conseil: exécutez `singular lives memorial <vie> --message \"...\"`.")
+        elif args.lives_command == "memorial":
+            try:
+                memorial_path = memorialize_life(args.name, message=args.message)
+            except KeyError as exc:
+                raise SystemExit(f"Vie introuvable: {args.name}") from exc
+            print(f"Mémorial enregistré: {memorial_path}")
+            print("Conseil: exécutez `singular lives clone <vie> --new-name \"...\"`.")
+        elif args.lives_command == "clone":
+            try:
+                metadata = clone_life(args.name, new_name=args.new_name)
+            except KeyError as exc:
+                raise SystemExit(f"Vie introuvable: {args.name}") from exc
+            os.environ["SINGULAR_HOME"] = str(metadata.path)
+            print(f"Vie clonée: {metadata.name} ({metadata.slug}) → {metadata.path}")
+            print("Conseil: exécutez `singular status --verbose` puis `singular loop --budget-seconds 10`.")
 
     elif args.command == "values":
         _ensure_active_life(resolve_life, args.life)

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from singular.lives import get_registry_root, load_registry, set_life_status
+from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
 
 from singular.dashboard.actions import DashboardActionService
@@ -412,6 +413,13 @@ def create_app(
                 ],
                 "global_status": "unknown",
                 "autonomy_metrics": {},
+                "vital_timeline": compute_vital_timeline(
+                    age=0,
+                    current_health=None,
+                    failure_rate=None,
+                    failure_streak=0,
+                    extinction_seen=False,
+                ),
             }
             return empty
 
@@ -496,6 +504,24 @@ def create_app(
             global_status = "stable"
 
         autonomy_metrics = compute_autonomy_metrics(records)
+        failure_streak = 0
+        max_failure_streak = 0
+        for rec in records:
+            accepted = rec.get("accepted")
+            if not isinstance(accepted, bool):
+                accepted = rec.get("ok")
+            if accepted is False:
+                failure_streak += 1
+                max_failure_streak = max(max_failure_streak, failure_streak)
+            elif accepted is True:
+                failure_streak = 0
+        vital_timeline = compute_vital_timeline(
+            age=len(mutations),
+            current_health=health_score,
+            failure_rate=(1 - accepted_rate) if accepted_rate is not None else None,
+            failure_streak=max_failure_streak,
+            extinction_seen=any(rec.get("event") == "death" for rec in records),
+        )
 
         return {
             "run": latest.stem,
@@ -508,6 +534,7 @@ def create_app(
             "suggested_actions": suggested_actions,
             "global_status": global_status,
             "autonomy_metrics": autonomy_metrics,
+            "vital_timeline": vital_timeline,
         }
 
 
@@ -1006,6 +1033,14 @@ def create_app(
                 "has_recent_activity": last_timestamp is not None,
                 "extinction_seen_in_runs": extinction_seen,
                 "run_terminated": run_terminated,
+                "vital_timeline": compute_vital_timeline(
+                    age=len(mutation_records),
+                    current_health=current_health_score,
+                    failure_rate=failure_rate,
+                    failure_streak=0,
+                    extinction_seen=extinction_seen,
+                    registry_status=registry_status,
+                ),
             }
         unattached_summary = {
             "records_count": sum(unattached_runs.values()),

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -65,6 +65,12 @@ class DashboardActionService:
                 result = self._lives_list(params)
             elif action == "lives_use":
                 result = self._lives_use(params)
+            elif action == "archive":
+                result = self._archive(params)
+            elif action == "memorial":
+                result = self._memorial(params)
+            elif action == "clone":
+                result = self._clone(params)
             else:
                 payload = ActionResult(
                     ok=False,
@@ -256,3 +262,60 @@ class DashboardActionService:
 
         data, log = self._capture(_run)
         return ActionResult(ok=True, action="lives_use", data=data, log=log)
+
+    def _archive(self, params: dict[str, Any]) -> ActionResult:
+        name = self._require_non_empty_text(params.get("name"), field="name", max_len=80)
+        from singular.lives import archive_life
+
+        def _run() -> dict[str, Any]:
+            meta = archive_life(name)
+            return {
+                "name": meta.name,
+                "slug": meta.slug,
+                "status": meta.status,
+                "guided_message": "Vie archivée: statut extinct, prête pour memorial.",
+            }
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="archive", data=data, log=log)
+
+    def _memorial(self, params: dict[str, Any]) -> ActionResult:
+        name = self._require_non_empty_text(params.get("name"), field="name", max_len=80)
+        message = self._require_non_empty_text(
+            params.get("message", "Merci pour ce cycle de vie."),
+            field="message",
+            max_len=500,
+        )
+        from singular.lives import memorialize_life
+
+        def _run() -> dict[str, Any]:
+            path = memorialize_life(name, message=message)
+            return {
+                "name": name,
+                "memorial_path": str(path),
+                "guided_message": "Mémorial créé. Vous pouvez maintenant cloner cette vie.",
+            }
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="memorial", data=data, log=log)
+
+    def _clone(self, params: dict[str, Any]) -> ActionResult:
+        name = self._require_non_empty_text(params.get("name"), field="name", max_len=80)
+        new_name = params.get("new_name")
+        if new_name is not None:
+            new_name = self._require_non_empty_text(new_name, field="new_name", max_len=80)
+        from singular.lives import clone_life
+
+        def _run() -> dict[str, Any]:
+            meta = clone_life(name, new_name=new_name)
+            os.environ["SINGULAR_HOME"] = str(meta.path)
+            return {
+                "source": name,
+                "name": meta.name,
+                "slug": meta.slug,
+                "path": str(meta.path),
+                "guided_message": "Clone actif. Recommandé: lancer `status` puis `loop`.",
+            }
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="clone", data=data, log=log)

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -75,6 +75,13 @@
     <div class='card'><div class='card-label'>Latence perception→action</div><div id='kpi-autonomy-latency' class='card-value'>n/a</div></div>
     <div class='card'><div class='card-label'>Coût ressources par gain</div><div id='kpi-autonomy-cost' class='card-value'>n/a</div></div>
   </div>
+  <h3>Timeline vitale</h3>
+  <div class='cards-grid'>
+    <div class='card'><div class='card-label'>Âge</div><div id='kpi-vital-age' class='card-value'>0</div></div>
+    <div class='card'><div class='card-label'>Risque</div><div id='kpi-vital-risk' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label'>État terminal</div><div id='kpi-vital-terminal' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label'>Causes</div><div id='kpi-vital-causes' class='card-value'>n/a</div></div>
+  </div>
 
   <div class='panel'>
     <h3 style='margin-top:0;'>Synthèse des vies</h3>
@@ -197,6 +204,7 @@
     <label>Budget boucle (s) <input id='action-budget' type='number' min='0.1' step='0.1' value='1.0'/></label>
     <div style='display:flex;gap:8px;flex-wrap:wrap;'>
       <button id='act-birth'>Créer vie</button><button id='act-talk'>Discuter</button><button id='act-loop'>Boucle</button>
+      <button id='act-archive'>Archiver</button><button id='act-memorial'>Mémorial</button><button id='act-clone'>Cloner</button>
     </div>
     <details>
       <summary>Actions secondaires</summary>
@@ -291,6 +299,11 @@ const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=
   document.getElementById('kpi-autonomy-decision').textContent=`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`;
   document.getElementById('kpi-autonomy-latency').textContent=fmtNum(autonomy.perception_to_action_latency_ms,' ms');
   document.getElementById('kpi-autonomy-cost').textContent=fmtNum(autonomy.resource_cost_per_gain);
+  const vital=d.vital_timeline||{};
+  document.getElementById('kpi-vital-age').textContent=String(vital.age??0);
+  document.getElementById('kpi-vital-risk').textContent=String(vital.risk_level||'n/a');
+  document.getElementById('kpi-vital-terminal').textContent=vital.terminal===true?'oui':'non';
+  document.getElementById('kpi-vital-causes').textContent=(vital.causes||[]).join(', ')||'n/a';
   setStatusTone(document.getElementById('kpi-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
 
   const notable=d.last_notable_mutation;
@@ -323,6 +336,9 @@ document.getElementById('act-loop').onclick=()=>runAction('loop',{budget_seconds
 document.getElementById('act-report').onclick=()=>runAction('report',{});
 document.getElementById('act-lives-list').onclick=()=>runAction('lives_list',{});
 document.getElementById('act-lives-use').onclick=()=>runAction('lives_use',{name:document.getElementById('action-life-name').value||''});
+document.getElementById('act-archive').onclick=()=>runAction('archive',{name:document.getElementById('action-life-name').value||''});
+document.getElementById('act-memorial').onclick=()=>runAction('memorial',{name:document.getElementById('action-life-name').value||'',message:'Merci pour ce cycle de vie.'});
+document.getElementById('act-clone').onclick=()=>runAction('clone',{name:document.getElementById('action-life-name').value||'',new_name:`${document.getElementById('action-life-name').value||'Vie'} clone`});
 const badge=(label,bg)=>`<span style="display:inline-block;padding:2px 8px;border-radius:999px;background:${bg};margin-right:4px;">${label}</span>`;
 const renderLivesBuckets=(rows)=>{const activeInRegistry=(rows||[]).filter(row=>row.is_registry_active_life===true);const extinctInRuns=(rows||[]).filter(row=>row.extinction_seen_in_runs===true);const aliveList=document.getElementById('alive-lives');const deadList=document.getElementById('dead-lives');document.getElementById('alive-count').textContent=String(activeInRegistry.length);document.getElementById('dead-count').textContent=String(extinctInRuns.length);aliveList.innerHTML='';deadList.innerHTML='';for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||'n/a';aliveList.appendChild(li);}for(const row of extinctInRuns){const li=document.createElement('li');li.textContent=row.life||'n/a';deadList.appendChild(li);}if(!activeInRegistry.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);}if(!extinctInRuns.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);}};
 const renderLivesTable=(rows)=>{const body=document.getElementById('lives-table-body');body.innerHTML='';for(const row of rows||[]){const tr=document.createElement('tr');const score=row.current_health_score===null||row.current_health_score===undefined?'n/a':Number(row.current_health_score).toFixed(1);const stability=row.stability===null||row.stability===undefined?'n/a':`${(Number(row.stability)*100).toFixed(1)}%`;const lastActivity=row.last_activity||'n/a';let badges='';if(row.selected_life){badges+=badge('Vie sélectionnée','#d1fadf');}else{badges+=badge('Vie non sélectionnée','#fde2e1');}if(row.is_registry_active_life){badges+=badge('Vie active dans le registre','#d1fadf');}else{badges+=badge(`Statut registre: ${row.life_status||'n/a'}`,'#fde2e1');}if(row.run_terminated){badges+=badge('Run terminé','#ffe7c2');}if(row.extinction_seen_in_runs){badges+=badge('Extinction détectée','#fecdca');}if(row.has_recent_activity){badges+=badge('Activité récente','#d9ecff');}if(row.trend==='dégradation'){badges+=badge('dégradation','#ffe7c2');}if((row.alerts_count||0)>0){badges+=badge(`${row.alerts_count} alertes`,'#fecdca');}tr.innerHTML=`<td>${row.life||'n/a'}</td><td>${score}</td><td>${row.trend||'n/a'}</td><td>${stability}</td><td>${lastActivity}</td><td>${row.iterations??0}</td><td>${badges}</td>`;body.appendChild(tr);}if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}};

--- a/src/singular/life/vital.py
+++ b/src/singular/life/vital.py
@@ -1,0 +1,88 @@
+"""Deterministic and observable vital-state rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VitalThresholds:
+    decline_age: int = 50
+    terminal_age: int = 120
+    terminal_health: float = 25.0
+    high_failure_rate: float = 0.6
+    terminal_failure_streak: int = 5
+    reproduction_min_age: int = 3
+    reproduction_max_age: int = 80
+
+
+def compute_vital_timeline(
+    *,
+    age: int,
+    current_health: float | None,
+    failure_rate: float | None,
+    failure_streak: int,
+    extinction_seen: bool,
+    registry_status: str | None = None,
+    thresholds: VitalThresholds = VitalThresholds(),
+) -> dict[str, object]:
+    """Return an observable timeline payload from deterministic rules."""
+
+    causes: list[str] = []
+    if extinction_seen or registry_status == "extinct":
+        state = "extinct"
+        causes.append("extinction_observed")
+    else:
+        state = "mature"
+        if age >= thresholds.decline_age:
+            state = "declining"
+            causes.append("age_decline_threshold")
+        if failure_rate is not None and failure_rate >= thresholds.high_failure_rate:
+            state = "declining"
+            causes.append("high_failure_rate")
+        if age >= thresholds.terminal_age:
+            state = "terminal"
+            causes.append("terminal_age_reached")
+        if (
+            current_health is not None
+            and current_health <= thresholds.terminal_health
+        ):
+            state = "terminal"
+            causes.append("critical_health_score")
+        if failure_streak >= thresholds.terminal_failure_streak:
+            state = "terminal"
+            causes.append("failure_streak")
+
+    risk_level = "low"
+    if state in {"declining"}:
+        risk_level = "medium"
+    if state in {"terminal", "extinct"}:
+        risk_level = "high"
+
+    reproduction_eligible = (
+        state in {"mature", "declining"}
+        and thresholds.reproduction_min_age <= age <= thresholds.reproduction_max_age
+        and (failure_rate is None or failure_rate < thresholds.high_failure_rate)
+        and (current_health is None or current_health > thresholds.terminal_health)
+    )
+
+    return {
+        "age": age,
+        "state": state,
+        "risk_level": risk_level,
+        "terminal": state in {"terminal", "extinct"},
+        "causes": causes,
+        "reproduction_eligible": reproduction_eligible,
+        "thresholds": {
+            "decline_age": thresholds.decline_age,
+            "terminal_age": thresholds.terminal_age,
+            "terminal_health": thresholds.terminal_health,
+            "high_failure_rate": thresholds.high_failure_rate,
+            "terminal_failure_streak": thresholds.terminal_failure_streak,
+            "reproduction_age_window": [
+                thresholds.reproduction_min_age,
+                thresholds.reproduction_max_age,
+            ],
+        },
+    }
+

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -153,6 +153,36 @@ def _slugify(name: str) -> str:
     return slug or "life"
 
 
+def _resolve_life_metadata(name: str) -> tuple[dict[str, Any], str, LifeMetadata]:
+    """Resolve a life by slug or name and return ``(registry, slug, metadata)``."""
+
+    registry = load_registry()
+    lives: dict[str, LifeMetadata] = registry.setdefault("lives", {})
+    if not lives:
+        raise KeyError(name)
+
+    slug: str | None = None
+    metadata: LifeMetadata | None = None
+    if name in lives:
+        slug = name
+        metadata = lives[name]
+    else:
+        candidate = _slugify(name)
+        if candidate in lives:
+            slug = candidate
+            metadata = lives[candidate]
+        else:
+            for candidate_slug, meta in lives.items():
+                if meta.name == name:
+                    slug = candidate_slug
+                    metadata = meta
+                    break
+
+    if slug is None or metadata is None:
+        raise KeyError(name)
+    return registry, slug, metadata
+
+
 def create_life(name: str) -> LifeMetadata:
     """Create a new life directory and register it."""
 
@@ -237,30 +267,8 @@ def bootstrap_life(name: str, seed: int | None = None) -> LifeMetadata:
 def delete_life(name: str) -> LifeMetadata:
     """Remove a life from the registry and delete its directory."""
 
-    registry = load_registry()
+    registry, slug, metadata = _resolve_life_metadata(name)
     lives: dict[str, LifeMetadata] = registry.setdefault("lives", {})
-    if not lives:
-        raise KeyError(name)
-
-    slug: str | None = None
-    metadata: LifeMetadata | None = None
-    if name in lives:
-        slug = name
-        metadata = lives[name]
-    else:
-        candidate = _slugify(name)
-        if candidate in lives:
-            slug = candidate
-            metadata = lives[candidate]
-        else:
-            for candidate_slug, meta in lives.items():
-                if meta.name == name:
-                    slug = candidate_slug
-                    metadata = meta
-                    break
-
-    if slug is None or metadata is None:
-        raise KeyError(name)
 
     try:
         shutil.rmtree(metadata.path)
@@ -273,6 +281,47 @@ def delete_life(name: str) -> LifeMetadata:
     save_registry(registry)
 
     return metadata
+
+
+def archive_life(name: str) -> LifeMetadata:
+    """Mark a life as extinct and return its metadata."""
+
+    registry, slug, metadata = _resolve_life_metadata(name)
+    metadata.status = "extinct"
+    if registry.get("active") == slug:
+        registry["active"] = next((key for key in registry["lives"] if key != slug), None)
+    save_registry(registry)
+    return metadata
+
+
+def memorialize_life(name: str, *, message: str) -> Path:
+    """Write a memorial note for a life and return the created file path."""
+
+    _, _, metadata = _resolve_life_metadata(name)
+    memorial_dir = metadata.path / "mem"
+    memorial_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).isoformat()
+    memorial_file = memorial_dir / "memorial.json"
+    payload = {"life": metadata.slug, "written_at": stamp, "message": message.strip()}
+    memorial_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return memorial_file
+
+
+def clone_life(name: str, *, new_name: str | None = None) -> LifeMetadata:
+    """Clone an existing life to a fresh life entry."""
+
+    _, _, source = _resolve_life_metadata(name)
+    clone_name = new_name or f"{source.name} clone"
+    clone_meta = create_life(clone_name)
+    shutil.copytree(source.path, clone_meta.path, dirs_exist_ok=True)
+    registry = load_registry()
+    lives: dict[str, LifeMetadata] = registry.get("lives", {})
+    current = lives.get(clone_meta.slug)
+    if current is not None:
+        current.status = "active"
+    registry["active"] = clone_meta.slug
+    save_registry(registry)
+    return lives.get(clone_meta.slug, clone_meta)
 
 
 def _remove_tree(path: Path) -> None:

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 from ..life.health import detect_health_state
+from ..life.vital import compute_vital_timeline
 from ..metrics.autonomy import compute_autonomy_metrics
 from ..psyche import Psyche
 from ..memory import get_mem_dir
@@ -73,6 +74,15 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "traits": {},
         "autonomy_metrics": {},
         "quests": {"active": [], "completed": []},
+        "vital_timeline": {
+            "age": 0,
+            "state": "mature",
+            "risk_level": "low",
+            "terminal": False,
+            "causes": [],
+            "reproduction_eligible": False,
+            "thresholds": {},
+        },
     }
     runs_dir = Path(RUNS_DIR)
     files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
@@ -123,6 +133,24 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                     "window": "10/50",
                 }
             payload["autonomy_metrics"] = compute_autonomy_metrics(records)
+            failure_streak = 0
+            max_failure_streak = 0
+            for rec in records:
+                accepted = rec.get("accepted")
+                if not isinstance(accepted, bool):
+                    accepted = rec.get("ok")
+                if accepted is False:
+                    failure_streak += 1
+                    max_failure_streak = max(max_failure_streak, failure_streak)
+                elif accepted is True:
+                    failure_streak = 0
+            payload["vital_timeline"] = compute_vital_timeline(
+                age=mutation_count,
+                current_health=health_scores[-1] if health_scores else None,
+                failure_rate=(1 - (ok_count / len(success_records))) if success_records else None,
+                failure_streak=max_failure_streak,
+                extinction_seen=any(r.get("event") == "death" for r in records),
+            )
             if verbose:
                 alerts = alerts_from_records(records)
                 payload["alerts"] = alerts
@@ -179,6 +207,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             ["Mood", str(payload.get("mood"))],
             ["Quêtes actives", str(len((payload.get("quests") or {}).get("active", [])))],
             ["Quêtes terminées", str(len((payload.get("quests") or {}).get("completed", [])))],
+            ["Âge vital", str((payload.get("vital_timeline") or {}).get("age", 0))],
+            ["État vital", str((payload.get("vital_timeline") or {}).get("state", "n/a"))],
+            ["Risque vital", str((payload.get("vital_timeline") or {}).get("risk_level", "n/a"))],
         ]
         _print_table(["Metric", "Value"], run_rows)
         if verbose:
@@ -218,6 +249,13 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         )
         print(f"Latence perception→action: {_fmt_number(autonomy.get('perception_to_action_latency_ms'), ' ms')}")
         print(f"Coût ressources par gain: {_fmt_number(autonomy.get('resource_cost_per_gain'))}")
+        vital = payload.get("vital_timeline") if isinstance(payload.get("vital_timeline"), dict) else {}
+        print(f"Âge vital: {vital.get('age', 0)}")
+        print(f"État vital: {vital.get('state', 'n/a')}")
+        print(f"Risque vital: {vital.get('risk_level', 'n/a')}")
+        causes = vital.get("causes")
+        if isinstance(causes, list) and causes:
+            print(f"Causes observées: {', '.join(str(c) for c in causes)}")
         health = payload.get("health")
         if isinstance(health, dict):
             print(

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -184,3 +184,40 @@ def test_birth_prints_registry_root_used(
     out = capsys.readouterr().out
     assert "Registre de vies utilisé:" in out
     assert str(root.resolve()) in out
+
+
+def test_lives_archive_memorial_clone_guided_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "guided"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+    capsys.readouterr()
+    main(["--root", str(root), "lives", "archive", "alpha"])
+    archive_out = capsys.readouterr().out
+    assert "Vie archivée" in archive_out
+    assert "singular lives memorial" in archive_out
+
+    main(
+        [
+            "--root",
+            str(root),
+            "lives",
+            "memorial",
+            "alpha",
+            "--message",
+            "Merci Alpha",
+        ]
+    )
+    memorial_out = capsys.readouterr().out
+    assert "Mémorial enregistré" in memorial_out
+    assert (root / "lives" / "alpha" / "mem" / "memorial.json").exists()
+
+    main(["--root", str(root), "lives", "clone", "alpha", "--new-name", "Alpha 2"])
+    clone_out = capsys.readouterr().out
+    assert "Vie clonée" in clone_out
+    assert "singular status --verbose" in clone_out

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -190,6 +190,8 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert "health_score" in payload
     assert "accepted_mutation_rate" in payload
     assert "last_notable_mutation" in payload
+    assert "vital_timeline" in payload
+    assert "state" in payload["vital_timeline"]
     assert "autonomy_metrics" in payload
     assert "proactive_initiative_rate" in payload["autonomy_metrics"]
 
@@ -818,6 +820,9 @@ def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: py
     assert "action-result" in body
     assert "Créer vie" in body
     assert "Discuter" in body
+    assert "Archiver" in body
+    assert "Mémorial" in body
+    assert "Cloner" in body
 
     ok = app._routes["/api/actions/{action}"]("lives_list", token="secret", payload="{}")
     assert ok["ok"] is True

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -108,6 +108,8 @@ def test_status_filters_non_mutation_records_for_success_rate(
     assert payload["mutation_count"] == 3
     assert payload["mutation_success_rate"] == 50.0
     assert payload["success_rate"] == 50.0
+    assert payload["vital_timeline"]["age"] == 3
+    assert payload["vital_timeline"]["state"] in {"mature", "declining", "terminal", "extinct"}
     assert "autonomy_metrics" in payload
     assert "proactive_initiative_rate" in payload["autonomy_metrics"]
 

--- a/tests/test_vital_transitions.py
+++ b/tests/test_vital_transitions.py
@@ -1,0 +1,67 @@
+from singular.life.vital import compute_vital_timeline
+
+
+def test_vital_transition_to_declining_on_age_threshold() -> None:
+    payload = compute_vital_timeline(
+        age=50,
+        current_health=80.0,
+        failure_rate=0.2,
+        failure_streak=0,
+        extinction_seen=False,
+    )
+    assert payload["state"] == "declining"
+    assert "age_decline_threshold" in payload["causes"]
+
+
+def test_vital_transition_to_terminal_on_failure_streak() -> None:
+    payload = compute_vital_timeline(
+        age=20,
+        current_health=70.0,
+        failure_rate=0.4,
+        failure_streak=5,
+        extinction_seen=False,
+    )
+    assert payload["state"] == "terminal"
+    assert payload["terminal"] is True
+    assert "failure_streak" in payload["causes"]
+
+
+def test_vital_transition_to_extinct_preempts_other_states() -> None:
+    payload = compute_vital_timeline(
+        age=1,
+        current_health=99.0,
+        failure_rate=0.0,
+        failure_streak=0,
+        extinction_seen=True,
+    )
+    assert payload["state"] == "extinct"
+    assert payload["risk_level"] == "high"
+    assert payload["causes"] == ["extinction_observed"]
+
+
+def test_vital_reproduction_window_boundary_conditions() -> None:
+    too_young = compute_vital_timeline(
+        age=2,
+        current_health=80.0,
+        failure_rate=0.2,
+        failure_streak=0,
+        extinction_seen=False,
+    )
+    eligible = compute_vital_timeline(
+        age=3,
+        current_health=80.0,
+        failure_rate=0.2,
+        failure_streak=0,
+        extinction_seen=False,
+    )
+    too_old = compute_vital_timeline(
+        age=81,
+        current_health=80.0,
+        failure_rate=0.2,
+        failure_streak=0,
+        extinction_seen=False,
+    )
+    assert too_young["reproduction_eligible"] is False
+    assert eligible["reproduction_eligible"] is True
+    assert too_old["reproduction_eligible"] is False
+


### PR DESCRIPTION
### Motivation
- Formaliser des règles déterministes et observables pour l’âge, le déclin, l’extinction et la reproduction afin d’avoir des indicateurs clairs et traçables pour chaque vie. 
- Exposer ces règles dans l’API et l’UI (status / cockpit) pour rendre les décisions opérationnelles et guidées. 
- Fournir des commandes d’accompagnement (`archive`, `memorial`, `clone`) pour des flux de fin de vie/clonage explicites et reproductibles.

### Description
- Ajout d’une spécification métier dans `docs/vital_lifecycle_rules.md` décrivant variables, seuils, priorités de transition et règles d’éligibilité reproduction. 
- Implémentation de `compute_vital_timeline` dans `src/singular/life/vital.py` retournant un payload observable (`age`, `state`, `risk_level`, `terminal`, `causes`, `reproduction_eligible`, `thresholds`). 
- Enrichissement de la commande `status` et du cockpit (`/api/cockpit`, lives comparison) pour calculer et exposer la `vital_timeline` (fichiers modifiés : `src/singular/organisms/status.py`, `src/singular/dashboard/__init__.py`, dashboard template). 
- Ajout de commandes CLI et actions dashboard guidées : `singular lives archive|memorial|clone` et boutons/actions correspondants dans le dashboard (`src/singular/cli.py`, `src/singular/dashboard/actions.py`, `src/singular/dashboard/templates/dashboard.html`), et utilities dans `src/singular/lives.py` (`archive_life`, `memorialize_life`, `clone_life`). 
- Ajout de tests couvrant les transitions vitales et les scénarios limites ainsi que mises à jour des tests existants pour valider l’intégration (nouveaux fichiers : `tests/test_vital_transitions.py`, mises à jour de `tests/test_status.py`, `tests/test_cli_lives.py`, `tests/test_dashboard.py`).

### Testing
- Vérification de syntaxe avec `python -m py_compile` sur les modules modifiés, qui a réussi. 
- Exécution ciblée des tests modifiés/ajoutés avec `pytest -q tests/test_vital_transitions.py tests/test_status.py tests/test_cli_lives.py tests/test_dashboard.py`, résultat : `35 passed, 1 warning`.
- Les modifications ont été commitées sous le message : "Add deterministic vital lifecycle rules and guided lifecycle commands".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf1b6e35c832ab41f667af667b112)