### PR TITLE
Add autonomous reproduction compatibility scoring, decisioning, and audit trail

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -46,7 +46,12 @@ from .health import HealthTracker
 from singular.governance.policy import MutationGovernancePolicy
 from singular.governance.values import load_value_weights
 
-from .reproduction import authorize_reproduction_write, crossover
+from .reproduction import (
+    ReproductionDecisionPolicy,
+    authorize_reproduction_write,
+    crossover,
+    decide_reproduction,
+)
 from .map_elites import MapElites
 from .test_coevolution import LivingTestPool, propose_test_candidates
 from .skill_genesis import create_skill
@@ -95,6 +100,7 @@ class WorldState:
     resource_pool: float = 100.0
     reputation: ReputationSystem = field(default_factory=ReputationSystem)
     world_resources: WorldResourcePool = field(default_factory=WorldResourcePool)
+    reproduction_cooldowns: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -109,6 +115,9 @@ class EcosystemRules:
     competition_bid_ceiling: float = 5.0
     reputation_action_weights: dict[str, float] = field(
         default_factory=lambda: {"share": 0.2, "steal": -0.2}
+    )
+    reproduction_policy: ReproductionDecisionPolicy = field(
+        default_factory=ReproductionDecisionPolicy
     )
 
 
@@ -1353,36 +1362,93 @@ def run(
                 and len(world.organisms) >= 2
             ):
                 parent_names = list(_pick_crossover_parents(rng, world))
+                cooldown_remaining = max(
+                    world.reproduction_cooldowns.get(parent_names[0], 0),
+                    world.reproduction_cooldowns.get(parent_names[1], 0),
+                )
                 pa = world.organisms[parent_names[0]].skills_dir
                 pb = world.organisms[parent_names[1]].skills_dir
                 child_dir = pa.parent / f"child_{state.iteration}"
                 child_skills_dir = child_dir / "skills"
                 child_skills_dir.mkdir(parents=True, exist_ok=True)
-                fname, code = crossover(pa, pb, rng)
-                target = child_skills_dir / fname
-                authorized, reason = authorize_reproduction_write(
-                    target,
-                    code,
-                    governance_policy=governance_policy,
+                target = child_skills_dir / "candidate_hybrid.py"
+                root = target.parent.parent if target.parent.name == "skills" else target.parent
+                simulated_governance = governance_policy.simulate_write(target, root=root)
+                decision = decide_reproduction(
+                    parent_a=parent_names[0],
+                    parent_b=parent_names[1],
+                    parent_a_skills=pa,
+                    parent_b_skills=pb,
+                    parent_a_health=min(1.0, world.organisms[parent_names[0]].energy / 5.0),
+                    parent_b_health=min(1.0, world.organisms[parent_names[1]].energy / 5.0),
+                    governance_allowed=simulated_governance.allowed,
+                    policy=ecosystem_rules.reproduction_policy,
                 )
-                if not authorized:
-                    logger.log_interaction(
-                        "governance_violation",
-                        parents=parent_names,
-                        target=str(target),
-                        reason=reason,
-                        corrective_action="write under allowlisted skills/ directory",
-                        alive=True,
+                if cooldown_remaining > 0:
+                    decision = decision.__class__(
+                        accepted=False,
+                        score=decision.score,
+                        reasons=[f"cooldown_active:{cooldown_remaining}"] + decision.reasons,
+                        components=decision.components,
+                    )
+                logger.log_interaction(
+                    "reproduction_decision",
+                    parents=parent_names,
+                    proposed_child=child_dir.name,
+                    accepted=decision.accepted,
+                    score=decision.score,
+                    reasons=decision.reasons,
+                    components=decision.components,
+                    cooldown_remaining=cooldown_remaining,
+                    alive=True,
+                )
+                if not decision.accepted:
+                    world.reproduction_cooldowns[parent_names[0]] = max(
+                        world.reproduction_cooldowns.get(parent_names[0], 0),
+                        ecosystem_rules.reproduction_policy.cooldown_ticks,
+                    )
+                    world.reproduction_cooldowns[parent_names[1]] = max(
+                        world.reproduction_cooldowns.get(parent_names[1], 0),
+                        ecosystem_rules.reproduction_policy.cooldown_ticks,
                     )
                 else:
-                    world.organisms[child_dir.name] = Organism(child_skills_dir)
-                    logger.log_interaction(
-                        INTERACTION_CROSSOVER,
-                        parents=parent_names,
-                        child=child_dir.name,
-                        child_skills_dir=str(child_dir),
-                        alive=True,
+                    fname, code = crossover(pa, pb, rng)
+                    target = child_skills_dir / fname
+                    authorized, reason = authorize_reproduction_write(
+                        target,
+                        code,
+                        governance_policy=governance_policy,
                     )
+                    if not authorized:
+                        logger.log_interaction(
+                            "governance_violation",
+                            parents=parent_names,
+                            target=str(target),
+                            reason=reason,
+                            corrective_action="write under allowlisted skills/ directory",
+                            alive=True,
+                        )
+                    else:
+                        world.organisms[child_dir.name] = Organism(child_skills_dir)
+                        world.reproduction_cooldowns[parent_names[0]] = (
+                            ecosystem_rules.reproduction_policy.cooldown_ticks
+                        )
+                        world.reproduction_cooldowns[parent_names[1]] = (
+                            ecosystem_rules.reproduction_policy.cooldown_ticks
+                        )
+                        logger.log_interaction(
+                            INTERACTION_CROSSOVER,
+                            parents=parent_names,
+                            child=child_dir.name,
+                            child_skills_dir=str(child_dir),
+                            alive=True,
+                        )
+            for name in list(world.reproduction_cooldowns):
+                remaining = int(world.reproduction_cooldowns[name]) - 1
+                if remaining <= 0:
+                    world.reproduction_cooldowns.pop(name, None)
+                else:
+                    world.reproduction_cooldowns[name] = remaining
             tick_count += 1
 
     for org in world.organisms.values():

--- a/src/singular/life/reproduction.py
+++ b/src/singular/life/reproduction.py
@@ -27,12 +27,17 @@ from pathlib import Path
 from typing import Any, Tuple
 
 from singular.governance.policy import MutationGovernancePolicy
+from singular.social.graph import SocialGraph
 
 
 __all__ = [
     "ReproductionVariationPolicy",
     "InheritanceRules",
+    "ReproductionDecisionPolicy",
+    "ReproductionDecision",
     "compute_parent_compatibility",
+    "compute_reproduction_compatibility",
+    "decide_reproduction",
     "inherit_psyche",
     "inherit_values",
     "inherit_episodic_memory",
@@ -57,6 +62,135 @@ class InheritanceRules:
 
     inherit_partial_memory: bool = True
     memory_episode_limit: int = 50
+
+
+@dataclass(frozen=True)
+class ReproductionDecisionPolicy:
+    """Thresholds and weights for autonomous reproduction decisions."""
+
+    compatibility_threshold: float = 0.6
+    social_weight: float = 0.35
+    skills_weight: float = 0.30
+    viability_weight: float = 0.25
+    governance_weight: float = 0.10
+    min_parent_health: float = 0.35
+    cooldown_ticks: int = 5
+
+
+@dataclass(frozen=True)
+class ReproductionDecision:
+    """Outcome of an autonomous reproduction decision."""
+
+    accepted: bool
+    score: float
+    reasons: list[str]
+    components: dict[str, float]
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _skills_complementarity(parent_a_skills: Path, parent_b_skills: Path) -> float:
+    skills_a = {path.stem for path in Path(parent_a_skills).glob("*.py")}
+    skills_b = {path.stem for path in Path(parent_b_skills).glob("*.py")}
+    if not skills_a and not skills_b:
+        return 0.0
+    union = skills_a | skills_b
+    if not union:
+        return 0.0
+    overlap = skills_a & skills_b
+    return 1.0 - (len(overlap) / len(union))
+
+
+def compute_reproduction_compatibility(
+    *,
+    parent_a: str,
+    parent_b: str,
+    parent_a_skills: Path,
+    parent_b_skills: Path,
+    parent_a_health: float,
+    parent_b_health: float,
+    governance_allowed: bool,
+    social_graph: SocialGraph | None = None,
+    policy: ReproductionDecisionPolicy | None = None,
+) -> tuple[float, dict[str, float]]:
+    """Compute a weighted compatibility score for two reproduction candidates."""
+
+    policy = policy or ReproductionDecisionPolicy()
+    graph = social_graph or SocialGraph()
+    relation = graph.get_relation(parent_a, parent_b)
+    affinity = _clamp01(float(relation.get("affinity", 0.5)))
+    trust = _clamp01(float(relation.get("trust", 0.5)))
+    rivalry = _clamp01(float(relation.get("rivalry", 0.0)))
+    social_score = _clamp01((0.5 * affinity) + (0.4 * trust) + (0.1 * (1.0 - rivalry)))
+    skills_score = _clamp01(_skills_complementarity(parent_a_skills, parent_b_skills))
+    viability_score = _clamp01((float(parent_a_health) + float(parent_b_health)) / 2.0)
+    governance_score = 1.0 if governance_allowed else 0.0
+
+    score = _clamp01(
+        (policy.social_weight * social_score)
+        + (policy.skills_weight * skills_score)
+        + (policy.viability_weight * viability_score)
+        + (policy.governance_weight * governance_score)
+    )
+    components = {
+        "social_affinity": round(social_score, 4),
+        "skills_complementarity": round(skills_score, 4),
+        "viability": round(viability_score, 4),
+        "governance": round(governance_score, 4),
+    }
+    return round(score, 4), components
+
+
+def decide_reproduction(
+    *,
+    parent_a: str,
+    parent_b: str,
+    parent_a_skills: Path,
+    parent_b_skills: Path,
+    parent_a_health: float,
+    parent_b_health: float,
+    governance_allowed: bool,
+    social_graph: SocialGraph | None = None,
+    policy: ReproductionDecisionPolicy | None = None,
+) -> ReproductionDecision:
+    """Return an autonomous accept/refuse decision with auditable reasons."""
+
+    policy = policy or ReproductionDecisionPolicy()
+    score, components = compute_reproduction_compatibility(
+        parent_a=parent_a,
+        parent_b=parent_b,
+        parent_a_skills=parent_a_skills,
+        parent_b_skills=parent_b_skills,
+        parent_a_health=parent_a_health,
+        parent_b_health=parent_b_health,
+        governance_allowed=governance_allowed,
+        social_graph=social_graph,
+        policy=policy,
+    )
+    reasons: list[str] = []
+    if score < policy.compatibility_threshold:
+        reasons.append(
+            f"compatibility_score_below_threshold:{score:.3f}<"
+            f"{policy.compatibility_threshold:.3f}"
+        )
+    if min(parent_a_health, parent_b_health) < policy.min_parent_health:
+        reasons.append(
+            f"parent_health_below_min:{min(parent_a_health, parent_b_health):.3f}<"
+            f"{policy.min_parent_health:.3f}"
+        )
+    if not governance_allowed:
+        reasons.append("governance_constraints_block_reproduction")
+    accepted = not reasons
+    if accepted:
+        reasons.append("accepted:compatibility_viability_governance_ok")
+    return ReproductionDecision(
+        accepted=accepted,
+        score=score,
+        reasons=reasons,
+        components=components,
+    )
 
 
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -13,12 +13,13 @@ sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / "src"))
 
 import singular.life.loop as life_loop  # noqa: E402
-from singular.life.loop import run, load_checkpoint  # noqa: E402
+from singular.life.loop import EcosystemRules, run, load_checkpoint  # noqa: E402
 from singular.life.health import detect_health_state  # noqa: E402
 from singular.life.test_coevolution import LivingTestPool, TestCandidate  # noqa: E402
 from singular.resource_manager import ResourceManager  # noqa: E402
 from singular.psyche import Psyche, Mood  # noqa: E402
 from singular.governance.policy import MutationGovernancePolicy  # noqa: E402
+from singular.life.reproduction import ReproductionDecisionPolicy  # noqa: E402
 
 
 def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
@@ -197,6 +198,57 @@ def test_load_checkpoint_ignores_extra_keys(tmp_path: Path):
     assert state.version == life_loop.CHECKPOINT_VERSION
     assert state.iteration == 3
     assert not hasattr(state, "unexpected")
+
+
+def test_reproduction_decision_is_logged_with_cooldown(tmp_path: Path, monkeypatch):
+    org_a = tmp_path / "org_a" / "skills"
+    org_b = tmp_path / "org_b" / "skills"
+    org_a.mkdir(parents=True)
+    org_b.mkdir(parents=True)
+    (org_a / "a.py").write_text("def f(x):\n    return x\n", encoding="utf-8")
+    (org_b / "b.py").write_text("def f(x):\n    return x + 1\n", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(RL, root=tmp_path / "logs")
+    )
+
+    world = life_loop.WorldState(
+        organisms={
+            "org_a": life_loop.Organism(org_a, energy=4.8),
+            "org_b": life_loop.Organism(org_b, energy=4.7),
+        }
+    )
+    world.reproduction_cooldowns["org_a"] = 2
+
+    run(
+        {"org_a": org_a, "org_b": org_b},
+        checkpoint,
+        budget_seconds=0.2,
+        max_iterations=1,
+        rng=random.Random(0),
+        run_id="repro-loop",
+        operators={"dec": _dec_operator},
+        world=world,
+        ecosystem_rules=EcosystemRules(
+            crossover_interval=1,
+            reproduction_policy=ReproductionDecisionPolicy(compatibility_threshold=0.2),
+        ),
+    )
+
+    events_path = tmp_path / "logs" / "repro-loop" / "events.jsonl"
+    events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+    decisions = [
+        e["payload"]
+        for e in events
+        if e.get("event_type") == "interaction"
+        and e.get("payload", {}).get("interaction") == "reproduction_decision"
+    ]
+    assert decisions
+    assert decisions[0]["accepted"] is False
+    assert any("cooldown_active" in reason for reason in decisions[0]["reasons"])
 
 
 def test_run_with_legacy_checkpoint_continues_without_crash(tmp_path: Path):

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -7,10 +7,13 @@ from singular.organisms.spawn import spawn
 from singular.governance.policy import MutationGovernancePolicy
 from singular.life.reproduction import (
     InheritanceRules,
+    ReproductionDecisionPolicy,
     ReproductionVariationPolicy,
     authorize_reproduction_write,
+    decide_reproduction,
     crossover,
 )
+from singular.social.graph import SocialGraph
 
 
 def test_reproduction(tmp_path: Path):
@@ -186,3 +189,65 @@ def test_authorize_reproduction_write_blocked(tmp_path: Path):
     assert not ok
     assert "corrective_action" in reason
     assert not target.exists()
+
+
+def test_reproduction_decision_refuses_incompatible_pair(tmp_path: Path):
+    skills_a = tmp_path / "a" / "skills"
+    skills_b = tmp_path / "b" / "skills"
+    skills_a.mkdir(parents=True)
+    skills_b.mkdir(parents=True)
+    (skills_a / "sum.py").write_text("def sum_it(x):\n    return x\n", encoding="utf-8")
+    (skills_b / "sum.py").write_text("def sum_it(x):\n    return x + 1\n", encoding="utf-8")
+
+    social = SocialGraph(path=tmp_path / "mem" / "social_graph.json")
+    for _ in range(8):
+        social.update_relation("org-a", "org-b", "resource_conflict")
+
+    decision = decide_reproduction(
+        parent_a="org-a",
+        parent_b="org-b",
+        parent_a_skills=skills_a,
+        parent_b_skills=skills_b,
+        parent_a_health=0.2,
+        parent_b_health=0.3,
+        governance_allowed=True,
+        social_graph=social,
+        policy=ReproductionDecisionPolicy(
+            compatibility_threshold=0.7,
+            min_parent_health=0.4,
+        ),
+    )
+
+    assert decision.accepted is False
+    assert any("compatibility_score_below_threshold" in reason for reason in decision.reasons)
+    assert any("parent_health_below_min" in reason for reason in decision.reasons)
+
+
+def test_reproduction_decision_accepts_high_affinity_and_viability(tmp_path: Path):
+    skills_a = tmp_path / "a" / "skills"
+    skills_b = tmp_path / "b" / "skills"
+    skills_a.mkdir(parents=True)
+    skills_b.mkdir(parents=True)
+    (skills_a / "vision.py").write_text("def solve(x):\n    return x\n", encoding="utf-8")
+    (skills_b / "planning.py").write_text("def solve(x):\n    return x + 2\n", encoding="utf-8")
+
+    social = SocialGraph(path=tmp_path / "mem" / "social_graph.json")
+    for _ in range(6):
+        social.update_relation("org-a", "org-b", "successful_assistance")
+
+    decision = decide_reproduction(
+        parent_a="org-a",
+        parent_b="org-b",
+        parent_a_skills=skills_a,
+        parent_b_skills=skills_b,
+        parent_a_health=0.9,
+        parent_b_health=0.85,
+        governance_allowed=True,
+        social_graph=social,
+        policy=ReproductionDecisionPolicy(compatibility_threshold=0.6),
+    )
+
+    assert decision.accepted is True
+    assert decision.score >= 0.6
+    assert decision.components["social_affinity"] > 0.7
+    assert decision.components["viability"] > 0.8


### PR DESCRIPTION
### Motivation
- Introduire une étape de décision autonome avant la création d’un enfant pour éviter croisements inappropriés et documenter les raisons des rejets/acceptations.
- Combiner facteurs sociaux, complémentarité de skills, santé/viabilité parentale et contraintes de gouvernance dans un score de compatibilité pondéré.

### Description
- Ajout d’une API de décision de reproduction : `ReproductionDecisionPolicy` et `decide_reproduction` produisant `ReproductionDecision` avec `accepted`, `score`, `reasons` et `components` dans `src/singular/life/reproduction.py`.
- Calcul pondéré de compatibilité (`compute_reproduction_compatibility`) combinant affinité/trust/rivalry via le `SocialGraph`, complémentarité de skills, viabilité (proxy énergie) et conformité gouvernance.
- Intégration dans la boucle évolutive (`src/singular/life/loop.py`) : proposition de partenaire, simulation de la contrainte gouvernance, décision accept/refuse, application d’un cooldown par parent et journalisation audit (`reproduction_decision`) via `RunLogger.log_interaction` avant d’écrire le skill hybride.
- Tests unitaires ajoutés couvrant le refus pour incompatibilité (score + santé insuffisants), l’acceptation pour affinité+viabilité élevées, et la journalisation d’un refus dû à cooldown dans la boucle (fichiers modifiés : `tests/test_reproduction.py`, `tests/test_loop.py`).

### Testing
- Initial run ciblé `pytest -q tests/test_reproduction.py tests/test_loop.py` revealed failures during development which were fixed iterativement; failing run was used to iterate corrections.
- Final focused automated tests executed: `pytest -q tests/test_reproduction.py tests/test_loop.py::test_reproduction_decision_is_logged_with_cooldown` (and related reproduction tests) — result: 11 passed, 0 failed (8 warnings).
- All newly added tests (`test_reproduction_decision_refuses_incompatible_pair`, `test_reproduction_decision_accepts_high_affinity_and_viability`, `test_reproduction_decision_is_logged_with_cooldown`) passed in the final validation run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de851b811c832ab06cc2dbf3a729f9)