### PR TITLE
Add deterministic perception→intrinsic-goals modulation rules

### DIFF
--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -7,6 +7,7 @@ import json
 
 from singular.governance.values import ValueWeights
 from singular.memory import _atomic_write_text, get_mem_dir
+from singular.goals.perception_rules import apply_perception_rules
 
 
 OBJECTIVE_CATALOGUE = ("coherence", "robustesse", "efficacite", "exploration")
@@ -105,6 +106,7 @@ class IntrinsicGoals:
         psyche: Any | None,
         health_score: float | None,
         resources: Mapping[str, float] | None,
+        perception_signals: Mapping[str, Any] | None = None,
     ) -> GoalWeights:
         """Update dynamic weights from psyche/health/resources for one tick."""
 
@@ -120,11 +122,19 @@ class IntrinsicGoals:
         warmth = _clamp(float((resources or {}).get("warmth", 50.0)) / 100.0)
         resource_stability = (energy + food + warmth) / 3.0
 
-        weights = GoalWeights(
+        base_weights = GoalWeights(
             coherence=0.2 + 0.35 * patience + 0.25 * resilience,
             robustesse=0.2 + 0.35 * (1.0 - health_norm) + 0.25 * (1.0 - resource_stability),
             efficacite=0.2 + 0.45 * health_norm + 0.2 * optimism,
             exploration=0.2 + 0.45 * curiosity + 0.2 * playfulness + 0.1 * (1.0 - energy),
+        )
+        modulation = apply_perception_rules(perception_signals)
+        deltas = modulation["deltas"]
+        weights = GoalWeights(
+            coherence=base_weights.coherence + float(deltas["coherence"]),
+            robustesse=base_weights.robustesse + float(deltas["robustesse"]),
+            efficacite=base_weights.efficacite + float(deltas["efficacite"]),
+            exploration=base_weights.exploration + float(deltas["exploration"]),
         ).normalized()
 
         self.state.tick = int(tick)
@@ -141,7 +151,10 @@ class IntrinsicGoals:
                     "resilience": resilience,
                     "optimism": optimism,
                     "playfulness": playfulness,
+                    "perception_rules_version": modulation["version"],
+                    "perception_rule_count": len(modulation["applied_rules"]),
                 },
+                "perception_rules": modulation,
             }
         )
         if len(self.state.history) > self.history_limit:

--- a/src/singular/goals/perception_rules.py
+++ b/src/singular/goals/perception_rules.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+RULESET_VERSION = "2026-04-14.v1"
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _extract_tech_debt_markers(perception_signals: Mapping[str, Any]) -> tuple[float | None, float | None]:
+    artifact_events = perception_signals.get("artifact_events")
+    latest: float | None = None
+    if isinstance(artifact_events, list):
+        for entry in artifact_events:
+            if not isinstance(entry, Mapping):
+                continue
+            if str(entry.get("type")) != "artifact.tech_debt.simple":
+                continue
+            payload = entry.get("data")
+            if isinstance(payload, Mapping):
+                latest = _float(payload.get("markers"), default=0.0)
+
+    previous_candidates = (
+        perception_signals.get("tech_debt_previous_markers"),
+        perception_signals.get("tech_debt_baseline_markers"),
+        perception_signals.get("artifact_tech_debt_previous"),
+    )
+    previous = next((
+        _float(candidate)
+        for candidate in previous_candidates
+        if candidate is not None
+    ), None)
+    return latest, previous
+
+
+def _extract_user_friction_index(perception_signals: Mapping[str, Any]) -> float | None:
+    for key in ("user_friction", "friction_index"):
+        if key in perception_signals:
+            return _clamp(_float(perception_signals[key], default=0.0))
+
+    memory = (
+        perception_signals.get("episode_memory")
+        or perception_signals.get("episodic_memory")
+        or perception_signals.get("memory")
+    )
+    if not isinstance(memory, Mapping):
+        return None
+
+    if "user_friction" in memory:
+        return _clamp(_float(memory.get("user_friction"), default=0.0))
+
+    if "friction_index" in memory:
+        return _clamp(_float(memory.get("friction_index"), default=0.0))
+
+    indicators = memory.get("friction_indicators")
+    if isinstance(indicators, Mapping):
+        blockers = _float(indicators.get("blockers"), default=0.0)
+        complaints = _float(indicators.get("complaints"), default=0.0)
+        retries = _float(indicators.get("retry_rate"), default=0.0)
+        return _clamp((blockers * 0.4) + (complaints * 0.4) + (retries * 0.2))
+
+    return None
+
+
+def apply_perception_rules(perception_signals: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return deterministic objective deltas derived from perception signals."""
+
+    deltas = {
+        "coherence": 0.0,
+        "robustesse": 0.0,
+        "efficacite": 0.0,
+        "exploration": 0.0,
+    }
+    applied_rules: list[dict[str, Any]] = []
+
+    if not isinstance(perception_signals, Mapping):
+        return {"version": RULESET_VERSION, "deltas": deltas, "applied_rules": applied_rules}
+
+    current_markers, previous_markers = _extract_tech_debt_markers(perception_signals)
+    if current_markers is not None and previous_markers is not None and current_markers > previous_markers:
+        delta = min(0.16, (current_markers - previous_markers) * 0.02)
+        deltas["robustesse"] += delta
+        deltas["exploration"] -= delta * 0.35
+        applied_rules.append(
+            {
+                "rule_id": "R-001-tech-debt-up",
+                "current_markers": current_markers,
+                "previous_markers": previous_markers,
+                "delta_robustesse": delta,
+            }
+        )
+
+    friction = _extract_user_friction_index(perception_signals)
+    if friction is not None:
+        if friction >= 0.5:
+            scaled = (friction - 0.5) * 2.0
+            coherence_delta = 0.04 + (0.10 * scaled)
+            efficacite_delta = 0.03 + (0.08 * scaled)
+            deltas["coherence"] += coherence_delta
+            deltas["efficacite"] += efficacite_delta
+            deltas["exploration"] -= (coherence_delta + efficacite_delta) * 0.4
+            applied_rules.append(
+                {
+                    "rule_id": "R-002-user-friction-high",
+                    "friction": friction,
+                    "delta_coherence": coherence_delta,
+                    "delta_efficacite": efficacite_delta,
+                }
+            )
+        else:
+            boost = (0.5 - friction) * 0.04
+            deltas["exploration"] += boost
+            applied_rules.append(
+                {
+                    "rule_id": "R-003-user-friction-low",
+                    "friction": friction,
+                    "delta_exploration": boost,
+                }
+            )
+
+    return {"version": RULESET_VERSION, "deltas": deltas, "applied_rules": applied_rules}

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -682,6 +682,7 @@ def run(
                     "food": resource_manager.food,
                     "warmth": resource_manager.warmth,
                 },
+                perception_signals=signals,
             )
             baseline_failure_risk = (
                 float(state.health_counters.get("sandbox_failures", 0))

--- a/tests/test_loop_perception_goals.py
+++ b/tests/test_loop_perception_goals.py
@@ -1,0 +1,66 @@
+import random
+from pathlib import Path
+
+import singular.life.loop as life_loop
+from singular.goals.intrinsic import GoalWeights
+
+
+class _CaptureGoals:
+    last_perception_signals = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def update_tick(self, *, tick, psyche, health_score, resources, perception_signals=None):
+        _CaptureGoals.last_perception_signals = perception_signals
+        return GoalWeights()
+
+    def influence_action_hypotheses(self, hypotheses):
+        return [
+            {
+                "action": h.action,
+                "long_term": h.long_term,
+                "sandbox_risk": h.sandbox_risk,
+                "resource_cost": h.resource_cost,
+            }
+            for h in hypotheses
+        ]
+
+    def influence_operator_scores(self, operator_stats):
+        return {name: 0.0 for name in operator_stats}
+
+
+def _dec_operator(tree, rng=None):
+    return tree
+
+
+def test_run_passes_capture_signals_to_intrinsic_goals(tmp_path: Path, monkeypatch) -> None:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "foo.py").write_text("result = 1", encoding="utf-8")
+
+    monkeypatch.setattr(life_loop, "IntrinsicGoals", _CaptureGoals)
+    monkeypatch.setattr(
+        life_loop,
+        "capture_signals",
+        lambda bus: {
+            "noise": 0.8,
+            "artifact_events": [
+                {"type": "artifact.tech_debt.simple", "data": {"markers": 7}},
+                {"type": "artifact.files.modified", "data": {"count": 2}},
+            ],
+        },
+    )
+
+    life_loop.run(
+        skills_dir,
+        tmp_path / "ckpt.json",
+        budget_seconds=0.05,
+        rng=random.Random(0),
+        max_iterations=1,
+        operators={"noop": _dec_operator},
+    )
+
+    assert _CaptureGoals.last_perception_signals is not None
+    assert "artifact_events" in _CaptureGoals.last_perception_signals
+    assert _CaptureGoals.last_perception_signals["artifact_events"][0]["type"] == "artifact.tech_debt.simple"

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,5 +1,6 @@
 from singular.psyche import Psyche, Mood
 from singular.motivation import GoalPolicy, Objective
+from singular.goals.intrinsic import IntrinsicGoals
 
 
 def test_curiosity_increases():
@@ -24,3 +25,58 @@ def test_goal_policy_arbitration_bounds() -> None:
     policy = GoalPolicy(besoin=1.0, priorite=0.8, urgence=0.6, alignement_valeurs=0.9)
     score = policy.arbitration_score()
     assert 0.0 <= score <= 1.0
+
+
+def test_intrinsic_goals_boost_robustesse_when_tech_debt_rises(tmp_path) -> None:
+    goals = IntrinsicGoals(path=tmp_path / "goals.json")
+    psyche = Psyche()
+
+    without_debt_rise = goals.update_tick(
+        tick=1,
+        psyche=psyche,
+        health_score=80.0,
+        resources={"energy": 80.0, "food": 80.0, "warmth": 80.0},
+        perception_signals={
+            "tech_debt_previous_markers": 3,
+            "artifact_events": [
+                {"type": "artifact.tech_debt.simple", "data": {"markers": 3}},
+            ],
+        },
+    )
+    with_debt_rise = goals.update_tick(
+        tick=2,
+        psyche=psyche,
+        health_score=80.0,
+        resources={"energy": 80.0, "food": 80.0, "warmth": 80.0},
+        perception_signals={
+            "tech_debt_previous_markers": 3,
+            "artifact_events": [
+                {"type": "artifact.tech_debt.simple", "data": {"markers": 9}},
+            ],
+        },
+    )
+
+    assert with_debt_rise.robustesse > without_debt_rise.robustesse
+
+
+def test_intrinsic_goals_adjust_coherence_and_efficacite_from_user_friction(tmp_path) -> None:
+    goals = IntrinsicGoals(path=tmp_path / "goals.json")
+    psyche = Psyche()
+
+    low_friction = goals.update_tick(
+        tick=1,
+        psyche=psyche,
+        health_score=75.0,
+        resources={"energy": 75.0, "food": 75.0, "warmth": 75.0},
+        perception_signals={"episode_memory": {"user_friction": 0.1}},
+    )
+    high_friction = goals.update_tick(
+        tick=2,
+        psyche=psyche,
+        health_score=75.0,
+        resources={"energy": 75.0, "food": 75.0, "warmth": 75.0},
+        perception_signals={"episode_memory": {"user_friction": 0.9}},
+    )
+
+    assert high_friction.coherence > low_friction.coherence
+    assert high_friction.efficacite > low_friction.efficacite


### PR DESCRIPTION
### Motivation
- Allow intrinsic goals to react deterministically to structured perception signals (including `artifact.*` events) so goal arbitration adapts to observable project state like rising technical debt or user friction.

### Description
- Extend `IntrinsicGoals.update_tick` to accept an optional `perception_signals` parameter and apply a modulation layer before normalizing goal weights.
- Add a versioned rule module `src/singular/goals/perception_rules.py` implementing deterministic rules that boost `robustesse` when `artifact.tech_debt.simple` markers rise and adjust `coherence`/`efficacite` from user-friction indicators, returning `deltas` and applied-rule metadata.
- Wire the main loop in `src/singular/life/loop.py` to forward the output of `capture_signals(...)` (including `artifact_events`) to `update_tick`, and persist rule version/count into the goals history.
- Add targeted tests: update `tests/test_objectives.py` to assert weight changes for synthetic perception signals and add `tests/test_loop_perception_goals.py` to verify that the loop passes captured signals into the intrinsic goals API.

### Testing
- Ran `pytest -q tests/test_objectives.py tests/test_loop_perception_goals.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de27ce0f10832a9a61a725d3ec61e9)