### PR TITLE
Add longitudinal skill scoring and governed lifecycle maintenance

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from singular.lives import get_registry_root, load_registry, set_life_status
 from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
+from singular.memory import read_skills
 
 from singular.dashboard.actions import DashboardActionService
 from singular.governance.policy import load_runtime_policy
@@ -235,6 +236,21 @@ def create_app(
             },
         }
 
+    def _skill_lifecycle_summary() -> dict[str, int]:
+        payload = {"active": 0, "dormant": 0, "archived": 0, "temporarily_disabled": 0, "deleted": 0, "total": 0}
+        for raw_entry in read_skills().values():
+            payload["total"] += 1
+            state = "active"
+            if isinstance(raw_entry, dict):
+                lifecycle = raw_entry.get("lifecycle")
+                if isinstance(lifecycle, dict) and isinstance(lifecycle.get("state"), str):
+                    state = lifecycle["state"]
+            if state in payload:
+                payload[state] += 1
+            else:
+                payload["active"] += 1
+        return payload
+
     def _iter_run_files(current_life_only: bool = False) -> list[Path]:
         files: list[Path] = []
         for directory in _runs_dirs(current_life_only=current_life_only):
@@ -450,6 +466,7 @@ def create_app(
                     failure_streak=0,
                     extinction_seen=False,
                 ),
+                "skills_lifecycle": _skill_lifecycle_summary(),
             }
             return empty
 
@@ -620,6 +637,7 @@ def create_app(
                 "risks": [str(alert.get("kind", "")) for alert in critical_alerts],
             },
             "vital_timeline": vital_timeline,
+            "skills_lifecycle": _skill_lifecycle_summary(),
         }
 
 
@@ -872,6 +890,7 @@ def create_app(
             "registry_lives_count": len(_registry_lives_paths()),
             "policy": policy.to_payload(),
             "policy_impact": policy.impact_summary(),
+            "skills_lifecycle": _skill_lifecycle_summary(),
         }
 
     @app.get("/timeline")

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -106,6 +106,15 @@
   </div>
 
   <div class='panel'>
+    <h3 style='margin-top:0;'>Cycle de vie des skills</h3>
+    <div class='cards-grid'>
+      <div class='card'><div class='card-label'>Skills actives</div><div id='kpi-skills-active' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Skills dormantes</div><div id='kpi-skills-dormant' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Skills archivées</div><div id='kpi-skills-archived' class='card-value'>0</div></div>
+    </div>
+  </div>
+
+  <div class='panel'>
     <h3 style='margin-top:0;'>Énergie / ressources & génération de code</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Énergie totale</div><div id='kpi-energy-total' class='card-value'>0</div></div>
@@ -286,6 +295,10 @@ const loadContext=()=>fetch('/dashboard/context').then(r=>r.json()).then(ctx=>{
   impactList.innerHTML='';
   for(const item of (ctx.policy_impact||[])){const li=document.createElement('li');li.textContent=String(item);impactList.appendChild(li);}
   if(!(ctx.policy_impact||[]).length){const li=document.createElement('li');li.textContent='Aucun impact disponible.';impactList.appendChild(li);}
+  const lifecycle=ctx.skills_lifecycle||{};
+  document.getElementById('kpi-skills-active').textContent=String(lifecycle.active||0);
+  document.getElementById('kpi-skills-dormant').textContent=String(lifecycle.dormant||0);
+  document.getElementById('kpi-skills-archived').textContent=String(lifecycle.archived||0);
 });
 
 const loadEco=()=>Promise.all([fetch(withScope('/ecosystem')).then(r=>r.json()),fetch(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc')).then(r=>r.json())]).then(([eco,lives])=>{
@@ -349,6 +362,7 @@ const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=
   document.getElementById('kpi-autonomy-latency').textContent=fmtNum(autonomy.perception_to_action_latency_ms,' ms');
   document.getElementById('kpi-autonomy-cost').textContent=fmtNum(autonomy.resource_cost_per_gain);
   const vital=d.vital_timeline||{};
+  const skillLifecycle=d.skills_lifecycle||{};
   const vitalMetrics=d.vital_metrics||{};
   const objectives=vitalMetrics.active_objectives||{};
   const energyResources=vitalMetrics.energy_resources||{};
@@ -365,6 +379,9 @@ const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=
   document.getElementById('kpi-resources-total').textContent=fmtNum(energyResources.total_resources);
   document.getElementById('kpi-code-progression').textContent=String(codeGeneration.progression||'n/a');
   document.getElementById('kpi-code-risks').textContent=risks.length?risks.join(', '):String(codeGeneration.risk_level||'n/a');
+  document.getElementById('kpi-skills-active').textContent=String(skillLifecycle.active||0);
+  document.getElementById('kpi-skills-dormant').textContent=String(skillLifecycle.dormant||0);
+  document.getElementById('kpi-skills-archived').textContent=String(skillLifecycle.archived||0);
   const objectivesList=document.getElementById('kpi-active-objectives-list');
   objectivesList.innerHTML='';
   for(const item of (objectives.items||[])){

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Mapping
 import json
 import os
 import tempfile
+from datetime import datetime, timedelta, timezone
 
 if os.name == "nt":
     import msvcrt
@@ -57,6 +58,11 @@ def get_episodic_file() -> Path:
 def get_skills_file() -> Path:
     """Return the path to the skills JSON file."""
     return get_mem_dir() / "skills.json"
+
+
+def get_skill_snapshots_dir() -> Path:
+    """Return the directory storing skill lifecycle snapshots."""
+    return get_mem_dir() / "skills_snapshots"
 
 
 def get_psyche_file() -> Path:
@@ -325,6 +331,204 @@ def update_score(
     return skills
 
 
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_skill_entry(entry: Any) -> dict[str, Any]:
+    if isinstance(entry, (int, float)):
+        entry = {"score": float(entry)}
+    if not isinstance(entry, dict):
+        entry = {}
+    score = float(entry.get("score", 0.0))
+    metrics = entry.get("metrics") if isinstance(entry.get("metrics"), dict) else {}
+    lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), dict) else {}
+    entry["score"] = score
+    entry["metrics"] = {
+        "usage_count": int(metrics.get("usage_count", 0) or 0),
+        "total_gain": float(metrics.get("total_gain", 0.0) or 0.0),
+        "average_gain": float(metrics.get("average_gain", 0.0) or 0.0),
+        "total_cost": float(metrics.get("total_cost", 0.0) or 0.0),
+        "average_cost": float(metrics.get("average_cost", 0.0) or 0.0),
+        "failure_count": int(metrics.get("failure_count", 0) or 0),
+        "last_used_at": metrics.get("last_used_at"),
+    }
+    state = lifecycle.get("state")
+    if not isinstance(state, str) or state not in {
+        "active",
+        "dormant",
+        "archived",
+        "temporarily_disabled",
+        "deleted",
+    }:
+        state = "active"
+    entry["lifecycle"] = {
+        "state": state,
+        "state_reason": lifecycle.get("state_reason"),
+        "disabled_until": lifecycle.get("disabled_until"),
+        "last_transition_at": lifecycle.get("last_transition_at"),
+        "snapshot_path": lifecycle.get("snapshot_path"),
+    }
+    return entry
+
+
+def record_skill_metric(
+    skill: str,
+    *,
+    gain: float,
+    cost: float,
+    success: bool,
+    path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Record longitudinal skill metrics (usage, gain, cost, failures)."""
+
+    skills = read_skills(path)
+    entry = _normalize_skill_entry(skills.get(skill))
+    metrics = entry["metrics"]
+    lifecycle = entry["lifecycle"]
+
+    metrics["usage_count"] += 1
+    metrics["total_gain"] += float(gain)
+    metrics["total_cost"] += max(float(cost), 0.0)
+    if not success:
+        metrics["failure_count"] += 1
+    usage_count = max(int(metrics["usage_count"]), 1)
+    metrics["average_gain"] = metrics["total_gain"] / usage_count
+    metrics["average_cost"] = metrics["total_cost"] / usage_count
+    metrics["last_used_at"] = _utc_now_iso()
+
+    lifecycle["state"] = "active"
+    lifecycle["state_reason"] = "recent_usage"
+    lifecycle["disabled_until"] = None
+    lifecycle["last_transition_at"] = _utc_now_iso()
+
+    skills[skill] = entry
+    write_skills(skills, path)
+    return skills
+
+
+def apply_skill_maintenance(
+    *,
+    dormant_after_days: int = 14,
+    archive_after_days: int = 30,
+    path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Apply lifecycle rules: inactive -> dormant -> archived."""
+
+    skills = read_skills(path)
+    now = datetime.now(timezone.utc)
+    for key, raw_entry in list(skills.items()):
+        entry = _normalize_skill_entry(raw_entry)
+        lifecycle = entry["lifecycle"]
+        if lifecycle["state"] in {"deleted", "temporarily_disabled"}:
+            skills[key] = entry
+            continue
+        last_used_raw = entry["metrics"].get("last_used_at")
+        if isinstance(last_used_raw, str):
+            try:
+                last_used_at = datetime.fromisoformat(last_used_raw.replace("Z", "+00:00"))
+            except ValueError:
+                last_used_at = None
+        else:
+            last_used_at = None
+        if last_used_at is None:
+            skills[key] = entry
+            continue
+        idle = now - last_used_at
+        if idle >= timedelta(days=archive_after_days):
+            lifecycle["state"] = "archived"
+            lifecycle["state_reason"] = "inactive_too_long"
+            lifecycle["last_transition_at"] = _utc_now_iso()
+        elif idle >= timedelta(days=dormant_after_days):
+            lifecycle["state"] = "dormant"
+            lifecycle["state_reason"] = "inactive"
+            lifecycle["last_transition_at"] = _utc_now_iso()
+        else:
+            lifecycle["state"] = "active"
+            lifecycle["state_reason"] = "healthy_activity"
+            lifecycle["last_transition_at"] = _utc_now_iso()
+        skills[key] = entry
+    write_skills(skills, path)
+    return skills
+
+
+def temporarily_disable_skill(
+    skill: str,
+    *,
+    duration_hours: int,
+    reason: str,
+    path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Temporarily disable a skill without deleting it."""
+    skills = read_skills(path)
+    entry = _normalize_skill_entry(skills.get(skill))
+    lifecycle = entry["lifecycle"]
+    lifecycle["state"] = "temporarily_disabled"
+    lifecycle["state_reason"] = reason
+    lifecycle["disabled_until"] = (
+        datetime.now(timezone.utc) + timedelta(hours=max(duration_hours, 1))
+    ).isoformat()
+    lifecycle["last_transition_at"] = _utc_now_iso()
+    skills[skill] = entry
+    write_skills(skills, path)
+    return skills
+
+
+def restore_skill(skill: str, path: Path | str | None = None) -> dict[str, Any]:
+    """Restore an archived/dormant/disabled skill to active state."""
+    skills = read_skills(path)
+    if skill not in skills:
+        raise KeyError(f"unknown skill: {skill}")
+    entry = _normalize_skill_entry(skills[skill])
+    lifecycle = entry["lifecycle"]
+    lifecycle["state"] = "active"
+    lifecycle["state_reason"] = "restored"
+    lifecycle["disabled_until"] = None
+    lifecycle["last_transition_at"] = _utc_now_iso()
+    skills[skill] = entry
+    write_skills(skills, path)
+    return skills
+
+
+def controlled_delete_skill(
+    skill: str,
+    *,
+    reason: str,
+    path: Path | str | None = None,
+    snapshots_dir: Path | str | None = None,
+) -> dict[str, Any]:
+    """Governed deletion: keep a snapshot and tombstone instead of hard removal."""
+
+    skills = read_skills(path)
+    if skill not in skills:
+        raise KeyError(f"unknown skill: {skill}")
+    entry = _normalize_skill_entry(skills[skill])
+    snapshots = Path(snapshots_dir) if snapshots_dir is not None else get_skill_snapshots_dir()
+    snapshots.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    snapshot_path = snapshots / f"{skill}-{ts}.json"
+    snapshot_path.write_text(
+        json.dumps(
+            {
+                "skill": skill,
+                "deleted_at": _utc_now_iso(),
+                "reason": reason,
+                "snapshot": entry,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    entry["lifecycle"]["state"] = "deleted"
+    entry["lifecycle"]["state_reason"] = reason
+    entry["lifecycle"]["snapshot_path"] = str(snapshot_path)
+    entry["lifecycle"]["last_transition_at"] = _utc_now_iso()
+    skills[skill] = entry
+    write_skills(skills, path)
+    return skills
+
+
 def update_note(
     skill: str, note: str, path: Path | str | None = None
 ) -> dict[str, Any]:
@@ -393,13 +597,30 @@ def _consolidate_applied_mutation(event: Event) -> None:
     payload = event.payload
     key = payload.get("skill")
     score_new = payload.get("score_new")
+    score_base = payload.get("score_base")
+    ms_new = payload.get("ms_new")
     if isinstance(key, str) and isinstance(score_new, (int, float)):
         update_score(key, float(score_new))
+        gain = 0.0
+        if isinstance(score_base, (int, float)):
+            gain = float(score_base) - float(score_new)
+        cost = float(ms_new) if isinstance(ms_new, (int, float)) else 0.0
+        record_skill_metric(key, gain=gain, cost=cost, success=True)
     add_procedural_memory({"event": "loop_mutation", **payload, "accepted": True})
 
 
 def _consolidate_rejected_mutation(event: Event) -> None:
     payload = event.payload
+    key = payload.get("skill")
+    if isinstance(key, str):
+        score_base = payload.get("score_base")
+        score_new = payload.get("score_new")
+        ms_new = payload.get("ms_new")
+        gain = 0.0
+        if isinstance(score_base, (int, float)) and isinstance(score_new, (int, float)):
+            gain = float(score_base) - float(score_new)
+        cost = float(ms_new) if isinstance(ms_new, (int, float)) else 0.0
+        record_skill_metric(key, gain=gain, cost=cost, success=False)
     add_procedural_memory({"event": "loop_mutation", **payload, "accepted": False})
 
 

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -10,6 +10,7 @@ from ..life.vital import compute_vital_timeline
 from ..metrics.autonomy import compute_autonomy_metrics
 from ..psyche import Psyche
 from ..memory import get_mem_dir
+from ..memory import read_skills
 from ..runs.logger import RUNS_DIR
 from ..schedulers.reevaluation import alerts_from_records
 
@@ -59,6 +60,30 @@ def _read_quest_status() -> dict[str, object]:
     completed = payload.get("completed") if isinstance(payload.get("completed"), list) else []
     return {"active": active, "completed": completed[-20:]}
 
+
+def _read_skill_lifecycle_status() -> dict[str, object]:
+    skills = read_skills()
+    summary = {
+        "active": 0,
+        "dormant": 0,
+        "archived": 0,
+        "temporarily_disabled": 0,
+        "deleted": 0,
+        "total": 0,
+    }
+    for raw_entry in skills.values():
+        summary["total"] += 1
+        state = "active"
+        if isinstance(raw_entry, dict):
+            lifecycle = raw_entry.get("lifecycle")
+            if isinstance(lifecycle, dict) and isinstance(lifecycle.get("state"), str):
+                state = lifecycle["state"]
+        if state in summary:
+            summary[state] += 1
+        else:
+            summary["active"] += 1
+    return summary
+
 def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     """Display basic metrics and current psyche state."""
 
@@ -74,6 +99,14 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "traits": {},
         "autonomy_metrics": {},
         "quests": {"active": [], "completed": []},
+        "skills_lifecycle": {
+            "active": 0,
+            "dormant": 0,
+            "archived": 0,
+            "temporarily_disabled": 0,
+            "deleted": 0,
+            "total": 0,
+        },
         "vital_timeline": {
             "age": 0,
             "state": "mature",
@@ -160,6 +193,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     mood = psyche.last_mood.value if psyche.last_mood else "neutral"
     payload["mood"] = mood
     payload["quests"] = _read_quest_status()
+    payload["skills_lifecycle"] = _read_skill_lifecycle_status()
     payload["traits"] = {
         "curiosity": round(psyche.curiosity, 2),
         "patience": round(psyche.patience, 2),
@@ -207,6 +241,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             ["Mood", str(payload.get("mood"))],
             ["Quêtes actives", str(len((payload.get("quests") or {}).get("active", [])))],
             ["Quêtes terminées", str(len((payload.get("quests") or {}).get("completed", [])))],
+            ["Skills actives", str((payload.get("skills_lifecycle") or {}).get("active", 0))],
+            ["Skills dormantes", str((payload.get("skills_lifecycle") or {}).get("dormant", 0))],
+            ["Skills archivées", str((payload.get("skills_lifecycle") or {}).get("archived", 0))],
             ["Âge vital", str((payload.get("vital_timeline") or {}).get("age", 0))],
             ["État vital", str((payload.get("vital_timeline") or {}).get("state", "n/a"))],
             ["Risque vital", str((payload.get("vital_timeline") or {}).get("risk_level", "n/a"))],
@@ -278,6 +315,10 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     quests = payload.get("quests") if isinstance(payload.get("quests"), dict) else {"active": [], "completed": []}
     print(f"Quêtes actives: {len(quests.get("active", []))}")
     print(f"Quêtes terminées: {len(quests.get("completed", []))}")
+    lifecycle = payload.get("skills_lifecycle") if isinstance(payload.get("skills_lifecycle"), dict) else {}
+    print(f"Skills actives: {lifecycle.get('active', 0)}")
+    print(f"Skills dormantes: {lifecycle.get('dormant', 0)}")
+    print(f"Skills archivées: {lifecycle.get('archived', 0)}")
     print("Traits:")
     for trait, value in payload["traits"].items():
         print(f"  {trait}: {value:.2f}")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -33,6 +33,7 @@ def test_dashboard_endpoints(tmp_path: Path, monkeypatch) -> None:
     context = client.get("/dashboard/context").json()
     assert context["policy"]["version"] == 1
     assert isinstance(context["policy_impact"], list)
+    assert "skills_lifecycle" in context
 
 
 def test_dashboard_quests_endpoint(tmp_path: Path, monkeypatch) -> None:
@@ -203,6 +204,7 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert "energy_resources" in payload["vital_metrics"]
     assert "code_generation" in payload["vital_metrics"]
     assert "risks" in payload["vital_metrics"]
+    assert "skills_lifecycle" in payload
 
 
 def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
@@ -244,6 +246,7 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Nombre de vies détectées" in body
     assert "Quêtes" in body
     assert "Cycle circadien & objectifs actifs" in body
+    assert "Cycle de vie des skills" in body
     assert "Énergie / ressources & génération de code" in body
     assert "Fenêtre temporelle" in body
     assert "Comparer vies (CSV)" in body

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6,7 +6,17 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from typing import Any
 
-from singular.memory import add_episode, update_trait, update_score, update_note
+from singular.memory import (
+    add_episode,
+    apply_skill_maintenance,
+    controlled_delete_skill,
+    restore_skill,
+    temporarily_disable_skill,
+    update_note,
+    update_score,
+    update_trait,
+    record_skill_metric,
+)
 import singular.memory as memory
 from singular.organisms.birth import birth
 
@@ -159,3 +169,59 @@ def test_values_helpers_without_yaml(
     # Writing values should raise an informative ImportError
     with pytest.raises(ImportError):
         memory.write_values({"a": 1}, values_path)
+
+
+def test_record_skill_metric_persists_longitudinal_fields(tmp_path: Path) -> None:
+    skills_path = tmp_path / "mem" / "skills.json"
+    update_score("alpha", 1.5, path=skills_path)
+
+    record_skill_metric("alpha", gain=0.4, cost=12.0, success=True, path=skills_path)
+    record_skill_metric("alpha", gain=-0.1, cost=8.0, success=False, path=skills_path)
+
+    payload = json.loads(skills_path.read_text(encoding="utf-8"))
+    metrics = payload["alpha"]["metrics"]
+    assert metrics["usage_count"] == 2
+    assert metrics["failure_count"] == 1
+    assert metrics["average_gain"] == pytest.approx(0.15)
+    assert metrics["average_cost"] == pytest.approx(10.0)
+    assert isinstance(metrics["last_used_at"], str)
+
+
+def test_skill_maintenance_archive_and_restore_is_lossless(tmp_path: Path) -> None:
+    skills_path = tmp_path / "mem" / "skills.json"
+    update_score("beta", 2.0, path=skills_path)
+    record_skill_metric("beta", gain=0.6, cost=4.0, success=True, path=skills_path)
+
+    data = json.loads(skills_path.read_text(encoding="utf-8"))
+    data["beta"]["metrics"]["last_used_at"] = "2020-01-01T00:00:00+00:00"
+    skills_path.parent.mkdir(parents=True, exist_ok=True)
+    skills_path.write_text(json.dumps(data), encoding="utf-8")
+
+    apply_skill_maintenance(dormant_after_days=5, archive_after_days=30, path=skills_path)
+    archived = json.loads(skills_path.read_text(encoding="utf-8"))
+    assert archived["beta"]["lifecycle"]["state"] == "archived"
+    assert archived["beta"]["metrics"]["usage_count"] == 1
+    assert archived["beta"]["metrics"]["average_gain"] == pytest.approx(0.6)
+
+    restore_skill("beta", path=skills_path)
+    restored = json.loads(skills_path.read_text(encoding="utf-8"))
+    assert restored["beta"]["lifecycle"]["state"] == "active"
+    assert restored["beta"]["metrics"]["usage_count"] == 1
+    assert restored["beta"]["metrics"]["average_gain"] == pytest.approx(0.6)
+
+
+def test_skill_temporary_disable_and_controlled_delete(tmp_path: Path) -> None:
+    skills_path = tmp_path / "mem" / "skills.json"
+    update_score("gamma", 0.2, path=skills_path)
+
+    temporarily_disable_skill("gamma", duration_hours=2, reason="cooldown", path=skills_path)
+    disabled = json.loads(skills_path.read_text(encoding="utf-8"))
+    assert disabled["gamma"]["lifecycle"]["state"] == "temporarily_disabled"
+    assert disabled["gamma"]["lifecycle"]["disabled_until"] is not None
+
+    controlled_delete_skill("gamma", reason="governance_cleanup", path=skills_path)
+    deleted = json.loads(skills_path.read_text(encoding="utf-8"))
+    assert deleted["gamma"]["lifecycle"]["state"] == "deleted"
+    snapshot = deleted["gamma"]["lifecycle"]["snapshot_path"]
+    assert isinstance(snapshot, str)
+    assert Path(snapshot).exists()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -145,3 +145,38 @@ def test_status_exposes_quest_counts(tmp_path, monkeypatch, capsys) -> None:
     payload = json.loads(capsys.readouterr().out)
     assert len(payload["quests"]["active"]) == 1
     assert len(payload["quests"]["completed"]) == 1
+
+
+def test_status_exposes_skill_lifecycle_counts(tmp_path, monkeypatch, capsys) -> None:
+    mem_dir = tmp_path / "mem"
+    mem_dir.mkdir()
+    (mem_dir / "skills.json").write_text(
+        json.dumps(
+            {
+                "alpha": {"score": 0.1, "lifecycle": {"state": "active"}},
+                "beta": {"score": 0.2, "lifecycle": {"state": "dormant"}},
+                "gamma": {"score": 0.3, "lifecycle": {"state": "archived"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class DummyPsyche:
+        last_mood = None
+        curiosity = 0.5
+        patience = 0.5
+        playfulness = 0.5
+        optimism = 0.5
+        resilience = 0.5
+
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(
+        status_mod.Psyche, "load_state", staticmethod(lambda: DummyPsyche())
+    )
+
+    status_mod.status(output_format="json")
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["skills_lifecycle"]["active"] == 1
+    assert payload["skills_lifecycle"]["dormant"] == 1
+    assert payload["skills_lifecycle"]["archived"] == 1


### PR DESCRIPTION
### Motivation
- Provide longitudinal metrics per skill (usage, average gain, cost, failures) and persist them to memory to enable lifecycle decisions and observability. 
- Introduce governed maintenance rules to avoid silent deletion of skills and allow controlled archival, temporary disable and restoration workflows. 
- Surface skill lifecycle state in `status` and the dashboard so operators can read the life trajectory of skills.

### Description
- Persist longitudinal skill metrics and lifecycle metadata in `mem/skills.json` and add a snapshots directory `mem/skills_snapshots` for governed deletion snapshots, implemented in `src/singular/memory.py` (helpers: `record_skill_metric`, `apply_skill_maintenance`, `temporarily_disable_skill`, `restore_skill`, `controlled_delete_skill`, normalization helpers). 
- Hook mutation consolidation to update metrics automatically on accepted/rejected mutations (`_consolidate_applied_mutation` / `_consolidate_rejected_mutation` in `src/singular/memory.py`). 
- Expose skill lifecycle counts (active, dormant, archived, temporarily_disabled, deleted, total) in the CLI `status` output (`src/singular/organisms/status.py`) and in the dashboard payloads (`/api/cockpit` and `/dashboard/context` in `src/singular/dashboard/__init__.py`). 
- Add a small UI panel to the dashboard to show cards for skills active/dormant/archived and wire the JS to display these counts (`src/singular/dashboard/templates/dashboard.html`). 
- Add regression tests covering longitudinal metrics persistence, archive/restore losslessness, temporary disable and controlled delete, and assertions that the dashboard/context and status include skill lifecycle data (tests added/updated in `tests/test_memory.py`, `tests/test_status.py`, `tests/test_dashboard.py`). 

### Testing
- Ran the focused test set including the new/regression tests: `pytest -q tests/test_memory.py::test_record_skill_metric_persists_longitudinal_fields tests/test_memory.py::test_skill_maintenance_archive_and_restore_is_lossless tests/test_memory.py::test_skill_temporary_disable_and_controlled_delete tests/test_status.py::test_status_exposes_skill_lifecycle_counts tests/test_dashboard.py::test_dashboard_endpoints tests/test_dashboard.py::test_dashboard_cockpit_endpoint_schema tests/test_dashboard.py::test_dashboard_index_contains_cockpit_cards` — result: all passed (7 passed). 
- Ran the broader modified-files test selection (`pytest -q tests/test_memory.py tests/test_status.py tests/test_dashboard.py`) — result: targeted changes passed, but two preexisting unrelated expectations failed in `tests/test_memory.py` (baseline around `psyche` and starter skills), not caused by these changes. 
- Files changed: `src/singular/memory.py`, `src/singular/organisms/status.py`, `src/singular/dashboard/__init__.py`, `src/singular/dashboard/templates/dashboard.html`, and tests `tests/test_memory.py`, `tests/test_status.py`, `tests/test_dashboard.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de542e33cc832aa46d8d8856cdade2)