### PR TITLE
Add structured feedback signals and adapt execution strategy, routine priorities and skill scoring

### DIFF
--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -17,6 +17,13 @@ def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
     return max(low, min(high, value))
 
 
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 @dataclass
 class GoalWeights:
     """Weights for the intrinsic objective catalogue."""
@@ -190,6 +197,81 @@ class IntrinsicGoals:
 
     def history(self) -> list[dict[str, Any]]:
         return list(self.state.history)
+
+    def derive_execution_strategy(
+        self, perception_signals: Mapping[str, Any] | None
+    ) -> dict[str, Any]:
+        """Build runtime strategy knobs from structured feedback signals."""
+
+        memory = (perception_signals or {}).get("episode_memory", {})
+        structured = memory.get("structured_feedback", {}) if isinstance(memory, Mapping) else {}
+        frustration = _clamp(_as_float(structured.get("frustration", 0.0))) if isinstance(structured, Mapping) else 0.0
+        satisfaction = _clamp(_as_float(structured.get("satisfaction", 0.0))) if isinstance(structured, Mapping) else 0.0
+        urgency = _clamp(_as_float(structured.get("urgency", 0.0))) if isinstance(structured, Mapping) else 0.0
+        theme = str(structured.get("theme", "general")) if isinstance(structured, Mapping) else "general"
+        negative_streak = int(memory.get("negative_feedback_streak", 0)) if isinstance(memory, Mapping) else 0
+
+        mode = "balanced"
+        if frustration >= 0.6 or negative_streak >= 2:
+            mode = "cautious"
+        elif urgency >= 0.6:
+            mode = "utility_focused"
+        elif satisfaction >= 0.75:
+            mode = "exploratory"
+
+        return {
+            "mode": mode,
+            "frustration": frustration,
+            "satisfaction": satisfaction,
+            "urgency": urgency,
+            "theme": theme,
+            "negative_feedback_streak": negative_streak,
+        }
+
+    def adjust_routine_priorities(
+        self,
+        routines: list[dict[str, Any]],
+        *,
+        perception_signals: Mapping[str, Any] | None,
+    ) -> list[dict[str, Any]]:
+        """Adjust routine priorities in-place for the next ACTION window."""
+
+        strategy = self.derive_execution_strategy(perception_signals)
+        mode = strategy["mode"]
+        theme = str(strategy["theme"])
+        urgency = float(strategy["urgency"])
+        frustration = float(strategy["frustration"])
+
+        adjusted: list[dict[str, Any]] = []
+        for routine in routines:
+            payload = dict(routine)
+            base = int(payload.get("priority", 50))
+            priority = base
+            routine_id = str(payload.get("id", "")).lower()
+            prompt = str(payload.get("prompt", "")).lower()
+            if mode == "cautious":
+                priority += int(10 + frustration * 20)
+                if any(token in routine_id or token in prompt for token in ("check", "verify", "monitor", "safety")):
+                    priority += 8
+                if any(token in routine_id or token in prompt for token in ("help", "user", "support", "respond")):
+                    priority += int(12 + urgency * 12)
+                elif urgency >= 0.6:
+                    priority -= int(8 + urgency * 18)
+            elif mode == "utility_focused":
+                priority += int(6 + urgency * 18)
+                if any(token in routine_id or token in prompt for token in ("help", "user", "support", "respond")):
+                    priority += 12
+            elif mode == "exploratory":
+                if any(token in routine_id or token in prompt for token in ("research", "explore", "discover")):
+                    priority += 14
+                else:
+                    priority -= 4
+            if theme != "general" and theme in f"{routine_id} {prompt}":
+                priority += 10
+            payload["priority"] = max(0, priority)
+            adjusted.append(payload)
+        adjusted.sort(key=lambda item: -int(item.get("priority", 0)))
+        return adjusted
 
     def objective_arbitration(
         self,

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from singular.events import Event, EventBus, get_global_event_bus
+from singular.goals import IntrinsicGoals
 from singular.governance.policy import MutationGovernancePolicy
 from singular.life.loop import run_tick
 from singular.memory import _atomic_write_text, get_base_dir, get_mem_dir
@@ -109,10 +110,12 @@ class OrchestratorService:
         )
         self.governance_policy = MutationGovernancePolicy(safe_mode=self.config.safe_mode)
         self.routines = RoutinesOrchestrator(state_path=self.mem_dir / "routines_state.json")
+        self.goals = IntrinsicGoals(path=self.mem_dir / "goals.json")
         self._running = False
         self._wake_requested = False
         self._pending_events: list[dict[str, Any]] = []
         self._tick_count = 0
+        self._latest_signals: dict[str, Any] = {}
 
         self._subscribe_external_stimuli()
 
@@ -235,6 +238,7 @@ class OrchestratorService:
     def _run_phase(self, phase: LifecyclePhase) -> None:
         if phase is LifecyclePhase.VEILLE:
             signals = capture_signals(bus=self.bus)
+            self._latest_signals = dict(signals)
             activated = self.quest_runtime.evaluate_triggers(signals)
             self._push_event(
                 phase,
@@ -255,13 +259,30 @@ class OrchestratorService:
             if mood.value == "fatigue":
                 tick_budget *= max(fatigue_slowdown, 1.0)
             skill_execution = None
+            execution_strategy: dict[str, Any] | None = None
             routine_executions: list[dict[str, Any]] = []
             if not self.config.dry_run:
+                strategy = self.goals.derive_execution_strategy(self._latest_signals)
+                execution_strategy = dict(strategy)
+                routine_specs = [
+                    {"id": spec.id, "prompt": spec.prompt, "priority": spec.priority}
+                    for spec in self.routines.specs
+                ]
+                adjusted_routines = self.goals.adjust_routine_priorities(
+                    routine_specs,
+                    perception_signals=self._latest_signals,
+                )
+                priority_overrides = {
+                    item["id"]: int(item["priority"])
+                    for item in adjusted_routines
+                    if "id" in item
+                }
                 action_context = {
                     "phase": phase.value,
                     "mood": mood.value,
                     "energy": self.resource_manager.energy,
                     "food": self.resource_manager.food,
+                    "execution_strategy": strategy,
                 }
                 skill_execution = self.skill_runtime.execute_best_skill(
                     task={"name": "orchestrator.action", "capabilities": []},
@@ -270,6 +291,7 @@ class OrchestratorService:
                 routine_executions = self.routines.execute_with_runtime(
                     skill_runtime=self.skill_runtime,
                     base_context=action_context,
+                    priority_overrides=priority_overrides,
                 )
                 run_tick(
                     skills_dirs=self.skills_dir,
@@ -305,6 +327,7 @@ class OrchestratorService:
                         if skill_execution is not None
                         else None
                     ),
+                    "execution_strategy": execution_strategy,
                 },
             )
             return

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import random
 import time
+import re
 
 from ..memory import add_episode, ensure_memory_structure, read_episodes
 from ..perception import capture_signals
@@ -50,6 +51,74 @@ def _user_message_for_error(provider: str, err: LLMProviderError) -> str:
     if isinstance(err, ProviderRetryExhaustedError):
         return f"Provider '{provider}' retries exhausted. Using local fallback replies."
     return f"Provider '{provider}' failed unexpectedly. Using local fallback replies."
+
+
+def _extract_structured_signals(text: str) -> dict[str, object]:
+    lowered = text.lower()
+    frustration_tokens = {
+        "bug",
+        "erreur",
+        "error",
+        "frustr",
+        "bloqué",
+        "bloque",
+        "impossible",
+        "nul",
+        "fail",
+        "failed",
+        "wtf",
+    }
+    satisfaction_tokens = {
+        "merci",
+        "super",
+        "parfait",
+        "great",
+        "thanks",
+        "top",
+        "cool",
+        "good",
+        "bien",
+    }
+    urgency_tokens = {
+        "urgent",
+        "asap",
+        "vite",
+        "maintenant",
+        "now",
+        "immédiat",
+        "immediat",
+        "deadline",
+    }
+    token_count = max(1, len(re.findall(r"\w+", lowered)))
+    frustration = min(
+        1.0,
+        sum(1 for token in frustration_tokens if token in lowered) / max(1.0, token_count * 0.2),
+    )
+    satisfaction = min(
+        1.0,
+        sum(1 for token in satisfaction_tokens if token in lowered) / max(1.0, token_count * 0.2),
+    )
+    urgency = min(
+        1.0,
+        0.35 * float("!" in text or "?" in text)
+        + sum(1 for token in urgency_tokens if token in lowered) * 0.35,
+    )
+    theme = "general"
+    for candidate, keywords in (
+        ("bugfix", ("bug", "erreur", "fix", "incident")),
+        ("performance", ("lent", "slow", "optim", "performance", "latence")),
+        ("planning", ("roadmap", "plan", "deadline", "priorit")),
+        ("support", ("help", "aide", "explain", "comprendre")),
+    ):
+        if any(keyword in lowered for keyword in keywords):
+            theme = candidate
+            break
+    return {
+        "frustration": round(frustration, 3),
+        "satisfaction": round(satisfaction, 3),
+        "urgency": round(urgency, 3),
+        "theme": theme,
+    }
 
 
 def talk(
@@ -140,7 +209,8 @@ def talk(
         mood_event: str | None,
         perf_msg: str | None,
     ) -> None:
-        add_episode({"role": "user", "text": user_input})
+        user_signals = _extract_structured_signals(user_input)
+        add_episode({"role": "user", "text": user_input, "structured_signals": user_signals})
         mood = psyche.feel(Mood.NEUTRAL)
         mood_report = mood_event or mood.value
 
@@ -189,6 +259,7 @@ def talk(
                 "text": response,
                 "raw_reply": reply,
                 "mood": mood.value,
+                "structured_signals": user_signals,
             }
         )
         psyche.gain()

--- a/src/singular/routines.py
+++ b/src/singular/routines.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 from time import perf_counter
-from typing import Any
+from typing import Any, Mapping
 
 from singular.memory import _atomic_write_text
 
@@ -200,6 +200,32 @@ class RoutinesOrchestrator:
         due.sort(key=lambda item: (-item.priority, item.deadline_at))
         return due
 
+    def due_tasks_with_priority_overrides(
+        self, priority_overrides: Mapping[str, int] | None
+    ) -> list[RoutineTask]:
+        tasks = self.due_tasks()
+        if not priority_overrides:
+            return tasks
+        adjusted: list[RoutineTask] = []
+        for task in tasks:
+            override = priority_overrides.get(task.id)
+            if isinstance(override, int):
+                adjusted.append(
+                    RoutineTask(
+                        id=task.id,
+                        prompt=task.prompt,
+                        description=task.description,
+                        priority=max(0, override),
+                        due_at=task.due_at,
+                        deadline_at=task.deadline_at,
+                        max_risk=task.max_risk,
+                    )
+                )
+            else:
+                adjusted.append(task)
+        adjusted.sort(key=lambda item: (-item.priority, item.deadline_at))
+        return adjusted
+
     def mark_executed(self, task: RoutineTask, *, success: bool, latency_ms: float) -> None:
         executed_at = self._now()
         next_run = executed_at + timedelta(
@@ -213,11 +239,17 @@ class RoutinesOrchestrator:
         )
         self._save_state()
 
-    def execute_with_runtime(self, *, skill_runtime: Any, base_context: dict[str, Any]) -> list[dict[str, Any]]:
+    def execute_with_runtime(
+        self,
+        *,
+        skill_runtime: Any,
+        base_context: dict[str, Any],
+        priority_overrides: Mapping[str, int] | None = None,
+    ) -> list[dict[str, Any]]:
         """Execute all due routines through the skill runtime."""
 
         outcomes: list[dict[str, Any]] = []
-        for task in self.due_tasks():
+        for task in self.due_tasks_with_priority_overrides(priority_overrides):
             started = perf_counter()
             result = skill_runtime.execute_best_skill(
                 task={

--- a/src/singular/skills/runtime.py
+++ b/src/singular/skills/runtime.py
@@ -54,7 +54,8 @@ class SkillRuntime:
         if not catalog:
             catalog = refresh_skill_catalog(skills_dir=self.skills_dir, mem_dir=self.mem_dir)
 
-        candidates = self._compatible_candidates(task_dict, skills_state, catalog)
+        strategy = context.get("execution_strategy", {}) if isinstance(context, dict) else {}
+        candidates = self._compatible_candidates(task_dict, skills_state, catalog, strategy=strategy)
         if not candidates:
             result = SkillExecutionResult(skill=None, status="failed", reason="no_compatible_skill")
             self.bus.publish(
@@ -118,6 +119,8 @@ class SkillRuntime:
         task: dict[str, Any],
         skills_state: dict[str, Any],
         catalog: dict[str, dict[str, Any]],
+        *,
+        strategy: dict[str, Any] | None = None,
     ) -> list[_ScoredCandidate]:
         required_signature = task.get("signature")
         required_capabilities = set(task.get("capabilities", []))
@@ -167,12 +170,18 @@ class SkillRuntime:
                     skill=skill,
                     path=path,
                     metadata={"state": metadata, "catalog": descriptor},
-                    score=self._score_candidate(metadata, descriptor),
+                    score=self._score_candidate(metadata, descriptor, strategy=strategy),
                 )
             )
         return candidates
 
-    def _score_candidate(self, metadata: dict[str, Any], descriptor: dict[str, Any]) -> float:
+    def _score_candidate(
+        self,
+        metadata: dict[str, Any],
+        descriptor: dict[str, Any],
+        *,
+        strategy: dict[str, Any] | None = None,
+    ) -> float:
         metrics = metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
         usage_count = max(int(metrics.get("usage_count", 0) or 0), 0)
         average_gain = float(metrics.get("average_gain", 0.0) or 0.0)
@@ -187,8 +196,31 @@ class SkillRuntime:
         expected_utility = average_gain
         resource_cost = max(0.0, average_cost)
         risk = self._estimated_risk(metadata, descriptor)
+        mode = str((strategy or {}).get("mode", "balanced"))
+        frustration = max(0.0, min(1.0, float((strategy or {}).get("frustration", 0.0) or 0.0))
+        )
+        urgency = max(0.0, min(1.0, float((strategy or {}).get("urgency", 0.0) or 0.0)))
 
-        return (expected_utility * 0.45) + (success_rate * 0.35) - (resource_cost * 0.1) - (risk * 0.1)
+        utility_w = 0.45
+        success_w = 0.35
+        cost_w = 0.1
+        risk_w = 0.1
+        if mode == "cautious":
+            success_w += 0.12 + frustration * 0.08
+            risk_w += 0.16 + frustration * 0.08
+            utility_w -= 0.08
+            expected_utility *= 0.7 + (0.3 * success_rate)
+            risk = min(1.0, risk + (frustration * 0.15))
+        elif mode == "utility_focused":
+            utility_w += 0.12 + urgency * 0.08
+            cost_w += 0.05
+            risk_w -= 0.03
+        elif mode == "exploratory":
+            novelty_bonus = max(0.0, 1.0 - (usage_count / 10.0))
+            expected_utility += novelty_bonus * 0.15
+            risk_w -= 0.03
+
+        return (expected_utility * utility_w) + (success_rate * success_w) - (resource_cost * cost_w) - (risk * risk_w)
 
     def _estimated_risk(self, metadata: dict[str, Any], descriptor: dict[str, Any]) -> float:
         metrics = metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -107,3 +107,37 @@ def test_intrinsic_goals_uses_skill_reputation_telemetry(tmp_path) -> None:
 
     assert with_telemetry.efficacite > baseline.efficacite
     assert with_telemetry.coherence > baseline.coherence
+
+
+def test_intrinsic_goals_strategy_turns_cautious_on_repeated_negative_feedback(tmp_path) -> None:
+    goals = IntrinsicGoals(path=tmp_path / "goals.json")
+    strategy = goals.derive_execution_strategy(
+        {
+            "episode_memory": {
+                "structured_feedback": {
+                    "frustration": 0.8,
+                    "satisfaction": 0.1,
+                    "urgency": 0.4,
+                    "theme": "support",
+                },
+                "negative_feedback_streak": 3,
+            }
+        }
+    )
+    assert strategy["mode"] == "cautious"
+
+
+def test_intrinsic_goals_adjust_routine_priorities_from_urgency(tmp_path) -> None:
+    goals = IntrinsicGoals(path=tmp_path / "goals.json")
+    adjusted = goals.adjust_routine_priorities(
+        [
+            {"id": "deep_research", "prompt": "explore roadmap", "priority": 70},
+            {"id": "user_support", "prompt": "help user quickly", "priority": 50},
+        ],
+        perception_signals={
+            "episode_memory": {
+                "structured_feedback": {"frustration": 0.2, "satisfaction": 0.2, "urgency": 0.8, "theme": "support"}
+            }
+        },
+    )
+    assert adjusted[0]["id"] == "user_support"

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -7,6 +7,8 @@ from singular.orchestrator.service import (
     OrchestratorService,
     SchedulerConfig,
 )
+from singular.routines import RoutinesOrchestrator
+from singular.skills.runtime import SkillExecutionResult
 
 
 def test_orchestrator_tick_persists_state(monkeypatch, tmp_path: Path) -> None:
@@ -123,3 +125,62 @@ def test_orchestrator_action_executes_skill_runtime(monkeypatch, tmp_path: Path)
     task, context = calls[0]
     assert task["name"] == "orchestrator.action"
     assert context["phase"] == "action"
+
+
+def test_orchestrator_repeated_negative_feedback_reprioritizes_action_routines(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "mem").mkdir(parents=True)
+    (life / "skills" / "a.py").write_text("result = 1", encoding="utf-8")
+    routines_config = tmp_path / "routines.yaml"
+    routines_config.write_text(
+        """
+routines:
+  - id: deep_research
+    prompt: "explore roadmap"
+    interval_minutes: 5
+    priority: 90
+  - id: user_support
+    prompt: "help user quickly"
+    interval_minutes: 5
+    priority: 40
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+    monkeypatch.setattr("singular.orchestrator.service.run_tick", lambda **kwargs: None)
+    monkeypatch.setattr(
+        "singular.orchestrator.service.capture_signals",
+        lambda bus: {
+            "episode_memory": {
+                "structured_feedback": {
+                    "frustration": 0.9,
+                    "satisfaction": 0.1,
+                    "urgency": 0.8,
+                    "theme": "support",
+                },
+                "negative_feedback_streak": 3,
+            }
+        },
+    )
+
+    calls: list[dict[str, object]] = []
+
+    def _fake_execute(task, context):
+        calls.append({"task": task, "context": context})
+        return SkillExecutionResult(skill="a", status="succeeded", score=0.9)
+
+    service = OrchestratorService(config=OrchestratorConfig(dry_run=False), bus=EventBus())
+    service.routines = RoutinesOrchestrator(
+        config_path=routines_config,
+        state_path=life / "mem" / "routines_state.json",
+    )
+    monkeypatch.setattr(service.skill_runtime, "execute_best_skill", _fake_execute)
+
+    service.tick()  # VEILLE
+    service.tick()  # ACTION
+
+    routine_tasks = [entry["task"] for entry in calls if str(entry["task"].get("name", "")).startswith("routine.")]
+    assert routine_tasks
+    assert routine_tasks[0]["name"] == "routine.user_support"
+    assert routine_tasks[0]["priority"] > 90

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -69,3 +69,26 @@ routines:
     assert calls
     assert calls[0]["task"]["name"] == "routine.answer_human_prompt"
     assert (life / "mem" / "routines_state.json").exists()
+
+
+def test_routines_apply_priority_overrides(tmp_path: Path) -> None:
+    config = tmp_path / "routines.yaml"
+    state = tmp_path / "routines_state.json"
+    config.write_text(
+        """
+routines:
+  - id: low
+    prompt: "Routine basse"
+    interval_minutes: 5
+    priority: 20
+  - id: high
+    prompt: "Routine haute"
+    interval_minutes: 5
+    priority: 80
+""".strip(),
+        encoding="utf-8",
+    )
+    orchestrator = RoutinesOrchestrator(config_path=config, state_path=state)
+    due = orchestrator.due_tasks_with_priority_overrides({"low": 95})
+    assert due[0].id == "low"
+    assert due[0].priority == 95

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -112,3 +112,40 @@ def test_execute_best_skill_rejects_malformed_catalog_annotations(monkeypatch, t
 
     assert result.status == "failed"
     assert result.reason == "no_compatible_skill"
+
+
+def test_execute_best_skill_cautious_strategy_prefers_reliable_skill(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("singular.skills.runtime.sandbox.run", lambda code: {"ok": True})
+    life = tmp_path / "life"
+    skills = life / "skills"
+    mem = life / "mem"
+    skills.mkdir(parents=True)
+    mem.mkdir(parents=True)
+
+    (skills / "fast.py").write_text("def run(context=None):\n    return {'ok': True}\n", encoding="utf-8")
+    (skills / "safe.py").write_text("def run(context=None):\n    return {'ok': True}\n", encoding="utf-8")
+    (mem / "skills.json").write_text(
+        """
+{
+  "fast": {
+    "capabilities": ["assist"],
+    "risk": 0.8,
+    "metrics": {"usage_count": 20, "average_gain": 2.0, "average_cost": 0.1, "failure_count": 8}
+  },
+  "safe": {
+    "capabilities": ["assist"],
+    "risk": 0.1,
+    "metrics": {"usage_count": 20, "average_gain": 1.0, "average_cost": 0.4, "failure_count": 1}
+  }
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    runtime = SkillRuntime(skills_dir=skills, mem_dir=mem)
+    result = runtime.execute_best_skill(
+        task={"name": "assist", "capabilities": ["assist"], "max_risk": 1.0},
+        context={"execution_strategy": {"mode": "cautious", "frustration": 0.9}},
+    )
+    assert result.status == "succeeded"
+    assert result.skill == "safe"

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -29,6 +29,7 @@ def test_talk_loop(monkeypatch, tmp_path):
     episodes = [e for e in read_episodes() if e.get("event") != "perception"]
     assert len(episodes) == 4
     assert episodes[0]["role"] == "user"
+    assert "structured_signals" in episodes[0]
     assert episodes[1]["role"] == "assistant"
     assert episodes[1]["raw_reply"]
     assert "Mood: neutral" in episodes[1]["text"]
@@ -95,6 +96,7 @@ def test_talk_single_prompt(monkeypatch, tmp_path):
     assert len(episodes) == 2
     assert episodes[0]["role"] == "user"
     assert episodes[0]["text"] == "hello"
+    assert episodes[0]["structured_signals"]["theme"] == "general"
     expected = _default_reply("hello", random.Random(123)) + " | Mood: neutral"
     assert outputs[0] == "Provider: stub"
     assert outputs[-1] == expected


### PR DESCRIPTION
### Motivation
- Capture lightweight structured user-feedback (frustration, satisfaction, urgency, theme) from conversation episodes to inform runtime decisions. 
- Use episodic feedback to influence intrinsic-goal behaviour so the system can become more cautious, more exploratory, or more utility-focused depending on user signals. 
- Reprioritise periodic routines and bias skill selection during the next ACTION window when repeated negative feedback is observed. 
- Propagate these strategy knobs into the Skill Runtime so operator scoring reflects the desired execution posture.

### Description
- Enrich `talk` episodes with extracted structured signals by adding `_extract_structured_signals` and persisting `structured_signals` on `user` and `assistant` episodes in `src/singular/organisms/talk.py`.
- Add strategy derivation and routine-priority adjustment APIs in `IntrinsicGoals` with `derive_execution_strategy` and `adjust_routine_priorities` (and helper `_as_float`) in `src/singular/goals/intrinsic.py`.
- Propagate the derived `execution_strategy` from `OrchestratorService` (VEILLE -> ACTION) and apply routine priority overrides before executing routines in `src/singular/orchestrator/service.py`.
- Extend `RoutinesOrchestrator` with `due_tasks_with_priority_overrides` and allow `execute_with_runtime(..., priority_overrides=...)` so one ACTION window can use modified priorities in `src/singular/routines.py`.
- Make `SkillRuntime` consume `execution_strategy` from the context and modulate candidate scoring (weights and bonuses for `cautious` / `utility_focused` / `exploratory` modes) in `src/singular/skills/runtime.py`.
- Add and update tests covering extraction and persistence of structured signals, strategy derivation, routine priority overrides, cautious-mode skill selection and the end-to-end case where repeated negative feedback reprioritises routines in the next ACTION phase (`tests/test_talk.py`, `tests/test_objectives.py`, `tests/test_routines.py`, `tests/test_skill_runtime.py`, `tests/test_orchestrator_service.py`).

### Testing
- Ran `pytest -q tests/test_talk.py tests/test_objectives.py tests/test_routines.py tests/test_skill_runtime.py tests/test_orchestrator_service.py` and all tests passed: `32 passed`.
- New unit/integration tests assert that `talk` stores `structured_signals`, `IntrinsicGoals.derive_execution_strategy` enters `cautious` on repeated negative feedback, routine priority overrides reorder due tasks, and `SkillRuntime` prefers a reliable skill when in `cautious` mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7080e5f0832ab5f41bbb83c8b230)