### PR TITLE
Ajouter les compétences du quotidien au dashboard et à `status`

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -18,6 +18,7 @@ from singular.memory import read_skills
 
 from singular.dashboard.actions import DashboardActionService
 from singular.governance.policy import load_runtime_policy
+from singular.skills_daily import build_daily_skills_snapshot
 from fastapi.responses import HTMLResponse
 
 from singular.schedulers.reevaluation import alerts_from_records
@@ -467,6 +468,7 @@ def create_app(
                     extinction_seen=False,
                 ),
                 "skills_lifecycle": _skill_lifecycle_summary(),
+                "daily_skills": build_daily_skills_snapshot([]),
             }
             return empty
 
@@ -638,6 +640,7 @@ def create_app(
             },
             "vital_timeline": vital_timeline,
             "skills_lifecycle": _skill_lifecycle_summary(),
+            "daily_skills": build_daily_skills_snapshot(records),
         }
 
 

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from singular.lives import get_registry_root
+from singular.skills_daily import build_daily_skills_snapshot
 
 
 @dataclass(slots=True)
@@ -44,11 +45,32 @@ class DashboardActionService:
         current_home = Path(os.environ.get("SINGULAR_HOME", str(self.home)))
         runs_dir = current_home / "runs"
         vital_metrics = self._consolidated_vital_metrics(runs_dir=runs_dir)
+        daily_skills = build_daily_skills_snapshot(self._read_run_records(runs_dir=runs_dir))
         return {
             "registry_root": str(self.root),
             "current_life_home": str(current_home),
             "vital_metrics": vital_metrics,
+            "daily_skills": daily_skills,
         }
+
+    def _read_run_records(self, *, runs_dir: Path) -> list[dict[str, Any]]:
+        records: list[dict[str, Any]] = []
+        if not runs_dir.exists():
+            return records
+        for file in runs_dir.iterdir():
+            if not file.is_file() or file.suffix != ".jsonl":
+                continue
+            for line in file.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(payload, dict):
+                    records.append(payload)
+        return records
 
     def _consolidated_vital_metrics(self, *, runs_dir: Path) -> dict[str, Any]:
         if not runs_dir.exists():

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -48,6 +48,7 @@
 <nav>
   <strong>Navigation :</strong>
   <a href="#cockpit">Cockpit</a> ·
+  <a href="#competences-quotidien">Compétences du quotidien</a> ·
   <a href="#timeline-section">Timeline</a> ·
   <a href="#vies">Vies</a> ·
   <a href="#logs-live">Logs</a> ·
@@ -112,6 +113,27 @@
       <div class='card'><div class='card-label'>Skills dormantes</div><div id='kpi-skills-dormant' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Skills archivées</div><div id='kpi-skills-archived' class='card-value'>0</div></div>
     </div>
+  </div>
+
+  <div class='panel' id='competences-quotidien'>
+    <h3 style='margin-top:0;'>Compétences du quotidien</h3>
+    <div class='cards-grid'>
+      <div class='card'><div class='card-label'>Fréquence (24h)</div><div id='daily-skill-uses-24h' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Fréquence (7j)</div><div id='daily-skill-uses-7d' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Top skill</div><div id='daily-skill-top' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label'>Progression apprise→utilisée→améliorée</div><div id='daily-skill-progression' class='card-value'>0→0→0</div></div>
+    </div>
+    <table border='1' cellspacing='0' cellpadding='6' style='margin-top:8px;border-collapse:collapse;width:100%;'>
+      <thead><tr>
+        <th>Compétence</th>
+        <th>Fréquence 24h/7j</th>
+        <th>Taux réussite</th>
+        <th>Dernière utilisation</th>
+        <th>Tâches associées</th>
+        <th>Tendance</th>
+      </tr></thead>
+      <tbody id='daily-skills-table-body'></tbody>
+    </table>
   </div>
 
   <div class='panel'>
@@ -280,6 +302,30 @@ const scopeState={currentLifeOnly:false};
 
 const setStatusTone=(el,tone)=>{el.classList.remove('status-good','status-warn','status-bad');if(tone==='good'){el.classList.add('status-good');}if(tone==='warn'){el.classList.add('status-warn');}if(tone==='bad'){el.classList.add('status-bad');}};
 const withScope=(url)=>{const u=new URL(url,window.location.origin);if(scopeState.currentLifeOnly){u.searchParams.set('current_life_only','true');}return `${u.pathname}${u.search}`;};
+const renderDailySkills=(dailySkills)=>{
+  const frequency=dailySkills?.frequency_totals||{};
+  const progression=dailySkills?.progression_pipeline||{};
+  const topSkills=dailySkills?.top_skills||[];
+  document.getElementById('daily-skill-uses-24h').textContent=String(frequency.uses_24h||0);
+  document.getElementById('daily-skill-uses-7d').textContent=String(frequency.uses_7d||0);
+  document.getElementById('daily-skill-top').textContent=String(topSkills[0]?.skill||'n/a');
+  document.getElementById('daily-skill-progression').textContent=`${progression.learned||0}→${progression.used||0}→${progression.improved||0}`;
+  const body=document.getElementById('daily-skills-table-body');
+  body.innerHTML='';
+  for(const item of topSkills){
+    const tr=document.createElement('tr');
+    const successRate=item.success_rate===null||item.success_rate===undefined?'n/a':`${(Number(item.success_rate)*100).toFixed(1)}%`;
+    const frequencyCell=`${item.frequency?.uses_24h||0}/${item.frequency?.uses_7d||0}`;
+    const tasks=(item.associated_tasks||[]).join(', ')||'n/a';
+    tr.innerHTML=`<td>${item.skill||'n/a'}</td><td>${frequencyCell}</td><td>${successRate}</td><td>${item.last_used_at||'n/a'}</td><td>${tasks}</td><td>${item.trend||'stable'}</td>`;
+    body.appendChild(tr);
+  }
+  if(!topSkills.length){
+    const tr=document.createElement('tr');
+    tr.innerHTML="<td colspan='6'>Aucune compétence quotidienne détectée.</td>";
+    body.appendChild(tr);
+  }
+};
 
 const loadContext=()=>fetch('/dashboard/context').then(r=>r.json()).then(ctx=>{
   document.getElementById('ctx-root').textContent=ctx.singular_root||'n/a';
@@ -382,6 +428,7 @@ const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=
   document.getElementById('kpi-skills-active').textContent=String(skillLifecycle.active||0);
   document.getElementById('kpi-skills-dormant').textContent=String(skillLifecycle.dormant||0);
   document.getElementById('kpi-skills-archived').textContent=String(skillLifecycle.archived||0);
+  renderDailySkills(d.daily_skills||{});
   const objectivesList=document.getElementById('kpi-active-objectives-list');
   objectivesList.innerHTML='';
   for(const item of (objectives.items||[])){

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -13,6 +13,7 @@ from ..memory import get_mem_dir
 from ..memory import read_skills
 from ..runs.logger import RUNS_DIR
 from ..schedulers.reevaluation import alerts_from_records
+from ..skills_daily import build_daily_skills_snapshot
 
 
 def _print_table(headers: list[str], rows: list[list[str]]) -> None:
@@ -107,6 +108,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             "deleted": 0,
             "total": 0,
         },
+        "daily_skills": build_daily_skills_snapshot([]),
         "vital_timeline": {
             "age": 0,
             "state": "mature",
@@ -121,12 +123,20 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
     if files:
         latest = files[-1]
+        all_records: list[dict[str, object]] = []
+        for run_file in files:
+            with run_file.open(encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        all_records.append(json.loads(line))
         records = []
         with latest.open(encoding="utf-8") as fh:
             for line in fh:
                 line = line.strip()
                 if line:
                     records.append(json.loads(line))
+        payload["daily_skills"] = build_daily_skills_snapshot(records=all_records)
         if records:
             last = records[-1]
             ms_new = last.get("ms_new")
@@ -244,6 +254,29 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             ["Skills actives", str((payload.get("skills_lifecycle") or {}).get("active", 0))],
             ["Skills dormantes", str((payload.get("skills_lifecycle") or {}).get("dormant", 0))],
             ["Skills archivées", str((payload.get("skills_lifecycle") or {}).get("archived", 0))],
+            [
+                "Top skill quotidienne",
+                (
+                    str(((payload.get("daily_skills") or {}).get("top_skills") or [{}])[0].get("skill") or "-")
+                    if ((payload.get("daily_skills") or {}).get("top_skills") or [])
+                    else "-"
+                ),
+            ],
+            [
+                "Fréquence skills (24h/7j)",
+                (
+                    f"{((payload.get('daily_skills') or {}).get('frequency_totals') or {}).get('uses_24h', 0)} / "
+                    f"{((payload.get('daily_skills') or {}).get('frequency_totals') or {}).get('uses_7d', 0)}"
+                ),
+            ],
+            [
+                "Progression apprise→utilisée→améliorée",
+                (
+                    f"{((payload.get('daily_skills') or {}).get('progression_pipeline') or {}).get('learned', 0)} → "
+                    f"{((payload.get('daily_skills') or {}).get('progression_pipeline') or {}).get('used', 0)} → "
+                    f"{((payload.get('daily_skills') or {}).get('progression_pipeline') or {}).get('improved', 0)}"
+                ),
+            ],
             ["Âge vital", str((payload.get("vital_timeline") or {}).get("age", 0))],
             ["État vital", str((payload.get("vital_timeline") or {}).get("state", "n/a"))],
             ["Risque vital", str((payload.get("vital_timeline") or {}).get("risk_level", "n/a"))],

--- a/src/singular/skills_daily.py
+++ b/src/singular/skills_daily.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _extract_skill_name(record: dict[str, Any]) -> str | None:
+    for key in ("skill", "skill_name", "operator", "op", "action"):
+        value = record.get(key)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized
+    return None
+
+
+def _extract_task_label(record: dict[str, Any]) -> str | None:
+    for key in ("task", "objective", "prompt", "event"):
+        value = record.get(key)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized if len(normalized) <= 80 else f"{normalized[:77]}..."
+    return None
+
+
+def build_daily_skills_snapshot(
+    records: list[dict[str, Any]], *, now: datetime | None = None
+) -> dict[str, Any]:
+    now_dt = now.astimezone(timezone.utc) if now is not None else datetime.now(timezone.utc)
+    since_24h = now_dt - timedelta(hours=24)
+    since_7d = now_dt - timedelta(days=7)
+    previous_24h = since_24h - timedelta(hours=24)
+    per_skill: dict[str, dict[str, Any]] = {}
+    total_24h = 0
+    total_7d = 0
+
+    for record in records:
+        skill_name = _extract_skill_name(record)
+        if skill_name is None:
+            continue
+        timestamp = _parse_timestamp(record.get("ts"))
+        accepted = record.get("accepted")
+        if not isinstance(accepted, bool):
+            accepted = record.get("ok")
+        skill_entry = per_skill.setdefault(
+            skill_name,
+            {
+                "skill": skill_name,
+                "total_uses": 0,
+                "uses_24h": 0,
+                "uses_7d": 0,
+                "uses_previous_24h": 0,
+                "success_total": 0,
+                "success_24h": 0,
+                "attempts_with_result": 0,
+                "last_used_at": None,
+                "first_seen_at": None,
+                "associated_tasks": [],
+            },
+        )
+        skill_entry["total_uses"] += 1
+        if timestamp is not None:
+            if skill_entry["first_seen_at"] is None or timestamp < skill_entry["first_seen_at"]:
+                skill_entry["first_seen_at"] = timestamp
+            if skill_entry["last_used_at"] is None or timestamp > skill_entry["last_used_at"]:
+                skill_entry["last_used_at"] = timestamp
+            if timestamp >= since_24h:
+                skill_entry["uses_24h"] += 1
+                total_24h += 1
+            if timestamp >= since_7d:
+                skill_entry["uses_7d"] += 1
+                total_7d += 1
+            if previous_24h <= timestamp < since_24h:
+                skill_entry["uses_previous_24h"] += 1
+        task_label = _extract_task_label(record)
+        if task_label and task_label not in skill_entry["associated_tasks"] and len(skill_entry["associated_tasks"]) < 4:
+            skill_entry["associated_tasks"].append(task_label)
+        if isinstance(accepted, bool):
+            skill_entry["attempts_with_result"] += 1
+            if accepted:
+                skill_entry["success_total"] += 1
+                if timestamp is not None and timestamp >= since_24h:
+                    skill_entry["success_24h"] += 1
+
+    top_skills: list[dict[str, Any]] = []
+    learned = 0
+    used = 0
+    improved = 0
+    for item in per_skill.values():
+        attempts = item["attempts_with_result"]
+        success_rate = item["success_total"] / attempts if attempts else None
+        success_rate_24h = item["success_24h"] / item["uses_24h"] if item["uses_24h"] else None
+        if item["uses_24h"] > item["uses_previous_24h"]:
+            trend = "hausse"
+        elif item["uses_24h"] < item["uses_previous_24h"]:
+            trend = "baisse"
+        else:
+            trend = "stable"
+        first_seen = item["first_seen_at"]
+        if isinstance(first_seen, datetime) and first_seen >= since_7d:
+            learned += 1
+        if item["uses_24h"] > 0:
+            used += 1
+        if trend == "hausse" and success_rate_24h is not None and success_rate_24h >= 0.6:
+            improved += 1
+        top_skills.append(
+            {
+                "skill": item["skill"],
+                "total_uses": item["total_uses"],
+                "frequency": {"uses_24h": item["uses_24h"], "uses_7d": item["uses_7d"]},
+                "success_rate": success_rate,
+                "last_used_at": (
+                    item["last_used_at"].isoformat() if isinstance(item["last_used_at"], datetime) else None
+                ),
+                "associated_tasks": item["associated_tasks"],
+                "trend": trend,
+            }
+        )
+    top_skills.sort(
+        key=lambda entry: (
+            int(entry["frequency"]["uses_24h"]),
+            int(entry["frequency"]["uses_7d"]),
+            int(entry["total_uses"]),
+        ),
+        reverse=True,
+    )
+    return {
+        "top_skills": top_skills[:8],
+        "frequency_totals": {"uses_24h": total_24h, "uses_7d": total_7d},
+        "progression_pipeline": {
+            "learned": learned,
+            "used": used,
+            "improved": improved,
+            "completion_rate": (improved / learned) if learned else None,
+        },
+    }


### PR DESCRIPTION
### Motivation
- Fournir une vue «Compétences du quotidien» qui synthétise les skills réellement utilisées (fréquence, réussite, dernière utilisation, tâches associées, tendance) et matérialise une progression «apprise → utilisée → améliorée». 
- Exposer ces données via les API du dashboard et la commande `status` pour pouvoir les consommer depuis l’UI, le CLI ou des scripts.

### Description
- Ajout d’un agrégateur partagé `build_daily_skills_snapshot` dans `src/singular/skills_daily.py` qui calcule `top_skills`, `frequency_totals` et `progression_pipeline` à partir des enregistrements de runs. 
- Intégration du snapshot au contexte d’action en exposant `daily_skills` depuis `DashboardActionService._context_payload` et en ajoutant la lecture des fichiers `*.jsonl` locaux via `_read_run_records` dans `src/singular/dashboard/actions.py`. 
- Extension du payload cockpit (`/api/cockpit`) pour inclure `daily_skills` (cas vide et cas avec runs) dans `src/singular/dashboard/__init__.py`. 
- Ajout d’une section visuelle «Compétences du quotidien» dans le template `src/singular/dashboard/templates/dashboard.html` (cartes + tableau) et rendu JS côté client, ainsi que exposition dans la commande `status` (`src/singular/organisms/status.py`) pour les formats `json` et `table`.

### Testing
- Compilation statique: `python -m compileall src/singular/skills_daily.py src/singular/dashboard/actions.py src/singular/dashboard/__init__.py src/singular/organisms/status.py` a réussi. 
- Exécution CLI tentée: `PYTHONPATH=src python -m singular.cli --root /tmp/singular-test --home /tmp/singular-test status --format json` a été exécutée mais l’environnement de test n’a pas de registre de vies/configuration complète, donc aucun run réel n’a été produit (comportement observé : message de registre manquant / pas de payload JSON utile). 
- Remarque: un premier essai d’exécution sans `PYTHONPATH` a échoué pour des dépendances manquantes (`fastapi`) dans cet environnement d’intégration, mais le code modifié est compilable et commité.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de725caec8832ab0626c349b8ab595)