### PR TITLE
Ajouter panneaux vitaux et filtres temporels / multi‑vies au dashboard

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 from collections import Counter
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 import os
 import sys
 from pathlib import Path
@@ -305,6 +305,17 @@ def create_app(
         except ValueError:
             return None
 
+    def _resolve_time_window_cutoff(time_window: str) -> datetime | None:
+        normalized = time_window.strip().lower()
+        now = datetime.now(timezone.utc)
+        if normalized == "24h":
+            return now - timedelta(hours=24)
+        if normalized == "7d":
+            return now - timedelta(days=7)
+        if normalized == "30d":
+            return now - timedelta(days=30)
+        return None
+
     def _event_type(record: dict[str, object]) -> str | None:
         event = record.get("event")
         if isinstance(event, str):
@@ -413,6 +424,24 @@ def create_app(
                 ],
                 "global_status": "unknown",
                 "autonomy_metrics": {},
+                "vital_metrics": {
+                    "circadian_cycle": {"phase": "indéterminée", "hour_utc": None},
+                    "active_objectives": {"count": 0, "items": []},
+                    "energy_resources": {
+                        "total_energy": 0.0,
+                        "total_resources": 0.0,
+                        "alive_organisms": 0,
+                        "total_organisms": 0,
+                    },
+                    "code_generation": {
+                        "progression": "n/a",
+                        "accepted": 0,
+                        "rejected": 0,
+                        "success_rate": None,
+                        "risk_level": "n/a",
+                    },
+                    "risks": [],
+                },
                 "vital_timeline": compute_vital_timeline(
                     age=0,
                     current_health=None,
@@ -504,6 +533,40 @@ def create_app(
             global_status = "stable"
 
         autonomy_metrics = compute_autonomy_metrics(records)
+        ecosystem = _compute_ecosystem(current_life_only=current_life_only)
+        summary = ecosystem.get("summary", {}) if isinstance(ecosystem, dict) else {}
+
+        hour_utc = datetime.now(timezone.utc).hour
+        if 5 <= hour_utc < 12:
+            circadian_phase = "matin"
+        elif 12 <= hour_utc < 18:
+            circadian_phase = "jour"
+        elif 18 <= hour_utc < 23:
+            circadian_phase = "soir"
+        else:
+            circadian_phase = "nuit"
+
+        active_objectives: list[dict[str, object]] = []
+        if quests_path.exists():
+            try:
+                quests_data = json.loads(quests_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                quests_data = {}
+            if isinstance(quests_data, dict):
+                raw_active = quests_data.get("active")
+                if isinstance(raw_active, list):
+                    for entry in raw_active:
+                        if isinstance(entry, dict):
+                            active_objectives.append(entry)
+
+        accepted_count = sum(1 for value in accepted_values if value is True)
+        rejected_count = sum(1 for value in accepted_values if value is False)
+        code_risk = "faible"
+        if critical_alerts:
+            code_risk = "élevé"
+        elif trend == "dégradation" or (accepted_rate is not None and accepted_rate < 0.5):
+            code_risk = "modéré"
+
         failure_streak = 0
         max_failure_streak = 0
         for rec in records:
@@ -534,6 +597,27 @@ def create_app(
             "suggested_actions": suggested_actions,
             "global_status": global_status,
             "autonomy_metrics": autonomy_metrics,
+            "vital_metrics": {
+                "circadian_cycle": {"phase": circadian_phase, "hour_utc": hour_utc},
+                "active_objectives": {
+                    "count": len(active_objectives),
+                    "items": active_objectives[:5],
+                },
+                "energy_resources": {
+                    "total_energy": float(summary.get("total_energy", 0.0) or 0.0),
+                    "total_resources": float(summary.get("total_resources", 0.0) or 0.0),
+                    "alive_organisms": int(summary.get("alive_organisms", 0) or 0),
+                    "total_organisms": int(summary.get("total_organisms", 0) or 0),
+                },
+                "code_generation": {
+                    "progression": trend,
+                    "accepted": accepted_count,
+                    "rejected": rejected_count,
+                    "success_rate": accepted_rate,
+                    "risk_level": code_risk,
+                },
+                "risks": [str(alert.get("kind", "")) for alert in critical_alerts],
+            },
             "vital_timeline": vital_timeline,
         }
 
@@ -903,17 +987,27 @@ def create_app(
         return None, None
 
     def _aggregate_lives(
+        *,
         current_life_only: bool = False,
+        compare_lives: set[str] | None = None,
+        time_window: str = "all",
     ) -> tuple[dict[str, dict[str, object]], dict[str, object]]:
         registry = load_registry()
         active_life = registry.get("active")
         registry_lives = registry.get("lives")
         if not isinstance(registry_lives, dict):
             registry_lives = {}
+        cutoff = _resolve_time_window_cutoff(time_window)
         by_life: dict[str, list[dict[str, object]]] = {}
         unattached_runs: dict[str, int] = {}
         for record in _load_run_records(current_life_only=current_life_only):
+            if cutoff is not None:
+                ts = _parse_ts(record.get("ts"))
+                if ts is None or ts < cutoff:
+                    continue
             life_name = _record_life(record)
+            if compare_lives and life_name != "unknown" and life_name not in compare_lives:
+                continue
             if life_name == "unknown":
                 run_id = _record_run_id(record)
                 unattached_runs[run_id] = unattached_runs.get(run_id, 0) + 1
@@ -1059,9 +1153,22 @@ def create_app(
         active_only: bool = False,
         degrading_only: bool = False,
         dead_only: bool = False,
+        time_window: str = "all",
+        compare_lives: str | None = None,
         current_life_only: bool = False,
     ) -> dict[str, object]:
-        comparison, unattached = _aggregate_lives(current_life_only=current_life_only)
+        compare_set: set[str] | None = None
+        if isinstance(compare_lives, str) and compare_lives.strip():
+            compare_set = {
+                part.strip()
+                for part in compare_lives.split(",")
+                if part.strip()
+            }
+        comparison, unattached = _aggregate_lives(
+            current_life_only=current_life_only,
+            compare_lives=compare_set,
+            time_window=time_window,
+        )
         lives_rows = [{"life": name, **payload} for name, payload in comparison.items()]
 
         if active_only:
@@ -1104,6 +1211,8 @@ def create_app(
                 "active_only": active_only,
                 "degrading_only": degrading_only,
                 "dead_only": dead_only,
+                "time_window": time_window,
+                "compare_lives": sorted(compare_set) if compare_set else [],
             },
         }
 

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -5,6 +5,7 @@ import json
 import os
 from contextlib import redirect_stdout
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -39,11 +40,88 @@ class DashboardActionService:
         else:
             self.home = Path(os.environ.get("SINGULAR_HOME", self.root))
 
-    def _context_payload(self) -> dict[str, str]:
+    def _context_payload(self) -> dict[str, Any]:
         current_home = Path(os.environ.get("SINGULAR_HOME", str(self.home)))
+        runs_dir = current_home / "runs"
+        vital_metrics = self._consolidated_vital_metrics(runs_dir=runs_dir)
         return {
             "registry_root": str(self.root),
             "current_life_home": str(current_home),
+            "vital_metrics": vital_metrics,
+        }
+
+    def _consolidated_vital_metrics(self, *, runs_dir: Path) -> dict[str, Any]:
+        if not runs_dir.exists():
+            return {
+                "health_score": None,
+                "accepted_mutation_rate": None,
+                "circadian_phase": "indéterminée",
+                "risk_level": "n/a",
+            }
+        latest_file: Path | None = None
+        latest_mtime = -1
+        for file in runs_dir.iterdir():
+            if not file.is_file() or file.suffix != ".jsonl":
+                continue
+            mtime = file.stat().st_mtime_ns
+            if mtime > latest_mtime:
+                latest_file = file
+                latest_mtime = mtime
+        if latest_file is None:
+            return {
+                "health_score": None,
+                "accepted_mutation_rate": None,
+                "circadian_phase": "indéterminée",
+                "risk_level": "n/a",
+            }
+        records: list[dict[str, Any]] = []
+        for line in latest_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                records.append(payload)
+        accepted_values: list[bool] = []
+        health_scores: list[float] = []
+        for record in records:
+            accepted = record.get("accepted")
+            if not isinstance(accepted, bool):
+                accepted = record.get("ok")
+            if isinstance(accepted, bool):
+                accepted_values.append(accepted)
+            health = record.get("health")
+            if isinstance(health, dict):
+                score = health.get("score")
+                if isinstance(score, (int, float)):
+                    health_scores.append(float(score))
+        accepted_rate = (
+            sum(1 for value in accepted_values if value) / len(accepted_values)
+            if accepted_values
+            else None
+        )
+        risk_level = "faible"
+        if accepted_rate is not None and accepted_rate < 0.5:
+            risk_level = "élevé"
+        elif accepted_rate is None:
+            risk_level = "n/a"
+        hour_utc = datetime.now(timezone.utc).hour
+        if 5 <= hour_utc < 12:
+            circadian_phase = "matin"
+        elif 12 <= hour_utc < 18:
+            circadian_phase = "jour"
+        elif 18 <= hour_utc < 23:
+            circadian_phase = "soir"
+        else:
+            circadian_phase = "nuit"
+        return {
+            "health_score": health_scores[-1] if health_scores else None,
+            "accepted_mutation_rate": accepted_rate,
+            "circadian_phase": circadian_phase,
+            "risk_level": risk_level,
         }
 
     def validate_token(self, token: str | None) -> None:

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -94,6 +94,27 @@
     </div>
   </div>
 
+
+  <div class='panel'>
+    <h3 style='margin-top:0;'>Cycle circadien & objectifs actifs</h3>
+    <div class='cards-grid'>
+      <div class='card'><div class='card-label'>Phase circadienne</div><div id='kpi-circadian-phase' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label'>Objectifs actifs</div><div id='kpi-active-objectives-count' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Progression quêtes</div><div id='kpi-quests-progress' class='card-value'>n/a</div></div>
+    </div>
+    <ul id='kpi-active-objectives-list' style='margin-top:6px;'></ul>
+  </div>
+
+  <div class='panel'>
+    <h3 style='margin-top:0;'>Énergie / ressources & génération de code</h3>
+    <div class='cards-grid'>
+      <div class='card'><div class='card-label'>Énergie totale</div><div id='kpi-energy-total' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Ressources totales</div><div id='kpi-resources-total' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Progression génération code</div><div id='kpi-code-progression' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label'>Risques</div><div id='kpi-code-risks' class='card-value'>n/a</div></div>
+    </div>
+  </div>
+
   <div class='panel'>
     <h3 style='margin-top:0;'>Dernière mutation notable</h3>
     <div id='kpi-notable-summary'>Aucune mutation notable</div>
@@ -167,6 +188,15 @@
     <label><input id='filter-active' type='checkbox'/> Statut registre: active</label>
     <label><input id='filter-degrading' type='checkbox'/> Seulement en dégradation</label>
     <label><input id='filter-dead' type='checkbox'/> Extinction détectée</label>
+    <label>Fenêtre temporelle
+      <select id='filter-time-window'>
+        <option value='all'>Toutes</option>
+        <option value='24h'>24h</option>
+        <option value='7d'>7 jours</option>
+        <option value='30d'>30 jours</option>
+      </select>
+    </label>
+    <label>Comparer vies (CSV) <input id='filter-compare-lives' placeholder='life-a,life-b'/></label>
   </div>
   <div style='display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-top:8px;'>
     <div style='border:1px solid #ddd;border-radius:8px;padding:8px;'>
@@ -304,10 +334,30 @@ const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=
   document.getElementById('kpi-autonomy-latency').textContent=fmtNum(autonomy.perception_to_action_latency_ms,' ms');
   document.getElementById('kpi-autonomy-cost').textContent=fmtNum(autonomy.resource_cost_per_gain);
   const vital=d.vital_timeline||{};
+  const vitalMetrics=d.vital_metrics||{};
+  const objectives=vitalMetrics.active_objectives||{};
+  const energyResources=vitalMetrics.energy_resources||{};
+  const codeGeneration=vitalMetrics.code_generation||{};
+  const risks=vitalMetrics.risks||[];
   document.getElementById('kpi-vital-age').textContent=String(vital.age??0);
   document.getElementById('kpi-vital-risk').textContent=String(vital.risk_level||'n/a');
   document.getElementById('kpi-vital-terminal').textContent=vital.terminal===true?'oui':'non';
   document.getElementById('kpi-vital-causes').textContent=(vital.causes||[]).join(', ')||'n/a';
+  document.getElementById('kpi-circadian-phase').textContent=String((vitalMetrics.circadian_cycle||{}).phase||'n/a');
+  document.getElementById('kpi-active-objectives-count').textContent=String(objectives.count||0);
+  document.getElementById('kpi-quests-progress').textContent=`${objectives.count||0} actifs`;
+  document.getElementById('kpi-energy-total').textContent=fmtNum(energyResources.total_energy);
+  document.getElementById('kpi-resources-total').textContent=fmtNum(energyResources.total_resources);
+  document.getElementById('kpi-code-progression').textContent=String(codeGeneration.progression||'n/a');
+  document.getElementById('kpi-code-risks').textContent=risks.length?risks.join(', '):String(codeGeneration.risk_level||'n/a');
+  const objectivesList=document.getElementById('kpi-active-objectives-list');
+  objectivesList.innerHTML='';
+  for(const item of (objectives.items||[])){
+    const li=document.createElement('li');
+    li.textContent=String(item.name||item.id||'objectif');
+    objectivesList.appendChild(li);
+  }
+  if(!(objectives.items||[]).length){const li=document.createElement('li');li.textContent='Aucun objectif actif';objectivesList.appendChild(li);}
   setStatusTone(document.getElementById('kpi-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
 
   const notable=d.last_notable_mutation;
@@ -349,11 +399,13 @@ const renderLivesTable=(rows)=>{const body=document.getElementById('lives-table-
 const renderUnattachedRuns=(payload)=>{const panel=document.getElementById('unattached-runs-panel');const list=document.getElementById('unattached-runs-list');const runs=(payload?.runs)||[];const runsCount=Number(payload?.runs_count||0);const recordsCount=Number(payload?.records_count||0);document.getElementById('unattached-runs-count').textContent=String(runsCount);document.getElementById('unattached-records-count').textContent=String(recordsCount);list.innerHTML='';if(!runsCount){panel.style.display='none';return;}panel.style.display='block';for(const item of runs){const li=document.createElement('li');li.textContent=`${item.run_id||'unknown'} · ${item.records_count||0} enregistrements`;list.appendChild(li);}};
 const renderGenealogyTree=(payload)=>{const nodes=payload?.nodes||[];const treeEl=document.getElementById('genealogy-tree');if(!nodes.length){treeEl.textContent='Aucune lignée enregistrée.';return;}const bySlug=new Map(nodes.map(node=>[node.slug,node]));const children=new Map();for(const node of nodes){children.set(node.slug,[]);}for(const node of nodes){for(const parent of (node.parents||[])){if(children.has(parent)){children.get(parent).push(node.slug);}}}const roots=nodes.filter(node=>(node.parents||[]).length===0).map(node=>node.slug);const lines=[];const visit=(slug,depth)=>{const node=bySlug.get(slug);if(!node){return;}const marker=node.active?'★':'•';const status=node.status==='extinct'?'✝':'✓';lines.push(`${'  '.repeat(depth)}${marker} ${node.name} (${node.slug}) [${status}]`);for(const child of (children.get(slug)||[])){visit(child,depth+1);}};for(const root of roots){visit(root,0);}const detached=nodes.filter(node=>!roots.includes(node.slug)&&!(node.parents||[]).every(parent=>bySlug.has(parent)));for(const node of detached){lines.push(`• ${node.name} (${node.slug}) [orphan]`);}treeEl.textContent=lines.join('\n');};
 const loadGenealogy=()=>fetch('/lives/genealogy').then(r=>r.json()).then(renderGenealogyTree).catch(()=>{document.getElementById('genealogy-tree').textContent='Impossible de charger la généalogie.';});
-const loadLivesBoard=()=>{const q=new URLSearchParams();q.set('sort_by',livesTableState.sortBy);q.set('sort_order',livesTableState.sortOrder);if(document.getElementById('filter-active').checked){q.set('active_only','true');}if(document.getElementById('filter-degrading').checked){q.set('degrading_only','true');}if(document.getElementById('filter-dead').checked){q.set('dead_only','true');}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}return fetch(`/lives/comparison?${q.toString()}`).then(r=>r.json()).then(d=>{renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})));renderLivesTable(d.table||[]);renderUnattachedRuns(d.unattached_runs);});};
+const loadLivesBoard=()=>{const q=new URLSearchParams();q.set('sort_by',livesTableState.sortBy);q.set('sort_order',livesTableState.sortOrder);if(document.getElementById('filter-active').checked){q.set('active_only','true');}if(document.getElementById('filter-degrading').checked){q.set('degrading_only','true');}if(document.getElementById('filter-dead').checked){q.set('dead_only','true');}const timeWindow=document.getElementById('filter-time-window').value||'all';q.set('time_window',timeWindow);const compareLives=(document.getElementById('filter-compare-lives').value||'').trim();if(compareLives){q.set('compare_lives',compareLives);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}return fetch(`/lives/comparison?${q.toString()}`).then(r=>r.json()).then(d=>{renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})));renderLivesTable(d.table||[]);renderUnattachedRuns(d.unattached_runs);});};
 for(const button of document.querySelectorAll('#lives-table [data-sort]')){button.onclick=()=>{const next=button.getAttribute('data-sort');if(livesTableState.sortBy===next){livesTableState.sortOrder=livesTableState.sortOrder==='desc'?'asc':'desc';}else{livesTableState.sortBy=next;livesTableState.sortOrder='desc';}loadLivesBoard();};}
 document.getElementById('filter-active').onchange=()=>loadLivesBoard();
 document.getElementById('filter-degrading').onchange=()=>loadLivesBoard();
 document.getElementById('filter-dead').onchange=()=>loadLivesBoard();
+document.getElementById('filter-time-window').onchange=()=>loadLivesBoard();
+document.getElementById('filter-compare-lives').onchange=()=>loadLivesBoard();
 const renderLiveEvents=()=>{const pre=document.getElementById('live-events');const rows=liveState.events.map(item=>`${item.ts||'n/a'} | ${item.run_id||'n/a'} | ${item.event||'unknown'}`);pre.textContent=rows.join('\n');if(liveState.autoScroll){pre.scrollTop=pre.scrollHeight;}};
 const updateLiveStatus=()=>{document.getElementById('live-status').textContent=liveState.paused?'Pause activée':'Lecture en direct';document.getElementById('live-toggle').textContent=liveState.paused?'Reprendre':'Pause';};
 document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -194,6 +194,12 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert "state" in payload["vital_timeline"]
     assert "autonomy_metrics" in payload
     assert "proactive_initiative_rate" in payload["autonomy_metrics"]
+    assert "vital_metrics" in payload
+    assert "circadian_cycle" in payload["vital_metrics"]
+    assert "active_objectives" in payload["vital_metrics"]
+    assert "energy_resources" in payload["vital_metrics"]
+    assert "code_generation" in payload["vital_metrics"]
+    assert "risks" in payload["vital_metrics"]
 
 
 def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
@@ -234,6 +240,12 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Vie courante (SINGULAR_HOME)" in body
     assert "Nombre de vies détectées" in body
     assert "Quêtes" in body
+    assert "Cycle circadien & objectifs actifs" in body
+    assert "Énergie / ressources & génération de code" in body
+    assert "Fenêtre temporelle" in body
+    assert "Comparer vies (CSV)" in body
+    assert "filter-time-window" in body
+    assert "filter-compare-lives" in body
 
 
 def test_dashboard_index_renders_main_sections(tmp_path: Path) -> None:
@@ -705,6 +717,44 @@ def test_lives_comparison_table_aggregation_filters_and_sorting(
 
     by_life_asc = route(sort_by="life", sort_order="asc")["table"]
     assert [row["life"] for row in by_life_asc] == ["life-a", "life-b", "life-c"]
+
+
+def test_lives_comparison_compare_lives_filter(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "compare.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-04-11T09:00:00",
+                        "skill": "life-a:skills/a.py",
+                        "accepted": True,
+                        "score_base": 10.0,
+                        "score_new": 8.0,
+                        "health": {"score": 80.0},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-04-11T10:00:00",
+                        "skill": "life-b:skills/b.py",
+                        "accepted": True,
+                        "score_base": 10.0,
+                        "score_new": 7.5,
+                        "health": {"score": 92.0},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    payload = app._routes["/lives/comparison"](compare_lives="life-a", time_window="all")
+    assert set(payload["lives"]) == {"life-a"}
+    assert payload["filters"]["compare_lives"] == ["life-a"]
+    assert payload["filters"]["time_window"] == "all"
 
 
 def test_psyche_missing_returns_404(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Donner visibilité sur métriques vitales consolidées (santé, acceptation, cycle circadien, risques) directement depuis le dashboard et depuis le contexte des actions. 
- Afficher panneaux dédiés pour cycle circadien, objectifs actifs, énergie/ressources et génération de code afin d’aider l’opérateur à prendre des décisions rapides. 
- Permettre analyses comparatives multi‑vies et fenêtres temporelles pour explorer comportement et évolutions sur périodes/ensembles de vies.

### Description

- Étendu le service d’actions dashboard : `DashboardActionService._context_payload` expose désormais `vital_metrics` calculées par la nouvelle méthode `DashboardActionService._consolidated_vital_metrics` (lire `src/singular/dashboard/actions.py`).
- Enrichi le payload `/api/cockpit` via `_summarize_cockpit` pour inclure `vital_metrics` (bloc contenant `circadian_cycle`, `active_objectives`, `energy_resources`, `code_generation`, `risks`) et calculs associés (lire `src/singular/dashboard/__init__.py`).
- Ajouté support de filtres temporels et de comparaison multi‑vies : nouvelle fonction `_resolve_time_window_cutoff`, et `_aggregate_lives` accepte maintenant `time_window` et `compare_lives` ; la route `/lives/comparison` propage ces paramètres (lire `src/singular/dashboard/__init__.py`).
- Ajouté widgets UI et logique client : nouveaux panneaux HTML/JS pour cycle circadien, objectifs actifs, énergie/ressources et génération de code, plus controles `time_window` et `compare_lives` qui injectent les query params (`src/singular/dashboard/templates/dashboard.html`).
- Tests : étendu `tests/test_dashboard.py` pour valider le nouveau schéma `vital_metrics`, la présence des panneaux/filtres dans la page et le filtrage `compare_lives`.

### Testing

- Tests automatisés exécutés : `pytest -q tests/test_dashboard.py`.
- Résultat : tous les tests ciblés ont réussi (`20 passed, 1 warning` in CI run of that test file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0f409638832a87dcbc41bed8bda5)