### PR TITLE
Add staged skill runtime and execute skills during ACTION phase

### DIFF
--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -23,6 +23,7 @@ from singular.perception import capture_signals
 from singular.psyche import Psyche
 from singular.resource_manager import ResourceManager
 from singular.quests import QuestRuntime
+from singular.skills.runtime import SkillRuntime
 
 
 class LifecyclePhase(Enum):
@@ -100,6 +101,11 @@ class OrchestratorService:
         self.resource_manager = ResourceManager(path=self.resources_path)
         self.psyche = Psyche.load_state()
         self.quest_runtime = QuestRuntime(base_dir=self.base_dir, mem_dir=self.mem_dir)
+        self.skill_runtime = SkillRuntime(
+            skills_dir=self.skills_dir,
+            mem_dir=self.mem_dir,
+            bus=self.bus,
+        )
         self.governance_policy = MutationGovernancePolicy(safe_mode=self.config.safe_mode)
         self._running = False
         self._wake_requested = False
@@ -246,7 +252,17 @@ class OrchestratorService:
             )
             if mood.value == "fatigue":
                 tick_budget *= max(fatigue_slowdown, 1.0)
+            skill_execution = None
             if not self.config.dry_run:
+                skill_execution = self.skill_runtime.execute_best_skill(
+                    task={"name": "orchestrator.action", "capabilities": []},
+                    context={
+                        "phase": phase.value,
+                        "mood": mood.value,
+                        "energy": self.resource_manager.energy,
+                        "food": self.resource_manager.food,
+                    },
+                )
                 run_tick(
                     skills_dirs=self.skills_dir,
                     checkpoint_path=self.checkpoint_path,
@@ -270,6 +286,16 @@ class OrchestratorService:
                     "tick_budget_seconds": tick_budget,
                     "allowed_actions": behavior.get("allowed_actions", []),
                     "quests": quest_outcomes,
+                    "skill_execution": (
+                        {
+                            "skill": skill_execution.skill,
+                            "status": skill_execution.status,
+                            "score": skill_execution.score,
+                            "reason": skill_execution.reason,
+                        }
+                        if skill_execution is not None
+                        else None
+                    ),
                 },
             )
             return

--- a/src/singular/skills/__init__.py
+++ b/src/singular/skills/__init__.py
@@ -1,0 +1,5 @@
+"""Skill execution runtime."""
+
+from .runtime import SkillRuntime, SkillExecutionResult, execute_best_skill
+
+__all__ = ["SkillRuntime", "SkillExecutionResult", "execute_best_skill"]

--- a/src/singular/skills/runtime.py
+++ b/src/singular/skills/runtime.py
@@ -1,0 +1,205 @@
+"""Central runtime to pick and execute the best skill."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from singular.events import EventBus, get_global_event_bus
+from singular.life import sandbox
+from singular.memory import read_skills
+
+
+@dataclass(frozen=True)
+class SkillExecutionResult:
+    """Result envelope for one runtime skill execution."""
+
+    skill: str | None
+    status: str
+    score: float | None = None
+    output: Any = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class _ScoredCandidate:
+    skill: str
+    path: Path
+    metadata: dict[str, Any]
+    score: float
+
+
+class SkillRuntime:
+    """Resolve compatible skills, rank them and run the best candidate."""
+
+    def __init__(
+        self,
+        *,
+        skills_dir: Path,
+        mem_dir: Path,
+        bus: EventBus | None = None,
+    ) -> None:
+        self.skills_dir = Path(skills_dir)
+        self.mem_dir = Path(mem_dir)
+        self.bus = bus or get_global_event_bus()
+
+    def execute_best_skill(self, task: str | dict[str, Any], context: dict[str, Any]) -> SkillExecutionResult:
+        """Execute the best compatible skill for ``task`` and ``context``."""
+
+        task_dict = self._normalize_task(task)
+        skills_state = read_skills(self.mem_dir / "skills.json")
+        candidates = self._compatible_candidates(task_dict, skills_state)
+        if not candidates:
+            result = SkillExecutionResult(skill=None, status="failed", reason="no_compatible_skill")
+            self.bus.publish(
+                "skill.execution.failed",
+                {
+                    "task": task_dict,
+                    "reason": result.reason,
+                },
+            )
+            return result
+
+        top = max(candidates, key=lambda item: item.score)
+        self.bus.publish(
+            "skill.execution.started",
+            {
+                "task": task_dict,
+                "skill": top.skill,
+                "score": top.score,
+            },
+        )
+        try:
+            code = top.path.read_text(encoding="utf-8")
+            wrapped = self._wrap_for_sandbox(code, context)
+            output = sandbox.run(wrapped)
+            result = SkillExecutionResult(
+                skill=top.skill,
+                status="succeeded",
+                score=top.score,
+                output=output,
+            )
+            self.bus.publish(
+                "skill.execution.succeeded",
+                {
+                    "task": task_dict,
+                    "skill": top.skill,
+                    "score": top.score,
+                    "output": output,
+                },
+            )
+            return result
+        except Exception as exc:
+            result = SkillExecutionResult(
+                skill=top.skill,
+                status="failed",
+                score=top.score,
+                reason=str(exc),
+            )
+            self.bus.publish(
+                "skill.execution.failed",
+                {
+                    "task": task_dict,
+                    "skill": top.skill,
+                    "score": top.score,
+                    "reason": str(exc),
+                },
+            )
+            return result
+
+    def _compatible_candidates(
+        self,
+        task: dict[str, Any],
+        skills_state: dict[str, Any],
+    ) -> list[_ScoredCandidate]:
+        required_signature = task.get("signature")
+        required_capabilities = set(task.get("capabilities", []))
+        max_risk = float(task.get("max_risk", 1.0))
+
+        candidates: list[_ScoredCandidate] = []
+        for path in sorted(self.skills_dir.glob("*.py")):
+            key = path.stem
+            raw_metadata = skills_state.get(key)
+            metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+            lifecycle = metadata.get("lifecycle") if isinstance(metadata.get("lifecycle"), dict) else {}
+            if lifecycle.get("state") in {"archived", "deleted", "temporarily_disabled"}:
+                continue
+            signature = metadata.get("signature")
+            if isinstance(required_signature, str) and isinstance(signature, str) and signature != required_signature:
+                continue
+            capabilities = metadata.get("capabilities") if isinstance(metadata.get("capabilities"), list) else []
+            if required_capabilities and not required_capabilities.issubset(set(capabilities)):
+                continue
+            risk = self._estimated_risk(metadata)
+            if risk > max_risk:
+                continue
+            candidates.append(
+                _ScoredCandidate(
+                    skill=key,
+                    path=path,
+                    metadata=metadata,
+                    score=self._score_candidate(metadata),
+                )
+            )
+        return candidates
+
+    def _score_candidate(self, metadata: dict[str, Any]) -> float:
+        metrics = metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
+        usage_count = max(int(metrics.get("usage_count", 0) or 0), 0)
+        average_gain = float(metrics.get("average_gain", 0.0) or 0.0)
+        average_cost = float(metrics.get("average_cost", 0.0) or 0.0)
+        failure_count = max(int(metrics.get("failure_count", 0) or 0), 0)
+
+        success_rate = 0.5
+        if usage_count > 0:
+            success_rate = max(0.0, min(1.0, 1.0 - (failure_count / usage_count)))
+
+        expected_utility = average_gain
+        resource_cost = max(0.0, average_cost)
+        risk = self._estimated_risk(metadata)
+
+        return (expected_utility * 0.45) + (success_rate * 0.35) - (resource_cost * 0.1) - (risk * 0.1)
+
+    def _estimated_risk(self, metadata: dict[str, Any]) -> float:
+        metrics = metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
+        usage_count = max(int(metrics.get("usage_count", 0) or 0), 0)
+        failure_count = max(int(metrics.get("failure_count", 0) or 0), 0)
+        historical_risk = (failure_count / usage_count) if usage_count else 0.5
+        declared_risk = float(metadata.get("risk", historical_risk) or historical_risk)
+        return max(0.0, min(1.0, declared_risk))
+
+    def _normalize_task(self, task: str | dict[str, Any]) -> dict[str, Any]:
+        if isinstance(task, str):
+            return {"name": task, "capabilities": [], "max_risk": 1.0}
+        capabilities = task.get("capabilities") if isinstance(task.get("capabilities"), list) else []
+        normalized = {
+            "name": str(task.get("name") or "task"),
+            "signature": task.get("signature") if isinstance(task.get("signature"), str) else None,
+            "capabilities": [str(cap) for cap in capabilities],
+            "max_risk": float(task.get("max_risk", 1.0) or 1.0),
+        }
+        return normalized
+
+    def _wrap_for_sandbox(self, source: str, context: dict[str, Any]) -> str:
+        context_literal = repr(context)
+        return (
+            f"{source}\n\n"
+            f"__runtime_context = {context_literal}\n"
+            "if 'run' in globals():\n"
+            "    result = run(__runtime_context)\n"
+            "elif 'result' not in globals():\n"
+            "    result = None\n"
+        )
+
+
+def execute_best_skill(task: str | dict[str, Any], context: dict[str, Any]) -> SkillExecutionResult:
+    """Convenience API using default paths and global event bus."""
+
+    from singular.memory import get_base_dir, get_mem_dir
+
+    runtime = SkillRuntime(
+        skills_dir=get_base_dir() / "skills",
+        mem_dir=get_mem_dir(),
+    )
+    return runtime.execute_best_skill(task, context)

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -92,3 +92,34 @@ def test_orchestrator_triggers_and_settles_quest(monkeypatch, tmp_path: Path) ->
     payload = quests_path.read_text(encoding="utf-8")
     assert '"repair"' in payload
     assert '"success"' in payload
+
+
+def test_orchestrator_action_executes_skill_runtime(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "mem").mkdir(parents=True)
+    (life / "skills" / "a.py").write_text("result = 1", encoding="utf-8")
+
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+
+    from singular.skills.runtime import SkillExecutionResult
+
+    calls: list[tuple[object, object]] = []
+
+    def _fake_execute(task, context):
+        calls.append((task, context))
+        return SkillExecutionResult(skill="a", status="succeeded", score=0.9)
+
+    monkeypatch.setattr("singular.orchestrator.service.run_tick", lambda **kwargs: None)
+
+    bus = EventBus()
+    service = OrchestratorService(config=OrchestratorConfig(dry_run=False), bus=bus)
+    service.state.current_phase = LifecyclePhase.ACTION.value
+    monkeypatch.setattr(service.skill_runtime, "execute_best_skill", _fake_execute)
+
+    service.tick()
+
+    assert calls
+    task, context = calls[0]
+    assert task["name"] == "orchestrator.action"
+    assert context["phase"] == "action"

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+from singular.events import EventBus
+from singular.skills.runtime import SkillRuntime
+
+
+def test_execute_best_skill_filters_and_scores(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("singular.skills.runtime.sandbox.run", lambda code: {"ok": True})
+    life = tmp_path / "life"
+    skills = life / "skills"
+    mem = life / "mem"
+    skills.mkdir(parents=True)
+    mem.mkdir(parents=True)
+
+    (skills / "good.py").write_text(
+        "def run(context=None):\n    return {'ok': True, 'name': 'good'}\n",
+        encoding="utf-8",
+    )
+    (skills / "bad.py").write_text(
+        "def run(context=None):\n    return {'ok': True, 'name': 'bad'}\n",
+        encoding="utf-8",
+    )
+
+    (mem / "skills.json").write_text(
+        """
+{
+  "good": {
+    "capabilities": ["math"],
+    "risk": 0.1,
+    "metrics": {
+      "usage_count": 10,
+      "average_gain": 2.0,
+      "average_cost": 0.2,
+      "failure_count": 1
+    }
+  },
+  "bad": {
+    "capabilities": ["math"],
+    "risk": 0.8,
+    "metrics": {
+      "usage_count": 10,
+      "average_gain": 0.1,
+      "average_cost": 2.0,
+      "failure_count": 8
+    }
+  }
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    events: list[str] = []
+    bus = EventBus()
+    bus.subscribe("skill.execution.started", lambda e: events.append(e.event_type))
+    bus.subscribe("skill.execution.succeeded", lambda e: events.append(e.event_type))
+
+    runtime = SkillRuntime(skills_dir=skills, mem_dir=mem, bus=bus)
+    result = runtime.execute_best_skill(
+        task={"name": "solve", "capabilities": ["math"], "max_risk": 0.5},
+        context={"x": 1},
+    )
+
+    assert result.status == "succeeded"
+    assert result.skill == "good"
+    assert events == ["skill.execution.started", "skill.execution.succeeded"]
+
+
+def test_execute_best_skill_emits_failed_when_none(tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    skills = life / "skills"
+    mem = life / "mem"
+    skills.mkdir(parents=True)
+    mem.mkdir(parents=True)
+    (mem / "skills.json").write_text("{}", encoding="utf-8")
+
+    failed_payloads: list[dict] = []
+    bus = EventBus()
+    bus.subscribe("skill.execution.failed", lambda e: failed_payloads.append(e.payload))
+
+    runtime = SkillRuntime(skills_dir=skills, mem_dir=mem, bus=bus)
+    result = runtime.execute_best_skill(
+        task={"name": "empty", "capabilities": ["missing"]},
+        context={},
+    )
+
+    assert result.status == "failed"
+    assert result.reason == "no_compatible_skill"
+    assert failed_payloads[-1]["reason"] == "no_compatible_skill"


### PR DESCRIPTION
### Motivation
- Provide a central runtime to pick and execute the most appropriate skill during a life `ACTION` tick so a life can actually run capabilities, not only mutate code.
- Improve selection quality by using a multi-step pipeline (compatibility, scoring, sandboxed execution) and emit standardized events for observability and traceability.

### Description
- Add a new runtime `src/singular/skills/runtime.py` containing `SkillRuntime`, `SkillExecutionResult`, and a convenience `execute_best_skill(task, context)` API that implements compatibility filtering, scoring, and sandbox execution.
- Export the runtime from `src/singular/skills/__init__.py` to provide a clear package API surface (`SkillRuntime`, `SkillExecutionResult`, `execute_best_skill`).
- Wire the runtime into the orchestrator by instantiating `SkillRuntime` in `OrchestratorService` and invoking `execute_best_skill(...)` during the `ACTION` phase, then include the execution outcome in the phase event payload.
- Emit standardized bus events `skill.execution.started`, `skill.execution.succeeded`, and `skill.execution.failed` for each execution attempt and handle sandbox exceptions/failed selection paths.
- Add unit tests `tests/test_skill_runtime.py` (selection, scoring and event emission) and extend `tests/test_orchestrator_service.py` to assert the ACTION phase calls the runtime.

### Testing
- Ran `pytest -q tests/test_skill_runtime.py tests/test_orchestrator_service.py` and the suite succeeded with all tests passing.
- The new tests exercise: `SkillRuntime.execute_best_skill` filtering/scoring/events and the orchestrator `ACTION`-phase integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de55ff5568832a84c84fcf90b88ed7)