### PR TITLE
Add bounded psyche trait overrides to birth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ singular report --format plain
 singular dashboard
 ```
 
+### Profils de naissance (traits initiaux)
+
+Le parser `birth` accepte des overrides bornés `[0,1]` pour les traits initiaux
+du psyche : `--curiosity`, `--patience`, `--playfulness`, `--optimism`,
+`--resilience`. Les valeurs sont persistées dans `mem/psyche.json`.
+
+```bash
+# Profil prudent : stabilité, patience, faible prise de risque
+singular birth --name "Prudent" \
+  --curiosity 0.20 --patience 0.90 --playfulness 0.15 --optimism 0.55 --resilience 0.90
+
+# Profil explorateur : curiosité et jeu plus élevés, patience plus basse
+singular birth --name "Explorateur" \
+  --curiosity 0.92 --patience 0.35 --playfulness 0.85 --optimism 0.75 --resilience 0.70
+```
+
 Par défaut, ``talk`` ouvre une session interactive. Pour obtenir une réponse
 unique et quitter immédiatement :
 

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -17,6 +17,18 @@ from typing import Any, Callable
 __all__ = ["main"]
 
 
+def _bounded_trait_value(raw: str) -> float:
+    """Parse a psyche trait override constrained to ``[0, 1]``."""
+
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError("doit être un nombre entre 0 et 1") from exc
+    if value < 0.0 or value > 1.0:
+        raise argparse.ArgumentTypeError("doit être compris entre 0 et 1")
+    return value
+
+
 def _extract_talk_life_alias(argv: list[str] | None) -> str | None:
     """Extract ``talk --life/--live`` value from raw argv when present."""
 
@@ -561,6 +573,36 @@ def main(argv: list[str] | None = None) -> int:
         default="New life",
         help="Human readable name for the life",
     )
+    birth_parser.add_argument(
+        "--curiosity",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    birth_parser.add_argument(
+        "--patience",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    birth_parser.add_argument(
+        "--playfulness",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    birth_parser.add_argument(
+        "--optimism",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    birth_parser.add_argument(
+        "--resilience",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
 
     spawn_parser = subparsers.add_parser(
         "spawn", help="Create child organism from two parents"
@@ -953,8 +995,23 @@ def main(argv: list[str] | None = None) -> int:
         os.environ["SINGULAR_SAFE_MODE"] = "1"
 
     if args.command == "birth":
+        psyche_overrides = {
+            trait: getattr(args, trait)
+            for trait in (
+                "curiosity",
+                "patience",
+                "playfulness",
+                "optimism",
+                "resilience",
+            )
+            if getattr(args, trait, None) is not None
+        }
         name = args.name or "New life"
-        metadata = bootstrap_life(name, seed=args.seed)
+        metadata = bootstrap_life(
+            name,
+            seed=args.seed,
+            psyche_overrides=psyche_overrides or None,
+        )
         registry_root = get_registry_root()
         os.environ["SINGULAR_HOME"] = str(metadata.path)
         print(f"Vie créée: {metadata.name} ({metadata.slug}) → {metadata.path}")

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -269,14 +269,19 @@ def resolve_life(name: str | None) -> Path | None:
     return target.path
 
 
-def bootstrap_life(name: str, seed: int | None = None) -> LifeMetadata:
+def bootstrap_life(
+    name: str,
+    seed: int | None = None,
+    *,
+    psyche_overrides: dict[str, float] | None = None,
+) -> LifeMetadata:
     """Create and initialise a life."""
 
     metadata = create_life(name)
 
     from .organisms.birth import birth  # Imported lazily to avoid cycles.
 
-    birth(seed=seed, home=metadata.path)
+    birth(seed=seed, home=metadata.path, psyche_overrides=psyche_overrides)
     registry = load_registry()
     lives: dict[str, LifeMetadata] = registry.get("lives", {})
     return lives.get(metadata.slug, metadata)

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 import random
 import string
+from math import isfinite
 from pathlib import Path
+from typing import Any
 
 from ..governance.values import ValueWeights
 from ..identity import create_identity
@@ -13,7 +15,38 @@ from ..memory import ensure_memory_structure, update_score, write_profile
 from ..psyche import Psyche
 
 
-def birth(seed: int | None = None, home: Path | None = None) -> None:
+_PSYCHE_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
+_PSYCHE_DEFAULTS = {trait: 0.5 for trait in _PSYCHE_TRAITS}
+
+
+def _resolve_psyche_overrides(
+    overrides: dict[str, Any] | None,
+) -> dict[str, float]:
+    """Validate and normalize optional psyche trait overrides."""
+
+    if not overrides:
+        return {}
+
+    normalized: dict[str, float] = {}
+    for key, raw_value in overrides.items():
+        if key not in _PSYCHE_DEFAULTS:
+            raise ValueError(f"unsupported psyche trait override: {key}")
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid psyche trait override for {key}: {raw_value!r}") from exc
+        if not isfinite(value) or value < 0.0 or value > 1.0:
+            raise ValueError(f"psyche trait override out of range for {key}: {value!r}")
+        normalized[key] = value
+    return normalized
+
+
+def birth(
+    seed: int | None = None,
+    home: Path | None = None,
+    *,
+    psyche_overrides: dict[str, Any] | None = None,
+) -> None:
     """Handle the ``birth`` subcommand.
 
     Parameters
@@ -87,6 +120,9 @@ def birth(seed: int | None = None, home: Path | None = None) -> None:
     identity = create_identity(name, soulseed, path=home / "id.json")
     write_profile(identity.__dict__, path=home / "mem" / "profile.json")
 
-    # Initialize the psyche with default traits and save its state
-    psyche = Psyche()
+    resolved_overrides = _resolve_psyche_overrides(psyche_overrides)
+    initial_traits = {**_PSYCHE_DEFAULTS, **resolved_overrides}
+
+    # Initialize the psyche with validated traits and save its state
+    psyche = Psyche(**initial_traits)
     psyche.save_state(path=home / "mem" / "psyche.json")

--- a/tests/test_cli_birth.py
+++ b/tests/test_cli_birth.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from singular.cli import main
+from singular.lives import load_registry
+
+
+def test_birth_persists_initial_psyche_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "registry-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(
+        [
+            "--root",
+            str(root),
+            "birth",
+            "--name",
+            "Prudent",
+            "--curiosity",
+            "0.2",
+            "--patience",
+            "0.9",
+            "--playfulness",
+            "0.1",
+            "--optimism",
+            "0.55",
+            "--resilience",
+            "0.95",
+        ]
+    )
+
+    registry = load_registry()
+    slug = registry["active"]
+    assert isinstance(slug, str)
+    meta = registry["lives"][slug]
+
+    psyche_path = Path(meta.path) / "mem" / "psyche.json"
+    payload = json.loads(psyche_path.read_text(encoding="utf-8"))
+
+    assert payload["curiosity"] == 0.2
+    assert payload["patience"] == 0.9
+    assert payload["playfulness"] == 0.1
+    assert payload["optimism"] == 0.55
+    assert payload["resilience"] == 0.95
+
+
+def test_birth_rejects_out_of_range_psyche_override() -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["birth", "--curiosity", "1.5"])
+    assert excinfo.value.code == 2


### PR DESCRIPTION
### Motivation

- Allow users to initialise an organism's psyche with explicit, bounded personality traits at birth so that different starting profiles can be reproduced and persisted.
- Ensure strict validation of those overrides to avoid invalid state and keep backwards compatibility with existing `bootstrap_life` call sites.

### Description

- Add CLI-level validator `_bounded_trait_value` and five optional `birth` flags: `--curiosity`, `--patience`, `--playfulness`, `--optimism`, `--resilience`, which accept floats in `[0,1]` and produce a `psyche_overrides` dict in `main` (`src/singular/cli.py`).
- Propagate the optional `psyche_overrides` through `bootstrap_life(...)` (`src/singular/lives.py`) into `organisms.birth.birth(...)` as an optional kwarg.
- Implement strict validation and normalization in `organisms/birth.py` via `_resolve_psyche_overrides`, merge overrides with `_PSYCHE_DEFAULTS`, instantiate `Psyche` with validated trait values, and persist the result to `mem/psyche.json`.
- Update `README.md` with two example birth profiles (`Prudent`, `Explorateur`) showing how to use the new flags, and add `tests/test_cli_birth.py` to verify persistence and argument rejection.

### Testing

- Added unit tests in `tests/test_cli_birth.py` that check the persisted `mem/psyche.json` contains the overridden traits and that out-of-range values cause the CLI to exit with a parser error.
- Ran `pytest -q tests/test_cli_birth.py tests/test_cli_lives.py` and all tests passed: `10 passed in 0.73s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de28e0a06c832aba71a4bc554bc846)