### PR TITLE
Add configurable starter skill profiles to birth CLI

### DIFF
--- a/configs/starter_skills.yaml
+++ b/configs/starter_skills.yaml
@@ -1,0 +1,24 @@
+{
+  "profiles": {
+    "minimal": ["addition", "subtraction", "multiplication"],
+    "assistant": [
+      "addition",
+      "subtraction",
+      "multiplication",
+      "validation",
+      "summary",
+      "intent_classification",
+      "entity_extraction",
+      "planning",
+      "metrics"
+    ],
+    "ops": [
+      "validation",
+      "planning",
+      "metrics",
+      "summary",
+      "intent_classification"
+    ],
+    "creative": ["summary", "entity_extraction", "planning", "addition"]
+  }
+}

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -603,6 +603,17 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Trait initial borné dans [0,1]",
     )
+    birth_parser.add_argument(
+        "--starter-profile",
+        default="minimal",
+        help="Profil de starter skills à appliquer (ex: minimal, assistant, ops, creative)",
+    )
+    birth_parser.add_argument(
+        "--starter-skill",
+        action="append",
+        default=[],
+        help="Skill starter individuel à ajouter (option répétable)",
+    )
 
     spawn_parser = subparsers.add_parser(
         "spawn", help="Create child organism from two parents"
@@ -1011,6 +1022,8 @@ def main(argv: list[str] | None = None) -> int:
             name,
             seed=args.seed,
             psyche_overrides=psyche_overrides or None,
+            starter_profile=args.starter_profile,
+            starter_skills=args.starter_skill,
         )
         registry_root = get_registry_root()
         os.environ["SINGULAR_HOME"] = str(metadata.path)

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -274,6 +274,8 @@ def bootstrap_life(
     seed: int | None = None,
     *,
     psyche_overrides: dict[str, float] | None = None,
+    starter_profile: str = "minimal",
+    starter_skills: list[str] | None = None,
 ) -> LifeMetadata:
     """Create and initialise a life."""
 
@@ -281,7 +283,13 @@ def bootstrap_life(
 
     from .organisms.birth import birth  # Imported lazily to avoid cycles.
 
-    birth(seed=seed, home=metadata.path, psyche_overrides=psyche_overrides)
+    birth(
+        seed=seed,
+        home=metadata.path,
+        psyche_overrides=psyche_overrides,
+        starter_profile=starter_profile,
+        starter_skills=starter_skills,
+    )
     registry = load_registry()
     lives: dict[str, LifeMetadata] = registry.get("lives", {})
     return lives.get(metadata.slug, metadata)

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import random
 import string
+import json
 from math import isfinite
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,91 @@ from ..psyche import Psyche
 
 _PSYCHE_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
 _PSYCHE_DEFAULTS = {trait: 0.5 for trait in _PSYCHE_TRAITS}
+_DEFAULT_STARTER_PROFILE = "minimal"
+_STARTER_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "starter_skills.yaml"
+_DEFAULT_STARTER_PROFILES: dict[str, list[str]] = {
+    "minimal": ["addition", "subtraction", "multiplication"],
+}
+_SKILL_TEMPLATES: dict[str, str] = {
+    "addition": (
+        '"""Simple addition skill."""\n\n'
+        "def add(a: float, b: float) -> float:\n"
+        '    """Return the sum of ``a`` and ``b``."""\n'
+        "    return a + b\n"
+    ),
+    "subtraction": (
+        '"""Simple subtraction skill."""\n\n'
+        "def subtract(a: float, b: float) -> float:\n"
+        '    """Return the difference of ``a`` and ``b``."""\n'
+        "    return a - b\n"
+    ),
+    "multiplication": (
+        '"""Simple multiplication skill."""\n\n'
+        "def multiply(a: float, b: float) -> float:\n"
+        '    """Return the product of ``a`` and ``b``."""\n'
+        "    return a * b\n"
+    ),
+    "validation": (
+        '"""Validation helpers for basic input checks."""\n\n'
+        "def validate_non_empty_text(text: str) -> bool:\n"
+        '    """Return ``True`` when ``text`` contains non-whitespace characters."""\n'
+        "    return bool(text.strip())\n"
+    ),
+    "summary": (
+        '"""Summary helpers for short text snippets."""\n\n'
+        "def summarize_preview(text: str, max_words: int = 12) -> str:\n"
+        '    """Return the first ``max_words`` words from ``text`` for quick previews."""\n'
+        "    words = text.split()\n"
+        "    return \" \".join(words[:max_words])\n"
+    ),
+    "intent_classification": (
+        '"""Intent classification helper using simple keyword heuristics."""\n\n'
+        "def classify_intent(message: str) -> str:\n"
+        '    """Return ``question``, ``request`` or ``statement`` from ``message``."""\n'
+        "    lowered = message.strip().lower()\n"
+        "    if not lowered:\n"
+        '        return "statement"\n'
+        "    if lowered.endswith(\"?\"):\n"
+        '        return "question"\n'
+        "    request_markers = (\"please\", \"peux-tu\", \"merci de\", \"fais\")\n"
+        "    if any(marker in lowered for marker in request_markers):\n"
+        '        return "request"\n'
+        '    return "statement"\n'
+    ),
+    "entity_extraction": (
+        '"""Entity extraction helper for lightweight token detection."""\n\n'
+        "def extract_capitalized_entities(text: str) -> list[str]:\n"
+        '    """Return unique capitalized tokens found in ``text`` preserving order."""\n'
+        "    entities: list[str] = []\n"
+        "    seen: set[str] = set()\n"
+        "    for token in text.split():\n"
+        "        cleaned = token.strip(\".,;:!?()[]{}\\\"'\")\n"
+        "        if cleaned and cleaned[0].isupper() and cleaned not in seen:\n"
+        "            entities.append(cleaned)\n"
+        "            seen.add(cleaned)\n"
+        "    return entities\n"
+    ),
+    "planning": (
+        '"""Planning helper to build a simple ordered checklist."""\n\n'
+        "def build_plan(goal: str, steps: list[str]) -> dict[str, object]:\n"
+        '    """Return a normalized plan payload for ``goal`` and ordered ``steps``."""\n'
+        "    cleaned_steps = [step.strip() for step in steps if step.strip()]\n"
+        "    return {\n"
+        '        "goal": goal.strip(),\n'
+        '        "steps": cleaned_steps,\n'
+        '        "total_steps": len(cleaned_steps),\n'
+        "    }\n"
+    ),
+    "metrics": (
+        '"""Metrics helper to compute simple completion ratios."""\n\n'
+        "def completion_ratio(completed: int, total: int) -> float:\n"
+        '    """Return a bounded completion ratio in ``[0.0, 1.0]``."""\n'
+        "    if total <= 0:\n"
+        "        return 0.0\n"
+        "    ratio = completed / total\n"
+        "    return max(0.0, min(1.0, ratio))\n"
+    ),
+}
 
 
 def _resolve_psyche_overrides(
@@ -41,11 +127,73 @@ def _resolve_psyche_overrides(
     return normalized
 
 
+def _load_starter_profiles(config_path: Path = _STARTER_CONFIG_PATH) -> dict[str, list[str]]:
+    """Load starter skill profiles from configuration with a safe default fallback."""
+
+    if not config_path.exists():
+        return dict(_DEFAULT_STARTER_PROFILES)
+
+    raw = config_path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return dict(_DEFAULT_STARTER_PROFILES)
+    else:
+        data = yaml.safe_load(raw)
+
+    if not isinstance(data, dict):
+        return dict(_DEFAULT_STARTER_PROFILES)
+    profiles = data.get("profiles")
+    if not isinstance(profiles, dict):
+        return dict(_DEFAULT_STARTER_PROFILES)
+
+    normalized: dict[str, list[str]] = {}
+    for profile, skills in profiles.items():
+        if isinstance(profile, str) and isinstance(skills, list):
+            normalized[profile] = [skill for skill in skills if isinstance(skill, str)]
+    if _DEFAULT_STARTER_PROFILE not in normalized:
+        normalized[_DEFAULT_STARTER_PROFILE] = list(
+            _DEFAULT_STARTER_PROFILES[_DEFAULT_STARTER_PROFILE]
+        )
+    return normalized
+
+
+def _resolve_starter_skills(
+    profile: str | None,
+    extra_skills: list[str] | None,
+    *,
+    profiles: dict[str, list[str]] | None = None,
+) -> list[str]:
+    """Resolve starter skill identifiers from profile and optional explicit extras."""
+
+    available_profiles = profiles or _load_starter_profiles()
+    selected_profile = profile or _DEFAULT_STARTER_PROFILE
+    base_skills = available_profiles.get(selected_profile)
+    if base_skills is None:
+        base_skills = available_profiles.get(
+            _DEFAULT_STARTER_PROFILE,
+            _DEFAULT_STARTER_PROFILES[_DEFAULT_STARTER_PROFILE],
+        )
+
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for skill_id in [*base_skills, *(extra_skills or [])]:
+        if skill_id in _SKILL_TEMPLATES and skill_id not in seen:
+            ordered.append(skill_id)
+            seen.add(skill_id)
+    return ordered
+
+
 def birth(
     seed: int | None = None,
     home: Path | None = None,
     *,
     psyche_overrides: dict[str, Any] | None = None,
+    starter_profile: str = _DEFAULT_STARTER_PROFILE,
+    starter_skills: list[str] | None = None,
 ) -> None:
     """Handle the ``birth`` subcommand.
 
@@ -81,90 +229,13 @@ def birth(
     skills_dir = home / "skills"
     if not skills_dir.exists() or not any(skills_dir.iterdir()):
         skills_dir.mkdir(parents=True, exist_ok=True)
-        default_skills = {
-            "addition.py": (
-                '"""Simple addition skill."""\n\n'
-                "def add(a: float, b: float) -> float:\n"
-                '    """Return the sum of ``a`` and ``b``."""\n'
-                "    return a + b\n"
-            ),
-            "subtraction.py": (
-                '"""Simple subtraction skill."""\n\n'
-                "def subtract(a: float, b: float) -> float:\n"
-                '    """Return the difference of ``a`` and ``b``."""\n'
-                "    return a - b\n"
-            ),
-            "multiplication.py": (
-                '"""Simple multiplication skill."""\n\n'
-                "def multiply(a: float, b: float) -> float:\n"
-                '    """Return the product of ``a`` and ``b``."""\n'
-                "    return a * b\n"
-            ),
-            "validation.py": (
-                '"""Validation helpers for basic input checks."""\n\n'
-                "def validate_non_empty_text(text: str) -> bool:\n"
-                '    """Return ``True`` when ``text`` contains non-whitespace characters."""\n'
-                "    return bool(text.strip())\n"
-            ),
-            "summary.py": (
-                '"""Summary helpers for short text snippets."""\n\n'
-                "def summarize_preview(text: str, max_words: int = 12) -> str:\n"
-                '    """Return the first ``max_words`` words from ``text`` for quick previews."""\n'
-                "    words = text.split()\n"
-                "    return \" \".join(words[:max_words])\n"
-            ),
-            "intent_classification.py": (
-                '"""Intent classification helper using simple keyword heuristics."""\n\n'
-                "def classify_intent(message: str) -> str:\n"
-                '    """Return ``question``, ``request`` or ``statement`` from ``message``."""\n'
-                "    lowered = message.strip().lower()\n"
-                "    if not lowered:\n"
-                '        return "statement"\n'
-                "    if lowered.endswith(\"?\"):\n"
-                '        return "question"\n'
-                "    request_markers = (\"please\", \"peux-tu\", \"merci de\", \"fais\")\n"
-                "    if any(marker in lowered for marker in request_markers):\n"
-                '        return "request"\n'
-                '    return "statement"\n'
-            ),
-            "entity_extraction.py": (
-                '"""Entity extraction helper for lightweight token detection."""\n\n'
-                "def extract_capitalized_entities(text: str) -> list[str]:\n"
-                '    """Return unique capitalized tokens found in ``text`` preserving order."""\n'
-                "    entities: list[str] = []\n"
-                "    seen: set[str] = set()\n"
-                "    for token in text.split():\n"
-                "        cleaned = token.strip(\".,;:!?()[]{}\\\"'\")\n"
-                "        if cleaned and cleaned[0].isupper() and cleaned not in seen:\n"
-                "            entities.append(cleaned)\n"
-                "            seen.add(cleaned)\n"
-                "    return entities\n"
-            ),
-            "planning.py": (
-                '"""Planning helper to build a simple ordered checklist."""\n\n'
-                "def build_plan(goal: str, steps: list[str]) -> dict[str, object]:\n"
-                '    """Return a normalized plan payload for ``goal`` and ordered ``steps``."""\n'
-                "    cleaned_steps = [step.strip() for step in steps if step.strip()]\n"
-                "    return {\n"
-                '        "goal": goal.strip(),\n'
-                '        "steps": cleaned_steps,\n'
-                '        "total_steps": len(cleaned_steps),\n'
-                "    }\n"
-            ),
-            "metrics.py": (
-                '"""Metrics helper to compute simple completion ratios."""\n\n'
-                "def completion_ratio(completed: int, total: int) -> float:\n"
-                '    """Return a bounded completion ratio in ``[0.0, 1.0]``."""\n'
-                "    if total <= 0:\n"
-                "        return 0.0\n"
-                "    ratio = completed / total\n"
-                "    return max(0.0, min(1.0, ratio))\n"
-            ),
-        }
-        for filename, code in default_skills.items():
-            (skills_dir / filename).write_text(code, encoding="utf-8")
+        selected_skills = _resolve_starter_skills(starter_profile, starter_skills)
+        for skill_id in selected_skills:
+            (skills_dir / f"{skill_id}.py").write_text(
+                _SKILL_TEMPLATES[skill_id], encoding="utf-8"
+            )
             update_score(
-                filename.removesuffix(".py"),
+                skill_id,
                 0.0,
                 path=home / "mem" / "skills.json",
             )

--- a/tests/test_birth_starter_profiles.py
+++ b/tests/test_birth_starter_profiles.py
@@ -1,0 +1,12 @@
+from singular.organisms.birth import _resolve_starter_skills
+
+
+def test_resolve_starter_skills_falls_back_to_minimal_profile() -> None:
+    profiles = {
+        "minimal": ["addition", "subtraction", "multiplication"],
+        "assistant": ["summary"],
+    }
+
+    resolved = _resolve_starter_skills("does-not-exist", ["summary"], profiles=profiles)
+
+    assert resolved == ["addition", "subtraction", "multiplication", "summary"]

--- a/tests/test_cli_birth.py
+++ b/tests/test_cli_birth.py
@@ -56,3 +56,82 @@ def test_birth_rejects_out_of_range_psyche_override() -> None:
     with pytest.raises(SystemExit) as excinfo:
         main(["birth", "--curiosity", "1.5"])
     assert excinfo.value.code == 2
+
+
+def test_birth_uses_minimal_starter_profile_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "registry-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(["--root", str(root), "birth", "--name", "Minimal"])
+
+    registry = load_registry()
+    slug = registry["active"]
+    life_home = Path(registry["lives"][slug].path)
+    skills = sorted(path.name for path in (life_home / "skills").glob("*.py"))
+    assert skills == ["addition.py", "multiplication.py", "subtraction.py"]
+
+
+def test_birth_applies_explicit_starter_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "registry-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(
+        [
+            "--root",
+            str(root),
+            "birth",
+            "--name",
+            "Operator",
+            "--starter-profile",
+            "ops",
+        ]
+    )
+
+    registry = load_registry()
+    slug = registry["active"]
+    life_home = Path(registry["lives"][slug].path)
+    skills = sorted(path.name for path in (life_home / "skills").glob("*.py"))
+    assert skills == [
+        "intent_classification.py",
+        "metrics.py",
+        "planning.py",
+        "summary.py",
+        "validation.py",
+    ]
+
+
+def test_birth_unknown_profile_falls_back_to_minimal_and_adds_explicit_skills(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "registry-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(
+        [
+            "--root",
+            str(root),
+            "birth",
+            "--name",
+            "Fallback",
+            "--starter-profile",
+            "unknown-profile",
+            "--starter-skill",
+            "summary",
+        ]
+    )
+
+    registry = load_registry()
+    slug = registry["active"]
+    life_home = Path(registry["lives"][slug].path)
+    skills = sorted(path.name for path in (life_home / "skills").glob("*.py"))
+    assert skills == ["addition.py", "multiplication.py", "subtraction.py", "summary.py"]


### PR DESCRIPTION
### Motivation
- Provide a versioned configuration for initial starter skills so new lives can be bootstrapped from named profiles instead of a hardcoded list.
- Allow users to choose a profile or add individual starter skills via the `birth` CLI to customize created lives at creation time.
- Ensure a safe fallback to a minimal set of skills when a profile is unknown or the config is malformed.

### Description
- Add a JSON/YAML-compatible configuration file at `configs/starter_skills.yaml` listing `minimal`, `assistant`, `ops`, and `creative` profiles with skill identifiers.
- Extend the `birth` CLI with `--starter-profile` and repeatable `--starter-skill` options in `src/singular/cli.py` and propagate them through `bootstrap_life` to `organisms.birth.birth`.
- Replace the hardcoded starter-skill creation in `src/singular/organisms/birth.py` with `_load_starter_profiles`, `_resolve_starter_skills` and `_SKILL_TEMPLATES`, writing selected skills to `mem/skills` and falling back to the `minimal` profile on unknown/malformed config.
- Add unit/CLI tests: new `tests/test_birth_starter_profiles.py` and additional cases in `tests/test_cli_birth.py` to cover default profile, explicit profile, and unknown-profile + explicit skill override.

### Testing
- Ran `pytest -q tests/test_cli_birth.py tests/test_birth_starter_profiles.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2c139920832aaabf1fe167830413)