### PR TITLE
Add configurable host sensor thresholds and severity-based host events

### DIFF
--- a/configs/host_sensors.yaml
+++ b/configs/host_sensors.yaml
@@ -1,0 +1,12 @@
+host_sensors:
+  cpu:
+    warning_percent: 85
+    critical_percent: 95
+  ram:
+    warning_percent: 80
+    critical_percent: 92
+  temperature:
+    warning_c: 75
+    critical_c: 85
+  disk:
+    critical_percent: 95

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from singular.events import EventBus, get_global_event_bus
-from singular.sensors import collect_host_metrics
+from singular.sensors import collect_host_metrics, load_host_sensor_thresholds
 
 
 def _read_optional_file() -> dict[str, Any]:
@@ -173,38 +173,111 @@ def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, A
     if not isinstance(host_metrics, dict):
         return []
 
+    thresholds = load_host_sensor_thresholds()
     events: list[dict[str, Any]] = []
 
     cpu_percent = host_metrics.get("cpu_percent")
-    if isinstance(cpu_percent, (int, float)) and float(cpu_percent) >= 90.0:
+    if isinstance(cpu_percent, (int, float)) and float(cpu_percent) >= thresholds.cpu_critical_percent:
         events.append(
             _build_perception_event(
-                event_type="host.cpu.high",
+                event_type="host.cpu.critical",
                 source="host_metrics",
-                confidence=0.92,
-                data={"cpu_percent": float(cpu_percent), "threshold": 90.0},
+                confidence=0.95,
+                data={
+                    "cpu_percent": float(cpu_percent),
+                    "severity": "critical",
+                    "threshold": thresholds.cpu_critical_percent,
+                },
+            )
+        )
+    elif isinstance(cpu_percent, (int, float)) and float(cpu_percent) >= thresholds.cpu_warning_percent:
+        events.append(
+            _build_perception_event(
+                event_type="host.cpu.warning",
+                source="host_metrics",
+                confidence=0.9,
+                data={
+                    "cpu_percent": float(cpu_percent),
+                    "severity": "warning",
+                    "threshold": thresholds.cpu_warning_percent,
+                },
             )
         )
 
     ram_used_percent = host_metrics.get("ram_used_percent")
-    if isinstance(ram_used_percent, (int, float)) and float(ram_used_percent) >= 85.0:
+    if isinstance(ram_used_percent, (int, float)) and float(ram_used_percent) >= thresholds.ram_critical_percent:
         events.append(
             _build_perception_event(
-                event_type="host.memory.pressure",
+                event_type="host.memory.critical",
                 source="host_metrics",
-                confidence=0.9,
-                data={"ram_used_percent": float(ram_used_percent), "threshold": 85.0},
+                confidence=0.94,
+                data={
+                    "ram_used_percent": float(ram_used_percent),
+                    "severity": "critical",
+                    "threshold": thresholds.ram_critical_percent,
+                },
+            )
+        )
+    elif isinstance(ram_used_percent, (int, float)) and float(ram_used_percent) >= thresholds.ram_warning_percent:
+        events.append(
+            _build_perception_event(
+                event_type="host.memory.warning",
+                source="host_metrics",
+                confidence=0.89,
+                data={
+                    "ram_used_percent": float(ram_used_percent),
+                    "severity": "warning",
+                    "threshold": thresholds.ram_warning_percent,
+                },
             )
         )
 
     host_temperature_c = host_metrics.get("host_temperature_c")
-    if isinstance(host_temperature_c, (int, float)) and float(host_temperature_c) >= 80.0:
+    if (
+        isinstance(host_temperature_c, (int, float))
+        and float(host_temperature_c) >= thresholds.temperature_critical_c
+    ):
+        events.append(
+            _build_perception_event(
+                event_type="host.thermal.critical",
+                source="host_metrics",
+                confidence=0.93,
+                data={
+                    "host_temperature_c": float(host_temperature_c),
+                    "severity": "critical",
+                    "threshold": thresholds.temperature_critical_c,
+                },
+            )
+        )
+    elif (
+        isinstance(host_temperature_c, (int, float))
+        and float(host_temperature_c) >= thresholds.temperature_warning_c
+    ):
         events.append(
             _build_perception_event(
                 event_type="host.thermal.warning",
                 source="host_metrics",
                 confidence=0.88,
-                data={"host_temperature_c": float(host_temperature_c), "threshold": 80.0},
+                data={
+                    "host_temperature_c": float(host_temperature_c),
+                    "severity": "warning",
+                    "threshold": thresholds.temperature_warning_c,
+                },
+            )
+        )
+
+    disk_used_percent = host_metrics.get("disk_used_percent")
+    if isinstance(disk_used_percent, (int, float)) and float(disk_used_percent) >= thresholds.disk_critical_percent:
+        events.append(
+            _build_perception_event(
+                event_type="host.disk.critical",
+                source="host_metrics",
+                confidence=0.91,
+                data={
+                    "disk_used_percent": float(disk_used_percent),
+                    "severity": "critical",
+                    "threshold": thresholds.disk_critical_percent,
+                },
             )
         )
 

--- a/src/singular/sensors/__init__.py
+++ b/src/singular/sensors/__init__.py
@@ -1,5 +1,6 @@
 """Host and system sensor helpers."""
 
+from .config import HostSensorThresholds, load_host_sensor_thresholds
 from .host import collect_host_metrics
 
-__all__ = ["collect_host_metrics"]
+__all__ = ["HostSensorThresholds", "collect_host_metrics", "load_host_sensor_thresholds"]

--- a/src/singular/sensors/config.py
+++ b/src/singular/sensors/config.py
@@ -1,0 +1,244 @@
+"""Configuration loader for host sensor thresholds."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+DEFAULT_HOST_SENSORS_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "host_sensors.yaml"
+ENV_HOST_SENSORS_CONFIG_PATH = "SINGULAR_HOST_SENSORS_CONFIG"
+ENV_HOST_SENSORS_OVERRIDES = "SINGULAR_HOST_SENSORS_OVERRIDES"
+
+
+class HostSensorsConfigError(ValueError):
+    """Raised when host sensor configuration is invalid."""
+
+
+@dataclass(frozen=True)
+class HostSensorThresholds:
+    """Thresholds used to generate ``host.*`` perception events."""
+
+    cpu_warning_percent: float = 85.0
+    cpu_critical_percent: float = 95.0
+    ram_warning_percent: float = 80.0
+    ram_critical_percent: float = 92.0
+    temperature_warning_c: float = 75.0
+    temperature_critical_c: float = 85.0
+    disk_critical_percent: float = 95.0
+
+    def to_dict(self) -> dict[str, float]:
+        return asdict(self)
+
+
+def _parse_scalar(value: str) -> Any:
+    text = value.strip()
+    if text.startswith("[") and text.endswith("]"):
+        inner = text[1:-1].strip()
+        if not inner:
+            return []
+        return [chunk.strip().strip('"').strip("'") for chunk in inner.split(",")]
+    if text.lower() in {"true", "false"}:
+        return text.lower() == "true"
+    try:
+        return int(text)
+    except ValueError:
+        try:
+            return float(text)
+        except ValueError:
+            return text.strip('"').strip("'")
+
+
+def _load_simple_yaml(path: Path) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    stack: list[tuple[int, dict[str, Any]]] = [(0, data)]
+
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        key, value = line.strip().split(":", 1)
+        while stack and indent < stack[-1][0]:
+            stack.pop()
+        current = stack[-1][1]
+        if not value.strip():
+            new: dict[str, Any] = {}
+            current[key.strip()] = new
+            stack.append((indent + 2, new))
+            continue
+        current[key.strip()] = _parse_scalar(value)
+    return data
+
+
+def _load_yaml_mapping(path: Path) -> Mapping[str, Any]:
+    try:
+        import yaml  # type: ignore[import-untyped]
+
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        payload = _load_simple_yaml(path)
+
+    if payload is None:
+        return {}
+    if not isinstance(payload, Mapping):
+        raise HostSensorsConfigError("host sensors config must be a mapping")
+    return payload
+
+
+def _coerce_percent(payload: Mapping[str, Any], key: str, *, min_v: float = 0.0, max_v: float = 100.0) -> float:
+    if key not in payload:
+        raise HostSensorsConfigError(f"missing required key: {key}")
+    raw = payload[key]
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise HostSensorsConfigError(f"invalid numeric value for {key}: {raw!r}") from exc
+    if value < min_v or value > max_v:
+        raise HostSensorsConfigError(f"value for {key} must be within [{min_v}, {max_v}]")
+    return value
+
+
+def _validate_threshold_order(low: float, high: float, *, low_name: str, high_name: str) -> None:
+    if low >= high:
+        raise HostSensorsConfigError(f"{low_name} must be < {high_name}")
+
+
+def validate_host_sensors_payload(payload: Mapping[str, Any]) -> HostSensorThresholds:
+    """Validate mapping and return strict host sensor thresholds."""
+
+    root = payload.get("host_sensors", payload)
+    if not isinstance(root, Mapping):
+        raise HostSensorsConfigError("`host_sensors` section must be a mapping")
+
+    expected_root = {"cpu", "ram", "temperature", "disk"}
+    unexpected_root = sorted(set(root.keys()) - expected_root)
+    if unexpected_root:
+        raise HostSensorsConfigError(f"unexpected keys: {', '.join(unexpected_root)}")
+
+    cpu = root.get("cpu", {})
+    ram = root.get("ram", {})
+    temperature = root.get("temperature", {})
+    disk = root.get("disk", {})
+    for section_name, section in {
+        "cpu": cpu,
+        "ram": ram,
+        "temperature": temperature,
+        "disk": disk,
+    }.items():
+        if not isinstance(section, Mapping):
+            raise HostSensorsConfigError(f"section `{section_name}` must be a mapping")
+
+    cpu_unexpected = sorted(set(cpu.keys()) - {"warning_percent", "critical_percent"})
+    ram_unexpected = sorted(set(ram.keys()) - {"warning_percent", "critical_percent"})
+    temp_unexpected = sorted(set(temperature.keys()) - {"warning_c", "critical_c"})
+    disk_unexpected = sorted(set(disk.keys()) - {"critical_percent"})
+    unexpected = cpu_unexpected + ram_unexpected + temp_unexpected + disk_unexpected
+    if unexpected:
+        raise HostSensorsConfigError(f"unexpected nested keys: {', '.join(unexpected)}")
+
+    cpu_warning = _coerce_percent(cpu, "warning_percent")
+    cpu_critical = _coerce_percent(cpu, "critical_percent")
+    ram_warning = _coerce_percent(ram, "warning_percent")
+    ram_critical = _coerce_percent(ram, "critical_percent")
+    temperature_warning = _coerce_percent(temperature, "warning_c", min_v=-50.0, max_v=200.0)
+    temperature_critical = _coerce_percent(temperature, "critical_c", min_v=-50.0, max_v=200.0)
+    disk_critical = _coerce_percent(disk, "critical_percent")
+
+    _validate_threshold_order(
+        cpu_warning,
+        cpu_critical,
+        low_name="cpu.warning_percent",
+        high_name="cpu.critical_percent",
+    )
+    _validate_threshold_order(
+        ram_warning,
+        ram_critical,
+        low_name="ram.warning_percent",
+        high_name="ram.critical_percent",
+    )
+    _validate_threshold_order(
+        temperature_warning,
+        temperature_critical,
+        low_name="temperature.warning_c",
+        high_name="temperature.critical_c",
+    )
+
+    return HostSensorThresholds(
+        cpu_warning_percent=cpu_warning,
+        cpu_critical_percent=cpu_critical,
+        ram_warning_percent=ram_warning,
+        ram_critical_percent=ram_critical,
+        temperature_warning_c=temperature_warning,
+        temperature_critical_c=temperature_critical,
+        disk_critical_percent=disk_critical,
+    )
+
+
+def _merge_nested(base: dict[str, Any], patch: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(base)
+    for key, value in patch.items():
+        if isinstance(value, Mapping) and isinstance(out.get(key), Mapping):
+            out[key] = _merge_nested(dict(out[key]), value)
+        else:
+            out[key] = value
+    return out
+
+
+def load_host_sensor_thresholds(path: Path | None = None) -> HostSensorThresholds:
+    """Load host thresholds from config with strict validation and env overrides."""
+
+    defaults = HostSensorThresholds()
+    base_payload: dict[str, Any] = {
+        "host_sensors": {
+            "cpu": {
+                "warning_percent": defaults.cpu_warning_percent,
+                "critical_percent": defaults.cpu_critical_percent,
+            },
+            "ram": {
+                "warning_percent": defaults.ram_warning_percent,
+                "critical_percent": defaults.ram_critical_percent,
+            },
+            "temperature": {
+                "warning_c": defaults.temperature_warning_c,
+                "critical_c": defaults.temperature_critical_c,
+            },
+            "disk": {
+                "critical_percent": defaults.disk_critical_percent,
+            },
+        }
+    }
+
+    selected = path
+    if selected is None:
+        raw_path = os.environ.get(ENV_HOST_SENSORS_CONFIG_PATH, "").strip()
+        selected = Path(raw_path) if raw_path else DEFAULT_HOST_SENSORS_CONFIG_PATH
+
+    if selected.exists():
+        payload = _load_yaml_mapping(selected)
+        base_payload = _merge_nested(base_payload, payload)
+
+    overrides_raw = os.environ.get(ENV_HOST_SENSORS_OVERRIDES, "").strip()
+    if overrides_raw:
+        try:
+            override_payload = json.loads(overrides_raw)
+        except json.JSONDecodeError as exc:
+            raise HostSensorsConfigError(f"invalid JSON in {ENV_HOST_SENSORS_OVERRIDES}") from exc
+        if not isinstance(override_payload, Mapping):
+            raise HostSensorsConfigError(f"{ENV_HOST_SENSORS_OVERRIDES} must contain a JSON mapping")
+        base_payload = _merge_nested(base_payload, dict(override_payload))
+
+    return validate_host_sensors_payload(base_payload)
+
+
+__all__ = [
+    "DEFAULT_HOST_SENSORS_CONFIG_PATH",
+    "ENV_HOST_SENSORS_CONFIG_PATH",
+    "ENV_HOST_SENSORS_OVERRIDES",
+    "HostSensorThresholds",
+    "HostSensorsConfigError",
+    "load_host_sensor_thresholds",
+    "validate_host_sensors_payload",
+]

--- a/tests/test_host_sensors_config.py
+++ b/tests/test_host_sensors_config.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from singular.sensors.config import (
+    HostSensorsConfigError,
+    load_host_sensor_thresholds,
+    validate_host_sensors_payload,
+)
+
+
+def test_load_host_sensor_thresholds_defaults_when_missing(tmp_path):
+    thresholds = load_host_sensor_thresholds(tmp_path / "missing.yaml")
+
+    assert thresholds.cpu_warning_percent == 85.0
+    assert thresholds.cpu_critical_percent == 95.0
+    assert thresholds.ram_warning_percent == 80.0
+    assert thresholds.ram_critical_percent == 92.0
+    assert thresholds.temperature_warning_c == 75.0
+    assert thresholds.temperature_critical_c == 85.0
+    assert thresholds.disk_critical_percent == 95.0
+
+
+def test_load_host_sensor_thresholds_from_yaml_and_env_override(tmp_path, monkeypatch):
+    config = tmp_path / "host_sensors.yaml"
+    config.write_text(
+        """
+host_sensors:
+  cpu:
+    warning_percent: 70
+    critical_percent: 90
+  ram:
+    warning_percent: 75
+    critical_percent: 88
+  temperature:
+    warning_c: 65
+    critical_c: 78
+  disk:
+    critical_percent: 93
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv(
+        "SINGULAR_HOST_SENSORS_OVERRIDES",
+        json.dumps({"host_sensors": {"cpu": {"critical_percent": 91}, "disk": {"critical_percent": 96}}}),
+    )
+
+    thresholds = load_host_sensor_thresholds(config)
+
+    assert thresholds.cpu_warning_percent == 70.0
+    assert thresholds.cpu_critical_percent == 91.0
+    assert thresholds.ram_warning_percent == 75.0
+    assert thresholds.ram_critical_percent == 88.0
+    assert thresholds.temperature_warning_c == 65.0
+    assert thresholds.temperature_critical_c == 78.0
+    assert thresholds.disk_critical_percent == 96.0
+
+
+def test_validate_host_sensor_thresholds_rejects_invalid_schema():
+    with pytest.raises(HostSensorsConfigError):
+        validate_host_sensors_payload(
+            {
+                "host_sensors": {
+                    "cpu": {"warning_percent": 90, "critical_percent": 80},
+                    "ram": {"warning_percent": 75, "critical_percent": 90},
+                    "temperature": {"warning_c": 70, "critical_c": 80},
+                    "disk": {"critical_percent": 95},
+                }
+            }
+        )

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -97,11 +97,11 @@ def test_capture_signals_integrates_host_metrics_and_publishes_host_events(tmp_p
         lambda: {
             "cpu_percent": 95.0,
             "cpu_load_1m": 4.0,
-            "ram_used_percent": 90.0,
+            "ram_used_percent": 95.0,
             "ram_available_mb": 512.0,
-            "disk_used_percent": 50.0,
+            "disk_used_percent": 97.0,
             "disk_free_gb": 100.0,
-            "host_temperature_c": 85.0,
+            "host_temperature_c": 86.0,
             "process_cpu_percent": 40.0,
             "process_rss_mb": 128.0,
         },
@@ -121,11 +121,17 @@ def test_capture_signals_integrates_host_metrics_and_publishes_host_events(tmp_p
     assert signals["host_metrics"]["cpu_percent"] == 95.0
     assert "host_events" in signals
     event_types = {event["type"] for event in signals["host_events"]}
-    assert {"host.cpu.high", "host.memory.pressure", "host.thermal.warning"}.issubset(event_types)
+    assert {
+        "host.cpu.critical",
+        "host.memory.critical",
+        "host.thermal.critical",
+        "host.disk.critical",
+    }.issubset(event_types)
 
-    assert any(evt.payload["event"]["type"] == "host.cpu.high" for evt in captured)
-    assert any(evt.payload["event"]["type"] == "host.memory.pressure" for evt in captured)
-    assert any(evt.payload["event"]["type"] == "host.thermal.warning" for evt in captured)
+    assert any(evt.payload["event"]["type"] == "host.cpu.critical" for evt in captured)
+    assert any(evt.payload["event"]["type"] == "host.memory.critical" for evt in captured)
+    assert any(evt.payload["event"]["type"] == "host.thermal.critical" for evt in captured)
+    assert any(evt.payload["event"]["type"] == "host.disk.critical" for evt in captured)
 
     for event in captured:
         payload = event.payload["event"]


### PR DESCRIPTION
### Motivation
- Make host health thresholds configurable and safe by moving hardcoded CPU/RAM/temperature/disk limits into a single YAML file with sane defaults.
- Provide a strict, well-tested loader that validates schema, enforces numeric ranges and order (warning < critical) and supports environment-based overrides.
- Use the configured thresholds to produce clearer, severity-tagged `host.*` perception events so downstream consumers can react to `warning` vs `critical` conditions.

### Description
- Add `configs/host_sensors.yaml` with default thresholds for CPU, RAM, temperature (warning/critical) and disk (critical). 
- Implement a strict loader and validator in `src/singular/sensors/config.py` exposing `HostSensorThresholds`, `load_host_sensor_thresholds` and `validate_host_sensors_payload`, and support env overrides via `SINGULAR_HOST_SENSORS_CONFIG` and `SINGULAR_HOST_SENSORS_OVERRIDES`.
- Export the loader from `src/singular/sensors/__init__.py` so the rest of the code can import it as `singular.sensors.load_host_sensor_thresholds`.
- Update host event derivation in `src/singular/perception.py` to consume configured thresholds and emit severity-specific events (`host.cpu.warning` / `host.cpu.critical`, `host.memory.warning` / `host.memory.critical`, `host.thermal.warning` / `host.thermal.critical`, and `host.disk.critical`) with standardized payload fields including `severity` and `threshold`.
- Add unit tests in `tests/test_host_sensors_config.py` for defaults, YAML loading and JSON env overrides and adjust `tests/test_perception.py` to assert the new critical host events are produced.

### Testing
- Ran `pytest -q tests/test_host_sensors_config.py tests/test_perception.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de772298e4832abda5aac565a9e27f)