### PR TITLE
Add generated quest heuristics and persist quest origin metadata

### DIFF
--- a/src/singular/goals/__init__.py
+++ b/src/singular/goals/__init__.py
@@ -1,5 +1,6 @@
 """Goal management subsystem."""
 
 from .intrinsic import GoalState, GoalWeights, IntrinsicGoals
+from .quest_generation import GeneratedQuest, generate_quests
 
-__all__ = ["GoalState", "GoalWeights", "IntrinsicGoals"]
+__all__ = ["GoalState", "GoalWeights", "IntrinsicGoals", "GeneratedQuest", "generate_quests"]

--- a/src/singular/goals/quest_generation.py
+++ b/src/singular/goals/quest_generation.py
@@ -1,0 +1,136 @@
+"""Quest generation heuristics driven by internal and external pressures."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Literal
+
+Origin = Literal["intrinsic", "external"]
+
+
+def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+    return max(low, min(high, value))
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class GeneratedQuest:
+    """Minimal generated quest payload.
+
+    The payload is intentionally compact so it can be persisted or transformed
+    into a richer runtime representation by the caller.
+    """
+
+    name: str
+    objective: str
+    rationale: str
+    origin: Origin
+    priority: float
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["priority"] = round(float(payload["priority"]), 3)
+        return payload
+
+
+def generate_quests(
+    *,
+    psyche_traits: Mapping[str, Any] | None,
+    outcomes_history: Mapping[str, Any] | None,
+    value_performance_tension: Mapping[str, Any] | float | None,
+    world_state: Mapping[str, Any] | None,
+    resources: Mapping[str, Any] | None,
+) -> list[GeneratedQuest]:
+    """Generate candidate quests from psyche, history, tensions, and world/resources."""
+
+    traits = psyche_traits or {}
+    history = outcomes_history or {}
+    world = world_state or {}
+    stock = resources or {}
+
+    resilience = _clamp(_as_float(traits.get("resilience", 0.5), default=0.5))
+    optimism = _clamp(_as_float(traits.get("optimism", 0.5), default=0.5))
+    curiosity = _clamp(_as_float(traits.get("curiosity", 0.5), default=0.5))
+
+    recent_successes = _as_float(history.get("recent_successes", 0.0), default=0.0)
+    recent_failures = _as_float(history.get("recent_failures", 0.0), default=0.0)
+
+    if isinstance(value_performance_tension, Mapping):
+        tension = _clamp(_as_float(value_performance_tension.get("score", 0.0), default=0.0))
+    else:
+        tension = _clamp(_as_float(value_performance_tension, default=0.0))
+
+    energy = _clamp(_as_float(stock.get("energy", 50.0), default=50.0) / 100.0)
+    food = _clamp(_as_float(stock.get("food", 50.0), default=50.0) / 100.0)
+    warmth = _clamp(_as_float(stock.get("warmth", 50.0), default=50.0) / 100.0)
+
+    delayed_crisis = _clamp(_as_float(world.get("delayed_crisis_pressure", 0.0), default=0.0))
+    opportunity = _clamp(_as_float(world.get("opportunity_pressure", 0.0), default=0.0))
+
+    generated: list[GeneratedQuest] = []
+
+    if tension >= 0.45:
+        generated.append(
+            GeneratedQuest(
+                name="realign_values_vs_performance",
+                objective="Réduire la friction entre valeurs et rendement.",
+                rationale="Tension valeurs/performance élevée.",
+                origin="intrinsic",
+                priority=_clamp(0.45 + tension * 0.5),
+            )
+        )
+
+    failure_pressure = _clamp((recent_failures - recent_successes) / 5.0)
+    if failure_pressure > 0.1:
+        generated.append(
+            GeneratedQuest(
+                name="recover_execution_reliability",
+                objective="Restaurer la stabilité d'exécution après une série d'échecs.",
+                rationale="Historique récent orienté vers l'échec.",
+                origin="intrinsic",
+                priority=_clamp(0.4 + failure_pressure * 0.5 + (1.0 - resilience) * 0.2),
+            )
+        )
+
+    resource_pressure = _clamp(1.0 - ((energy + food + warmth) / 3.0))
+    if resource_pressure >= 0.35:
+        generated.append(
+            GeneratedQuest(
+                name="stabilize_critical_resources",
+                objective="Sécuriser énergie, nourriture et chaleur.",
+                rationale="Niveau de ressources en baisse.",
+                origin="external",
+                priority=_clamp(0.5 + resource_pressure * 0.4),
+            )
+        )
+
+    if delayed_crisis >= 0.4:
+        generated.append(
+            GeneratedQuest(
+                name="anticipate_world_crisis",
+                objective="Anticiper les crises différées du monde.",
+                rationale="Signaux de crise environnementale retardée détectés.",
+                origin="external",
+                priority=_clamp(0.5 + delayed_crisis * 0.4 + (1.0 - optimism) * 0.2),
+            )
+        )
+
+    if opportunity >= 0.4 and curiosity >= 0.45:
+        generated.append(
+            GeneratedQuest(
+                name="capture_emergent_opportunity",
+                objective="Exploiter une opportunité externe émergente.",
+                rationale="Fenêtre d'opportunité détectée avec curiosité suffisante.",
+                origin="external",
+                priority=_clamp(0.35 + opportunity * 0.4 + curiosity * 0.2),
+            )
+        )
+
+    generated.sort(key=lambda quest: quest.priority, reverse=True)
+    return generated

--- a/src/singular/life/quest.py
+++ b/src/singular/life/quest.py
@@ -42,6 +42,7 @@ class Spec:
     penalty: dict[str, Any] = field(default_factory=dict)
     cooldown: int = 0
     success: dict[str, Any] = field(default_factory=dict)
+    origin: str = "external"
 
 
 def load(path: Path) -> Spec:
@@ -114,6 +115,10 @@ def load(path: Path) -> Spec:
     if not isinstance(success, dict):
         raise SpecValidationError("'success' must be an object")
 
+    origin = data.get("origin", "external")
+    if origin not in {"intrinsic", "external"}:
+        raise SpecValidationError("'origin' must be 'intrinsic' or 'external'")
+
     constraints = Constraints(pure=True, no_import=True, time_ms_max=time_ms_max)
 
     return Spec(
@@ -126,4 +131,5 @@ def load(path: Path) -> Spec:
         penalty=penalty,
         cooldown=cooldown,
         success=success,
+        origin=origin,
     )

--- a/src/singular/quests.py
+++ b/src/singular/quests.py
@@ -19,6 +19,7 @@ class QuestRecord:
     name: str
     status: str
     started_at: str
+    origin: str = "external"
     completed_at: str | None = None
     reason: str | None = None
 
@@ -65,11 +66,14 @@ class QuestRuntime:
                 started_at = item.get("started_at")
                 if not all(isinstance(v, str) and v for v in (name, status, started_at)):
                     continue
+                raw_origin = item.get("origin")
+                origin = raw_origin if raw_origin in {"intrinsic", "external"} else "external"
                 out.append(
                     QuestRecord(
                         name=name,
                         status=status,
                         started_at=started_at,
+                        origin=origin,
                         completed_at=item.get("completed_at") if isinstance(item.get("completed_at"), str) else None,
                         reason=item.get("reason") if isinstance(item.get("reason"), str) else None,
                     )
@@ -163,6 +167,7 @@ class QuestRuntime:
                         name=spec.name,
                         status="active",
                         started_at=self._now().isoformat(),
+                        origin=spec.origin,
                     )
                 )
                 add_episode(
@@ -270,6 +275,7 @@ class QuestRuntime:
                         name=spec.name,
                         status="success",
                         started_at=record.started_at,
+                        origin=record.origin,
                         completed_at=self._now().isoformat(),
                     )
                 )
@@ -292,6 +298,7 @@ class QuestRuntime:
                         name=spec.name,
                         status="failure",
                         started_at=record.started_at,
+                        origin=record.origin,
                         completed_at=self._now().isoformat(),
                         reason="timeout",
                     )

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -72,7 +72,8 @@ def test_orchestrator_triggers_and_settles_quest(monkeypatch, tmp_path: Path) ->
   "reward": {"mood": "pleasure", "resource_delta": {"food": 1}},
   "penalty": {"mood": "pain"},
   "cooldown": 30,
-  "success": {"resource_min": {"energy": 0}}
+  "success": {"resource_min": {"energy": 0}},
+  "origin": "intrinsic"
 }
 """.strip(),
         encoding="utf-8",
@@ -95,6 +96,7 @@ def test_orchestrator_triggers_and_settles_quest(monkeypatch, tmp_path: Path) ->
     payload = quests_path.read_text(encoding="utf-8")
     assert '"repair"' in payload
     assert '"success"' in payload
+    assert '"origin": "intrinsic"' in payload
 
 
 def test_orchestrator_action_executes_skill_runtime(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_quest.py
+++ b/tests/test_quest.py
@@ -21,6 +21,7 @@ def test_load_valid_spec(tmp_path):
     assert spec.reward == {}
     assert spec.penalty == {}
     assert spec.cooldown == 0
+    assert spec.origin == "external"
 
 
 def test_load_extended_quest_fields(tmp_path):
@@ -34,6 +35,7 @@ def test_load_extended_quest_fields(tmp_path):
         "penalty": {"mood": "pain", "resource_delta": {"energy": -1}},
         "cooldown": 60,
         "success": {"resource_min": {"energy": 80}},
+        "origin": "intrinsic",
     }
     path = tmp_path / "spec.json"
     path.write_text(json.dumps(spec_data), encoding="utf-8")
@@ -44,6 +46,7 @@ def test_load_extended_quest_fields(tmp_path):
     assert spec.reward["mood"] == "pleasure"
     assert spec.penalty["mood"] == "pain"
     assert spec.cooldown == 60
+    assert spec.origin == "intrinsic"
 
 
 @pytest.mark.parametrize(
@@ -63,5 +66,20 @@ def test_load_invalid_constraints(tmp_path, constraints):
     }
     path = tmp_path / "spec.json"
     path.write_text(json.dumps(spec_data), encoding="utf-8")
+    with pytest.raises(quest.SpecValidationError):
+        quest.load(path)
+
+
+def test_load_invalid_origin(tmp_path):
+    spec_data = {
+        "name": "adder",
+        "signature": "adder(a, b)",
+        "examples": [{"input": [1, 2], "output": 3}],
+        "constraints": {"pure": True, "no_import": True, "time_ms_max": 50},
+        "origin": "human",
+    }
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(spec_data), encoding="utf-8")
+
     with pytest.raises(quest.SpecValidationError):
         quest.load(path)

--- a/tests/test_quest_generation.py
+++ b/tests/test_quest_generation.py
@@ -1,0 +1,29 @@
+from singular.goals.quest_generation import generate_quests
+
+
+def test_generate_quests_mixes_intrinsic_and_external_pressures() -> None:
+    quests = generate_quests(
+        psyche_traits={"resilience": 0.2, "optimism": 0.3, "curiosity": 0.8},
+        outcomes_history={"recent_successes": 1, "recent_failures": 4},
+        value_performance_tension={"score": 0.75},
+        world_state={"delayed_crisis_pressure": 0.7, "opportunity_pressure": 0.65},
+        resources={"energy": 20, "food": 25, "warmth": 30},
+    )
+
+    assert quests
+    origins = {item.origin for item in quests}
+    assert "intrinsic" in origins
+    assert "external" in origins
+    assert quests == sorted(quests, key=lambda item: item.priority, reverse=True)
+
+
+def test_generate_quests_returns_empty_for_stable_state() -> None:
+    quests = generate_quests(
+        psyche_traits={"resilience": 0.8, "optimism": 0.9, "curiosity": 0.2},
+        outcomes_history={"recent_successes": 5, "recent_failures": 0},
+        value_performance_tension=0.1,
+        world_state={"delayed_crisis_pressure": 0.1, "opportunity_pressure": 0.1},
+        resources={"energy": 90, "food": 85, "warmth": 95},
+    )
+
+    assert quests == []


### PR DESCRIPTION
### Motivation

- Provide a small, testable generator to propose quests from internal psyche signals, execution outcome history, value-vs-performance tension, and world/resource pressures.  
- Track and persist the provenance of quests (`intrinsic` vs `external`) so runtime logic and observability can distinguish self-generated objectives from externally authored ones.

### Description

- Add `src/singular/goals/quest_generation.py` implementing `GeneratedQuest` and `generate_quests(...)` to produce ranked candidate quests from `psyche_traits`, `outcomes_history`, `value_performance_tension`, `world_state`, and `resources`.  
- Export `GeneratedQuest` and `generate_quests` via `src/singular/goals/__init__.py` for upstream use.  
- Extend quest spec model `Spec` in `src/singular/life/quest.py` with an `origin` field defaulting to `"external"` and validate it accepts only `"intrinsic"` or `"external"`.  
- Persist `origin` on runtime records by adding `origin` to `QuestRecord` and wiring it through `src/singular/quests.py` during load, activation and completion so `mem/quests_state.json` includes provenance.

### Testing

- Added unit tests in `tests/test_quest_generation.py` and extended `tests/test_quest.py` and `tests/test_orchestrator_service.py` to cover generation behavior, `origin` validation, and persistence during trigger+settle.  
- Ran `pytest -q tests/test_quest.py tests/test_quest_generation.py tests/test_orchestrator_service.py::test_orchestrator_triggers_and_settles_quest` and observed all tests pass (9 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deb7210410832a992df52f222e8585)