### PR TITLE
Enhance talk context with self-narrative preamble and hallucination guard

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -10,6 +10,7 @@ import re
 from ..memory import add_episode, ensure_memory_structure, read_episodes
 from ..perception import capture_signals
 from ..psyche import Mood, Psyche
+from ..self_narrative import load as load_self_narrative, summarize_short
 from ..providers import (
     LLMProviderError,
     ProviderMisconfiguredError,
@@ -20,6 +21,11 @@ from ..providers import (
     load_llm_client,
 )
 from ..runs.logger import log_provider_event
+
+_CONTEXT_BUDGET_CHARS = 420
+_UNKNOWN_GUARD = (
+    "Garde anti-hallucination: si une information demandée est inconnue, réponds explicitement \"inconnu\"."
+)
 
 
 def _default_reply(prompt: str, rng: random.Random) -> str:
@@ -121,6 +127,34 @@ def _extract_structured_signals(text: str) -> dict[str, object]:
     }
 
 
+def _trim_for_budget(text: str, budget: int) -> str:
+    cleaned = " ".join(text.split())
+    if budget <= 3:
+        return cleaned[:budget]
+    if len(cleaned) <= budget:
+        return cleaned
+    return f"{cleaned[: budget - 3]}..."
+
+
+def _build_system_preamble(
+    *,
+    narrative_summary: str,
+    last_event: str | None,
+    mood_event: str | None,
+) -> str:
+    available_for_summary = max(0, _CONTEXT_BUDGET_CHARS - len(_UNKNOWN_GUARD) - 120)
+    summary = _trim_for_budget(narrative_summary, available_for_summary)
+    event_fragment = _trim_for_budget(last_event or "inconnu", 80)
+    mood_fragment = _trim_for_budget(mood_event or "inconnu", 40)
+    preamble = (
+        f"Contexte identitaire: {summary}\n"
+        f"Dernier événement utilisateur: {event_fragment}\n"
+        f"Humeur récente: {mood_fragment}\n"
+        f"{_UNKNOWN_GUARD}"
+    )
+    return _trim_for_budget(preamble, _CONTEXT_BUDGET_CHARS)
+
+
 def talk(
     provider: str | None = None,
     seed: int | None = None,
@@ -208,11 +242,19 @@ def talk(
         last_failure: dict | None,
         mood_event: str | None,
         perf_msg: str | None,
+        self_narrative_summary: str,
+        self_narrative_version: int,
     ) -> None:
         user_signals = _extract_structured_signals(user_input)
         add_episode({"role": "user", "text": user_input, "structured_signals": user_signals})
         mood = psyche.feel(Mood.NEUTRAL)
         mood_report = mood_event or mood.value
+        system_preamble = _build_system_preamble(
+            narrative_summary=self_narrative_summary,
+            last_event=last_event,
+            mood_event=mood_event,
+        )
+        provider_prompt = f"{system_preamble}\n\nUtilisateur: {user_input}"
 
         start = time.perf_counter()
         fallback_used = client is None
@@ -222,7 +264,7 @@ def talk(
             reply = _default_reply(user_input, rng)
         else:
             try:
-                reply = client.generate_reply(user_input)
+                reply = client.generate_reply(provider_prompt)
             except LLMProviderError as err:
                 fallback_used = True
                 error_category = getattr(err, "category", "provider_error")
@@ -260,6 +302,12 @@ def talk(
                 "raw_reply": reply,
                 "mood": mood.value,
                 "structured_signals": user_signals,
+                "context": {
+                    "self_narrative_version": self_narrative_version,
+                    "self_narrative_summary": _trim_for_budget(
+                        self_narrative_summary, 180
+                    ),
+                },
             }
         )
         psyche.gain()
@@ -267,11 +315,18 @@ def talk(
 
     if prompt is not None:
         context = gather_context()
-        respond(prompt, *context)
+        self_narrative = load_self_narrative()
+        respond(
+            prompt,
+            *context,
+            summarize_short(self_narrative),
+            self_narrative.schema_version,
+        )
         return
 
     while True:
         context = gather_context()
+        self_narrative = load_self_narrative()
         try:
             user_input = input("you: ")
         except EOFError:
@@ -283,4 +338,9 @@ def talk(
         if user_input.strip().lower() in {"exit", "quit"}:
             break
 
-        respond(user_input, *context)
+        respond(
+            user_input,
+            *context,
+            summarize_short(self_narrative),
+            self_narrative.schema_version,
+        )

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -216,6 +216,59 @@ def test_talk_logs_provider_events(monkeypatch, tmp_path):
     assert events[0]["error_category"] is None
 
 
+def test_talk_injects_self_narrative_in_provider_prompt(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    inputs = iter(["bonjour", "quit"])
+    captured: dict[str, str] = {}
+
+    def fake_generate(prompt: str, *, timeout: float = 8.0) -> str:
+        del timeout
+        captured["prompt"] = prompt
+        return "ok"
+
+    client = LLMProviderClient(name="openai", generate=fake_generate)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: client)
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    monkeypatch.setattr("builtins.print", lambda _msg: None)
+
+    talk(provider="openai")
+
+    sent = captured["prompt"]
+    assert "Contexte identitaire:" in sent
+    assert "cap:" in sent
+    assert "si une information demandée est inconnue" in sent
+    assert "Utilisateur: bonjour" in sent
+
+
+def test_talk_bounds_context_budget_and_logs_narrative_version(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    inputs = iter(["hello", "quit"])
+    captured: dict[str, str] = {}
+
+    def fake_generate(prompt: str, *, timeout: float = 8.0) -> str:
+        del timeout
+        captured["prompt"] = prompt
+        return "ok"
+
+    client = LLMProviderClient(name="openai", generate=fake_generate)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: client)
+    monkeypatch.setattr(
+        "singular.organisms.talk.summarize_short",
+        lambda *_args, **_kwargs: "x" * 2000,
+    )
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    monkeypatch.setattr("builtins.print", lambda _msg: None)
+
+    talk(provider="openai")
+
+    assert len(captured["prompt"].split("Utilisateur:")[0]) <= 425
+    assistant_episodes = [e for e in read_episodes() if e.get("role") == "assistant"]
+    assert assistant_episodes
+    assert assistant_episodes[-1]["context"]["self_narrative_version"] == 1
+
+
 def test_talk_subcommand_life_argument_has_priority(monkeypatch, tmp_path):
     root = tmp_path / "world"
     monkeypatch.delenv("SINGULAR_HOME", raising=False)


### PR DESCRIPTION
### Motivation
- Ensure `talk()` includes a concise representation of the agent's self-narrative in the system/preamble sent to LLMs to provide identity/context awareness while preventing prompt drift. 
- Bound the size of that context and add an explicit anti-hallucination instruction so providers answer "inconnu" when information is unknown. 
- Surface the self-narrative metadata used for each assistant reply so downstream traces can know which narrative version produced a response.

### Description
- Import `load` and `summarize_short` from `self_narrative`, add `_CONTEXT_BUDGET_CHARS` and `_UNKNOWN_GUARD`, and implement `_trim_for_budget` and `_build_system_preamble` to produce a bounded system preamble. 
- Load the self-narrative for each response (including `--prompt` mode) and inject the trimmed `summarize_short()` output into the provider prompt before calling `client.generate_reply`. 
- Add an explicit anti-hallucination sentence in the preamble instructing the provider to reply `"inconnu"` when information is unknown. 
- Persist context metadata in assistant episodes under `context`, including `context.self_narrative_version` and a trimmed `self_narrative_summary`. 
- Add unit tests in `tests/test_talk.py` to verify preamble injection, context budget bounding, and that `self_narrative_version` is recorded, and rely on existing `tests/test_self_narrative.py` behavior.

### Testing
- Ran `pytest -q tests/test_talk.py tests/test_self_narrative.py` and all tests passed. 
- The added tests exercise prompt injection, budget enforcement, and episode context tracing and succeeded (total: 18 passed for the two test files run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dea09e9f90832aaa5d11ec444e69b8)