### PR TITLE
Add skill catalog and capability-driven runtime selection

### DIFF
--- a/src/singular/life/skill_catalog.py
+++ b/src/singular/life/skill_catalog.py
@@ -1,0 +1,182 @@
+"""Skill catalog metadata extraction and persistence utilities."""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+_CATALOG_FILENAME = "skill_catalog.json"
+
+
+_LINE_PATTERN = re.compile(r"^\s*([a-zA-Z_][a-zA-Z0-9_\- ]*)\s*:\s*(.+?)\s*$")
+
+
+def catalog_path(mem_dir: Path) -> Path:
+    """Return the path of the skill catalog file for ``mem_dir``."""
+
+    return Path(mem_dir) / _CATALOG_FILENAME
+
+
+def refresh_skill_catalog(*, skills_dir: Path, mem_dir: Path) -> dict[str, dict[str, Any]]:
+    """Scan ``skills_dir`` and persist a lightweight metadata catalog in ``mem_dir``."""
+
+    catalog: dict[str, dict[str, Any]] = {}
+    for skill_file in sorted(Path(skills_dir).glob("*.py")):
+        catalog[skill_file.stem] = _extract_skill_metadata(skill_file)
+
+    path = catalog_path(mem_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(catalog, ensure_ascii=False, indent=2), encoding="utf-8")
+    return catalog
+
+
+def read_skill_catalog(mem_dir: Path) -> dict[str, dict[str, Any]]:
+    """Read ``mem/skill_catalog.json`` if it exists."""
+
+    path = catalog_path(mem_dir)
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    out: dict[str, dict[str, Any]] = {}
+    for key, value in payload.items():
+        if isinstance(key, str) and isinstance(value, dict):
+            out[key] = value
+    return out
+
+
+def _extract_skill_metadata(skill_file: Path) -> dict[str, Any]:
+    source = skill_file.read_text(encoding="utf-8")
+    parse_errors: list[str] = []
+    module = ast.parse(source)
+
+    module_doc = ast.get_docstring(module) or ""
+    doc = _parse_docstring_annotations(module_doc, parse_errors)
+
+    run_node = _find_primary_callable(module)
+    input_format = doc.get("input_format") or _annotation_to_text(
+        run_node.args.args[0].annotation if run_node and run_node.args.args else None
+    )
+    output_format = doc.get("output_format") or _annotation_to_text(
+        run_node.returns if run_node else None
+    )
+
+    reliability = _parse_float(doc.get("reliability"), 0.5, parse_errors, "reliability")
+    estimated_cost = _parse_float(doc.get("estimated_cost"), 0.5, parse_errors, "estimated_cost")
+
+    capability_tags = _split_csv(doc.get("capability_tags"))
+    if not capability_tags:
+        capability_tags = _infer_capabilities(skill_file.stem, run_node)
+
+    preconditions = _split_csv(doc.get("preconditions"))
+
+    metadata: dict[str, Any] = {
+        "skill": skill_file.stem,
+        "capability_tags": capability_tags,
+        "preconditions": preconditions,
+        "input_format": input_format or "unknown",
+        "output_format": output_format or "unknown",
+        "estimated_cost": max(0.0, estimated_cost),
+        "reliability": min(1.0, max(0.0, reliability)),
+        "annotation_valid": len(parse_errors) == 0,
+        "parse_errors": parse_errors,
+    }
+    return metadata
+
+
+def _find_primary_callable(module: ast.Module) -> ast.FunctionDef | None:
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "run":
+            return node
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef):
+            return node
+    return None
+
+
+def _parse_docstring_annotations(doc: str, parse_errors: list[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    aliases = {
+        "capabilities": "capability_tags",
+        "capability tags": "capability_tags",
+        "capability_tags": "capability_tags",
+        "preconditions": "preconditions",
+        "input": "input_format",
+        "input_format": "input_format",
+        "output": "output_format",
+        "output_format": "output_format",
+        "cost": "estimated_cost",
+        "estimated_cost": "estimated_cost",
+        "reliability": "reliability",
+    }
+    for line in doc.splitlines():
+        match = _LINE_PATTERN.match(line)
+        if not match:
+            continue
+        raw_key = match.group(1).strip().lower()
+        value = match.group(2).strip()
+        key = aliases.get(raw_key)
+        if not key:
+            continue
+        values[key] = value
+
+    if "reliability" in values and _safe_float(values["reliability"]) is None:
+        parse_errors.append("invalid reliability")
+    if "estimated_cost" in values and _safe_float(values["estimated_cost"]) is None:
+        parse_errors.append("invalid estimated_cost")
+    return values
+
+
+def _split_csv(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    return [piece.strip() for piece in raw.split(",") if piece.strip()]
+
+
+def _safe_float(raw: str | None) -> float | None:
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_float(raw: str | None, default: float, parse_errors: list[str], name: str) -> float:
+    parsed = _safe_float(raw)
+    if parsed is None:
+        if raw is not None:
+            parse_errors.append(f"{name} must be a float")
+        return default
+    return parsed
+
+
+def _annotation_to_text(annotation: ast.expr | None) -> str | None:
+    if annotation is None:
+        return None
+    try:
+        return ast.unparse(annotation)
+    except Exception:
+        return None
+
+
+def _infer_capabilities(stem: str, run_node: ast.FunctionDef | None) -> list[str]:
+    inferred = [piece for piece in stem.split("_") if piece]
+    if run_node and run_node.name != "run":
+        inferred.append(run_node.name)
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for item in inferred:
+        norm = item.lower()
+        if norm not in seen:
+            deduped.append(norm)
+            seen.add(norm)
+    return deduped

--- a/src/singular/life/skill_genesis.py
+++ b/src/singular/life/skill_genesis.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from singular.governance.policy import MutationGovernancePolicy
 from singular.memory import read_skills, write_skills
 
+from .skill_catalog import refresh_skill_catalog
+
 
 @dataclass(frozen=True)
 class SkillGenesisResult:
@@ -127,6 +129,7 @@ def create_skill(
             "trigger": trigger,
         }
         write_skills(skills_after, mem_dir / "skills.json")
+        refresh_skill_catalog(skills_dir=skills_dir, mem_dir=mem_dir)
         _append_journal(
             mem_dir,
             {

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -14,6 +14,7 @@ from ..governance.values import ValueWeights
 from ..identity import create_identity
 from ..memory import ensure_memory_structure, update_score, write_profile
 from ..psyche import Psyche
+from ..life.skill_catalog import refresh_skill_catalog
 
 
 _PSYCHE_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
@@ -239,6 +240,8 @@ def birth(
                 0.0,
                 path=home / "mem" / "skills.json",
             )
+
+    refresh_skill_catalog(skills_dir=skills_dir, mem_dir=home / "mem")
 
     if seed is not None:
         random.seed(seed)

--- a/src/singular/skills/runtime.py
+++ b/src/singular/skills/runtime.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from singular.events import EventBus, get_global_event_bus
 from singular.life import sandbox
+from singular.life.skill_catalog import read_skill_catalog, refresh_skill_catalog
 from singular.memory import read_skills
 
 
@@ -49,7 +50,11 @@ class SkillRuntime:
 
         task_dict = self._normalize_task(task)
         skills_state = read_skills(self.mem_dir / "skills.json")
-        candidates = self._compatible_candidates(task_dict, skills_state)
+        catalog = read_skill_catalog(self.mem_dir)
+        if not catalog:
+            catalog = refresh_skill_catalog(skills_dir=self.skills_dir, mem_dir=self.mem_dir)
+
+        candidates = self._compatible_candidates(task_dict, skills_state, catalog)
         if not candidates:
             result = SkillExecutionResult(skill=None, status="failed", reason="no_compatible_skill")
             self.bus.publish(
@@ -112,71 +117,99 @@ class SkillRuntime:
         self,
         task: dict[str, Any],
         skills_state: dict[str, Any],
+        catalog: dict[str, dict[str, Any]],
     ) -> list[_ScoredCandidate]:
         required_signature = task.get("signature")
         required_capabilities = set(task.get("capabilities", []))
+        required_preconditions = set(task.get("preconditions", []))
+        required_input = task.get("input_format")
+        required_output = task.get("output_format")
         max_risk = float(task.get("max_risk", 1.0))
 
         candidates: list[_ScoredCandidate] = []
-        for path in sorted(self.skills_dir.glob("*.py")):
-            key = path.stem
-            raw_metadata = skills_state.get(key)
+        for skill, descriptor in sorted(catalog.items()):
+            path = self.skills_dir / f"{skill}.py"
+            if not path.exists():
+                continue
+            if descriptor.get("annotation_valid") is False:
+                continue
+
+            raw_metadata = skills_state.get(skill)
             metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
             lifecycle = metadata.get("lifecycle") if isinstance(metadata.get("lifecycle"), dict) else {}
             if lifecycle.get("state") in {"archived", "deleted", "temporarily_disabled"}:
                 continue
-            signature = metadata.get("signature")
+
+            signature = metadata.get("signature") if isinstance(metadata.get("signature"), str) else None
             if isinstance(required_signature, str) and isinstance(signature, str) and signature != required_signature:
                 continue
-            capabilities = metadata.get("capabilities") if isinstance(metadata.get("capabilities"), list) else []
-            if required_capabilities and not required_capabilities.issubset(set(capabilities)):
+
+            descriptor_caps = descriptor.get("capability_tags") if isinstance(descriptor.get("capability_tags"), list) else []
+            metadata_caps = metadata.get("capabilities") if isinstance(metadata.get("capabilities"), list) else []
+            capability_tags = {str(cap) for cap in [*descriptor_caps, *metadata_caps]}
+            if required_capabilities and not required_capabilities.issubset(capability_tags):
                 continue
-            risk = self._estimated_risk(metadata)
+
+            preconditions = set(descriptor.get("preconditions", []))
+            if required_preconditions and not required_preconditions.issubset(preconditions):
+                continue
+
+            if isinstance(required_input, str) and descriptor.get("input_format") not in {required_input, "unknown"}:
+                continue
+            if isinstance(required_output, str) and descriptor.get("output_format") not in {required_output, "unknown"}:
+                continue
+
+            risk = self._estimated_risk(metadata, descriptor)
             if risk > max_risk:
                 continue
             candidates.append(
                 _ScoredCandidate(
-                    skill=key,
+                    skill=skill,
                     path=path,
-                    metadata=metadata,
-                    score=self._score_candidate(metadata),
+                    metadata={"state": metadata, "catalog": descriptor},
+                    score=self._score_candidate(metadata, descriptor),
                 )
             )
         return candidates
 
-    def _score_candidate(self, metadata: dict[str, Any]) -> float:
+    def _score_candidate(self, metadata: dict[str, Any], descriptor: dict[str, Any]) -> float:
         metrics = metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
         usage_count = max(int(metrics.get("usage_count", 0) or 0), 0)
         average_gain = float(metrics.get("average_gain", 0.0) or 0.0)
-        average_cost = float(metrics.get("average_cost", 0.0) or 0.0)
+        average_cost = float(metrics.get("average_cost", descriptor.get("estimated_cost", 0.5)) or 0.0)
         failure_count = max(int(metrics.get("failure_count", 0) or 0), 0)
 
-        success_rate = 0.5
+        success_rate = float(descriptor.get("reliability", 0.5) or 0.5)
         if usage_count > 0:
-            success_rate = max(0.0, min(1.0, 1.0 - (failure_count / usage_count)))
+            historical_success = max(0.0, min(1.0, 1.0 - (failure_count / usage_count)))
+            success_rate = (success_rate * 0.4) + (historical_success * 0.6)
 
         expected_utility = average_gain
         resource_cost = max(0.0, average_cost)
-        risk = self._estimated_risk(metadata)
+        risk = self._estimated_risk(metadata, descriptor)
 
         return (expected_utility * 0.45) + (success_rate * 0.35) - (resource_cost * 0.1) - (risk * 0.1)
 
-    def _estimated_risk(self, metadata: dict[str, Any]) -> float:
+    def _estimated_risk(self, metadata: dict[str, Any], descriptor: dict[str, Any]) -> float:
         metrics = metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
         usage_count = max(int(metrics.get("usage_count", 0) or 0), 0)
         failure_count = max(int(metrics.get("failure_count", 0) or 0), 0)
         historical_risk = (failure_count / usage_count) if usage_count else 0.5
-        declared_risk = float(metadata.get("risk", historical_risk) or historical_risk)
+        declared_risk = float(metadata.get("risk", 1.0 - float(descriptor.get("reliability", 0.5))) or historical_risk)
         return max(0.0, min(1.0, declared_risk))
 
     def _normalize_task(self, task: str | dict[str, Any]) -> dict[str, Any]:
         if isinstance(task, str):
-            return {"name": task, "capabilities": [], "max_risk": 1.0}
+            return {"name": task, "capabilities": [], "preconditions": [], "max_risk": 1.0}
         capabilities = task.get("capabilities") if isinstance(task.get("capabilities"), list) else []
+        preconditions = task.get("preconditions") if isinstance(task.get("preconditions"), list) else []
         normalized = {
             "name": str(task.get("name") or "task"),
             "signature": task.get("signature") if isinstance(task.get("signature"), str) else None,
             "capabilities": [str(cap) for cap in capabilities],
+            "preconditions": [str(pre) for pre in preconditions],
+            "input_format": task.get("input_format") if isinstance(task.get("input_format"), str) else None,
+            "output_format": task.get("output_format") if isinstance(task.get("output_format"), str) else None,
             "max_risk": float(task.get("max_risk", 1.0) or 1.0),
         }
         return normalized

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -30,7 +30,7 @@ def test_birth_creates_memory_files(tmp_path: Path) -> None:
     birth(home=tmp_path)
     mem = tmp_path / "mem"
     assert mem.is_dir()
-    for name in ["profile.json", "values.yaml", "episodic.jsonl", "skills.json"]:
+    for name in ["profile.json", "values.yaml", "episodic.jsonl", "skills.json", "skill_catalog.json"]:
         assert (mem / name).exists()
 
 
@@ -139,6 +139,9 @@ def test_birth_initializes_default_skills(tmp_path: Path) -> None:
         (tmp_path / "mem" / "skills.json").read_text(encoding="utf-8")
     )
     assert skills_data == {name: {"score": 0.0} for name in expected_skill_names}
+
+    catalog = json.loads((tmp_path / "mem" / "skill_catalog.json").read_text(encoding="utf-8"))
+    assert set(catalog) >= set(expected_skill_names)
 
 
 def test_values_helpers_without_yaml(

--- a/tests/test_skill_catalog.py
+++ b/tests/test_skill_catalog.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from singular.life.skill_catalog import read_skill_catalog, refresh_skill_catalog
+
+
+def test_refresh_skill_catalog_extracts_docstring_annotations(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    mem_dir = tmp_path / "mem"
+    skills_dir.mkdir(parents=True)
+    mem_dir.mkdir(parents=True)
+
+    (skills_dir / "math_skill.py").write_text(
+        '"""Capabilities: math, arithmetic\n'
+        "Preconditions: numeric_input\n"
+        "Input: dict[str, float]\n"
+        "Output: float\n"
+        "Cost: 0.2\n"
+        "Reliability: 0.9\n"
+        '"""\n\n'
+        "def run(context: dict[str, float]) -> float:\n"
+        "    return float(context.get('x', 0.0))\n",
+        encoding="utf-8",
+    )
+
+    catalog = refresh_skill_catalog(skills_dir=skills_dir, mem_dir=mem_dir)
+
+    assert "math_skill" in catalog
+    descriptor = catalog["math_skill"]
+    assert descriptor["capability_tags"] == ["math", "arithmetic"]
+    assert descriptor["preconditions"] == ["numeric_input"]
+    assert descriptor["input_format"] == "dict[str, float]"
+    assert descriptor["output_format"] == "float"
+    assert descriptor["estimated_cost"] == 0.2
+    assert descriptor["reliability"] == 0.9
+    assert descriptor["annotation_valid"] is True
+
+    reloaded = read_skill_catalog(mem_dir)
+    assert reloaded["math_skill"]["capability_tags"] == ["math", "arithmetic"]

--- a/tests/test_skill_genesis.py
+++ b/tests/test_skill_genesis.py
@@ -45,6 +45,8 @@ def test_skill_genesis_creation_allowed(monkeypatch, tmp_path: Path) -> None:
     assert result.target.exists()
     payload = json.loads((mem_dir / "skills.json").read_text(encoding="utf-8"))
     assert result.skill_name in payload
+    catalog = json.loads((mem_dir / "skill_catalog.json").read_text(encoding="utf-8"))
+    assert result.skill_name in catalog
     assert (mem_dir / "skill_genesis.jsonl").exists()
 
 

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -86,3 +86,29 @@ def test_execute_best_skill_emits_failed_when_none(tmp_path: Path) -> None:
     assert result.status == "failed"
     assert result.reason == "no_compatible_skill"
     assert failed_payloads[-1]["reason"] == "no_compatible_skill"
+
+
+def test_execute_best_skill_rejects_malformed_catalog_annotations(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("singular.skills.runtime.sandbox.run", lambda code: {"ok": True})
+    life = tmp_path / "life"
+    skills = life / "skills"
+    mem = life / "mem"
+    skills.mkdir(parents=True)
+    mem.mkdir(parents=True)
+
+    (skills / "json_skill.py").write_text(
+        '"""Capabilities: json\nInput: json\nOutput: dict\nReliability: very-high\n"""\n\n'
+        "def run(context=None):\n    return {'ok': True}\n",
+        encoding="utf-8",
+    )
+
+    (mem / "skills.json").write_text('{"json_skill": {"risk": 0.0}}', encoding="utf-8")
+
+    runtime = SkillRuntime(skills_dir=skills, mem_dir=mem)
+    result = runtime.execute_best_skill(
+        task={"name": "json task", "capabilities": ["json"], "input_format": "json"},
+        context={"payload": {}},
+    )
+
+    assert result.status == "failed"
+    assert result.reason == "no_compatible_skill"


### PR DESCRIPTION
### Motivation
- Introduire des métadonnées légères pour les skills (tags de capacité, préconditions, formats I/O, coût estimé, fiabilité) afin d’améliorer et sécuriser la sélection des skills plutôt que de se baser seulement sur le nom de fichier.
- Remplir automatiquement ce catalogue à la naissance d’un organisme et après création de nouveaux skills pour garder l’état mémoire cohérent.

### Description
- Ajout du module `src/singular/life/skill_catalog.py` qui extrait des annotations/docstrings et écrit `mem/skill_catalog.json` (capability_tags, preconditions, input/output format, estimated_cost, reliability, annotation_valid, parse_errors).
- Modification du runtime `SkillRuntime` (`src/singular/skills/runtime.py`) pour lire/rafraîchir le catalogue et sélectionner les candidats en combinant contraintes du catalogue (capabilities, preconditions, formats, annotation_valid) avec l’état historique (metrics, lifecycle); le scoring intègre désormais la fiabilité déclarée et le coût estimé.
- Rafraîchissement automatique du catalogue intégré dans la naissance d’un organisme (`src/singular/organisms/birth.py`) après création des starter skills et après création réussie d’un skill (`src/singular/life/skill_genesis.py`).
- Ajout et mise à jour de tests: `tests/test_skill_catalog.py` (extraction/persistance), extension de `tests/test_skill_runtime.py` (régression: rejet d’annotations malformées), et adaptations de `tests/test_memory.py` et `tests/test_skill_genesis.py` pour vérifier la génération/actualisation du catalogue.

### Testing
- Tests ciblés exécutés: `pytest -q tests/test_skill_catalog.py tests/test_skill_runtime.py tests/test_skill_genesis.py::test_skill_genesis_creation_allowed tests/test_memory.py::test_birth_creates_memory_files` — tous les tests ciblés sont passés (6 passed).
- Les modifications incluent de nouveaux tests automatisés ajoutés au dépôt (`tests/test_skill_catalog.py`) et des mises à jour d’assertions dans les tests existants pour couvrir la présence et l’usage de `mem/skill_catalog.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de667a1d64832a9643ba6d28033e35)