### PR TITLE
Add run usage telemetry and reputation-aware skill/operator selection

### DIFF
--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -121,11 +121,37 @@ class IntrinsicGoals:
         food = _clamp(float((resources or {}).get("food", 50.0)) / 100.0)
         warmth = _clamp(float((resources or {}).get("warmth", 50.0)) / 100.0)
         resource_stability = (energy + food + warmth) / 3.0
+        telemetry_efficiency_penalty = 0.0
+        telemetry_quality_pressure = 0.0
+        telemetry_failure_pressure = 0.0
+        skill_reputation = (perception_signals or {}).get("skill_reputation")
+        if isinstance(skill_reputation, Mapping) and skill_reputation:
+            sample_count = 0.0
+            total_cost = 0.0
+            total_quality = 0.0
+            total_failures = 0.0
+            for raw_stats in skill_reputation.values():
+                if not isinstance(raw_stats, Mapping):
+                    continue
+                sample_count += 1.0
+                total_cost += float(raw_stats.get("mean_cost", 0.0))
+                total_quality += float(raw_stats.get("mean_quality", 0.5))
+                total_failures += float(raw_stats.get("recent_failures", 0.0))
+            if sample_count > 0:
+                mean_cost = total_cost / sample_count
+                mean_quality = total_quality / sample_count
+                mean_failures = total_failures / sample_count
+                telemetry_efficiency_penalty = _clamp(mean_cost / 200.0, 0.0, 1.0)
+                telemetry_quality_pressure = _clamp(1.0 - mean_quality, 0.0, 1.0)
+                telemetry_failure_pressure = _clamp(mean_failures / 3.0, 0.0, 1.0)
 
         base_weights = GoalWeights(
-            coherence=0.2 + 0.35 * patience + 0.25 * resilience,
-            robustesse=0.2 + 0.35 * (1.0 - health_norm) + 0.25 * (1.0 - resource_stability),
-            efficacite=0.2 + 0.45 * health_norm + 0.2 * optimism,
+            coherence=0.2 + 0.35 * patience + 0.25 * resilience + 0.2 * telemetry_quality_pressure,
+            robustesse=0.2
+            + 0.35 * (1.0 - health_norm)
+            + 0.25 * (1.0 - resource_stability)
+            + 0.2 * telemetry_failure_pressure,
+            efficacite=0.2 + 0.45 * health_norm + 0.2 * optimism + 0.2 * telemetry_efficiency_penalty,
             exploration=0.2 + 0.45 * curiosity + 0.2 * playfulness + 0.1 * (1.0 - energy),
         )
         modulation = apply_perception_rules(perception_signals)
@@ -217,14 +243,31 @@ class IntrinsicGoals:
             )
         return adjusted
 
-    def influence_operator_scores(self, operator_stats: Mapping[str, Mapping[str, float]]) -> dict[str, float]:
-        """Return per-operator biases for selector integration."""
+    def influence_operator_scores(
+        self,
+        operator_stats: Mapping[str, Mapping[str, float]],
+        skill_reputation: Mapping[str, Mapping[str, float | int]] | None = None,
+    ) -> dict[str, float]:
+        """Return per-operator biases using objective weights and usage telemetry."""
 
         if not operator_stats:
             return {}
         max_count = max(float(stats.get("count", 0.0)) for stats in operator_stats.values())
         if max_count <= 0.0:
             max_count = 1.0
+        reputation_cost = 0.0
+        reputation_failures = 0.0
+        reputation_quality = 0.0
+        reputation_samples = 0.0
+        if skill_reputation:
+            for stats in skill_reputation.values():
+                reputation_cost += float(stats.get("mean_cost", 0.0))
+                reputation_failures += float(stats.get("recent_failures", 0.0))
+                reputation_quality += float(stats.get("mean_quality", 0.0))
+                reputation_samples += 1.0
+        mean_reputation_cost = reputation_cost / reputation_samples if reputation_samples else 0.0
+        mean_reputation_quality = reputation_quality / reputation_samples if reputation_samples else 0.5
+        reputation_failure_penalty = _clamp(reputation_failures / max(reputation_samples, 1.0) / 3.0, 0.0, 1.0)
 
         biases: dict[str, float] = {}
         for name, stats in operator_stats.items():
@@ -233,10 +276,13 @@ class IntrinsicGoals:
             mean_reward = reward / count if count > 0 else 0.0
             exploration_signal = 1.0 - (count / max_count)
             efficiency_signal = _clamp(mean_reward + 0.5, 0.0, 1.0)
+            telemetry_alignment = _clamp(
+                mean_reputation_quality * 0.7 + (1.0 - reputation_failure_penalty) * 0.3
+            )
             biases[name] = self.objective_arbitration(
                 expected_gain=mean_reward,
-                sandbox_risk=0.0,
-                resource_cost=count / max_count,
+                sandbox_risk=reputation_failure_penalty,
+                resource_cost=_clamp((count / max_count) * 0.6 + mean_reputation_cost * 0.4),
                 novelty=exploration_signal,
-            ) + self.state.weights.efficacite * efficiency_signal
+            ) + self.state.weights.efficacite * efficiency_signal + self.state.weights.coherence * telemetry_alignment
         return biases

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -353,6 +353,10 @@ def manage_resources(
     return resource_manager.mood()
 
 
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
 def log_mutation(
     logger: RunLogger,
     iteration: int,
@@ -393,6 +397,18 @@ def log_mutation(
         score_base=base_score,
         score_new=mutated_score,
     )
+    reward_delta = base_score - mutated_score
+    perceived_quality = _clamp01(0.5 + (reward_delta * 0.5))
+    user_satisfaction = _clamp01(
+        (0.65 if accepted else 0.15) + (0.35 * perceived_quality)
+    )
+    usage_metrics = {
+        "success": accepted,
+        "latency_ms": ms_new,
+        "resource_cost": ms_base + ms_new,
+        "perceived_quality": perceived_quality,
+        "user_satisfaction": user_satisfaction,
+    }
     logger.log(
         key,
         op_name,
@@ -408,6 +424,7 @@ def log_mutation(
         human_summary=human_summary,
         loop_modifications=loop_modifications,
         health=health,
+        usage_metrics=usage_metrics,
     )
 
 
@@ -481,19 +498,55 @@ def _compute_loop_modifications(original: str, mutated: str) -> dict[str, int]:
 
 
 def _choose_skill(
-    rng: random.Random, organisms: Dict[str, Organism]
+    rng: random.Random,
+    organisms: Dict[str, Organism],
+    skill_reputation: Mapping[str, Mapping[str, float | int]] | None = None,
 ) -> tuple[str, Path]:
-    """Randomly choose an organism and one of its skills."""
+    """Choose a skill with utility-aware priority and exploration fallback."""
 
     if not organisms:
         raise RuntimeError("no organisms available")
 
-    org_name = rng.choice(list(organisms.keys()))
-    org = organisms[org_name]
-    available = list(org.skills_dir.glob("*.py"))
-    if not available:
-        raise RuntimeError(f"no skills available for organism {org_name}")
-    return org_name, rng.choice(available)
+    candidates: list[tuple[str, Path]] = []
+    for org_name, org in organisms.items():
+        available = list(org.skills_dir.glob("*.py"))
+        for skill_path in available:
+            candidates.append((org_name, skill_path))
+    if not candidates:
+        raise RuntimeError("no skills available for any organism")
+
+    def priority(org_name: str, skill_path: Path) -> float:
+        key = (
+            f"{org_name}:{skill_path.stem}"
+            if len(organisms) > 1
+            else skill_path.stem
+        )
+        rep = dict((skill_reputation or {}).get(key, {}))
+        quality = float(rep.get("mean_quality", 0.5))
+        use_count = float(rep.get("use_count", 0.0))
+        success_rate = float(rep.get("success_rate", 0.5))
+        recent_failures = float(rep.get("recent_failures", 0.0))
+        # Trigger rule: frequently used + low quality => targeted mutation.
+        targeted_mutation = 1.5 if use_count >= 5.0 and quality <= 0.45 else 0.0
+        return (
+            1.0
+            + (1.0 - quality) * 0.8
+            + use_count * 0.03
+            + recent_failures * 0.1
+            + (1.0 - success_rate) * 0.4
+            + targeted_mutation
+        )
+
+    weighted = [(org_name, skill_path, max(0.01, priority(org_name, skill_path))) for org_name, skill_path in candidates]
+    total = sum(weight for _, _, weight in weighted)
+    pick = rng.random() * total
+    cumulative = 0.0
+    for org_name, skill_path, weight in weighted:
+        cumulative += weight
+        if cumulative >= pick:
+            return org_name, skill_path
+    fallback_org, fallback_skill, _ = weighted[-1]
+    return fallback_org, fallback_skill
 
 
 def _pick_crossover_parents(rng: random.Random, world: WorldState) -> tuple[str, str]:
@@ -653,6 +706,7 @@ def run(
             signals = capture_signals(bus=event_bus)
             temp = get_temperature()
             signals["temperature"] = temp
+            signals["skill_reputation"] = logger.skill_reputation()
             resource_manager.update_from_environment(temp)
             state.iteration += 1
 
@@ -661,7 +715,11 @@ def run(
                 _, org_name, skill_path = heapq.heappop(delayed)
                 decision = Psyche.Decision.ACCEPT
             else:
-                org_name, skill_path = _choose_skill(rng, world.organisms)
+                org_name, skill_path = _choose_skill(
+                    rng,
+                    world.organisms,
+                    skill_reputation=logger.skill_reputation(),
+                )
                 decision = Psyche.Decision.ACCEPT
                 if hasattr(psyche, "irrational_decision"):
                     decision = psyche.irrational_decision(rng)
@@ -815,7 +873,10 @@ def run(
             )
             score_by_index = {index: score for index, _, score in reflection.alternative_scores}
             belief_bias = belief_store.operator_preference_bias(operators.keys())
-            combined_bias = intrinsic_goals.influence_operator_scores(stats)
+            combined_bias = intrinsic_goals.influence_operator_scores(
+                stats,
+                skill_reputation=logger.skill_reputation(),
+            )
             psyche_bias = getattr(psyche, "operator_bias", lambda names: {})(list(operators.keys()))
             for operator_name, extra_bias in belief_bias.items():
                 combined_bias[operator_name] = combined_bias.get(operator_name, 0.0) + extra_bias
@@ -1123,6 +1184,7 @@ def run(
                 "diff": diff,
                 "impacted_file": skill_path.name,
                 "timing_ms": {"base": ms_base, "new": ms_new},
+                "skill_reputation": logger.skill_reputation().get(key, {}),
             }
             event_bus.publish(
                 "mutation.applied" if accepted else "mutation.rejected",

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Mapping
 
 from ..psyche import Psyche
 from ..memory import add_episode, add_procedural_memory
@@ -21,6 +21,8 @@ RUNS_DIR = _BASE_DIR / "runs"
 # Number of run logs to retain
 MAX_RUN_LOGS = int(os.environ.get("SINGULAR_RUNS_KEEP", "20"))
 EVENT_SCHEMA_VERSION = 1
+USAGE_REPUTATION_SCHEMA_VERSION = 1
+DEFAULT_REPUTATION_UPDATE_EVERY = int(os.environ.get("SINGULAR_REPUTATION_UPDATE_EVERY", "5"))
 
 # ---------------------------------------------------------------------------
 # Mood style helpers
@@ -120,6 +122,7 @@ class RunLogger:
     run_id: str
     root: Path = RUNS_DIR
     psyche: Psyche = field(default_factory=Psyche.load_state)
+    reputation_update_every: int = DEFAULT_REPUTATION_UPDATE_EVERY
 
     def __post_init__(self) -> None:
         self.root = Path(self.root)
@@ -132,6 +135,10 @@ class RunLogger:
         self._events_file = self.events_path.open("a", encoding="utf-8")
         self.consciousness_path = self.run_dir / "consciousness.jsonl"
         self._consciousness_file = self.consciousness_path.open("a", encoding="utf-8")
+        self.skill_reputation_path = self.run_dir / "skill_reputation.json"
+        self._skill_telemetry: dict[str, dict[str, float | int]] = {}
+        self._skill_reputation: dict[str, dict[str, float | int]] = {}
+        self._load_skill_reputation()
 
         # Resume from existing temporary file if present
         tmp_pattern = f"{self.run_id}-*.jsonl.tmp"
@@ -150,6 +157,103 @@ class RunLogger:
             self.tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
             _ensure_dir(self.tmp_path)
             self._file = self.tmp_path.open("a", encoding="utf-8")
+
+    def _load_skill_reputation(self) -> None:
+        if not self.skill_reputation_path.exists():
+            return
+        try:
+            payload = json.loads(self.skill_reputation_path.read_text(encoding="utf-8"))
+        except (OSError, TypeError, json.JSONDecodeError):
+            return
+        if not isinstance(payload, Mapping):
+            return
+        skills = payload.get("skills")
+        if isinstance(skills, Mapping):
+            for skill_name, raw in skills.items():
+                if isinstance(raw, Mapping):
+                    self._skill_reputation[str(skill_name)] = {
+                        "success_rate": float(raw.get("success_rate", 0.0)),
+                        "mean_cost": float(raw.get("mean_cost", 0.0)),
+                        "recent_failures": int(raw.get("recent_failures", 0)),
+                        "mean_quality": float(raw.get("mean_quality", 0.0)),
+                        "mean_satisfaction": float(raw.get("mean_satisfaction", 0.0)),
+                        "use_count": int(raw.get("use_count", 0)),
+                    }
+
+    def _append_skill_telemetry(
+        self,
+        *,
+        skill: str,
+        success: bool,
+        latency_ms: float,
+        resource_cost: float,
+        perceived_quality: float,
+        user_satisfaction: float,
+    ) -> None:
+        telemetry = self._skill_telemetry.setdefault(
+            skill,
+            {
+                "count": 0,
+                "successes": 0,
+                "total_latency_ms": 0.0,
+                "total_resource_cost": 0.0,
+                "total_quality": 0.0,
+                "total_satisfaction": 0.0,
+                "recent_failures": 0,
+            },
+        )
+        telemetry["count"] = int(telemetry["count"]) + 1
+        telemetry["successes"] = int(telemetry["successes"]) + int(bool(success))
+        telemetry["total_latency_ms"] = float(telemetry["total_latency_ms"]) + float(latency_ms)
+        telemetry["total_resource_cost"] = float(telemetry["total_resource_cost"]) + float(resource_cost)
+        telemetry["total_quality"] = float(telemetry["total_quality"]) + float(perceived_quality)
+        telemetry["total_satisfaction"] = float(telemetry["total_satisfaction"]) + float(user_satisfaction)
+        telemetry["recent_failures"] = (
+            0 if success else min(int(telemetry["recent_failures"]) + 1, 1000)
+        )
+
+    def _maybe_update_skill_reputation(self, *, force: bool = False) -> None:
+        pending = sum(int(skill_data.get("count", 0)) for skill_data in self._skill_telemetry.values())
+        threshold = max(1, int(self.reputation_update_every))
+        if not force and pending < threshold:
+            return
+        if pending <= 0:
+            return
+
+        for skill_name, telemetry in self._skill_telemetry.items():
+            count = max(1, int(telemetry.get("count", 0)))
+            success_rate = float(telemetry.get("successes", 0)) / count
+            mean_cost = float(telemetry.get("total_resource_cost", 0.0)) / count
+            recent_failures = int(telemetry.get("recent_failures", 0))
+            mean_quality = float(telemetry.get("total_quality", 0.0)) / count
+            mean_satisfaction = float(telemetry.get("total_satisfaction", 0.0)) / count
+
+            previous = self._skill_reputation.get(skill_name, {})
+            previous_count = int(previous.get("use_count", 0))
+            blend = 0.0 if previous_count <= 0 else min(0.8, previous_count / (previous_count + count))
+            self._skill_reputation[skill_name] = {
+                "success_rate": (float(previous.get("success_rate", success_rate)) * blend)
+                + (success_rate * (1.0 - blend)),
+                "mean_cost": (float(previous.get("mean_cost", mean_cost)) * blend)
+                + (mean_cost * (1.0 - blend)),
+                "recent_failures": recent_failures,
+                "mean_quality": (float(previous.get("mean_quality", mean_quality)) * blend)
+                + (mean_quality * (1.0 - blend)),
+                "mean_satisfaction": (float(previous.get("mean_satisfaction", mean_satisfaction)) * blend)
+                + (mean_satisfaction * (1.0 - blend)),
+                "use_count": previous_count + count,
+            }
+
+        payload = {
+            "version": USAGE_REPUTATION_SCHEMA_VERSION,
+            "updated_at": datetime.utcnow().isoformat(timespec="seconds"),
+            "skills": self._skill_reputation,
+        }
+        self.skill_reputation_path.write_text(json.dumps(payload), encoding="utf-8")
+        self._skill_telemetry.clear()
+
+    def skill_reputation(self) -> dict[str, dict[str, float | int]]:
+        return {name: dict(stats) for name, stats in self._skill_reputation.items()}
 
     def _write_record(self, record: dict[str, Any]) -> None:
         self._file.write(json.dumps(record) + "\n")
@@ -217,6 +321,7 @@ class RunLogger:
         human_summary: str | None = None,
         loop_modifications: dict[str, int] | None = None,
         health: dict[str, float | int] | None = None,
+        usage_metrics: Mapping[str, float | bool] | None = None,
     ) -> None:
         """Append a mutation record to the log file."""
 
@@ -238,9 +343,20 @@ class RunLogger:
             "human_summary": human_summary,
             "loop_modifications": loop_modifications or {},
             "health": health or {},
+            "usage_metrics": dict(usage_metrics or {}),
         }
         self._write_record(record)
         self._write_event("mutation", record, ts)
+        if usage_metrics:
+            self._append_skill_telemetry(
+                skill=skill,
+                success=bool(usage_metrics.get("success", ok)),
+                latency_ms=float(usage_metrics.get("latency_ms", ms_new)),
+                resource_cost=float(usage_metrics.get("resource_cost", 0.0)),
+                perceived_quality=float(usage_metrics.get("perceived_quality", 0.0)),
+                user_satisfaction=float(usage_metrics.get("user_satisfaction", 0.0)),
+            )
+            self._maybe_update_skill_reputation()
 
         self.psyche.process_run_record(record)
         mood = getattr(self.psyche, "last_mood", None)
@@ -359,6 +475,7 @@ class RunLogger:
             os.fsync(self._events_file.fileno())
             self._events_file.close()
         if not self._file.closed:
+            self._maybe_update_skill_reputation(force=True)
             self._file.flush()
             os.fsync(self._file.fileno())
             self._file.close()

--- a/tests/test_loop_perception_goals.py
+++ b/tests/test_loop_perception_goals.py
@@ -7,6 +7,7 @@ from singular.goals.intrinsic import GoalWeights
 
 class _CaptureGoals:
     last_perception_signals = None
+    last_skill_reputation = None
 
     def __init__(self, *args, **kwargs):
         pass
@@ -26,7 +27,8 @@ class _CaptureGoals:
             for h in hypotheses
         ]
 
-    def influence_operator_scores(self, operator_stats):
+    def influence_operator_scores(self, operator_stats, skill_reputation=None):
+        _CaptureGoals.last_skill_reputation = skill_reputation
         return {name: 0.0 for name in operator_stats}
 
 
@@ -64,3 +66,39 @@ def test_run_passes_capture_signals_to_intrinsic_goals(tmp_path: Path, monkeypat
     assert _CaptureGoals.last_perception_signals is not None
     assert "artifact_events" in _CaptureGoals.last_perception_signals
     assert _CaptureGoals.last_perception_signals["artifact_events"][0]["type"] == "artifact.tech_debt.simple"
+    assert isinstance(_CaptureGoals.last_skill_reputation, dict)
+
+
+def test_choose_skill_prioritizes_frequent_low_quality_skills(tmp_path: Path) -> None:
+    org_dir = tmp_path / "org" / "skills"
+    org_dir.mkdir(parents=True)
+    low_quality = org_dir / "high_use_low_quality.py"
+    low_quality.write_text("result = 1", encoding="utf-8")
+    healthy = org_dir / "healthy.py"
+    healthy.write_text("result = 1", encoding="utf-8")
+
+    organisms = {"org": life_loop.Organism(org_dir)}
+    reputation = {
+        "high_use_low_quality": {
+            "use_count": 12,
+            "mean_quality": 0.2,
+            "success_rate": 0.4,
+            "recent_failures": 3,
+        },
+        "healthy": {
+            "use_count": 4,
+            "mean_quality": 0.8,
+            "success_rate": 0.9,
+            "recent_failures": 0,
+        },
+    }
+
+    selections = [
+        life_loop._choose_skill(
+            random.Random(seed),
+            organisms,
+            skill_reputation=reputation,
+        )[1].stem
+        for seed in range(25)
+    ]
+    assert selections.count("high_use_low_quality") > selections.count("healthy")

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -80,3 +80,30 @@ def test_intrinsic_goals_adjust_coherence_and_efficacite_from_user_friction(tmp_
 
     assert high_friction.coherence > low_friction.coherence
     assert high_friction.efficacite > low_friction.efficacite
+
+
+def test_intrinsic_goals_uses_skill_reputation_telemetry(tmp_path) -> None:
+    goals = IntrinsicGoals(path=tmp_path / "goals.json")
+    psyche = Psyche()
+
+    baseline = goals.update_tick(
+        tick=1,
+        psyche=psyche,
+        health_score=80.0,
+        resources={"energy": 80.0, "food": 80.0, "warmth": 80.0},
+        perception_signals={},
+    )
+    with_telemetry = goals.update_tick(
+        tick=2,
+        psyche=psyche,
+        health_score=80.0,
+        resources={"energy": 80.0, "food": 80.0, "warmth": 80.0},
+        perception_signals={
+            "skill_reputation": {
+                "skill_a": {"mean_cost": 180.0, "mean_quality": 0.25, "recent_failures": 4},
+            }
+        },
+    )
+
+    assert with_telemetry.efficacite > baseline.efficacite
+    assert with_telemetry.coherence > baseline.coherence

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -126,3 +126,50 @@ def test_human_summary_quality_minimum() -> None:
     assert "rejetée" in summary
     assert "score" in summary
     assert "perf" in summary
+
+
+def test_run_logger_aggregates_skill_reputation_from_usage_metrics(tmp_path: Path) -> None:
+    logger = RunLogger("telemetry", root=tmp_path, reputation_update_every=1)
+    logger.log(
+        "skill_x",
+        "op_a",
+        "diff",
+        True,
+        2.0,
+        3.0,
+        0.4,
+        0.2,
+        usage_metrics={
+            "success": True,
+            "latency_ms": 3.0,
+            "resource_cost": 5.0,
+            "perceived_quality": 0.9,
+            "user_satisfaction": 0.8,
+        },
+    )
+    logger.log(
+        "skill_x",
+        "op_b",
+        "diff",
+        False,
+        2.0,
+        6.0,
+        0.2,
+        0.5,
+        usage_metrics={
+            "success": False,
+            "latency_ms": 6.0,
+            "resource_cost": 8.0,
+            "perceived_quality": 0.2,
+            "user_satisfaction": 0.1,
+        },
+    )
+    logger.close()
+
+    reputation_path = tmp_path / "telemetry" / "skill_reputation.json"
+    payload = json.loads(reputation_path.read_text(encoding="utf-8"))
+    stats = payload["skills"]["skill_x"]
+    assert stats["use_count"] == 2
+    assert 0.0 <= stats["success_rate"] <= 1.0
+    assert stats["mean_cost"] > 0.0
+    assert stats["recent_failures"] >= 1


### PR DESCRIPTION
### Motivation
- Collect per-execution usage telemetry (succès, latence, coût, qualité perçue, satisfaction) to measure which skills are actually useful in practice.
- Aggregate those signals into a persistent per-skill reputation so the system can prioritise fixes and allocate mutation effort where it matters.
- Use reputation signals in goal weighting and operator/skill selection to favour high-utility behaviour and trigger targeted mutations for frequently used but low-quality skills.

### Description
- Added per-run usage telemetry in `RunLogger.log` and new `usage_metrics` support fields (`success`, `latency_ms`, `resource_cost`, `perceived_quality`, `user_satisfaction`). (see `src/singular/runs/logger.py`).
- Implemented periodic aggregation and persistent skill reputation stored at `runs/<run_id>/skill_reputation.json` via `_append_skill_telemetry`, `_maybe_update_skill_reputation` and `skill_reputation()` accessors in `RunLogger`.
- Wired telemetry into the mutation loop: `log_mutation` now computes `usage_metrics` (perceived quality and satisfaction) and passes them through `RunLogger.log`, the loop publishes `skill_reputation` in perception signals, and `mutation` events include the skill reputation snapshot (see `src/singular/life/loop.py`).
- Made `IntrinsicGoals` consume `skill_reputation` in `update_tick` to modulate objective weights and extended `influence_operator_scores` to accept `skill_reputation` and bias operator selection using cost/quality/failure signals (see `src/singular/goals/intrinsic.py`).
- Replaced `_choose_skill` with a reputation-aware weighted chooser that implements the trigger rule: "frequently used + low quality => targeted mutation priority" and otherwise balances exploration and utility (see `src/singular/life/loop.py`).
- Updated and added tests to validate telemetry aggregation, propagation to goals, and targeted selection behaviour (`tests/test_runs_logger.py`, `tests/test_objectives.py`, `tests/test_loop_perception_goals.py`).

### Testing
- Ran `pytest -q tests/test_runs_logger.py tests/test_objectives.py tests/test_loop_perception_goals.py tests/test_beliefs_store.py` and all tests passed (`20 passed`).
- New/updated unit tests exercise aggregation into `skill_reputation.json`, telemetry propagation to `IntrinsicGoals`, and selection bias toward frequently-used low-quality skills. 
- Changes committed with message `Add usage telemetry and reputation-aware skill/operator selection`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6eea3008832ab829eb9dd181fc3c)