### PR TITLE
Integrate host metrics and derived host threshold events in perception

### DIFF
--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from singular.events import EventBus, get_global_event_bus
+from singular.sensors import collect_host_metrics
 
 
 def _read_optional_file() -> dict[str, Any]:
@@ -155,6 +156,61 @@ def _build_perception_event(
     }
 
 
+
+
+def _collect_host_signals() -> dict[str, float | None] | None:
+    """Collect host metrics in a backward-compatible best-effort mode."""
+
+    try:
+        return collect_host_metrics()
+    except Exception:
+        return None
+
+
+def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Emit normalized host events when predefined thresholds are exceeded."""
+
+    if not isinstance(host_metrics, dict):
+        return []
+
+    events: list[dict[str, Any]] = []
+
+    cpu_percent = host_metrics.get("cpu_percent")
+    if isinstance(cpu_percent, (int, float)) and float(cpu_percent) >= 90.0:
+        events.append(
+            _build_perception_event(
+                event_type="host.cpu.high",
+                source="host_metrics",
+                confidence=0.92,
+                data={"cpu_percent": float(cpu_percent), "threshold": 90.0},
+            )
+        )
+
+    ram_used_percent = host_metrics.get("ram_used_percent")
+    if isinstance(ram_used_percent, (int, float)) and float(ram_used_percent) >= 85.0:
+        events.append(
+            _build_perception_event(
+                event_type="host.memory.pressure",
+                source="host_metrics",
+                confidence=0.9,
+                data={"ram_used_percent": float(ram_used_percent), "threshold": 85.0},
+            )
+        )
+
+    host_temperature_c = host_metrics.get("host_temperature_c")
+    if isinstance(host_temperature_c, (int, float)) and float(host_temperature_c) >= 80.0:
+        events.append(
+            _build_perception_event(
+                event_type="host.thermal.warning",
+                source="host_metrics",
+                confidence=0.88,
+                data={"host_temperature_c": float(host_temperature_c), "threshold": 80.0},
+            )
+        )
+
+    return events
+
+
 def _collect_artifact_signals(root: Path, state: _ArtifactScanState) -> list[dict[str, Any]]:
     files_mtime = _list_sandbox_files(root)
     previous_files = state.files_mtime
@@ -257,20 +313,36 @@ def capture_signals(
     signals.update(_read_optional_file())
     signals.update(_query_optional_weather_api())
 
+    host_metrics = _collect_host_signals()
+    if host_metrics is not None:
+        signals["host_metrics"] = host_metrics
+
     root = _resolve_sandbox_root(sandbox_root)
     state = artifact_state or _ARTIFACT_STATE
     filter_instance = noise_filter or _NOISE_FILTER
     artifact_events = _collect_artifact_signals(root, state)
-    filtered_events = [event for event in artifact_events if filter_instance.allow(event)]
+    host_events = _derive_host_events(host_metrics)
+    candidate_events = [*artifact_events, *host_events]
+    filtered_events = [event for event in candidate_events if filter_instance.allow(event)]
     if filtered_events:
-        signals["artifact_events"] = filtered_events
+        signals["artifact_events"] = [
+            event for event in filtered_events if str(event.get("type", "")).startswith("artifact.")
+        ]
+        signals["host_events"] = [
+            event for event in filtered_events if str(event.get("type", "")).startswith("host.")
+        ]
+        if not signals["artifact_events"]:
+            signals.pop("artifact_events")
+        if not signals["host_events"]:
+            signals.pop("host_events")
 
     if publish_event:
         emitter = bus or get_global_event_bus()
         emitter.publish("signal.captured", {"signals": dict(signals)}, payload_version=1)
         for event in filtered_events:
+            topic = "artifact.perception" if str(event.get("type", "")).startswith("artifact.") else "host.perception"
             emitter.publish(
-                "artifact.perception",
+                topic,
                 {"version": "1.0", "event": event},
                 payload_version=1,
             )

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -87,3 +87,59 @@ def test_capture_signals_publishes_normalized_artifact_events(tmp_path):
         assert set(normalized) >= {"type", "source", "confidence", "timestamp"}
 
     assert "artifact_events" in signals
+
+
+def test_capture_signals_integrates_host_metrics_and_publishes_host_events(tmp_path, monkeypatch):
+    reset_perception_state()
+
+    monkeypatch.setattr(
+        "singular.perception.collect_host_metrics",
+        lambda: {
+            "cpu_percent": 95.0,
+            "cpu_load_1m": 4.0,
+            "ram_used_percent": 90.0,
+            "ram_available_mb": 512.0,
+            "disk_used_percent": 50.0,
+            "disk_free_gb": 100.0,
+            "host_temperature_c": 85.0,
+            "process_cpu_percent": 40.0,
+            "process_rss_mb": 128.0,
+        },
+    )
+
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    (sandbox / "app.py").write_text("print('ok')\n", encoding="utf-8")
+
+    bus = EventBus(mode="sync")
+    captured = []
+    bus.subscribe("host.perception", lambda event: captured.append(event))
+
+    signals = capture_signals(bus=bus, sandbox_root=sandbox)
+
+    assert "host_metrics" in signals
+    assert signals["host_metrics"]["cpu_percent"] == 95.0
+    assert "host_events" in signals
+    event_types = {event["type"] for event in signals["host_events"]}
+    assert {"host.cpu.high", "host.memory.pressure", "host.thermal.warning"}.issubset(event_types)
+
+    assert any(evt.payload["event"]["type"] == "host.cpu.high" for evt in captured)
+    assert any(evt.payload["event"]["type"] == "host.memory.pressure" for evt in captured)
+    assert any(evt.payload["event"]["type"] == "host.thermal.warning" for evt in captured)
+
+    for event in captured:
+        payload = event.payload["event"]
+        assert set(payload) >= {"type", "source", "confidence", "timestamp"}
+
+
+def test_capture_signals_skips_host_metrics_when_sensor_unavailable(monkeypatch):
+    reset_perception_state()
+
+    def _boom():
+        raise RuntimeError("sensor unavailable")
+
+    monkeypatch.setattr("singular.perception.collect_host_metrics", _boom)
+
+    signals = capture_signals()
+
+    assert "host_metrics" not in signals


### PR DESCRIPTION
### Motivation
- Surface host-level telemetry in the perception snapshot so other components can reason about system state.
- Emit normalized, derived events when important host thresholds are crossed (CPU, memory, thermal) for monitoring/alerts.
- Preserve upward compatibility so perception remains robust if host sensors or optional dependencies are unavailable.

### Description
- Import and call `collect_host_metrics()` via a best-effort wrapper `_collect_host_signals()` and expose results under `signals["host_metrics"]` when available.
- Add `_derive_host_events()` to produce normalized events `host.cpu.high`, `host.memory.pressure`, and `host.thermal.warning` (each includes `confidence`, `timestamp`, `source`, and `data` with the triggering value and threshold).
- Merge artifact and host candidate events into the existing noise/filter pipeline, then split final results into `signals["artifact_events"]` and `signals["host_events"]` only when present.
- Publish derived host events on `host.perception` while keeping artifact events on `artifact.perception`, and preserve the existing `signal.captured` emission behavior and payload shape.

### Testing
- Added tests in `tests/test_perception.py` to verify host metrics integration, derived host event emission when thresholds are exceeded, and graceful fallback when host metrics collection raises.
- Ran `pytest -q tests/test_perception.py tests/test_host_sensor.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de764d3c34832abd60ff07e8640d45)