### PR TITLE
Étendre la simulation monde : dettes écologiques/relationnelles et événements retardés

### DIFF
--- a/src/singular/environment/sim_world.py
+++ b/src/singular/environment/sim_world.py
@@ -37,10 +37,30 @@ ACTION_TYPE_TO_WORLD_EFFECT: dict[str, dict[str, Any]] = {
     "resource.cooperation": {
         "produce_resources": {"renewable": {"solar": 0.6}},
         "health_delta": 0.3,
+        "relational_debt_delta": -1.0,
     },
     "resource.conflict": {
         "consume_resources": {"renewable": {"biomass": 0.7}},
         "health_delta": -0.5,
+        "ecological_debt_delta": 2.5,
+        "relational_debt_delta": 2.0,
+    },
+    "resource.overexploitation": {
+        "consume_resources": {"renewable": {"biomass": 1.6, "solar": 0.9}},
+        "health_delta": -0.7,
+        "ecological_debt_delta": 5.0,
+        "delayed_events": [
+            {
+                "kind": "crisis",
+                "label": "ecosystem-backlash",
+                "in_ticks": 2,
+                "effect": {
+                    "consume_resources": {"renewable": {"biomass": 2.0}},
+                    "health_delta": -1.1,
+                    "ecological_debt_delta": 2.0,
+                },
+            }
+        ],
     },
     "skill.execution.succeeded": {
         "produce_resources": {"renewable": {"solar": 0.4}},
@@ -97,7 +117,15 @@ def default_world_state() -> dict[str, Any]:
             "signals": {
                 "resource_pressure": 0.2,
                 "cohesion": 0.85,
+                "ecological_debt": 0.0,
+                "relational_debt": 0.0,
+                "delayed_risk": 0.0,
             },
+        },
+        "dynamics": {
+            "ecological_debt": 0.0,
+            "relational_debt": 0.0,
+            "delayed_events": [],
         },
     }
 
@@ -170,6 +198,23 @@ def _apply_action_to_state(next_state: dict[str, Any], action: dict[str, Any]) -
 
     health = next_state.setdefault("global_health", {})
     health["score"] = _clamp(float(health.get("score", 50.0)) + float(action.get("health_delta", 0.0)))
+    dynamics = next_state.setdefault("dynamics", {})
+    ecological_debt = float(dynamics.get("ecological_debt", 0.0)) + float(action.get("ecological_debt_delta", 0.0))
+    relational_debt = float(dynamics.get("relational_debt", 0.0)) + float(action.get("relational_debt_delta", 0.0))
+    dynamics["ecological_debt"] = _clamp(ecological_debt, minimum=0.0, maximum=100.0)
+    dynamics["relational_debt"] = _clamp(relational_debt, minimum=0.0, maximum=100.0)
+    delayed_events = dynamics.setdefault("delayed_events", [])
+    for delayed_event in action.get("delayed_events", []):
+        if not isinstance(delayed_event, dict):
+            continue
+        delayed_events.append(
+            {
+                "kind": str(delayed_event.get("kind", "unknown")),
+                "label": str(delayed_event.get("label", "scheduled-effect")),
+                "in_ticks": max(int(delayed_event.get("in_ticks", 1)), 1),
+                "effect": deepcopy(delayed_event.get("effect", {})),
+            }
+        )
 
     external = next_state.setdefault("external", {})
     entities = external.setdefault("entities", [])
@@ -213,6 +258,12 @@ def map_action_type_to_effect(action_type: str, payload: dict[str, Any] | None =
 def _merge_action_effect(total: dict[str, Any], effect: dict[str, Any]) -> dict[str, Any]:
     merged = deepcopy(total)
     merged["health_delta"] = float(merged.get("health_delta", 0.0)) + float(effect.get("health_delta", 0.0))
+    merged["ecological_debt_delta"] = float(merged.get("ecological_debt_delta", 0.0)) + float(
+        effect.get("ecological_debt_delta", 0.0)
+    )
+    merged["relational_debt_delta"] = float(merged.get("relational_debt_delta", 0.0)) + float(
+        effect.get("relational_debt_delta", 0.0)
+    )
     for family in ("consume_resources", "produce_resources"):
         family_dst = merged.setdefault(family, {})
         family_src = effect.get(family, {})
@@ -285,12 +336,43 @@ def tick_world(
     tick_count = max(int(steps), 0)
     resources = next_state.get("resources", {})
     renewable = resources.get("renewable", {})
+    dynamics = next_state.setdefault("dynamics", {})
+    ecological_debt = _clamp(float(dynamics.get("ecological_debt", 0.0)), minimum=0.0, maximum=100.0)
+    relational_debt = _clamp(float(dynamics.get("relational_debt", 0.0)), minimum=0.0, maximum=100.0)
+    delayed_events = list(dynamics.get("delayed_events", []))
+    fired_delayed_events: list[dict[str, Any]] = []
 
     for _ in range(tick_count):
         for payload in renewable.values():
             regen_rate = max(float(payload.get("regen_rate", 0.0)), 0.0)
             capacity = max(float(payload.get("capacity", 100.0)), 0.0)
-            payload["amount"] = min(capacity, max(float(payload.get("amount", 0.0)), 0.0) + regen_rate)
+            regen_penalty = (ecological_debt / 100.0) * 0.4
+            effective_regen = regen_rate * max(0.1, 1.0 - regen_penalty)
+            payload["amount"] = min(capacity, max(float(payload.get("amount", 0.0)), 0.0) + effective_regen)
+        matured: list[dict[str, Any]] = []
+        pending: list[dict[str, Any]] = []
+        for entry in delayed_events:
+            if not isinstance(entry, dict):
+                continue
+            remaining = int(entry.get("in_ticks", 1)) - 1
+            updated_entry = dict(entry)
+            updated_entry["in_ticks"] = remaining
+            if remaining <= 0:
+                matured.append(updated_entry)
+            else:
+                pending.append(updated_entry)
+        for matured_entry in matured:
+            fired_delayed_events.append(
+                {
+                    "kind": str(matured_entry.get("kind", "unknown")),
+                    "label": str(matured_entry.get("label", "scheduled-effect")),
+                }
+            )
+            effect_payload = matured_entry.get("effect", {})
+            if isinstance(effect_payload, dict):
+                _apply_action_to_state(next_state, effect_payload)
+        delayed_events = pending
+        dynamics["delayed_events"] = delayed_events
         next_state["world_clock"] = int(next_state.get("world_clock", 0)) + 1
 
     total_capacity = 0.0
@@ -304,9 +386,21 @@ def tick_world(
     health = next_state.setdefault("global_health", {})
     signals = health.setdefault("signals", {})
     signals["resource_pressure"] = round(pressure, 3)
+    dynamics = next_state.setdefault("dynamics", {})
+    ecological_debt = _clamp(float(dynamics.get("ecological_debt", 0.0)), minimum=0.0, maximum=100.0)
+    relational_debt = _clamp(float(dynamics.get("relational_debt", 0.0)), minimum=0.0, maximum=100.0)
+    delayed_risk = _clamp(len(dynamics.get("delayed_events", [])) / 8.0, minimum=0.0, maximum=1.0)
+    signals["ecological_debt"] = round(ecological_debt / 100.0, 3)
+    signals["relational_debt"] = round(relational_debt / 100.0, 3)
+    signals["delayed_risk"] = round(delayed_risk, 3)
+    if fired_delayed_events:
+        health["delayed_events_fired"] = fired_delayed_events
+    else:
+        health.pop("delayed_events_fired", None)
 
     base_score = float(health.get("score", 50.0))
-    drift = (coverage - 0.5) * 2.5 * tick_count
+    debt_drag = ((ecological_debt * 0.012) + (relational_debt * 0.009)) * tick_count
+    drift = ((coverage - 0.5) * 2.5 * tick_count) - debt_drag
     updated_score = _clamp(base_score + drift)
     health["score"] = round(updated_score, 3)
     if drift > 0.2:

--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -146,6 +146,8 @@ class IntrinsicGoals:
         energy = _clamp(float((resources or {}).get("energy", 50.0)) / 100.0)
         food = _clamp(float((resources or {}).get("food", 50.0)) / 100.0)
         warmth = _clamp(float((resources or {}).get("warmth", 50.0)) / 100.0)
+        ecological_debt = _clamp(float((resources or {}).get("ecological_debt", 0.0)) / 100.0)
+        relational_debt = _clamp(float((resources or {}).get("relational_debt", 0.0)) / 100.0)
         resource_stability = (energy + food + warmth) / 3.0
         telemetry_efficiency_penalty = 0.0
         telemetry_quality_pressure = 0.0
@@ -159,6 +161,8 @@ class IntrinsicGoals:
         injuries_pressure = 0.0
         success_boost = 0.0
         repeated_failure_pressure = 0.0
+        delayed_crisis_pressure = 0.0
+        delayed_opportunity_pressure = 0.0
         if isinstance(narrative, Mapping):
             risk_aversion = _mean_mapping_value(narrative.get("risk_aversion_by_action_family"))
             confidence_map = narrative.get("accumulated_confidence_by_action_family")
@@ -172,6 +176,22 @@ class IntrinsicGoals:
             repeated_failure_pressure = _clamp(
                 _as_float(execution_history.get("repeated_failure_pressure", 0.0), default=0.0)
             )
+        world_events = (perception_signals or {}).get("world_events")
+        if isinstance(world_events, list):
+            total_events = float(len(world_events))
+            crisis_count = 0.0
+            opportunity_count = 0.0
+            for event in world_events:
+                if not isinstance(event, Mapping):
+                    continue
+                event_type = str(event.get("type", ""))
+                if "delayed.crisis" in event_type:
+                    crisis_count += 1.0
+                if "delayed.opportunity" in event_type:
+                    opportunity_count += 1.0
+            if total_events > 0.0:
+                delayed_crisis_pressure = _clamp(crisis_count / total_events)
+                delayed_opportunity_pressure = _clamp(opportunity_count / total_events)
 
         skill_reputation = (perception_signals or {}).get("skill_reputation")
         if isinstance(skill_reputation, Mapping) and skill_reputation:
@@ -234,11 +254,14 @@ class IntrinsicGoals:
             robustesse=0.2
             + 0.35 * (1.0 - health_norm)
             + 0.25 * (1.0 - resource_stability)
+            + 0.22 * ecological_debt
+            + 0.14 * relational_debt
             + 0.2 * telemetry_failure_pressure
             + 0.25 * host_environmental_pressure
             + 0.1 * host_environmental_variance
             + 0.25 * injuries_pressure
             + 0.18 * risk_aversion
+            + 0.2 * delayed_crisis_pressure
             + 0.2 * repeated_failure_pressure,
             efficacite=0.2
             + 0.45 * health_norm
@@ -247,12 +270,17 @@ class IntrinsicGoals:
             + 0.2 * (1.0 - host_environmental_pressure)
             + 0.22 * success_boost
             + 0.15 * accumulated_confidence
+            + 0.12 * delayed_opportunity_pressure
+            - 0.1 * ecological_debt
             - 0.12 * repeated_failure_pressure,
             exploration=0.2
             + 0.45 * curiosity
             + 0.2 * playfulness
             + 0.1 * (1.0 - energy)
             + 0.18 * accumulated_confidence
+            - 0.15 * ecological_debt
+            - 0.1 * relational_debt
+            - 0.22 * delayed_crisis_pressure
             - 0.25 * risk_aversion
             - 0.18 * repeated_failure_pressure,
         )
@@ -286,6 +314,10 @@ class IntrinsicGoals:
                     "injuries_pressure": injuries_pressure,
                     "success_boost": success_boost,
                     "repeated_failure_pressure": repeated_failure_pressure,
+                    "ecological_debt": ecological_debt,
+                    "relational_debt": relational_debt,
+                    "delayed_crisis_pressure": delayed_crisis_pressure,
+                    "delayed_opportunity_pressure": delayed_opportunity_pressure,
                     "intrinsic_modulation_version": INTRINSIC_MODULATION_VERSION,
                     "perception_rules_version": modulation["version"],
                     "perception_rule_count": len(modulation["applied_rules"]),

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -837,6 +837,8 @@ def run(
                     "energy": resource_manager.energy,
                     "food": resource_manager.food,
                     "warmth": resource_manager.warmth,
+                    "ecological_debt": resource_manager.ecological_debt,
+                    "relational_debt": resource_manager.relational_debt,
                 },
                 perception_signals=signals,
             )
@@ -1366,11 +1368,12 @@ def run(
 
             world_state_path = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_state.json"
             world_effects_path = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_effects.json"
-            sim_world.apply_action_effects(
+            updated_world_state = sim_world.apply_action_effects(
                 world_effects,
                 state_path=world_state_path,
                 effects_path=world_effects_path,
             )
+            resource_manager.apply_world_state(updated_world_state)
             save_checkpoint(checkpoint_path, state)
 
             dead, reason = org.monitor.check(

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -408,6 +408,26 @@ def _derive_world_events(world_state: dict[str, Any] | None) -> list[dict[str, A
                 data={"resources": opportunities},
             )
         )
+    signals = health.get("signals", {}) if isinstance(health.get("signals"), dict) else {}
+    delayed_risk = float(signals.get("delayed_risk", 0.0) or 0.0)
+    if delayed_risk >= 0.35:
+        events.append(
+            _build_perception_event(
+                event_type="world.delayed.crisis",
+                source="world_state",
+                confidence=min(0.95, 0.6 + delayed_risk * 0.35),
+                data={"risk": round(delayed_risk, 3)},
+            )
+        )
+    elif delayed_risk > 0.0:
+        events.append(
+            _build_perception_event(
+                event_type="world.delayed.opportunity",
+                source="world_state",
+                confidence=0.7,
+                data={"risk": round(delayed_risk, 3)},
+            )
+        )
     return events
 
 

--- a/src/singular/resource_manager.py
+++ b/src/singular/resource_manager.py
@@ -21,6 +21,8 @@ class ResourceManager:
     energy: float = 100.0
     food: float = 50.0
     warmth: float = 50.0
+    ecological_debt: float = 0.0
+    relational_debt: float = 0.0
     path: Path = Path("resources.json")
     energy_threshold: float = 20.0
     food_threshold: float = 20.0
@@ -32,7 +34,7 @@ class ResourceManager:
                 data = json.loads(self.path.read_text(encoding="utf-8"))
             except Exception:
                 return
-            for field in ("energy", "food", "warmth"):
+            for field in ("energy", "food", "warmth", "ecological_debt", "relational_debt"):
                 if field in data:
                     setattr(self, field, float(data[field]))
 
@@ -41,9 +43,17 @@ class ResourceManager:
         self.energy = max(0.0, min(100.0, self.energy))
         self.food = max(0.0, min(100.0, self.food))
         self.warmth = max(0.0, min(100.0, self.warmth))
+        self.ecological_debt = max(0.0, min(100.0, self.ecological_debt))
+        self.relational_debt = max(0.0, min(100.0, self.relational_debt))
 
     def _save(self) -> None:
-        data = {"energy": self.energy, "food": self.food, "warmth": self.warmth}
+        data = {
+            "energy": self.energy,
+            "food": self.food,
+            "warmth": self.warmth,
+            "ecological_debt": self.ecological_debt,
+            "relational_debt": self.relational_debt,
+        }
         _atomic_write_text(self.path, json.dumps(data))
 
     # mutation methods -----------------------------------------------------
@@ -63,7 +73,8 @@ class ResourceManager:
         self._save()
 
     def add_food(self, amount: float) -> None:
-        self.food += amount
+        effective = amount * max(0.2, 1.0 - (self.ecological_debt / 150.0))
+        self.food += effective
         self._clamp()
         self._save()
 
@@ -75,8 +86,9 @@ class ResourceManager:
         is persisted.
         """
 
-        self.food -= rate
-        self.energy += rate * 2
+        eco_penalty = self.ecological_debt / 100.0
+        self.food -= rate * (1.0 + (0.35 * eco_penalty))
+        self.energy += (rate * 2) * max(0.2, 1.0 - (0.5 * eco_penalty))
         self._clamp()
         self._save()
 
@@ -86,7 +98,38 @@ class ResourceManager:
         self._save()
 
     def add_warmth(self, amount: float) -> None:
-        self.warmth += amount
+        effective = amount * max(0.25, 1.0 - (self.relational_debt / 140.0))
+        self.warmth += effective
+        self._clamp()
+        self._save()
+
+    def apply_world_state(self, world_state: dict[str, object] | None) -> None:
+        """Project world debts into local resources to model indirect mortality pressure."""
+
+        if not isinstance(world_state, dict):
+            return
+        dynamics = world_state.get("dynamics")
+        signals = (
+            world_state.get("global_health", {}).get("signals", {})
+            if isinstance(world_state.get("global_health"), dict)
+            else {}
+        )
+        eco_norm = 0.0
+        rel_norm = 0.0
+        delayed_risk = 0.0
+        if isinstance(dynamics, dict):
+            eco_norm = max(0.0, min(1.0, float(dynamics.get("ecological_debt", 0.0)) / 100.0))
+            rel_norm = max(0.0, min(1.0, float(dynamics.get("relational_debt", 0.0)) / 100.0))
+        if isinstance(signals, dict):
+            delayed_risk = max(0.0, min(1.0, float(signals.get("delayed_risk", 0.0))))
+
+        self.ecological_debt = (self.ecological_debt * 0.7) + (eco_norm * 100.0 * 0.3)
+        self.relational_debt = (self.relational_debt * 0.7) + (rel_norm * 100.0 * 0.3)
+
+        stress_factor = (eco_norm * 0.6) + (rel_norm * 0.4) + (delayed_risk * 0.5)
+        self.energy -= stress_factor * 1.8
+        self.food -= (eco_norm + delayed_risk) * 0.9
+        self.warmth -= (rel_norm * 1.0) + (delayed_risk * 0.4)
         self._clamp()
         self._save()
 
@@ -118,6 +161,10 @@ class ResourceManager:
             moods.append("angry")
         if self.warmth < self.warmth_threshold:
             moods.append("cold")
+        if self.relational_debt >= 55.0:
+            moods.append("tense")
+        if self.ecological_debt >= 60.0:
+            moods.append("strained")
         if not moods:
             moods.append("content")
         return moods

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -19,6 +19,20 @@ def test_update_from_environment_decreases_warmth(tmp_path):
     assert rm.warmth < 50.0
 
 
+def test_world_debt_pressure_reduces_local_resources(tmp_path):
+    path = tmp_path / "resources.json"
+    rm = ResourceManager(energy=80.0, food=80.0, warmth=80.0, path=path)
+    rm.apply_world_state(
+        {
+            "dynamics": {"ecological_debt": 80.0, "relational_debt": 70.0},
+            "global_health": {"signals": {"delayed_risk": 0.6}},
+        }
+    )
+    assert rm.energy < 80.0
+    assert rm.food < 80.0
+    assert rm.warmth < 80.0
+
+
 def test_notify_supports_levels_and_actions() -> None:
     messages: list[str] = []
     notify(

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -233,3 +233,30 @@ def test_intrinsic_goals_strategy_applies_repeated_failure_penalty(tmp_path) -> 
     assert strategy["mode"] == "cautious"
     assert strategy["repeated_failure_penalty"] == 0.8
     assert strategy["intrinsic_modulation_version"] == "intrinsic-mod-v2"
+
+
+def test_intrinsic_goals_raise_robustesse_under_eco_relational_debt(tmp_path) -> None:
+    goals = IntrinsicGoals(path=tmp_path / "goals.json")
+    psyche = Psyche()
+
+    baseline = goals.update_tick(
+        tick=1,
+        psyche=psyche,
+        health_score=82.0,
+        resources={"energy": 82.0, "food": 82.0, "warmth": 82.0, "ecological_debt": 0.0, "relational_debt": 0.0},
+        perception_signals={},
+    )
+    pressured = goals.update_tick(
+        tick=2,
+        psyche=psyche,
+        health_score=82.0,
+        resources={"energy": 82.0, "food": 82.0, "warmth": 82.0, "ecological_debt": 70.0, "relational_debt": 65.0},
+        perception_signals={
+            "world_events": [
+                {"type": "world.delayed.crisis", "data": {"risk": 0.7}},
+            ]
+        },
+    )
+
+    assert pressured.robustesse > baseline.robustesse
+    assert pressured.exploration < baseline.exploration

--- a/tests/test_sim_world.py
+++ b/tests/test_sim_world.py
@@ -84,3 +84,17 @@ def test_apply_action_effects_writes_atomic_cumulative_effects(tmp_path: Path) -
     assert "global_health" in updated
     ledger = effects_path.read_text(encoding="utf-8")
     assert '"last_effect_count": 2' in ledger
+
+
+def test_overexploitation_schedules_and_triggers_delayed_crisis(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "world_state.json"
+    state = load_world_state(path)
+    over = map_action_type_to_effect("resource.overexploitation")
+    updated = apply_action(over, state=state, state_path=path)
+    assert updated["dynamics"]["ecological_debt"] > 0.0
+    assert updated["dynamics"]["delayed_events"]
+
+    ticked = tick_world(state=updated, state_path=path, steps=2)
+    fired = ticked["global_health"].get("delayed_events_fired", [])
+    assert any(entry.get("kind") == "crisis" for entry in fired)
+    assert ticked["global_health"]["signals"]["delayed_risk"] >= 0.0


### PR DESCRIPTION
### Motivation
- Modéliser dettes systémiques (écologique et relationnelle) et effets différés pour rendre la dynamique monde plus réaliste. 
- Faire remonter ces tensions vers les agents via `ResourceManager` et la priorisation intrinsèque pour qu'elles influencent comportements et risques indirects de mortalité.

### Description
- Ajout dans `sim_world` de deux dynamiques `ecological_debt` / `relational_debt`, d'un mécanisme de `delayed_events` et d'un nouvel effet `resource.overexploitation` qui programme une crise différée. 
- Extension de `ResourceManager` avec attributs locaux de dette, rendement dégradé (`add_food`, `metabolize`, `add_warmth`) et méthode `apply_world_state()` pour appliquer la pression monde aux ressources locales. 
- Intégration des dettes et des événements différés dans `IntrinsicGoals.update_tick()` pour accroître la `robustesse` et réduire l'`exploration` sous pression, et ajout de signaux perceptifs (`world.delayed.crisis` / `world.delayed.opportunity`) dans la perception. 
- Chaînage dans la boucle principale pour transmettre les nouvelles dimensions ressources aux objectifs et appliquer l'état monde retourné par `apply_action_effects()` au `ResourceManager` après chaque lot d'effets. 

### Testing
- Ajout de tests unitaires ciblés : `test_overexploitation_schedules_and_triggers_delayed_crisis`, `test_world_debt_pressure_reduces_local_resources`, et `test_intrinsic_goals_raise_robustesse_under_eco_relational_debt`; les tests existants mis à jour en conséquence. 
- Commande exécutée : `pytest -q tests/test_sim_world.py tests/test_environment.py tests/test_objectives.py tests/test_atomic_writes.py tests/test_loop.py::test_energy_debit_and_food_credit` et la suite ciblée a réussi (`27 passed`, quelques warnings). 
- Tests atomiques d'écriture ont été vérifiés et restent sûrs après modifications (tests de sauvegarde atomique passés).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb4017c90832ab62b5b16eab72392)