### PR TITLE
Add utility starter-pack skills at birth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Chaque instance est **singulière** : deux personnes qui font naître un organis
 
 - **Naissance** : une commande génère un nouvel organisme avec une identité unique (*seed*, traits de personnalité, valeurs).  
 - **Corps** : ses *skills* (petites fonctions de code) représentent ses muscles et organes.  
+- **Starter-pack de skills** : dès la naissance, il reçoit un socle utilitaire (validation, résumé, intention, entités, planification, métriques) prêt à être muté.  
 - **Esprit** : mémoire, traits de caractère, humeur et valeurs éthiques évolutives.  
 - **Évolution** : il modifie son propre code par petites mutations, teste les résultats en sandbox, et conserve ce qui fonctionne mieux.  
 - **Apprentissage** : il peut acquérir de nouvelles compétences en relevant des *quêtes* (spécifications JSON).  
@@ -40,6 +41,17 @@ singular status --format table
 singular report --format plain
 singular dashboard
 ```
+
+À la naissance, Singular initialise un **starter-pack de skills utilitaires** dans `skills/` :
+
+- `validation.py` : vérifications simples d’entrées (ex. texte non vide).
+- `summary.py` : résumé court par extraction des premiers mots.
+- `intent_classification.py` : classification heuristique (`question`, `request`, `statement`).
+- `entity_extraction.py` : extraction légère d’entités via tokens capitalisés.
+- `planning.py` : construction d’un plan structuré à partir d’un objectif et de steps.
+- `metrics.py` : métrique de progression (`completion_ratio`) bornée entre `0.0` et `1.0`.
+
+Ce pack complète les skills arithmétiques historiques (`addition`, `subtraction`, `multiplication`) pour donner, dès les premiers ticks, des briques cognitives prêtes à l’emploi.
 
 ### Profils de naissance (traits initiaux)
 

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -100,6 +100,66 @@ def birth(
                 '    """Return the product of ``a`` and ``b``."""\n'
                 "    return a * b\n"
             ),
+            "validation.py": (
+                '"""Validation helpers for basic input checks."""\n\n'
+                "def validate_non_empty_text(text: str) -> bool:\n"
+                '    """Return ``True`` when ``text`` contains non-whitespace characters."""\n'
+                "    return bool(text.strip())\n"
+            ),
+            "summary.py": (
+                '"""Summary helpers for short text snippets."""\n\n'
+                "def summarize_preview(text: str, max_words: int = 12) -> str:\n"
+                '    """Return the first ``max_words`` words from ``text`` for quick previews."""\n'
+                "    words = text.split()\n"
+                "    return \" \".join(words[:max_words])\n"
+            ),
+            "intent_classification.py": (
+                '"""Intent classification helper using simple keyword heuristics."""\n\n'
+                "def classify_intent(message: str) -> str:\n"
+                '    """Return ``question``, ``request`` or ``statement`` from ``message``."""\n'
+                "    lowered = message.strip().lower()\n"
+                "    if not lowered:\n"
+                '        return "statement"\n'
+                "    if lowered.endswith(\"?\"):\n"
+                '        return "question"\n'
+                "    request_markers = (\"please\", \"peux-tu\", \"merci de\", \"fais\")\n"
+                "    if any(marker in lowered for marker in request_markers):\n"
+                '        return "request"\n'
+                '    return "statement"\n'
+            ),
+            "entity_extraction.py": (
+                '"""Entity extraction helper for lightweight token detection."""\n\n'
+                "def extract_capitalized_entities(text: str) -> list[str]:\n"
+                '    """Return unique capitalized tokens found in ``text`` preserving order."""\n'
+                "    entities: list[str] = []\n"
+                "    seen: set[str] = set()\n"
+                "    for token in text.split():\n"
+                "        cleaned = token.strip(\".,;:!?()[]{}\\\"'\")\n"
+                "        if cleaned and cleaned[0].isupper() and cleaned not in seen:\n"
+                "            entities.append(cleaned)\n"
+                "            seen.add(cleaned)\n"
+                "    return entities\n"
+            ),
+            "planning.py": (
+                '"""Planning helper to build a simple ordered checklist."""\n\n'
+                "def build_plan(goal: str, steps: list[str]) -> dict[str, object]:\n"
+                '    """Return a normalized plan payload for ``goal`` and ordered ``steps``."""\n'
+                "    cleaned_steps = [step.strip() for step in steps if step.strip()]\n"
+                "    return {\n"
+                '        "goal": goal.strip(),\n'
+                '        "steps": cleaned_steps,\n'
+                '        "total_steps": len(cleaned_steps),\n'
+                "    }\n"
+            ),
+            "metrics.py": (
+                '"""Metrics helper to compute simple completion ratios."""\n\n'
+                "def completion_ratio(completed: int, total: int) -> float:\n"
+                '    """Return a bounded completion ratio in ``[0.0, 1.0]``."""\n'
+                "    if total <= 0:\n"
+                "        return 0.0\n"
+                "    ratio = completed / total\n"
+                "    return max(0.0, min(1.0, ratio))\n"
+            ),
         }
         for filename, code in default_skills.items():
             (skills_dir / filename).write_text(code, encoding="utf-8")

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -111,18 +111,24 @@ def test_birth_initializes_default_skills(tmp_path: Path) -> None:
     birth(home=tmp_path)
 
     skills_dir = tmp_path / "skills"
-    assert (skills_dir / "addition.py").exists()
-    assert (skills_dir / "subtraction.py").exists()
-    assert (skills_dir / "multiplication.py").exists()
+    expected_skill_names = [
+        "addition",
+        "subtraction",
+        "multiplication",
+        "validation",
+        "summary",
+        "intent_classification",
+        "entity_extraction",
+        "planning",
+        "metrics",
+    ]
+    for name in expected_skill_names:
+        assert (skills_dir / f"{name}.py").exists()
 
     skills_data = json.loads(
         (tmp_path / "mem" / "skills.json").read_text(encoding="utf-8")
     )
-    assert skills_data == {
-        "addition": {"score": 0.0},
-        "subtraction": {"score": 0.0},
-        "multiplication": {"score": 0.0},
-    }
+    assert skills_data == {name: {"score": 0.0} for name in expected_skill_names}
 
 
 def test_values_helpers_without_yaml(


### PR DESCRIPTION
### Motivation
- Provide a small set of utility skills at organism creation to give early cognitive building blocks (validation, summary, intent classification, entity extraction, planning, metrics). 
- Keep generated skills pure, testable, and documented via simple docstrings so they can be mutated/tested by the life-cycle machinery.

### Description
- Expanded the `default_skills` mapping in `src/singular/organisms/birth.py` to include six new utility skills: `validation.py`, `summary.py`, `intent_classification.py`, `entity_extraction.py`, `planning.py`, and `metrics.py`, each with a concise docstring and simple pure function signature. 
- Continued to initialize scores for every created skill by calling `update_score(<skill_name>, 0.0, path=home / "mem" / "skills.json")` in the skill creation loop. 
- Updated `tests/test_memory.py` to assert the presence of the full starter-pack and that `mem/skills.json` contains zeroed scores for all created skills. 
- Updated `README.md` (Quickstart / Concepts) to list the new starter-pack and briefly explain what each skill provides immediately after birth.

### Testing
- Ran `pytest -q tests/test_memory.py::test_birth_initializes_default_skills`, which passed. 
- Ran `pytest -q tests/test_memory.py`, which showed one unrelated failure: `test_birth_initializes_identity_profile_and_psyche` failed due to additional keys (`schema_version` and `mood_history`) present in the generated `mem/psyche.json`, causing the test assertion to mismatch; the new skills change does not affect psyche initialization and the specific default-skills test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2a796884832a83a344059029b67e)