### PR TITLE
Persist host metrics, compute aggregates, and expose environmental impact in status/report

### DIFF
--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -131,6 +131,8 @@ class IntrinsicGoals:
         telemetry_efficiency_penalty = 0.0
         telemetry_quality_pressure = 0.0
         telemetry_failure_pressure = 0.0
+        host_environmental_pressure = 0.0
+        host_environmental_variance = 0.0
         skill_reputation = (perception_signals or {}).get("skill_reputation")
         if isinstance(skill_reputation, Mapping) and skill_reputation:
             sample_count = 0.0
@@ -152,13 +154,50 @@ class IntrinsicGoals:
                 telemetry_quality_pressure = _clamp(1.0 - mean_quality, 0.0, 1.0)
                 telemetry_failure_pressure = _clamp(mean_failures / 3.0, 0.0, 1.0)
 
+        host_aggregates = (perception_signals or {}).get("host_metrics_aggregates")
+        if isinstance(host_aggregates, Mapping):
+            rolling = host_aggregates.get("rolling_means", {})
+            variance = host_aggregates.get("variance", {})
+            if isinstance(rolling, Mapping):
+                cpu_roll = rolling.get("cpu_percent")
+                ram_roll = rolling.get("ram_used_percent")
+                temp_roll = rolling.get("host_temperature_c")
+                cpu_pressure = (
+                    _clamp(_as_float(cpu_roll.get("20", cpu_roll.get("5", 0.0))) / 100.0)
+                    if isinstance(cpu_roll, Mapping)
+                    else 0.0
+                )
+                ram_pressure = (
+                    _clamp(_as_float(ram_roll.get("20", ram_roll.get("5", 0.0))) / 100.0)
+                    if isinstance(ram_roll, Mapping)
+                    else 0.0
+                )
+                thermal_pressure = (
+                    _clamp(_as_float(temp_roll.get("20", temp_roll.get("5", 0.0))) / 95.0)
+                    if isinstance(temp_roll, Mapping)
+                    else 0.0
+                )
+                host_environmental_pressure = _clamp(
+                    (cpu_pressure * 0.45) + (ram_pressure * 0.35) + (thermal_pressure * 0.2)
+                )
+            if isinstance(variance, Mapping):
+                cpu_variance = _clamp(_as_float(variance.get("cpu_percent", 0.0)) / 400.0)
+                ram_variance = _clamp(_as_float(variance.get("ram_used_percent", 0.0)) / 400.0)
+                host_environmental_variance = _clamp((cpu_variance + ram_variance) / 2.0)
+
         base_weights = GoalWeights(
             coherence=0.2 + 0.35 * patience + 0.25 * resilience + 0.2 * telemetry_quality_pressure,
             robustesse=0.2
             + 0.35 * (1.0 - health_norm)
             + 0.25 * (1.0 - resource_stability)
-            + 0.2 * telemetry_failure_pressure,
-            efficacite=0.2 + 0.45 * health_norm + 0.2 * optimism + 0.2 * telemetry_efficiency_penalty,
+            + 0.2 * telemetry_failure_pressure
+            + 0.25 * host_environmental_pressure
+            + 0.1 * host_environmental_variance,
+            efficacite=0.2
+            + 0.45 * health_norm
+            + 0.2 * optimism
+            + 0.35 * telemetry_efficiency_penalty
+            + 0.2 * (1.0 - host_environmental_pressure),
             exploration=0.2 + 0.45 * curiosity + 0.2 * playfulness + 0.1 * (1.0 - energy),
         )
         modulation = apply_perception_rules(perception_signals)
@@ -184,6 +223,8 @@ class IntrinsicGoals:
                     "resilience": resilience,
                     "optimism": optimism,
                     "playfulness": playfulness,
+                    "host_environmental_pressure": host_environmental_pressure,
+                    "host_environmental_variance": host_environmental_variance,
                     "perception_rules_version": modulation["version"],
                     "perception_rule_count": len(modulation["applied_rules"]),
                 },

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -13,6 +13,7 @@ from ..memory import get_mem_dir
 from ..memory import read_skills
 from ..runs.logger import RUNS_DIR
 from ..schedulers.reevaluation import alerts_from_records
+from ..sensors import compute_host_metrics_aggregates, summarize_environmental_impact
 from ..skills_daily import build_daily_skills_snapshot
 
 
@@ -118,6 +119,15 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             "reproduction_eligible": False,
             "thresholds": {},
         },
+        "host_environment": {
+            "aggregates": {},
+            "impact": {},
+        },
+    }
+    host_aggregates = compute_host_metrics_aggregates()
+    payload["host_environment"] = {
+        "aggregates": host_aggregates,
+        "impact": summarize_environmental_impact(host_aggregates),
     }
     runs_dir = Path(RUNS_DIR)
     files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
@@ -280,6 +290,14 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             ["Âge vital", str((payload.get("vital_timeline") or {}).get("age", 0))],
             ["État vital", str((payload.get("vital_timeline") or {}).get("state", "n/a"))],
             ["Risque vital", str((payload.get("vital_timeline") or {}).get("risk_level", "n/a"))],
+            [
+                "Impact environnement hôte",
+                str(((payload.get("host_environment") or {}).get("impact") or {}).get("impact_level", "low")),
+            ],
+            [
+                "Biais décisionnel hôte",
+                str(((payload.get("host_environment") or {}).get("impact") or {}).get("decision_bias", "balanced")),
+            ],
         ]
         _print_table(["Metric", "Value"], run_rows)
         if verbose:
@@ -323,6 +341,10 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         print(f"Âge vital: {vital.get('age', 0)}")
         print(f"État vital: {vital.get('state', 'n/a')}")
         print(f"Risque vital: {vital.get('risk_level', 'n/a')}")
+        host_environment = payload.get("host_environment") if isinstance(payload.get("host_environment"), dict) else {}
+        host_impact = host_environment.get("impact") if isinstance(host_environment.get("impact"), dict) else {}
+        print(f"Impact environnement hôte: {host_impact.get('impact_level', 'low')}")
+        print(f"Biais décisionnel hôte: {host_impact.get('decision_bias', 'balanced')}")
         causes = vital.get("causes")
         if isinstance(causes, list) and causes:
             print(f"Causes observées: {', '.join(str(c) for c in causes)}")

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -22,7 +22,12 @@ from typing import Any
 
 from singular.events import EventBus, get_global_event_bus
 from singular.governance.policy import MutationGovernancePolicy
-from singular.sensors import collect_host_metrics, load_host_sensor_thresholds
+from singular.sensors import (
+    append_host_metrics_sample,
+    collect_host_metrics,
+    compute_host_metrics_aggregates,
+    load_host_sensor_thresholds,
+)
 
 
 def _read_optional_file() -> dict[str, Any]:
@@ -406,6 +411,11 @@ def capture_signals(
     host_metrics = _collect_host_signals()
     if host_metrics is not None:
         signals["host_metrics"] = host_metrics
+        try:
+            append_host_metrics_sample(host_metrics)
+            signals["host_metrics_aggregates"] = compute_host_metrics_aggregates()
+        except Exception:
+            pass
 
     root = _resolve_sandbox_root(sandbox_root)
     state = artifact_state or _ARTIFACT_STATE

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -11,6 +11,7 @@ from .logger import RUNS_DIR
 from ..governance.policy import load_runtime_policy
 from ..life.health import detect_health_state
 from ..memory import read_skills, get_skills_file
+from ..sensors import compute_host_metrics_aggregates, summarize_environmental_impact
 
 
 def load_run_records(
@@ -131,6 +132,8 @@ def _build_report_payload(
     if skills_path is None:
         skills_path = get_skills_file()
     policy = load_runtime_policy()
+    host_aggregates = compute_host_metrics_aggregates()
+    host_impact = summarize_environmental_impact(host_aggregates)
 
     return {
         "schema_version": 1,
@@ -157,6 +160,10 @@ def _build_report_payload(
         "policy": {
             "active": policy.to_payload(),
             "impact": policy.impact_summary(),
+        },
+        "host_environment": {
+            "aggregates": host_aggregates,
+            "impact": host_impact,
         },
     }
 
@@ -213,6 +220,10 @@ def _render_markdown(payload: dict[str, Any]) -> str:
     lines.extend(["", "## Politiques actives"])
     for item in payload.get("policy", {}).get("impact", []):
         lines.append(f"- {item}")
+    lines.extend(["", "## Environnement hôte"])
+    host_impact = payload.get("host_environment", {}).get("impact", {})
+    lines.append(f"- Niveau d'impact: {host_impact.get('impact_level', 'low')}")
+    lines.append(f"- Biais décisionnel: {host_impact.get('decision_bias', 'balanced')}")
 
     return "\n".join(lines) + "\n"
 
@@ -276,6 +287,12 @@ def report(
             f"{payload['health']['score']:.2f}/100 "
             f"({payload['health']['trend']}, comparaison fenêtres {payload['health']['window']})"
         )
+    host_impact = payload.get("host_environment", {}).get("impact", {})
+    print(
+        "Impact environnement hôte: "
+        f"{host_impact.get('impact_level', 'low')} "
+        f"(biais: {host_impact.get('decision_bias', 'balanced')})"
+    )
 
     counter = summary["operator_histogram"]
     if output_format == "table":

--- a/src/singular/sensors/__init__.py
+++ b/src/singular/sensors/__init__.py
@@ -2,5 +2,19 @@
 
 from .config import HostSensorThresholds, load_host_sensor_thresholds
 from .host import collect_host_metrics
+from .host_metrics_store import (
+    append_host_metrics_sample,
+    compute_host_metrics_aggregates,
+    load_host_metrics_samples,
+    summarize_environmental_impact,
+)
 
-__all__ = ["HostSensorThresholds", "collect_host_metrics", "load_host_sensor_thresholds"]
+__all__ = [
+    "HostSensorThresholds",
+    "append_host_metrics_sample",
+    "collect_host_metrics",
+    "compute_host_metrics_aggregates",
+    "load_host_metrics_samples",
+    "load_host_sensor_thresholds",
+    "summarize_environmental_impact",
+]

--- a/src/singular/sensors/host_metrics_store.py
+++ b/src/singular/sensors/host_metrics_store.py
@@ -1,0 +1,213 @@
+"""Persistent host-metrics storage and simple aggregations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import json
+import os
+
+from singular.memory import _append_jsonl_line, get_mem_dir
+
+_DEFAULT_RETENTION_SAMPLES = 2000
+_DEFAULT_WINDOWS = (5, 20, 60)
+_METRICS_KEYS = (
+    "cpu_percent",
+    "ram_used_percent",
+    "disk_used_percent",
+    "host_temperature_c",
+    "process_cpu_percent",
+    "process_rss_mb",
+)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def host_metrics_file() -> Path:
+    """Return the host metrics JSONL storage path."""
+    return get_mem_dir() / "host_metrics.jsonl"
+
+
+def _retention_samples() -> int:
+    raw = os.getenv("SINGULAR_HOST_METRICS_RETENTION_SAMPLES", str(_DEFAULT_RETENTION_SAMPLES))
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_RETENTION_SAMPLES
+    return max(1, value)
+
+
+def _aggregation_windows() -> tuple[int, ...]:
+    raw = os.getenv("SINGULAR_HOST_METRICS_WINDOWS", "")
+    if not raw.strip():
+        return _DEFAULT_WINDOWS
+    windows: list[int] = []
+    for token in raw.split(","):
+        try:
+            candidate = int(token.strip())
+        except ValueError:
+            continue
+        if candidate > 0:
+            windows.append(candidate)
+    return tuple(sorted(set(windows))) or _DEFAULT_WINDOWS
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def append_host_metrics_sample(metrics: dict[str, Any]) -> None:
+    """Append one host sample and enforce retention."""
+
+    path = host_metrics_file()
+    payload = {
+        "ts": _utc_now_iso(),
+        "metrics": {key: _safe_float(metrics.get(key)) for key in _METRICS_KEYS},
+    }
+    _append_jsonl_line(path, payload)
+    _trim_retention(path=path, retention=_retention_samples())
+
+
+def _trim_retention(*, path: Path, retention: int) -> None:
+    if retention <= 0 or not path.exists():
+        return
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    if len(lines) <= retention:
+        return
+    path.write_text("\n".join(lines[-retention:]) + "\n", encoding="utf-8")
+
+
+def load_host_metrics_samples(*, limit: int | None = None) -> list[dict[str, Any]]:
+    """Load persisted host metrics samples."""
+
+    path = host_metrics_file()
+    if not path.exists():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    if limit is not None and limit > 0:
+        lines = lines[-limit:]
+    samples: list[dict[str, Any]] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            samples.append(payload)
+    return samples
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _variance(values: list[float], mean: float) -> float:
+    if len(values) <= 1:
+        return 0.0
+    return sum((value - mean) ** 2 for value in values) / len(values)
+
+
+def compute_host_metrics_aggregates(
+    samples: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Compute rolling averages, peaks and variances on persisted samples."""
+
+    if samples is None:
+        samples = load_host_metrics_samples(limit=max(_aggregation_windows()) * 4)
+    windows = _aggregation_windows()
+    metrics_by_key: dict[str, list[float]] = {key: [] for key in _METRICS_KEYS}
+    for sample in samples:
+        metrics = sample.get("metrics")
+        if not isinstance(metrics, dict):
+            continue
+        for key in _METRICS_KEYS:
+            value = _safe_float(metrics.get(key))
+            if value is not None:
+                metrics_by_key[key].append(value)
+
+    rolling_means: dict[str, dict[str, float]] = {}
+    peaks: dict[str, float] = {}
+    variances: dict[str, float] = {}
+    for key, values in metrics_by_key.items():
+        if not values:
+            continue
+        peaks[key] = max(values)
+        mean_all = _mean(values)
+        variances[key] = _variance(values, mean_all)
+        rolling_means[key] = {
+            str(window): _mean(values[-window:]) for window in windows if len(values) >= 1
+        }
+
+    return {
+        "sample_count": len(samples),
+        "windows": list(windows),
+        "rolling_means": rolling_means,
+        "peaks": peaks,
+        "variance": variances,
+        "latest": samples[-1] if samples else None,
+    }
+
+
+def summarize_environmental_impact(aggregates: dict[str, Any] | None) -> dict[str, Any]:
+    """Summarize host environmental pressure and expected decision impact."""
+
+    if not isinstance(aggregates, dict):
+        return {
+            "pressure_score": 0.0,
+            "variance_score": 0.0,
+            "impact_level": "low",
+            "decision_bias": "balanced",
+        }
+    rolling = aggregates.get("rolling_means", {})
+    variance = aggregates.get("variance", {})
+    cpu_20 = _safe_float(((rolling.get("cpu_percent") or {}).get("20"))) if isinstance(rolling, dict) else None
+    ram_20 = _safe_float(((rolling.get("ram_used_percent") or {}).get("20"))) if isinstance(rolling, dict) else None
+    temp_20 = _safe_float(((rolling.get("host_temperature_c") or {}).get("20"))) if isinstance(rolling, dict) else None
+    cpu_pressure = max(0.0, min((cpu_20 or 0.0) / 100.0, 1.0))
+    ram_pressure = max(0.0, min((ram_20 or 0.0) / 100.0, 1.0))
+    thermal_pressure = max(0.0, min((temp_20 or 0.0) / 95.0, 1.0))
+    pressure_score = (cpu_pressure * 0.45) + (ram_pressure * 0.35) + (thermal_pressure * 0.2)
+
+    cpu_var = _safe_float((variance or {}).get("cpu_percent")) if isinstance(variance, dict) else None
+    ram_var = _safe_float((variance or {}).get("ram_used_percent")) if isinstance(variance, dict) else None
+    variance_score = max(0.0, min((((cpu_var or 0.0) / 400.0) + ((ram_var or 0.0) / 400.0)) / 2.0, 1.0))
+
+    if pressure_score >= 0.8:
+        level = "critical"
+    elif pressure_score >= 0.6:
+        level = "high"
+    elif pressure_score >= 0.4:
+        level = "moderate"
+    else:
+        level = "low"
+
+    if pressure_score >= 0.65 or variance_score >= 0.55:
+        bias = "robustesse"
+    elif pressure_score <= 0.25 and variance_score <= 0.2:
+        bias = "efficacite_exploration"
+    else:
+        bias = "balanced"
+
+    return {
+        "pressure_score": round(pressure_score, 4),
+        "variance_score": round(variance_score, 4),
+        "impact_level": level,
+        "decision_bias": bias,
+    }

--- a/tests/test_host_metrics_store.py
+++ b/tests/test_host_metrics_store.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+
+from singular.sensors.host_metrics_store import (
+    append_host_metrics_sample,
+    compute_host_metrics_aggregates,
+    host_metrics_file,
+    summarize_environmental_impact,
+)
+
+
+def test_host_metrics_store_writes_jsonl_with_retention(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setenv("SINGULAR_HOST_METRICS_RETENTION_SAMPLES", "3")
+
+    for idx in range(5):
+        append_host_metrics_sample(
+            {
+                "cpu_percent": 10 + idx,
+                "ram_used_percent": 20 + idx,
+                "disk_used_percent": 30 + idx,
+            }
+        )
+
+    lines = host_metrics_file().read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    latest = json.loads(lines[-1])
+    assert latest["metrics"]["cpu_percent"] == 14.0
+
+
+def test_host_metrics_aggregates_and_impact(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setenv("SINGULAR_HOST_METRICS_RETENTION_SAMPLES", "200")
+
+    for idx in range(30):
+        append_host_metrics_sample(
+            {
+                "cpu_percent": 70 + (idx % 5),
+                "ram_used_percent": 65 + (idx % 4),
+                "host_temperature_c": 72 + (idx % 3),
+            }
+        )
+
+    aggregates = compute_host_metrics_aggregates()
+    impact = summarize_environmental_impact(aggregates)
+    assert aggregates["sample_count"] == 30
+    assert aggregates["rolling_means"]["cpu_percent"]["20"] >= 70.0
+    assert impact["impact_level"] in {"moderate", "high", "critical"}
+    assert impact["decision_bias"] == "robustesse"
+

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -109,6 +109,47 @@ def test_intrinsic_goals_uses_skill_reputation_telemetry(tmp_path) -> None:
     assert with_telemetry.coherence > baseline.coherence
 
 
+def test_intrinsic_goals_account_for_host_environment_pressure(tmp_path) -> None:
+    goals = IntrinsicGoals(path=tmp_path / "goals.json")
+    psyche = Psyche()
+
+    low_pressure = goals.update_tick(
+        tick=1,
+        psyche=psyche,
+        health_score=80.0,
+        resources={"energy": 80.0, "food": 80.0, "warmth": 80.0},
+        perception_signals={
+            "host_metrics_aggregates": {
+                "rolling_means": {
+                    "cpu_percent": {"20": 18.0},
+                    "ram_used_percent": {"20": 22.0},
+                    "host_temperature_c": {"20": 35.0},
+                },
+                "variance": {"cpu_percent": 5.0, "ram_used_percent": 7.0},
+            }
+        },
+    )
+    high_pressure = goals.update_tick(
+        tick=2,
+        psyche=psyche,
+        health_score=80.0,
+        resources={"energy": 80.0, "food": 80.0, "warmth": 80.0},
+        perception_signals={
+            "host_metrics_aggregates": {
+                "rolling_means": {
+                    "cpu_percent": {"20": 90.0},
+                    "ram_used_percent": {"20": 91.0},
+                    "host_temperature_c": {"20": 84.0},
+                },
+                "variance": {"cpu_percent": 110.0, "ram_used_percent": 95.0},
+            }
+        },
+    )
+
+    assert high_pressure.robustesse > low_pressure.robustesse
+    assert high_pressure.efficacite < low_pressure.efficacite
+
+
 def test_intrinsic_goals_strategy_turns_cautious_on_repeated_negative_feedback(tmp_path) -> None:
     goals = IntrinsicGoals(path=tmp_path / "goals.json")
     strategy = goals.derive_execution_strategy(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -246,6 +246,8 @@ def test_report_export_json_schema(monkeypatch, tmp_path):
     assert isinstance(payload["alerts"], list)
     assert payload["policy"]["active"]["version"] == 1
     assert isinstance(payload["policy"]["impact"], list)
+    assert "host_environment" in payload
+    assert "impact_level" in payload["host_environment"]["impact"]
 
 
 def test_report_export_json_is_stable(monkeypatch, tmp_path):

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -112,6 +112,8 @@ def test_status_filters_non_mutation_records_for_success_rate(
     assert payload["vital_timeline"]["state"] in {"mature", "declining", "terminal", "extinct"}
     assert "autonomy_metrics" in payload
     assert "proactive_initiative_rate" in payload["autonomy_metrics"]
+    assert "host_environment" in payload
+    assert "impact" in payload["host_environment"]
 
 
 def test_status_exposes_quest_counts(tmp_path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
### Motivation
- Fournir un stockage léger horodaté des métriques hôte pour permettre une rétention configurable et des agrégations exploitable par la prise de décision. 
- Influencer les poids d’objectifs intrinsèques en fonction de la pression/variance environnementale du host afin d’adapter priorités (robustesse/efficacité). 
- Rendre l’impact environnemental visible via les commandes CLI `status` et `report` pour informer l’opérateur des biais de décision liés à l’état de la machine.

### Description
- Ajout d’un module de persistance et d’agrégation `src/singular/sensors/host_metrics_store.py` qui écrit `mem/host_metrics.jsonl`, gère la rétention via `SINGULAR_HOST_METRICS_RETENTION_SAMPLES` et calcule moyennes glissantes, pics et variance, ainsi qu’un résumé `summarize_environmental_impact()`.
- Intégration dans la collecte de perception: `capture_signals()` persiste chaque échantillon (`append_host_metrics_sample`) et expose `host_metrics_aggregates` dans les signaux (modification de `src/singular/perception.py` et export dans `src/singular/sensors/__init__.py`).
- `IntrinsicGoals.update_tick()` consomme `host_metrics_aggregates` pour calculer une `host_environmental_pressure` et `host_environmental_variance` qui modulents les poids de `robustesse` et `efficacite` et sont tracés dans l’historique (`src/singular/goals/intrinsic.py`).
- `status` et `report` affichent et exportent maintenant le bloc `host_environment` (agrégats + impact, tant en `plain`/`table`/`json`/export markdown/json) afin d’exposer le `impact_level` et le `decision_bias` (`src/singular/organisms/status.py`, `src/singular/runs/report.py`).
- Tests ajoutés/ajustés: `tests/test_host_metrics_store.py` (rétention, agrégats, impact), et mises à jour des tests existants pour valider l’exposition dans `status`/`report` et l’adaptation des objectifs (`tests/test_objectives.py`, `tests/test_status.py`, `tests/test_report.py`).

### Testing
- Exécuté `pytest -q tests/test_host_metrics_store.py tests/test_objectives.py tests/test_status.py tests/test_report.py` et la suite ciblée a réussi (tests verts). 
- Exécuté `pytest -q tests/test_perception.py tests/test_loop_perception_goals.py` et la suite ciblée a réussi (tests verts). 
- Les nouveaux tests couvrent écriture JSONL avec rétention, calcul des agrégats/impact et l’effet sur `IntrinsicGoals` ainsi que l’inclusion de `host_environment` dans les payloads CLI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7d9f248c832ab029b35bf4c637f4)