### PR TITLE
Add versioned self-narrative module with resilient persistence

### DIFF
--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -1,0 +1,376 @@
+"""Versioned persistent self-narrative memory."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+import json
+
+SCHEMA_VERSION = 1
+
+_TRAIT_KEYS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
+
+
+@dataclass
+class IdentitySummary:
+    """Condensed identity metadata."""
+
+    name: str = "Singular"
+    born_at: str = ""
+    logical_age: int = 0
+
+
+@dataclass
+class LifePeriod:
+    """A notable period in life history."""
+
+    title: str
+    start_at: str | None = None
+    end_at: str | None = None
+    highlights: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TraitTrend:
+    """Trend information for one trait."""
+
+    value: float = 0.5
+    trend: str = "stable"
+
+
+@dataclass
+class RegretsAndPride:
+    """Meaningful wins, losses and costs."""
+
+    significant_successes: list[str] = field(default_factory=list)
+    significant_failures: list[str] = field(default_factory=list)
+    abandoned_skills: list[str] = field(default_factory=list)
+    costly_incidents: list[str] = field(default_factory=list)
+
+
+@dataclass
+class SelfNarrative:
+    """Persistent self narrative with explicit schema version."""
+
+    schema_version: int
+    identity: IdentitySummary
+    life_periods: list[LifePeriod]
+    trait_trends: dict[str, TraitTrend]
+    regrets_and_pride: RegretsAndPride
+    current_heading: str
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["trait_trends"] = {
+            key: asdict(value) for key, value in self.trait_trends.items()
+        }
+        return payload
+
+
+def _default_trait_trends() -> dict[str, TraitTrend]:
+    return {key: TraitTrend() for key in _TRAIT_KEYS}
+
+
+def _default_narrative() -> SelfNarrative:
+    return SelfNarrative(
+        schema_version=SCHEMA_VERSION,
+        identity=IdentitySummary(),
+        life_periods=[],
+        trait_trends=_default_trait_trends(),
+        regrets_and_pride=RegretsAndPride(),
+        current_heading="Clarifier ma prochaine étape utile.",
+    )
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _compute_logical_age(born_at: str | None, now: datetime | None = None) -> int:
+    born = _parse_iso(born_at)
+    if born is None:
+        return 0
+    if born.tzinfo is None:
+        born = born.replace(tzinfo=timezone.utc)
+    current = now or datetime.now(timezone.utc)
+    delta = current - born
+    if delta.total_seconds() <= 0:
+        return 0
+    return int(delta.days)
+
+
+def _coerce_trend(value: str | None) -> str:
+    if value in {"up", "down", "stable"}:
+        return value
+    return "stable"
+
+
+def _coerce_float(value: Any, default: float = 0.5) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0.0, min(1.0, numeric))
+
+
+def _path_or_default(path: Path | str | None) -> Path:
+    if path is not None:
+        return Path(path)
+    return Path("mem") / "self_narrative.json"
+
+
+def _materialize(payload: Mapping[str, Any]) -> SelfNarrative:
+    schema_version = int(payload.get("schema_version", 0) or 0)
+    identity_payload = payload.get("identity") if isinstance(payload.get("identity"), Mapping) else {}
+    born_at = identity_payload.get("born_at")
+
+    identity = IdentitySummary(
+        name=str(identity_payload.get("name", "Singular")),
+        born_at=str(born_at) if born_at else "",
+        logical_age=int(identity_payload.get("logical_age", 0) or 0),
+    )
+
+    life_periods: list[LifePeriod] = []
+    raw_periods = payload.get("life_periods")
+    if isinstance(raw_periods, list):
+        for item in raw_periods:
+            if not isinstance(item, Mapping):
+                continue
+            highlights = item.get("highlights")
+            life_periods.append(
+                LifePeriod(
+                    title=str(item.get("title", "Période")),
+                    start_at=str(item.get("start_at")) if item.get("start_at") else None,
+                    end_at=str(item.get("end_at")) if item.get("end_at") else None,
+                    highlights=[str(h) for h in highlights] if isinstance(highlights, list) else [],
+                )
+            )
+
+    trait_trends = _default_trait_trends()
+    raw_traits = payload.get("trait_trends")
+    if isinstance(raw_traits, Mapping):
+        for key in _TRAIT_KEYS:
+            current = raw_traits.get(key)
+            if isinstance(current, Mapping):
+                trait_trends[key] = TraitTrend(
+                    value=_coerce_float(current.get("value"), default=trait_trends[key].value),
+                    trend=_coerce_trend(current.get("trend") if isinstance(current, Mapping) else None),
+                )
+
+    regrets_payload = (
+        payload.get("regrets_and_pride")
+        if isinstance(payload.get("regrets_and_pride"), Mapping)
+        else {}
+    )
+    regrets = RegretsAndPride(
+        significant_successes=[
+            str(value)
+            for value in regrets_payload.get("significant_successes", [])
+            if isinstance(regrets_payload.get("significant_successes"), list)
+        ],
+        significant_failures=[
+            str(value)
+            for value in regrets_payload.get("significant_failures", [])
+            if isinstance(regrets_payload.get("significant_failures"), list)
+        ],
+        abandoned_skills=[
+            str(value)
+            for value in regrets_payload.get("abandoned_skills", [])
+            if isinstance(regrets_payload.get("abandoned_skills"), list)
+        ],
+        costly_incidents=[
+            str(value)
+            for value in regrets_payload.get("costly_incidents", [])
+            if isinstance(regrets_payload.get("costly_incidents"), list)
+        ],
+    )
+
+    narrative = SelfNarrative(
+        schema_version=max(schema_version, SCHEMA_VERSION),
+        identity=identity,
+        life_periods=life_periods,
+        trait_trends=trait_trends,
+        regrets_and_pride=regrets,
+        current_heading=str(payload.get("current_heading", "Clarifier ma prochaine étape utile.")),
+    )
+    narrative.identity.logical_age = _compute_logical_age(narrative.identity.born_at)
+    return narrative
+
+
+def _migrate(payload: Mapping[str, Any]) -> SelfNarrative:
+    """Soft migration from older/partial payloads to current schema."""
+
+    narrative = _materialize(payload)
+    if narrative.schema_version < SCHEMA_VERSION:
+        narrative.schema_version = SCHEMA_VERSION
+    return narrative
+
+
+def load(path: Path | str | None = None) -> SelfNarrative:
+    """Load narrative from disk with graceful fallback for missing/corrupt file."""
+
+    file_path = _path_or_default(path)
+    if not file_path.exists():
+        narrative = _default_narrative()
+        save(narrative, file_path)
+        return narrative
+
+    try:
+        payload = json.loads(file_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        backup = file_path.with_suffix(file_path.suffix + f".corrupt-{int(datetime.now(timezone.utc).timestamp())}")
+        try:
+            file_path.rename(backup)
+        except OSError:
+            pass
+        narrative = _default_narrative()
+        save(narrative, file_path)
+        return narrative
+
+    if not isinstance(payload, Mapping):
+        narrative = _default_narrative()
+        save(narrative, file_path)
+        return narrative
+
+    narrative = _migrate(payload)
+    save(narrative, file_path)
+    return narrative
+
+
+def save(narrative: SelfNarrative, path: Path | str | None = None) -> SelfNarrative:
+    """Persist narrative JSON and return canonicalized object."""
+
+    file_path = _path_or_default(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    narrative.schema_version = SCHEMA_VERSION
+    narrative.identity.logical_age = _compute_logical_age(narrative.identity.born_at)
+    file_path.write_text(
+        json.dumps(narrative.to_dict(), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return narrative
+
+
+def _extend_unique(target: list[str], values: Any) -> None:
+    if not isinstance(values, list):
+        return
+    for value in values:
+        text = str(value).strip()
+        if text and text not in target:
+            target.append(text)
+
+
+def update_from_signals(
+    signals: Mapping[str, Any], path: Path | str | None = None
+) -> SelfNarrative:
+    """Update persisted narrative from external signals and return it."""
+
+    narrative = load(path)
+
+    identity_patch = signals.get("identity")
+    if isinstance(identity_patch, Mapping):
+        if "name" in identity_patch:
+            narrative.identity.name = str(identity_patch.get("name") or narrative.identity.name)
+        if "born_at" in identity_patch:
+            narrative.identity.born_at = str(identity_patch.get("born_at") or "")
+
+    current_heading = signals.get("current_heading")
+    if isinstance(current_heading, str) and current_heading.strip():
+        narrative.current_heading = current_heading.strip()
+
+    periods = signals.get("life_periods")
+    if isinstance(periods, list):
+        for period in periods:
+            if not isinstance(period, Mapping):
+                continue
+            narrative.life_periods.append(
+                LifePeriod(
+                    title=str(period.get("title", "Période")),
+                    start_at=str(period.get("start_at")) if period.get("start_at") else None,
+                    end_at=str(period.get("end_at")) if period.get("end_at") else None,
+                    highlights=[str(x) for x in period.get("highlights", [])]
+                    if isinstance(period.get("highlights"), list)
+                    else [],
+                )
+            )
+
+    trait_signals = signals.get("trait_trends")
+    if isinstance(trait_signals, Mapping):
+        for trait in _TRAIT_KEYS:
+            patch = trait_signals.get(trait)
+            if not isinstance(patch, Mapping):
+                continue
+            baseline = narrative.trait_trends[trait]
+            baseline.value = _coerce_float(patch.get("value"), baseline.value)
+            baseline.trend = _coerce_trend(patch.get("trend"))
+
+    regrets_signals = signals.get("regrets_and_pride")
+    if isinstance(regrets_signals, Mapping):
+        _extend_unique(
+            narrative.regrets_and_pride.significant_successes,
+            regrets_signals.get("significant_successes"),
+        )
+        _extend_unique(
+            narrative.regrets_and_pride.significant_failures,
+            regrets_signals.get("significant_failures"),
+        )
+        _extend_unique(
+            narrative.regrets_and_pride.abandoned_skills,
+            regrets_signals.get("abandoned_skills"),
+        )
+        _extend_unique(
+            narrative.regrets_and_pride.costly_incidents,
+            regrets_signals.get("costly_incidents"),
+        )
+
+    save(narrative, path)
+    return narrative
+
+
+def summarize_short(narrative: SelfNarrative | None = None, path: Path | str | None = None) -> str:
+    """Return a compact one-line summary."""
+
+    current = narrative or load(path)
+    return (
+        f"{current.identity.name} · âge logique {current.identity.logical_age}j · "
+        f"cap: {current.current_heading}"
+    )
+
+
+def summarize_long(narrative: SelfNarrative | None = None, path: Path | str | None = None) -> str:
+    """Return a richer human-readable summary."""
+
+    current = narrative or load(path)
+    traits = ", ".join(
+        f"{name}={trend.value:.2f} ({trend.trend})"
+        for name, trend in current.trait_trends.items()
+    )
+    periods = "; ".join(period.title for period in current.life_periods[-3:]) or "aucune période marquante"
+
+    wins = ", ".join(current.regrets_and_pride.significant_successes[-3:]) or "aucune"
+    losses = ", ".join(current.regrets_and_pride.significant_failures[-3:]) or "aucune"
+    dropped = ", ".join(current.regrets_and_pride.abandoned_skills[-3:]) or "aucune"
+    incidents = ", ".join(current.regrets_and_pride.costly_incidents[-3:]) or "aucun"
+
+    return (
+        f"Identité: {current.identity.name} (né·e {current.identity.born_at or 'inconnu'}, "
+        f"âge logique {current.identity.logical_age} jours).\n"
+        f"Périodes marquantes: {periods}.\n"
+        f"Traits: {traits}.\n"
+        f"Fiertés: {wins}.\n"
+        f"Regrets/échecs: {losses}.\n"
+        f"Skills abandonnées: {dropped}.\n"
+        f"Incidents coûteux: {incidents}.\n"
+        f"Cap actuel: {current.current_heading}."
+    )

--- a/tests/test_self_narrative.py
+++ b/tests/test_self_narrative.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from singular.self_narrative import (
+    SCHEMA_VERSION,
+    load,
+    summarize_long,
+    summarize_short,
+    update_from_signals,
+)
+
+
+def test_load_creates_default_file_when_missing(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "self_narrative.json"
+
+    narrative = load(path)
+
+    assert path.exists()
+    assert narrative.schema_version == SCHEMA_VERSION
+    assert narrative.identity.name == "Singular"
+    assert set(narrative.trait_trends) == {
+        "curiosity",
+        "patience",
+        "playfulness",
+        "optimism",
+        "resilience",
+    }
+
+
+def test_load_fallback_on_corrupted_file(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "self_narrative.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not-valid-json", encoding="utf-8")
+
+    narrative = load(path)
+
+    assert narrative.identity.name == "Singular"
+    backups = list(path.parent.glob("self_narrative.json.corrupt-*"))
+    assert backups
+
+
+def test_update_from_signals_persists_expected_shape(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "self_narrative.json"
+    born_at = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+
+    narrative = update_from_signals(
+        {
+            "identity": {"name": "Nova", "born_at": born_at},
+            "current_heading": "Construire une mémoire plus robuste.",
+            "life_periods": [
+                {
+                    "title": "Redémarrage",
+                    "start_at": "2026-04-10T00:00:00+00:00",
+                    "highlights": ["nettoyage", "recentrage"],
+                }
+            ],
+            "trait_trends": {
+                "curiosity": {"value": 0.8, "trend": "up"},
+                "patience": {"value": 0.55, "trend": "stable"},
+            },
+            "regrets_and_pride": {
+                "significant_successes": ["stabilité retrouvée"],
+                "significant_failures": ["boucle trop coûteuse"],
+                "abandoned_skills": ["heuristique-v0"],
+                "costly_incidents": ["fuite mémoire"],
+            },
+        },
+        path=path,
+    )
+
+    assert narrative.identity.name == "Nova"
+    assert narrative.identity.logical_age >= 5
+    assert narrative.life_periods[-1].title == "Redémarrage"
+    assert narrative.trait_trends["curiosity"].trend == "up"
+    assert "stabilité retrouvée" in narrative.regrets_and_pride.significant_successes
+
+
+def test_summaries_include_current_heading(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "self_narrative.json"
+    update_from_signals({"current_heading": "Mieux décider."}, path)
+
+    short = summarize_short(path=path)
+    long = summarize_long(path=path)
+
+    assert "cap" in short
+    assert "Mieux décider." in short
+    assert "Cap actuel" in long
+    assert "Mieux décider." in long


### PR DESCRIPTION
### Motivation
- Provide a dedicated, versioned persistent store for a self-narrative that captures a condensed identity, notable life periods, trait trends, regrets/fiertés and the current heading.
- Make the narrative robust to missing, partial or corrupted on-disk payloads and allow forward-compatible migrations.

### Description
- Add `src/singular/self_narrative.py` implementing a `SelfNarrative` dataclass schema guarded by `SCHEMA_VERSION` and composed of `IdentitySummary`, `LifePeriod`, `TraitTrend` and `RegretsAndPride` types.
- Implement `load()`, `save()`, `update_from_signals(...)`, `summarize_short(...)` and `summarize_long(...)` with JSON persistence at `mem/self_narrative.json` by default and helpers to coerce/validate inputs and compute `logical_age`.
- Provide soft migration/canonicalization when loading partial/older payloads and a graceful fallback that renames corrupt files to `*.corrupt-<timestamp>` and regenerates a sane default.
- Add `tests/test_self_narrative.py` to cover creation when missing, fallback on corruption, updates via signals, and both short and long summaries.

### Testing
- Ran `pytest -q tests/test_self_narrative.py` and all tests passed (`4 passed` in the run).
- New tests exercise missing-file creation, corruption backup, `update_from_signals` shape handling, and summary output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9ea99c54832aade2884d52c9c4de)