### PR TITLE
Expose objective trajectory in status and dashboard

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -117,6 +117,113 @@ def create_app(
             return float(value)
         return None
 
+    def _extract_objective_priorities(record: dict[str, object]) -> dict[str, float]:
+        candidates = (
+            record.get("objective_priorities"),
+            record.get("objective_weights"),
+            record.get("objectives"),
+        )
+        for candidate in candidates:
+            if not isinstance(candidate, dict):
+                continue
+            parsed: dict[str, float] = {}
+            for key, value in candidate.items():
+                if not isinstance(key, str):
+                    continue
+                if isinstance(value, (int, float)):
+                    parsed[key] = float(value)
+                elif isinstance(value, dict):
+                    nested_priority = value.get("priority")
+                    if isinstance(nested_priority, (int, float)):
+                        parsed[key] = float(nested_priority)
+            if parsed:
+                return parsed
+        return {}
+
+    def _build_trajectory(records: list[dict[str, object]]) -> dict[str, object]:
+        active: list[dict[str, object]] = []
+        paused: list[dict[str, object]] = []
+        completed: list[dict[str, object]] = []
+        if quests_path.exists():
+            try:
+                quests_data = json.loads(quests_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                quests_data = {}
+            if isinstance(quests_data, dict):
+                active = quests_data.get("active") if isinstance(quests_data.get("active"), list) else []
+                paused = quests_data.get("paused") if isinstance(quests_data.get("paused"), list) else []
+                completed = quests_data.get("completed") if isinstance(quests_data.get("completed"), list) else []
+
+        objective_status: dict[str, str] = {}
+        for item in active:
+            if isinstance(item, dict) and isinstance(item.get("name"), str):
+                objective_status[item["name"]] = "in_progress"
+        for item in paused:
+            if isinstance(item, dict) and isinstance(item.get("name"), str):
+                objective_status[item["name"]] = "abandoned"
+        for item in completed:
+            if isinstance(item, dict) and isinstance(item.get("name"), str):
+                objective_status[item["name"]] = "completed"
+
+        previous: dict[str, float] = {}
+        priority_changes: list[dict[str, object]] = []
+        for record in records:
+            priorities = _extract_objective_priorities(record)
+            if not priorities:
+                continue
+            ts = record.get("ts") if isinstance(record.get("ts"), str) else None
+            for objective, new_value in priorities.items():
+                old_value = previous.get(objective)
+                if old_value is None:
+                    previous[objective] = new_value
+                    continue
+                if abs(new_value - old_value) >= 0.01:
+                    priority_changes.append(
+                        {
+                            "objective": objective,
+                            "at": ts,
+                            "from": round(old_value, 4),
+                            "to": round(new_value, 4),
+                            "delta": round(new_value - old_value, 4),
+                        }
+                    )
+                    previous[objective] = new_value
+
+        links: list[dict[str, object]] = []
+        major_events = {"death", "interaction", "quest", "quest_triggered", "quest_resolved", "consciousness"}
+        for record in records:
+            event = record.get("event")
+            if not isinstance(event, str):
+                continue
+            if event not in major_events and not isinstance(record.get("self_narrative_event"), str):
+                continue
+            objective = record.get("objective")
+            if not isinstance(objective, str):
+                continue
+            links.append(
+                {
+                    "objective": objective,
+                    "event": record.get("self_narrative_event", event),
+                    "at": record.get("ts") if isinstance(record.get("ts"), str) else None,
+                    "run": _record_run_id(record),
+                }
+            )
+
+        return {
+            "objectives": {
+                "counts": {
+                    "in_progress": sum(1 for status in objective_status.values() if status == "in_progress"),
+                    "abandoned": sum(1 for status in objective_status.values() if status == "abandoned"),
+                    "completed": sum(1 for status in objective_status.values() if status == "completed"),
+                },
+                "in_progress": [name for name, status in objective_status.items() if status == "in_progress"],
+                "abandoned": [name for name, status in objective_status.items() if status == "abandoned"],
+                "completed": [name for name, status in objective_status.items() if status == "completed"],
+            },
+            "priority_changes": priority_changes[-40:],
+            "objective_narrative_links": links[-40:],
+        }
+
     def _record_run_id(record: dict[str, object]) -> str:
         run_id = record.get("run_id")
         if isinstance(run_id, str) and run_id:
@@ -469,6 +576,7 @@ def create_app(
                 ),
                 "skills_lifecycle": _skill_lifecycle_summary(),
                 "daily_skills": build_daily_skills_snapshot([]),
+                "trajectory": _build_trajectory([]),
             }
             return empty
 
@@ -566,18 +674,10 @@ def create_app(
         else:
             circadian_phase = "nuit"
 
-        active_objectives: list[dict[str, object]] = []
-        if quests_path.exists():
-            try:
-                quests_data = json.loads(quests_path.read_text(encoding="utf-8"))
-            except json.JSONDecodeError:
-                quests_data = {}
-            if isinstance(quests_data, dict):
-                raw_active = quests_data.get("active")
-                if isinstance(raw_active, list):
-                    for entry in raw_active:
-                        if isinstance(entry, dict):
-                            active_objectives.append(entry)
+        trajectory = _build_trajectory(records)
+        objectives = trajectory.get("objectives", {}) if isinstance(trajectory.get("objectives"), dict) else {}
+        in_progress_names = objectives.get("in_progress") if isinstance(objectives.get("in_progress"), list) else []
+        active_objectives = [{"name": name} for name in in_progress_names if isinstance(name, str)]
 
         accepted_count = sum(1 for value in accepted_values if value is True)
         rejected_count = sum(1 for value in accepted_values if value is False)
@@ -641,6 +741,7 @@ def create_app(
             "vital_timeline": vital_timeline,
             "skills_lifecycle": _skill_lifecycle_summary(),
             "daily_skills": build_daily_skills_snapshot(records),
+            "trajectory": trajectory,
         }
 
 

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -159,6 +159,21 @@
   </div>
 
   <div class='panel'>
+    <h3 style='margin-top:0;'>Trajectory des objectifs</h3>
+    <div class='cards-grid'>
+      <div class='card'><div class='card-label'>En cours</div><div id='kpi-trajectory-in-progress' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Abandonnés</div><div id='kpi-trajectory-abandoned' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Complétés</div><div id='kpi-trajectory-completed' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Changements priorité</div><div id='kpi-trajectory-priority-count' class='card-value'>0</div></div>
+      <div class='card'><div class='card-label'>Liens narratifs</div><div id='kpi-trajectory-links-count' class='card-value'>0</div></div>
+    </div>
+    <h4 style='margin-bottom:6px;'>Derniers changements de priorité</h4>
+    <ul id='kpi-priority-changes-list' style='margin-top:0;'></ul>
+    <h4 style='margin-bottom:6px;'>Liens objectifs ↔ événements majeurs</h4>
+    <ul id='kpi-objective-links-list' style='margin-top:0;'></ul>
+  </div>
+
+  <div class='panel'>
     <h3 style='margin-top:0;'>Cycle de vie des skills</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Skills actives</div><div id='kpi-skills-active' class='card-value'>0</div></div>
@@ -556,6 +571,11 @@ const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=
   const skillLifecycle=d.skills_lifecycle||{};
   const vitalMetrics=d.vital_metrics||{};
   const objectives=vitalMetrics.active_objectives||{};
+  const trajectory=d.trajectory||{};
+  const trajectoryObjectives=trajectory.objectives||{};
+  const trajectoryCounts=trajectoryObjectives.counts||{};
+  const priorityChanges=trajectory.priority_changes||[];
+  const objectiveLinks=trajectory.objective_narrative_links||[];
   const energyResources=vitalMetrics.energy_resources||{};
   const codeGeneration=vitalMetrics.code_generation||{};
   const risks=vitalMetrics.risks||[];
@@ -582,6 +602,27 @@ const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=
     objectivesList.appendChild(li);
   }
   if(!(objectives.items||[]).length){const li=document.createElement('li');li.textContent='Aucun objectif actif';objectivesList.appendChild(li);}
+  document.getElementById('kpi-trajectory-in-progress').textContent=String(trajectoryCounts.in_progress||0);
+  document.getElementById('kpi-trajectory-abandoned').textContent=String(trajectoryCounts.abandoned||0);
+  document.getElementById('kpi-trajectory-completed').textContent=String(trajectoryCounts.completed||0);
+  document.getElementById('kpi-trajectory-priority-count').textContent=String(priorityChanges.length||0);
+  document.getElementById('kpi-trajectory-links-count').textContent=String(objectiveLinks.length||0);
+  const priorityList=document.getElementById('kpi-priority-changes-list');
+  priorityList.innerHTML='';
+  for(const change of priorityChanges.slice(-5).reverse()){
+    const li=document.createElement('li');
+    li.textContent=`${change.objective||'objectif'} · ${change.from??'n/a'} → ${change.to??'n/a'} (${change.at||'n/a'})`;
+    priorityList.appendChild(li);
+  }
+  if(!priorityChanges.length){const li=document.createElement('li');li.textContent='Aucun changement détecté';priorityList.appendChild(li);}
+  const linksList=document.getElementById('kpi-objective-links-list');
+  linksList.innerHTML='';
+  for(const link of objectiveLinks.slice(-5).reverse()){
+    const li=document.createElement('li');
+    li.textContent=`${link.objective||'objectif'} ↔ ${link.event||'événement'} (${link.at||'n/a'})`;
+    linksList.appendChild(li);
+  }
+  if(!objectiveLinks.length){const li=document.createElement('li');li.textContent='Aucun lien narratif détecté';linksList.appendChild(li);}
   setStatusTone(document.getElementById('kpi-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
 
   const notable=d.last_notable_mutation;

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -52,16 +52,123 @@ def _fmt_number(value: object, unit: str = "") -> str:
 def _read_quest_status() -> dict[str, object]:
     path = get_mem_dir() / "quests_state.json"
     if not path.exists():
-        return {"active": [], "completed": []}
+        return {"active": [], "paused": [], "completed": []}
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return {"active": [], "completed": []}
+        return {"active": [], "paused": [], "completed": []}
     if not isinstance(payload, dict):
-        return {"active": [], "completed": []}
+        return {"active": [], "paused": [], "completed": []}
     active = payload.get("active") if isinstance(payload.get("active"), list) else []
+    paused = payload.get("paused") if isinstance(payload.get("paused"), list) else []
     completed = payload.get("completed") if isinstance(payload.get("completed"), list) else []
-    return {"active": active, "completed": completed[-20:]}
+    return {"active": active, "paused": paused, "completed": completed[-20:]}
+
+
+def _extract_objective_priorities(record: dict[str, object]) -> dict[str, float]:
+    candidates = (
+        record.get("objective_priorities"),
+        record.get("objective_weights"),
+        record.get("objectives"),
+    )
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        parsed: dict[str, float] = {}
+        for key, value in candidate.items():
+            if not isinstance(key, str):
+                continue
+            if isinstance(value, (int, float)):
+                parsed[key] = float(value)
+            elif isinstance(value, dict):
+                nested_priority = value.get("priority")
+                if isinstance(nested_priority, (int, float)):
+                    parsed[key] = float(nested_priority)
+        if parsed:
+            return parsed
+    return {}
+
+
+def _build_trajectory_payload(
+    *,
+    records: list[dict[str, object]],
+    quests: dict[str, object],
+) -> dict[str, object]:
+    active = quests.get("active") if isinstance(quests.get("active"), list) else []
+    paused = quests.get("paused") if isinstance(quests.get("paused"), list) else []
+    completed = quests.get("completed") if isinstance(quests.get("completed"), list) else []
+
+    objective_status: dict[str, str] = {}
+    for item in active:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            objective_status[item["name"]] = "in_progress"
+    for item in paused:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            objective_status[item["name"]] = "abandoned"
+    for item in completed:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            objective_status[item["name"]] = "completed"
+
+    objective_counts = {
+        "in_progress": sum(1 for status in objective_status.values() if status == "in_progress"),
+        "abandoned": sum(1 for status in objective_status.values() if status == "abandoned"),
+        "completed": sum(1 for status in objective_status.values() if status == "completed"),
+    }
+
+    previous: dict[str, float] = {}
+    priority_changes: list[dict[str, object]] = []
+    for record in records:
+        priorities = _extract_objective_priorities(record)
+        if not priorities:
+            continue
+        ts = record.get("ts")
+        for objective, new_value in priorities.items():
+            old_value = previous.get(objective)
+            if old_value is None:
+                previous[objective] = new_value
+                continue
+            if abs(new_value - old_value) >= 0.01:
+                priority_changes.append(
+                    {
+                        "objective": objective,
+                        "at": ts if isinstance(ts, str) else None,
+                        "from": round(old_value, 4),
+                        "to": round(new_value, 4),
+                        "delta": round(new_value - old_value, 4),
+                    }
+                )
+                previous[objective] = new_value
+
+    narrative_links: list[dict[str, object]] = []
+    major_events = {"death", "interaction", "quest", "quest_triggered", "quest_resolved", "consciousness"}
+    for record in records:
+        event = record.get("event")
+        if not isinstance(event, str):
+            continue
+        if event not in major_events and not isinstance(record.get("self_narrative_event"), str):
+            continue
+        objective = record.get("objective")
+        if not isinstance(objective, str):
+            continue
+        narrative_links.append(
+            {
+                "objective": objective,
+                "event": record.get("self_narrative_event", event),
+                "at": record.get("ts") if isinstance(record.get("ts"), str) else None,
+                "run": record.get("_run_file") if isinstance(record.get("_run_file"), str) else None,
+            }
+        )
+
+    return {
+        "objectives": {
+            "counts": objective_counts,
+            "in_progress": [name for name, status in objective_status.items() if status == "in_progress"],
+            "abandoned": [name for name, status in objective_status.items() if status == "abandoned"],
+            "completed": [name for name, status in objective_status.items() if status == "completed"],
+        },
+        "priority_changes": priority_changes[-40:],
+        "objective_narrative_links": narrative_links[-40:],
+    }
 
 
 def _read_skill_lifecycle_status() -> dict[str, object]:
@@ -101,7 +208,17 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "mood": None,
         "traits": {},
         "autonomy_metrics": {},
-        "quests": {"active": [], "completed": []},
+        "quests": {"active": [], "paused": [], "completed": []},
+        "trajectory": {
+            "objectives": {
+                "counts": {"in_progress": 0, "abandoned": 0, "completed": 0},
+                "in_progress": [],
+                "abandoned": [],
+                "completed": [],
+            },
+            "priority_changes": [],
+            "objective_narrative_links": [],
+        },
         "skills_lifecycle": {
             "active": 0,
             "dormant": 0,
@@ -131,11 +248,11 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "aggregates": host_aggregates,
         "impact": summarize_environmental_impact(host_aggregates),
     }
+    all_records: list[dict[str, object]] = []
     runs_dir = Path(RUNS_DIR)
     files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
     if files:
         latest = files[-1]
-        all_records: list[dict[str, object]] = []
         for run_file in files:
             with run_file.open(encoding="utf-8") as fh:
                 for line in fh:
@@ -215,6 +332,10 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     mood = psyche.last_mood.value if psyche.last_mood else "neutral"
     payload["mood"] = mood
     payload["quests"] = _read_quest_status()
+    payload["trajectory"] = _build_trajectory_payload(
+        records=all_records if "all_records" in locals() else [],
+        quests=payload["quests"] if isinstance(payload["quests"], dict) else {},
+    )
     payload["skills_lifecycle"] = _read_skill_lifecycle_status()
     payload["traits"] = {
         "curiosity": round(psyche.curiosity, 2),

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -205,6 +205,10 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert "code_generation" in payload["vital_metrics"]
     assert "risks" in payload["vital_metrics"]
     assert "skills_lifecycle" in payload
+    assert "trajectory" in payload
+    assert "objectives" in payload["trajectory"]
+    assert "priority_changes" in payload["trajectory"]
+    assert "objective_narrative_links" in payload["trajectory"]
 
 
 def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
@@ -246,6 +250,9 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Nombre de vies détectées" in body
     assert "Quêtes" in body
     assert "Cycle circadien & objectifs actifs" in body
+    assert "Trajectory des objectifs" in body
+    assert "kpi-trajectory-in-progress" in body
+    assert "kpi-priority-changes-list" in body
     assert "Cycle de vie des skills" in body
     assert "Énergie / ressources & génération de code" in body
     assert "Fenêtre temporelle" in body

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -123,6 +123,7 @@ def test_status_exposes_quest_counts(tmp_path, monkeypatch, capsys) -> None:
         json.dumps(
             {
                 "active": [{"name": "q1", "status": "active", "started_at": "2026-01-01T00:00:00+00:00"}],
+                "paused": [{"name": "q2", "status": "paused", "started_at": "2026-01-01T00:00:00+00:00"}],
                 "completed": [{"name": "q0", "status": "success", "started_at": "2026-01-01T00:00:00+00:00", "completed_at": "2026-01-01T00:01:00+00:00"}],
             }
         ),
@@ -146,7 +147,58 @@ def test_status_exposes_quest_counts(tmp_path, monkeypatch, capsys) -> None:
     status_mod.status(output_format="json")
     payload = json.loads(capsys.readouterr().out)
     assert len(payload["quests"]["active"]) == 1
+    assert len(payload["quests"]["paused"]) == 1
     assert len(payload["quests"]["completed"]) == 1
+    assert payload["trajectory"]["objectives"]["counts"]["in_progress"] == 1
+    assert payload["trajectory"]["objectives"]["counts"]["abandoned"] == 1
+    assert payload["trajectory"]["objectives"]["counts"]["completed"] == 1
+
+
+def test_status_exposes_trajectory_priority_and_narrative_links(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    run_file = tmp_path / "demo.jsonl"
+    with run_file.open("w", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "ts": "2026-04-12T10:00:00+00:00",
+                    "objective_weights": {"coherence": 0.4},
+                }
+            )
+            + "\n"
+        )
+        fh.write(
+            json.dumps(
+                {
+                    "ts": "2026-04-12T10:05:00+00:00",
+                    "objective_weights": {"coherence": 0.7},
+                    "event": "consciousness",
+                    "objective": "coherence",
+                }
+            )
+            + "\n"
+        )
+
+    class DummyPsyche:
+        last_mood = None
+        curiosity = 0.5
+        patience = 0.5
+        playfulness = 0.5
+        optimism = 0.5
+        resilience = 0.5
+
+    monkeypatch.setattr(status_mod, "RUNS_DIR", tmp_path)
+    monkeypatch.setattr(
+        status_mod.Psyche, "load_state", staticmethod(lambda: DummyPsyche())
+    )
+
+    status_mod.status(output_format="json")
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["trajectory"]["priority_changes"]
+    assert payload["trajectory"]["priority_changes"][0]["objective"] == "coherence"
+    assert payload["trajectory"]["objective_narrative_links"]
+    assert payload["trajectory"]["objective_narrative_links"][0]["objective"] == "coherence"
 
 
 def test_status_exposes_skill_lifecycle_counts(tmp_path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
### Motivation
- Surface objective lifecycle and history so operators can see which objectives are in-progress, abandoned or completed, how objective priorities changed over time, and which major narrative events are linked to objectives.
- Make the same information available via the `status` CLI payload and the dashboard cockpit so the UI can render an objectives "trajectory" view.

### Description
- Added trajectory extraction helpers (`_extract_objective_priorities`, `_build_trajectory_payload`) and included a `trajectory` section in the `status` JSON payload returned by `status()` in `src/singular/organisms/status.py`.
- Extended the cockpit backend in `src/singular/dashboard/__init__.py` to compute the same `trajectory` model from run records and quests, exposing it in the `/api/cockpit` response via `_build_trajectory`.
- Updated quest state reading to include `paused` objectives and map them to the `abandoned` trajectory bucket when building the trajectory payload (files: `src/singular/organisms/status.py`, `src/singular/dashboard/__init__.py`).
- Added a new UI panel and client-side rendering to the dashboard template to display trajectory KPIs, recent priority changes and objective↔narrative links (`src/singular/dashboard/templates/dashboard.html`).
- Added and updated tests to validate the `trajectory` schema and UI presence (`tests/test_status.py`, `tests/test_dashboard.py`).

### Testing
- Ran `pytest tests/test_status.py tests/test_dashboard.py` which executed the new and updated tests.
- Result: all tests passed (`26 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69debef4cd30832a98230be00dfa9e8f)