### PR TITLE
Add explicit world-effect mapping and world feedback signals in life/runtime

### DIFF
--- a/src/singular/environment/sim_world.py
+++ b/src/singular/environment/sim_world.py
@@ -10,11 +10,50 @@ import json
 import os
 import tempfile
 from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 _BASE_DIR = Path(os.environ.get("SINGULAR_HOME", "."))
 DEFAULT_WORLD_STATE_PATH = _BASE_DIR / "mem" / "world_state.json"
+DEFAULT_WORLD_EFFECTS_PATH = _BASE_DIR / "mem" / "world_effects.json"
+
+ACTION_TYPE_TO_WORLD_EFFECT: dict[str, dict[str, Any]] = {
+    "mutation.applied": {
+        "produce_resources": {"renewable": {"biomass": 1.0}},
+        "health_delta": 0.4,
+    },
+    "mutation.rejected": {
+        "consume_resources": {"renewable": {"solar": 0.8}},
+        "health_delta": -0.4,
+    },
+    "resource.competition.granted": {
+        "consume_resources": {"renewable": {"solar": 0.5}},
+        "health_delta": 0.1,
+    },
+    "resource.competition.denied": {
+        "health_delta": -0.2,
+    },
+    "resource.cooperation": {
+        "produce_resources": {"renewable": {"solar": 0.6}},
+        "health_delta": 0.3,
+    },
+    "resource.conflict": {
+        "consume_resources": {"renewable": {"biomass": 0.7}},
+        "health_delta": -0.5,
+    },
+    "skill.execution.succeeded": {
+        "produce_resources": {"renewable": {"solar": 0.4}},
+        "health_delta": 0.2,
+    },
+    "skill.execution.failed": {
+        "consume_resources": {"renewable": {"solar": 0.4}},
+        "health_delta": -0.3,
+    },
+    "skill.execution.no_compatible": {
+        "health_delta": -0.1,
+    },
+}
 
 
 def default_world_state() -> dict[str, Any]:
@@ -105,21 +144,7 @@ def _clamp(value: float, minimum: float = 0.0, maximum: float = 100.0) -> float:
     return max(minimum, min(maximum, value))
 
 
-def apply_action(
-    action: dict[str, Any],
-    *,
-    state: dict[str, Any] | None = None,
-    state_path: Path | str | None = None,
-) -> dict[str, Any]:
-    """Apply a generic action payload to the world and persist it.
-
-    Supported keys include ``consume_resources``, ``produce_resources``,
-    ``health_delta``, ``entities`` and ``artifacts`` (with ``add``/``remove``),
-    and ``map_updates`` for adding spaces/niches.
-    """
-
-    next_state = deepcopy(state) if state is not None else load_world_state(state_path)
-
+def _apply_action_to_state(next_state: dict[str, Any], action: dict[str, Any]) -> dict[str, Any]:
     resources = next_state.setdefault("resources", {})
     renewable = resources.setdefault("renewable", {})
     non_renewable = resources.setdefault("non_renewable", {})
@@ -165,6 +190,84 @@ def apply_action(
     niches = map_data.setdefault("niches", [])
     spaces.extend(action.get("map_updates", {}).get("add_spaces", []))
     niches.extend(action.get("map_updates", {}).get("add_niches", []))
+    return next_state
+
+
+def map_action_type_to_effect(action_type: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    template = deepcopy(ACTION_TYPE_TO_WORLD_EFFECT.get(action_type, {}))
+    if not payload:
+        return template
+    for key in ("consume_resources", "produce_resources", "entities", "artifacts", "map_updates"):
+        incoming = payload.get(key)
+        if not isinstance(incoming, dict):
+            continue
+        existing = template.setdefault(key, {})
+        if isinstance(existing, dict):
+            for subkey, subvalue in incoming.items():
+                existing[subkey] = subvalue
+    if "health_delta" in payload:
+        template["health_delta"] = float(payload["health_delta"])
+    return template
+
+
+def _merge_action_effect(total: dict[str, Any], effect: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(total)
+    merged["health_delta"] = float(merged.get("health_delta", 0.0)) + float(effect.get("health_delta", 0.0))
+    for family in ("consume_resources", "produce_resources"):
+        family_dst = merged.setdefault(family, {})
+        family_src = effect.get(family, {})
+        if not isinstance(family_src, dict):
+            continue
+        for resource_type, payload in family_src.items():
+            if not isinstance(payload, dict):
+                continue
+            dst_payload = family_dst.setdefault(resource_type, {})
+            for name, amount in payload.items():
+                dst_payload[name] = float(dst_payload.get(name, 0.0)) + float(amount)
+    return merged
+
+
+def apply_action_effects(
+    effects: list[dict[str, Any]],
+    *,
+    state: dict[str, Any] | None = None,
+    state_path: Path | str | None = None,
+    effects_path: Path | str | None = None,
+) -> dict[str, Any]:
+    next_state = deepcopy(state) if state is not None else load_world_state(state_path)
+    cumulative: dict[str, Any] = {"health_delta": 0.0}
+    for effect in effects:
+        _apply_action_to_state(next_state, effect)
+        cumulative = _merge_action_effect(cumulative, effect)
+    save_world_state(next_state, state_path)
+
+    ledger_path = Path(effects_path) if effects_path is not None else DEFAULT_WORLD_EFFECTS_PATH
+    ledger = {
+        "version": 1,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "cumulative_effect": cumulative,
+        "last_effect_count": len(effects),
+    }
+    _atomic_write_json(ledger_path, ledger)
+    return next_state
+
+
+def apply_action(
+    action: dict[str, Any],
+    *,
+    state: dict[str, Any] | None = None,
+    state_path: Path | str | None = None,
+) -> dict[str, Any]:
+    """Apply a generic action payload to the world and persist it.
+
+    Supported keys include ``consume_resources``, ``produce_resources``,
+    ``health_delta``, ``entities`` and ``artifacts`` (with ``add``/``remove``),
+    and ``map_updates`` for adding spaces/niches.
+    """
+
+    next_state = deepcopy(state) if state is not None else load_world_state(state_path)
+
+    _apply_action_to_state(next_state, action)
 
     save_world_state(next_state, state_path)
     return next_state

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -24,7 +24,7 @@ from singular.beliefs.meta_learning import (
     register_run_result,
 )
 from singular.events import EventBus, get_global_event_bus
-from singular.memory import register_memory_event_handlers, update_score
+from singular.memory import add_episode, register_memory_event_handlers, update_score
 from singular.psyche import Psyche, Mood
 from singular.runs.logger import RunLogger
 from singular.runs.explain import summarize_mutation
@@ -35,6 +35,7 @@ from graine.evolver.generate import propose_mutations
 from singular.environment import artifacts as env_artifacts
 from singular.environment import files as env_files
 from singular.environment import notifications as env_notifications
+from singular.environment import sim_world
 from singular.environment.reputation import ReputationSystem
 from singular.environment.world_resources import CompetitorIntent, WorldResourcePool
 from singular.goals import IntrinsicGoals
@@ -126,6 +127,15 @@ OrganismInputs = Mapping[str, Path] | Iterable[Path] | Path
 INTERACTION_RESOURCE_COMPETITION = "resource_competition"
 INTERACTION_CROSSOVER = "crossover"
 INTERACTION_EXTINCTION = "extinction"
+
+ACTION_TYPE_FROM_LOOP_EVENT: dict[str, str] = {
+    "mutation.accepted": "mutation.applied",
+    "mutation.rejected": "mutation.rejected",
+    "resource.granted": "resource.competition.granted",
+    "resource.denied": "resource.competition.denied",
+    "resource.cooperation": "resource.cooperation",
+    "resource.conflict": "resource.conflict",
+}
 
 
 CHECKPOINT_VERSION = 1
@@ -716,7 +726,10 @@ def run(
                 continue
 
             resource_manager.metabolize()
-            signals = capture_signals(bus=event_bus)
+            try:
+                signals = capture_signals(bus=event_bus)
+            except TypeError:
+                signals = capture_signals()
             temp = get_temperature()
             signals["temperature"] = temp
             signals["skill_reputation"] = logger.skill_reputation()
@@ -978,6 +991,7 @@ def run(
                 if map_elites
                 else mutated_score <= base_score
             )
+            world_effects: list[dict[str, object]] = []
             security_metadata: dict[str, object] = {
                 "governance_checked": False,
                 "allowed": accepted,
@@ -1033,6 +1047,13 @@ def run(
                     org.energy -= 0.1
                 else:
                     org.energy += 0.2
+                    effect_type = ACTION_TYPE_FROM_LOOP_EVENT["mutation.accepted"]
+                    world_effects.append(
+                        sim_world.map_action_type_to_effect(
+                            effect_type,
+                            {"health_delta": 0.2 if accepted else 0.0},
+                        )
+                    )
                     world.reputation.update(
                         org_name,
                         "share",
@@ -1041,6 +1062,8 @@ def run(
                     env_artifacts.save_text(f"mutation_{state.iteration}", diff)
             else:
                 org.energy -= 0.1
+                effect_type = ACTION_TYPE_FROM_LOOP_EVENT["mutation.rejected"]
+                world_effects.append(sim_world.map_action_type_to_effect(effect_type))
                 world.reputation.update(
                     org_name,
                     "steal",
@@ -1171,6 +1194,11 @@ def run(
                 competitor_intents=competitor_intents,
             )
             if action_resolution.granted:
+                world_effects.append(
+                    sim_world.map_action_type_to_effect(
+                        ACTION_TYPE_FROM_LOOP_EVENT["resource.granted"]
+                    )
+                )
                 world.resource_pool = max(
                     0.0,
                     world.resource_pool
@@ -1193,12 +1221,28 @@ def run(
                 )
 
             if cooperation_partners:
+                world_effects.append(
+                    sim_world.map_action_type_to_effect(
+                        ACTION_TYPE_FROM_LOOP_EVENT["resource.cooperation"]
+                    )
+                )
                 for partner in cooperation_partners:
                     world.reputation.update(partner, "share")
                 world.reputation.update(org_name, "share")
                 org.energy += action_resolution.relation_bonus
             elif action_resolution.conflicts:
+                world_effects.append(
+                    sim_world.map_action_type_to_effect(
+                        ACTION_TYPE_FROM_LOOP_EVENT["resource.conflict"]
+                    )
+                )
                 world.reputation.update(org_name, "steal")
+            else:
+                world_effects.append(
+                    sim_world.map_action_type_to_effect(
+                        ACTION_TYPE_FROM_LOOP_EVENT["resource.denied"]
+                    )
+                )
 
             for other in world.organisms.values():
                 other.energy = max(0.1, other.energy - ecosystem_rules.passive_energy_decay)
@@ -1320,6 +1364,13 @@ def run(
             if hasattr(psyche, "save_state"):
                 psyche.save_state()
 
+            world_state_path = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_state.json"
+            world_effects_path = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_effects.json"
+            sim_world.apply_action_effects(
+                world_effects,
+                state_path=world_state_path,
+                effects_path=world_effects_path,
+            )
             save_checkpoint(checkpoint_path, state)
 
             dead, reason = org.monitor.check(

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from singular.environment.sim_world import load_world_state
 from singular.events import EventBus, get_global_event_bus
 from singular.governance.policy import MutationGovernancePolicy
 from singular.sensors import (
@@ -357,6 +358,59 @@ def _collect_artifact_signals(root: Path, state: _ArtifactScanState) -> list[dic
     return events
 
 
+def _derive_world_events(world_state: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(world_state, dict):
+        return []
+    events: list[dict[str, Any]] = []
+    health = world_state.get("global_health", {}) if isinstance(world_state.get("global_health"), dict) else {}
+    trend = str(health.get("trend", "stable"))
+    score = float(health.get("score", 50.0) or 50.0)
+    if trend == "degrading" or score < 45.0:
+        events.append(
+            _build_perception_event(
+                event_type="world.health.degradation",
+                source="world_state",
+                confidence=0.9,
+                data={"trend": trend, "score": score},
+            )
+        )
+
+    resources = world_state.get("resources", {}) if isinstance(world_state.get("resources"), dict) else {}
+    renewable = resources.get("renewable", {}) if isinstance(resources.get("renewable"), dict) else {}
+    scarcity: list[dict[str, float | str]] = []
+    opportunities: list[dict[str, float | str]] = []
+    for name, payload in renewable.items():
+        if not isinstance(payload, dict):
+            continue
+        amount = float(payload.get("amount", 0.0) or 0.0)
+        capacity = max(float(payload.get("capacity", 0.0) or 0.0), 0.0)
+        coverage = (amount / capacity) if capacity else 0.0
+        if coverage <= 0.2:
+            scarcity.append({"resource": str(name), "coverage": round(coverage, 3)})
+        if coverage >= 0.8:
+            opportunities.append({"resource": str(name), "coverage": round(coverage, 3)})
+
+    if scarcity:
+        events.append(
+            _build_perception_event(
+                event_type="world.resource.scarcity",
+                source="world_state",
+                confidence=0.92,
+                data={"resources": scarcity},
+            )
+        )
+    if opportunities:
+        events.append(
+            _build_perception_event(
+                event_type="world.opportunity.window",
+                source="world_state",
+                confidence=0.85,
+                data={"resources": opportunities},
+            )
+        )
+    return events
+
+
 
 def reset_perception_state() -> None:
     """Reset in-memory artifact scan and anti-noise state (tests/helpers)."""
@@ -398,6 +452,7 @@ def capture_signals(
     sandbox_root: str | Path | None = None,
     noise_filter: PerceptionNoiseFilter | None = None,
     artifact_state: _ArtifactScanState | None = None,
+    world_state: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Collect sensory signals and optionally publish perception events."""
     signals: dict[str, Any] = {
@@ -422,7 +477,14 @@ def capture_signals(
     filter_instance = noise_filter or _NOISE_FILTER
     artifact_events = _collect_artifact_signals(root, state)
     host_events = _derive_host_events(host_metrics)
-    candidate_events = [*artifact_events, *host_events]
+    resolved_world_state = world_state
+    if resolved_world_state is None:
+        try:
+            resolved_world_state = load_world_state()
+        except Exception:
+            resolved_world_state = None
+    world_events = _derive_world_events(resolved_world_state)
+    candidate_events = [*artifact_events, *host_events, *world_events]
     filtered_events = [event for event in candidate_events if filter_instance.allow(event)]
     if filtered_events:
         signals["artifact_events"] = [
@@ -435,12 +497,23 @@ def capture_signals(
             signals.pop("artifact_events")
         if not signals["host_events"]:
             signals.pop("host_events")
+        signals["world_events"] = [
+            event for event in filtered_events if str(event.get("type", "")).startswith("world.")
+        ]
+        if not signals["world_events"]:
+            signals.pop("world_events")
 
     if publish_event:
         emitter = bus or get_global_event_bus()
         emitter.publish("signal.captured", {"signals": dict(signals)}, payload_version=1)
         for event in filtered_events:
-            topic = "artifact.perception" if str(event.get("type", "")).startswith("artifact.") else "host.perception"
+            topic = (
+                "artifact.perception"
+                if str(event.get("type", "")).startswith("artifact.")
+                else "host.perception"
+                if str(event.get("type", "")).startswith("host.")
+                else "world.perception"
+            )
             emitter.publish(
                 topic,
                 {"version": "1.0", "event": event},

--- a/src/singular/skills/runtime.py
+++ b/src/singular/skills/runtime.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from singular.environment import sim_world
 from singular.events import EventBus, get_global_event_bus
 from singular.life import sandbox
 from singular.life.skill_catalog import read_skill_catalog, refresh_skill_catalog
@@ -58,6 +59,7 @@ class SkillRuntime:
         candidates = self._compatible_candidates(task_dict, skills_state, catalog, strategy=strategy)
         if not candidates:
             result = SkillExecutionResult(skill=None, status="failed", reason="no_compatible_skill")
+            self._apply_world_effect("skill.execution.no_compatible")
             self.bus.publish(
                 "skill.execution.failed",
                 {
@@ -95,6 +97,7 @@ class SkillRuntime:
                     "output": output,
                 },
             )
+            self._apply_world_effect("skill.execution.succeeded")
             return result
         except Exception as exc:
             result = SkillExecutionResult(
@@ -112,7 +115,28 @@ class SkillRuntime:
                     "reason": str(exc),
                 },
             )
+            self._apply_world_effect("skill.execution.failed")
             return result
+
+    def _apply_world_effect(self, action_type: str) -> None:
+        effect = sim_world.map_action_type_to_effect(action_type)
+        if not effect:
+            return
+        state_path = self.mem_dir / "world_state.json"
+        effects_path = self.mem_dir / "world_effects.json"
+        sim_world.apply_action_effects(
+            [effect],
+            state_path=state_path,
+            effects_path=effects_path,
+        )
+        self.bus.publish(
+            "world.effect.applied",
+            {
+                "action_type": action_type,
+                "effect": effect,
+            },
+            payload_version=1,
+        )
 
     def _compatible_candidates(
         self,

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -235,3 +235,25 @@ def test_capture_signals_publishes_host_star_events_on_host_perception_topic(mon
     }
     assert all(event_type.startswith("host.") for event_type in emitted_types)
     assert all(signal_event["type"] in emitted_types for signal_event in signals["host_events"])
+
+
+def test_capture_signals_derives_world_events(monkeypatch):
+    reset_perception_state()
+    monkeypatch.setattr(
+        "singular.perception.load_world_state",
+        lambda: {
+            "global_health": {"trend": "degrading", "score": 40.0},
+            "resources": {
+                "renewable": {
+                    "solar": {"amount": 10.0, "capacity": 100.0},
+                    "biomass": {"amount": 90.0, "capacity": 100.0},
+                }
+            },
+        },
+    )
+    signals = capture_signals()
+    assert "world_events" in signals
+    event_types = {event["type"] for event in signals["world_events"]}
+    assert "world.health.degradation" in event_types
+    assert "world.resource.scarcity" in event_types
+    assert "world.opportunity.window" in event_types

--- a/tests/test_sim_world.py
+++ b/tests/test_sim_world.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
-from singular.environment.sim_world import apply_action, load_world_state, tick_world
+from singular.environment.sim_world import (
+    apply_action,
+    apply_action_effects,
+    load_world_state,
+    map_action_type_to_effect,
+    tick_world,
+)
 
 
 def test_load_world_state_creates_default_when_missing(tmp_path: Path) -> None:
@@ -63,3 +69,18 @@ def test_tick_world_regenerates_and_updates_health(tmp_path: Path) -> None:
     assert ticked["resources"]["renewable"]["biomass"]["amount"] == 16.0
     assert ticked["global_health"]["trend"] == "degrading"
     assert 0.0 <= ticked["global_health"]["signals"]["resource_pressure"] <= 1.0
+
+
+def test_apply_action_effects_writes_atomic_cumulative_effects(tmp_path: Path) -> None:
+    state_path = tmp_path / "mem" / "world_state.json"
+    effects_path = tmp_path / "mem" / "world_effects.json"
+    _ = load_world_state(state_path)
+    effects = [
+        map_action_type_to_effect("mutation.applied"),
+        map_action_type_to_effect("resource.conflict"),
+    ]
+    updated = apply_action_effects(effects, state_path=state_path, effects_path=effects_path)
+    assert effects_path.exists()
+    assert "global_health" in updated
+    ledger = effects_path.read_text(encoding="utf-8")
+    assert '"last_effect_count": 2' in ledger

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 
 from singular.events import EventBus
 from singular.skills.runtime import SkillRuntime
@@ -149,3 +150,25 @@ def test_execute_best_skill_cautious_strategy_prefers_reliable_skill(monkeypatch
     )
     assert result.status == "succeeded"
     assert result.skill == "safe"
+
+
+def test_execute_best_skill_persists_world_effects(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("singular.skills.runtime.sandbox.run", lambda code: {"ok": True})
+    life = tmp_path / "life"
+    skills = life / "skills"
+    mem = life / "mem"
+    skills.mkdir(parents=True)
+    mem.mkdir(parents=True)
+    (skills / "good.py").write_text("def run(context=None):\n    return {'ok': True}\n", encoding="utf-8")
+    (mem / "skills.json").write_text('{"good": {"capabilities": ["assist"], "risk": 0.1}}', encoding="utf-8")
+
+    runtime = SkillRuntime(skills_dir=skills, mem_dir=mem)
+    result = runtime.execute_best_skill(
+        task={"name": "assist", "capabilities": ["assist"]},
+        context={},
+    )
+
+    assert result.status == "succeeded"
+    effects = json.loads((mem / "world_effects.json").read_text(encoding="utf-8"))
+    assert effects["last_effect_count"] == 1
+    assert effects["cumulative_effect"]["health_delta"] > 0


### PR DESCRIPTION
### Motivation
- Surface how agent actions and runtime outcomes affect the shared world model and make those effects explicit and composable. 
- Ensure world state side-effects from many in-tick events are persisted atomically to avoid partial updates and keep an auditable ledger. 
- Feed derived world signals back into perception so goals and runtime adaptation can react to degradation, scarcity and opportunities.

### Description
- Introduce an explicit `ACTION_TYPE_TO_WORLD_EFFECT` mapping and helper `map_action_type_to_effect` in `src/singular/environment/sim_world.py` to translate action/event types into world-effect payloads. 
- Add `_apply_action_to_state`, `_merge_action_effect` and `apply_action_effects()` to apply multiple effects to the world state and atomically write a cumulative ledger to `mem/world_effects.json` using `_atomic_write_json`. 
- Update the life loop (`src/singular/life/loop.py`) to accumulate per-tick `world_effects` (mutations, resource arbitration outcomes, cooperation/conflict) and persist them once per tick via `sim_world.apply_action_effects()`, plus a compatibility fallback when `capture_signals()` is monkeypatched without kwargs. 
- Extend runtime skill execution (`src/singular/skills/runtime.py`) to apply mapped world effects for `succeeded`, `failed` and `no_compatible_skill` outcomes and publish `world.effect.applied`. 
- Enrich perception (`src/singular/perception.py`) with `_derive_world_events()` producing `world.health.degradation`, `world.resource.scarcity` and `world.opportunity.window`; include these as `world_events` in `capture_signals()` and publish them on `world.perception`. 
- Add and update unit tests covering atomic persistence of cumulative world effects, derived world perception events, and runtime-driven world-effect persistence (`tests/test_sim_world.py`, `tests/test_perception.py`, `tests/test_skill_runtime.py`).

### Testing
- Ran targeted unit tests: `pytest -q tests/test_sim_world.py tests/test_perception.py tests/test_skill_runtime.py tests/test_loop_perception_goals.py` and observed all tests passing (20 passed). 
- Exercised loop-specific scenarios: `pytest -q tests/test_loop.py::test_irrational_refusal tests/test_loop.py::test_irrational_delay tests/test_loop.py::test_irrational_curiosity` and they passed (3 passed) after adding a small compatibility fallback. 
- Test runs produced only unrelated deprecation warnings; no failing tests remained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb055ef0c832ab4af9f6833d6382e)