### PR TITLE
Ajouter un module de simulation du monde persistant (apply_action / tick_world)

### DIFF
--- a/mem/world_state.json
+++ b/mem/world_state.json
@@ -1,0 +1,85 @@
+{
+  "world_clock": 0,
+  "map": {
+    "spaces": [
+      {
+        "id": "core",
+        "kind": "hub",
+        "stability": 0.9
+      },
+      {
+        "id": "wilds",
+        "kind": "exploration",
+        "stability": 0.7
+      }
+    ],
+    "niches": [
+      {
+        "id": "craft",
+        "space_id": "core",
+        "specialization": "fabrication"
+      },
+      {
+        "id": "research",
+        "space_id": "core",
+        "specialization": "insight"
+      },
+      {
+        "id": "forage",
+        "space_id": "wilds",
+        "specialization": "biomass"
+      }
+    ]
+  },
+  "resources": {
+    "renewable": {
+      "solar": {
+        "amount": 70.0,
+        "regen_rate": 5.0,
+        "capacity": 100.0
+      },
+      "biomass": {
+        "amount": 45.0,
+        "regen_rate": 3.0,
+        "capacity": 75.0
+      }
+    },
+    "non_renewable": {
+      "ore": {
+        "amount": 80.0
+      },
+      "rare_earth": {
+        "amount": 20.0
+      }
+    }
+  },
+  "external": {
+    "entities": [
+      {
+        "id": "trader-01",
+        "type": "merchant",
+        "stance": "neutral"
+      },
+      {
+        "id": "observer-01",
+        "type": "monitor",
+        "stance": "supportive"
+      }
+    ],
+    "artifacts": [
+      {
+        "id": "relay",
+        "kind": "communication",
+        "integrity": 0.95
+      }
+    ]
+  },
+  "global_health": {
+    "score": 82.0,
+    "trend": "stable",
+    "signals": {
+      "resource_pressure": 0.2,
+      "cohesion": 0.85
+    }
+  }
+}

--- a/src/singular/environment/__init__.py
+++ b/src/singular/environment/__init__.py
@@ -1,5 +1,5 @@
 """Environment helper modules providing I/O and artifact utilities."""
 
-from . import artifacts, files, notifications, reputation, world_resources
+from . import artifacts, files, notifications, reputation, sim_world, world_resources
 
-__all__ = ["files", "notifications", "artifacts", "reputation", "world_resources"]
+__all__ = ["files", "notifications", "artifacts", "reputation", "world_resources", "sim_world"]

--- a/src/singular/environment/sim_world.py
+++ b/src/singular/environment/sim_world.py
@@ -1,0 +1,217 @@
+"""Simulation world state backed by ``mem/world_state.json``.
+
+The module is intentionally data-driven: callers can pass generic action
+payloads to evolve the world without changing Python code.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+_BASE_DIR = Path(os.environ.get("SINGULAR_HOME", "."))
+DEFAULT_WORLD_STATE_PATH = _BASE_DIR / "mem" / "world_state.json"
+
+
+def default_world_state() -> dict[str, Any]:
+    """Return the default world model."""
+
+    return {
+        "world_clock": 0,
+        "map": {
+            "spaces": [
+                {"id": "core", "kind": "hub", "stability": 0.9},
+                {"id": "wilds", "kind": "exploration", "stability": 0.7},
+            ],
+            "niches": [
+                {"id": "craft", "space_id": "core", "specialization": "fabrication"},
+                {"id": "research", "space_id": "core", "specialization": "insight"},
+                {"id": "forage", "space_id": "wilds", "specialization": "biomass"},
+            ],
+        },
+        "resources": {
+            "renewable": {
+                "solar": {"amount": 70.0, "regen_rate": 5.0, "capacity": 100.0},
+                "biomass": {"amount": 45.0, "regen_rate": 3.0, "capacity": 75.0},
+            },
+            "non_renewable": {
+                "ore": {"amount": 80.0},
+                "rare_earth": {"amount": 20.0},
+            },
+        },
+        "external": {
+            "entities": [
+                {"id": "trader-01", "type": "merchant", "stance": "neutral"},
+                {"id": "observer-01", "type": "monitor", "stance": "supportive"},
+            ],
+            "artifacts": [
+                {"id": "relay", "kind": "communication", "integrity": 0.95}
+            ],
+        },
+        "global_health": {
+            "score": 82.0,
+            "trend": "stable",
+            "signals": {
+                "resource_pressure": 0.2,
+                "cohesion": 0.85,
+            },
+        },
+    }
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False
+    )
+    try:
+        with tmp:
+            json.dump(payload, tmp, ensure_ascii=False, indent=2)
+            tmp.write("\n")
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp.name, path)
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except FileNotFoundError:
+            pass
+
+
+def load_world_state(path: Path | str | None = None) -> dict[str, Any]:
+    """Load world state from disk, creating defaults if absent."""
+
+    world_path = Path(path) if path is not None else DEFAULT_WORLD_STATE_PATH
+    if not world_path.exists():
+        state = default_world_state()
+        _atomic_write_json(world_path, state)
+        return state
+    with world_path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_world_state(state: dict[str, Any], path: Path | str | None = None) -> None:
+    """Persist world state to disk."""
+
+    world_path = Path(path) if path is not None else DEFAULT_WORLD_STATE_PATH
+    _atomic_write_json(world_path, state)
+
+
+def _clamp(value: float, minimum: float = 0.0, maximum: float = 100.0) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def apply_action(
+    action: dict[str, Any],
+    *,
+    state: dict[str, Any] | None = None,
+    state_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Apply a generic action payload to the world and persist it.
+
+    Supported keys include ``consume_resources``, ``produce_resources``,
+    ``health_delta``, ``entities`` and ``artifacts`` (with ``add``/``remove``),
+    and ``map_updates`` for adding spaces/niches.
+    """
+
+    next_state = deepcopy(state) if state is not None else load_world_state(state_path)
+
+    resources = next_state.setdefault("resources", {})
+    renewable = resources.setdefault("renewable", {})
+    non_renewable = resources.setdefault("non_renewable", {})
+
+    for name, amount in action.get("consume_resources", {}).get("renewable", {}).items():
+        if name not in renewable:
+            continue
+        renewable[name]["amount"] = max(0.0, renewable[name]["amount"] - max(float(amount), 0.0))
+
+    for name, amount in action.get("consume_resources", {}).get("non_renewable", {}).items():
+        if name not in non_renewable:
+            continue
+        non_renewable[name]["amount"] = max(0.0, non_renewable[name]["amount"] - max(float(amount), 0.0))
+
+    for name, amount in action.get("produce_resources", {}).get("renewable", {}).items():
+        if name not in renewable:
+            renewable[name] = {"amount": 0.0, "regen_rate": 0.0, "capacity": 100.0}
+        capacity = float(renewable[name].get("capacity", 100.0))
+        renewable[name]["amount"] = min(
+            capacity,
+            renewable[name]["amount"] + max(float(amount), 0.0),
+        )
+
+    health = next_state.setdefault("global_health", {})
+    health["score"] = _clamp(float(health.get("score", 50.0)) + float(action.get("health_delta", 0.0)))
+
+    external = next_state.setdefault("external", {})
+    entities = external.setdefault("entities", [])
+    artifacts = external.setdefault("artifacts", [])
+
+    for new_entity in action.get("entities", {}).get("add", []):
+        entities.append(new_entity)
+    if remove_ids := set(action.get("entities", {}).get("remove", [])):
+        external["entities"] = [entry for entry in entities if entry.get("id") not in remove_ids]
+
+    for new_artifact in action.get("artifacts", {}).get("add", []):
+        artifacts.append(new_artifact)
+    if remove_ids := set(action.get("artifacts", {}).get("remove", [])):
+        external["artifacts"] = [entry for entry in artifacts if entry.get("id") not in remove_ids]
+
+    map_data = next_state.setdefault("map", {})
+    spaces = map_data.setdefault("spaces", [])
+    niches = map_data.setdefault("niches", [])
+    spaces.extend(action.get("map_updates", {}).get("add_spaces", []))
+    niches.extend(action.get("map_updates", {}).get("add_niches", []))
+
+    save_world_state(next_state, state_path)
+    return next_state
+
+
+def tick_world(
+    *,
+    state: dict[str, Any] | None = None,
+    state_path: Path | str | None = None,
+    steps: int = 1,
+) -> dict[str, Any]:
+    """Advance world time and apply renewable regeneration + health drift."""
+
+    next_state = deepcopy(state) if state is not None else load_world_state(state_path)
+    tick_count = max(int(steps), 0)
+    resources = next_state.get("resources", {})
+    renewable = resources.get("renewable", {})
+
+    for _ in range(tick_count):
+        for payload in renewable.values():
+            regen_rate = max(float(payload.get("regen_rate", 0.0)), 0.0)
+            capacity = max(float(payload.get("capacity", 100.0)), 0.0)
+            payload["amount"] = min(capacity, max(float(payload.get("amount", 0.0)), 0.0) + regen_rate)
+        next_state["world_clock"] = int(next_state.get("world_clock", 0)) + 1
+
+    total_capacity = 0.0
+    total_amount = 0.0
+    for payload in renewable.values():
+        total_amount += float(payload.get("amount", 0.0))
+        total_capacity += float(payload.get("capacity", 0.0))
+    coverage = (total_amount / total_capacity) if total_capacity else 0.0
+
+    pressure = _clamp((1.0 - coverage) * 100.0, minimum=0.0, maximum=1.0)
+    health = next_state.setdefault("global_health", {})
+    signals = health.setdefault("signals", {})
+    signals["resource_pressure"] = round(pressure, 3)
+
+    base_score = float(health.get("score", 50.0))
+    drift = (coverage - 0.5) * 2.5 * tick_count
+    updated_score = _clamp(base_score + drift)
+    health["score"] = round(updated_score, 3)
+    if drift > 0.2:
+        health["trend"] = "improving"
+    elif drift < -0.2:
+        health["trend"] = "degrading"
+    else:
+        health["trend"] = "stable"
+
+    save_world_state(next_state, state_path)
+    return next_state

--- a/tests/test_sim_world.py
+++ b/tests/test_sim_world.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from singular.environment.sim_world import apply_action, load_world_state, tick_world
+
+
+def test_load_world_state_creates_default_when_missing(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "world_state.json"
+
+    state = load_world_state(path)
+
+    assert path.exists()
+    assert state["world_clock"] == 0
+    assert state["resources"]["renewable"]["solar"]["amount"] > 0
+
+
+def test_apply_action_updates_resources_map_and_external(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "world_state.json"
+    _ = load_world_state(path)
+
+    updated = apply_action(
+        {
+            "consume_resources": {
+                "renewable": {"solar": 10},
+                "non_renewable": {"ore": 5},
+            },
+            "produce_resources": {
+                "renewable": {"biomass": 4},
+            },
+            "health_delta": -3,
+            "entities": {
+                "add": [{"id": "visitor-01", "type": "envoy", "stance": "friendly"}],
+                "remove": ["trader-01"],
+            },
+            "artifacts": {
+                "add": [{"id": "sensor-grid", "kind": "infrastructure", "integrity": 1.0}],
+            },
+            "map_updates": {
+                "add_spaces": [{"id": "delta", "kind": "frontier", "stability": 0.6}],
+                "add_niches": [{"id": "mining", "space_id": "delta", "specialization": "ore"}],
+            },
+        },
+        state_path=path,
+    )
+
+    assert updated["resources"]["renewable"]["solar"]["amount"] == 60.0
+    assert updated["resources"]["non_renewable"]["ore"]["amount"] == 75.0
+    assert updated["global_health"]["score"] == 79.0
+    assert any(e["id"] == "visitor-01" for e in updated["external"]["entities"])
+    assert all(e["id"] != "trader-01" for e in updated["external"]["entities"])
+    assert any(s["id"] == "delta" for s in updated["map"]["spaces"])
+
+
+def test_tick_world_regenerates_and_updates_health(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "world_state.json"
+    state = load_world_state(path)
+    state["resources"]["renewable"]["solar"]["amount"] = 20.0
+    state["resources"]["renewable"]["biomass"]["amount"] = 10.0
+
+    ticked = tick_world(state=state, state_path=path, steps=2)
+
+    assert ticked["world_clock"] == 2
+    assert ticked["resources"]["renewable"]["solar"]["amount"] == 30.0
+    assert ticked["resources"]["renewable"]["biomass"]["amount"] == 16.0
+    assert ticked["global_health"]["trend"] == "degrading"
+    assert 0.0 <= ticked["global_health"]["signals"]["resource_pressure"] <= 1.0


### PR DESCRIPTION
### Motivation

- Fournir un modèle de monde piloté par données persistant en JSON pour simuler carte, ressources, entités et santé globale sans modifier le code métier.
- Permettre aux appels externes de faire évoluer le monde via des payloads génériques (`apply_action`) et de faire avancer le temps (`tick_world`).

### Description

- Ajout de `src/singular/environment/sim_world.py` qui expose `load_world_state`, `save_world_state`, `apply_action(...)` et `tick_world(...)` et utilise un écriture JSON atomique pour persister l’état.
- Le modèle de monde contient carte (espaces/niches), ressources renouvelables/non renouvelables, entités/artéfacts externes et `global_health`, et `apply_action` supporte consumption/production, ajout/suppression d’entités/artéfacts et ajouts de map.
- `tick_world` avance `world_clock`, régénère les ressources renouvelables, calcule la pression sur les ressources et ajuste le score/tendance de la santé globale.
- Export du module dans `src/singular/environment/__init__.py`, ajout de l’état initial persisté `mem/world_state.json` et ajout des tests unitaires `tests/test_sim_world.py`.

### Testing

- Lancé `pytest -q tests/test_sim_world.py tests/test_environment.py` et la suite ciblée a réussi avec `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deac1aad44832ab982b73efd50c647)