### PR TITLE
Add periodic routines orchestration and execute routines during ACTION phase

### DIFF
--- a/configs/routines.yaml
+++ b/configs/routines.yaml
@@ -1,0 +1,21 @@
+routines:
+  - id: summarize_inbox
+    description: Résumer les nouveaux messages de la boîte de réception.
+    prompt: "Résume les nouveautés de la inbox et propose 3 prochaines actions."
+    interval_minutes: 30
+    priority: 80
+  - id: check_technical_debt
+    description: Vérifier les signaux de dette technique et lister les remédiations.
+    prompt: "Inspecte les signaux de dette technique et priorise les corrections."
+    interval_minutes: 180
+    priority: 70
+  - id: consolidate_memory
+    description: Consolider la mémoire épisodique vers des éléments exploitables.
+    prompt: "Consolide la mémoire: épisodes clés, apprentissages, actions suivantes."
+    interval_minutes: 240
+    priority: 60
+  - id: answer_human_prompt
+    description: Traiter une sollicitation humaine en attente.
+    prompt: "Détecte et réponds au prochain prompt humain en attente."
+    interval_minutes: 15
+    priority: 90

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -24,6 +24,7 @@ from singular.psyche import Psyche
 from singular.resource_manager import ResourceManager
 from singular.quests import QuestRuntime
 from singular.skills.runtime import SkillRuntime
+from singular.routines import RoutinesOrchestrator
 
 
 class LifecyclePhase(Enum):
@@ -107,6 +108,7 @@ class OrchestratorService:
             bus=self.bus,
         )
         self.governance_policy = MutationGovernancePolicy(safe_mode=self.config.safe_mode)
+        self.routines = RoutinesOrchestrator(state_path=self.mem_dir / "routines_state.json")
         self._running = False
         self._wake_requested = False
         self._pending_events: list[dict[str, Any]] = []
@@ -253,15 +255,21 @@ class OrchestratorService:
             if mood.value == "fatigue":
                 tick_budget *= max(fatigue_slowdown, 1.0)
             skill_execution = None
+            routine_executions: list[dict[str, Any]] = []
             if not self.config.dry_run:
+                action_context = {
+                    "phase": phase.value,
+                    "mood": mood.value,
+                    "energy": self.resource_manager.energy,
+                    "food": self.resource_manager.food,
+                }
                 skill_execution = self.skill_runtime.execute_best_skill(
                     task={"name": "orchestrator.action", "capabilities": []},
-                    context={
-                        "phase": phase.value,
-                        "mood": mood.value,
-                        "energy": self.resource_manager.energy,
-                        "food": self.resource_manager.food,
-                    },
+                    context=action_context,
+                )
+                routine_executions = self.routines.execute_with_runtime(
+                    skill_runtime=self.skill_runtime,
+                    base_context=action_context,
                 )
                 run_tick(
                     skills_dirs=self.skills_dir,
@@ -286,6 +294,7 @@ class OrchestratorService:
                     "tick_budget_seconds": tick_budget,
                     "allowed_actions": behavior.get("allowed_actions", []),
                     "quests": quest_outcomes,
+                    "routines": routine_executions,
                     "skill_execution": (
                         {
                             "skill": skill_execution.skill,

--- a/src/singular/routines.py
+++ b/src/singular/routines.py
@@ -1,0 +1,259 @@
+"""Periodic routines orchestration and state persistence."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+from singular.memory import _atomic_write_text
+
+DEFAULT_ROUTINES_PATH = Path(__file__).resolve().parents[2] / "configs" / "routines.yaml"
+
+
+@dataclass(frozen=True)
+class RoutineSpec:
+    """Static routine configuration loaded from YAML."""
+
+    id: str
+    prompt: str
+    description: str
+    interval_minutes: int = 60
+    priority: int = 50
+    max_risk: float = 1.0
+
+
+@dataclass
+class RoutineTask:
+    """One due routine execution task."""
+
+    id: str
+    prompt: str
+    description: str
+    priority: int
+    due_at: str
+    deadline_at: str
+    max_risk: float
+
+
+@dataclass
+class RoutineRunState:
+    """Persisted execution state for a routine."""
+
+    last_run_at: str | None = None
+    last_success: bool | None = None
+    last_latency_ms: float | None = None
+    next_run_at: str | None = None
+
+
+class RoutinesOrchestrator:
+    """Generate due routine tasks and persist execution state."""
+
+    def __init__(self, *, config_path: Path | None = None, state_path: Path) -> None:
+        self.config_path = config_path or DEFAULT_ROUTINES_PATH
+        self.state_path = state_path
+        self.specs = self._load_specs()
+        self.state = self._load_state()
+
+    def _now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def _load_specs(self) -> list[RoutineSpec]:
+        if not self.config_path.exists():
+            return []
+        try:
+            import yaml  # type: ignore
+        except ImportError:
+            payload = self._load_simple_routines_yaml(self.config_path)
+        else:
+            try:
+                payload = yaml.safe_load(self.config_path.read_text(encoding="utf-8"))
+            except Exception:
+                return []
+        if not isinstance(payload, dict):
+            return []
+
+        routines = payload.get("routines", [])
+        specs: list[RoutineSpec] = []
+        if not isinstance(routines, list):
+            return specs
+        for raw in routines:
+            if not isinstance(raw, dict):
+                continue
+            routine_id = raw.get("id")
+            prompt = raw.get("prompt")
+            if not isinstance(routine_id, str) or not routine_id.strip():
+                continue
+            if not isinstance(prompt, str) or not prompt.strip():
+                continue
+            specs.append(
+                RoutineSpec(
+                    id=routine_id.strip(),
+                    prompt=prompt.strip(),
+                    description=str(raw.get("description", "")).strip(),
+                    interval_minutes=max(1, int(raw.get("interval_minutes", 60))),
+                    priority=max(0, int(raw.get("priority", 50))),
+                    max_risk=max(0.0, min(1.0, float(raw.get("max_risk", 1.0)))),
+                )
+            )
+        return specs
+
+
+    def _load_simple_routines_yaml(self, path: Path) -> dict[str, Any]:
+        routines: list[dict[str, Any]] = []
+        current: dict[str, Any] | None = None
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or line == "routines:":
+                continue
+            if line.startswith("- "):
+                if current:
+                    routines.append(current)
+                current = {}
+                line = line[2:].strip()
+                if ":" in line:
+                    key, value = line.split(":", 1)
+                    current[key.strip()] = self._parse_scalar(value)
+                continue
+            if current is not None and ":" in line:
+                key, value = line.split(":", 1)
+                current[key.strip()] = self._parse_scalar(value)
+        if current:
+            routines.append(current)
+        return {"routines": routines}
+
+    def _parse_scalar(self, value: str) -> Any:
+        text = value.strip().strip('"').strip("'")
+        if not text:
+            return ""
+        try:
+            return int(text)
+        except ValueError:
+            try:
+                return float(text)
+            except ValueError:
+                return text
+
+    def _load_state(self) -> dict[str, RoutineRunState]:
+        if not self.state_path.exists():
+            return {}
+        try:
+            payload = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        routines = payload.get("routines", {}) if isinstance(payload, dict) else {}
+        if not isinstance(routines, dict):
+            return {}
+
+        state: dict[str, RoutineRunState] = {}
+        for key, raw in routines.items():
+            if not isinstance(key, str) or not isinstance(raw, dict):
+                continue
+            state[key] = RoutineRunState(
+                last_run_at=raw.get("last_run_at") if isinstance(raw.get("last_run_at"), str) else None,
+                last_success=raw.get("last_success") if isinstance(raw.get("last_success"), bool) else None,
+                last_latency_ms=float(raw.get("last_latency_ms")) if isinstance(raw.get("last_latency_ms"), (int, float)) else None,
+                next_run_at=raw.get("next_run_at") if isinstance(raw.get("next_run_at"), str) else None,
+            )
+        return state
+
+    def _save_state(self) -> None:
+        payload = {
+            "routines": {name: asdict(item) for name, item in self.state.items()},
+            "updated_at": self._now().isoformat(),
+        }
+        _atomic_write_text(self.state_path, json.dumps(payload, ensure_ascii=False, indent=2))
+
+    def _parse_iso(self, value: str | None) -> datetime | None:
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+
+    def due_tasks(self) -> list[RoutineTask]:
+        now = self._now()
+        due: list[RoutineTask] = []
+        for spec in self.specs:
+            snapshot = self.state.get(spec.id, RoutineRunState())
+            next_run = self._parse_iso(snapshot.next_run_at)
+            if next_run is None:
+                next_run = now
+            if next_run > now:
+                continue
+            deadline = next_run + timedelta(minutes=spec.interval_minutes)
+            due.append(
+                RoutineTask(
+                    id=spec.id,
+                    prompt=spec.prompt,
+                    description=spec.description,
+                    priority=spec.priority,
+                    due_at=next_run.isoformat(),
+                    deadline_at=deadline.isoformat(),
+                    max_risk=spec.max_risk,
+                )
+            )
+        due.sort(key=lambda item: (-item.priority, item.deadline_at))
+        return due
+
+    def mark_executed(self, task: RoutineTask, *, success: bool, latency_ms: float) -> None:
+        executed_at = self._now()
+        next_run = executed_at + timedelta(
+            minutes=next((spec.interval_minutes for spec in self.specs if spec.id == task.id), 60)
+        )
+        self.state[task.id] = RoutineRunState(
+            last_run_at=executed_at.isoformat(),
+            last_success=success,
+            last_latency_ms=max(0.0, float(latency_ms)),
+            next_run_at=next_run.isoformat(),
+        )
+        self._save_state()
+
+    def execute_with_runtime(self, *, skill_runtime: Any, base_context: dict[str, Any]) -> list[dict[str, Any]]:
+        """Execute all due routines through the skill runtime."""
+
+        outcomes: list[dict[str, Any]] = []
+        for task in self.due_tasks():
+            started = perf_counter()
+            result = skill_runtime.execute_best_skill(
+                task={
+                    "name": f"routine.{task.id}",
+                    "capabilities": [],
+                    "max_risk": task.max_risk,
+                    "priority": task.priority,
+                    "due_at": task.due_at,
+                    "deadline_at": task.deadline_at,
+                    "prompt": task.prompt,
+                },
+                context={
+                    **base_context,
+                    "routine": {
+                        "id": task.id,
+                        "description": task.description,
+                        "prompt": task.prompt,
+                        "priority": task.priority,
+                        "due_at": task.due_at,
+                        "deadline_at": task.deadline_at,
+                    },
+                },
+            )
+            latency_ms = (perf_counter() - started) * 1000.0
+            success = result.status == "succeeded"
+            self.mark_executed(task, success=success, latency_ms=latency_ms)
+            outcomes.append(
+                {
+                    "routine": task.id,
+                    "status": result.status,
+                    "skill": result.skill,
+                    "score": result.score,
+                    "reason": result.reason,
+                    "latency_ms": latency_ms,
+                    "priority": task.priority,
+                    "deadline_at": task.deadline_at,
+                }
+            )
+        return outcomes

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from singular.routines import RoutinesOrchestrator
+from singular.skills.runtime import SkillExecutionResult
+
+
+def test_routines_generates_due_tasks_and_persists_state(tmp_path: Path) -> None:
+    config = tmp_path / "routines.yaml"
+    state = tmp_path / "routines_state.json"
+    config.write_text(
+        """
+routines:
+  - id: summarize_inbox
+    prompt: "Resume inbox"
+    interval_minutes: 5
+    priority: 80
+""".strip(),
+        encoding="utf-8",
+    )
+
+    orchestrator = RoutinesOrchestrator(config_path=config, state_path=state)
+    due = orchestrator.due_tasks()
+
+    assert len(due) == 1
+    task = due[0]
+    orchestrator.mark_executed(task, success=True, latency_ms=42.0)
+
+    payload = state.read_text(encoding="utf-8")
+    assert "summarize_inbox" in payload
+    assert "last_run_at" in payload
+    assert "next_run_at" in payload
+
+
+def test_routines_executed_during_action_phase(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    (life / "mem").mkdir(parents=True)
+    (life / "skills").mkdir(parents=True)
+
+    routines_config = tmp_path / "routines.yaml"
+    routines_config.write_text(
+        """
+routines:
+  - id: answer_human_prompt
+    prompt: "Repondre humain"
+    interval_minutes: 5
+    priority: 90
+""".strip(),
+        encoding="utf-8",
+    )
+
+    calls: list[dict] = []
+
+    class _Runtime:
+        def execute_best_skill(self, task, context):
+            calls.append({"task": task, "context": context})
+            return SkillExecutionResult(skill="a", status="succeeded", score=0.9)
+
+    orchestrator = RoutinesOrchestrator(
+        config_path=routines_config,
+        state_path=life / "mem" / "routines_state.json",
+    )
+
+    outcomes = orchestrator.execute_with_runtime(
+        skill_runtime=_Runtime(),
+        base_context={"phase": "action"},
+    )
+
+    assert outcomes
+    assert calls
+    assert calls[0]["task"]["name"] == "routine.answer_human_prompt"
+    assert (life / "mem" / "routines_state.json").exists()


### PR DESCRIPTION
### Motivation
- Introduire des routines périodiques (ex: résumé inbox, vérification dette technique, consolidation mémoire, réponse à prompt humain) pour générer automatiquement des tâches à exécuter régulièrement pendant la phase `ACTION` de l’orchestrateur.
- Permettre que ces routines soient traitées par le `Skill Runtime` et que leur état d’exécution soit persisté pour suivi et planification future.

### Description
- Ajout d’un fichier de configuration d’exemples `configs/routines.yaml` contenant plusieurs routines avec `id`, `prompt`, `interval_minutes` et `priority`.
- Nouveau module `src/singular/routines.py` fournissant la classe `RoutinesOrchestrator` qui charge les specs (avec un parser YAML de secours si `PyYAML` est absent), génère les tâches dues (`due_tasks`), exécute les tâches via `skill_runtime.execute_best_skill` et persiste l’état dans `mem/routines_state.json` (champs persistés : `last_run_at`, `last_success`, `last_latency_ms`, `next_run_at`).
- Intégration dans `src/singular/orchestrator/service.py` : import et instanciation de `RoutinesOrchestrator`, exécution des routines via `execute_with_runtime` dans la phase `ACTION`, et inclusion des résultats `routines` dans les événements de phase transmis par l’orchestrateur.
- Ajout de tests `tests/test_routines.py` couvrant la génération des tâches dues, la persistance de l’état et l’exécution via un runtime factice.

### Testing
- Tests unitaires exécutés avec `pytest -q tests/test_routines.py tests/test_orchestrator_service.py tests/test_skill_runtime.py`.
- Résultat : tous les tests ciblés ont réussi (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de61064904832aba1aa94265a8c84e)