### PR TITLE
Add auditable birth artifacts (initial snapshot, birth certificate, biography)

### DIFF
--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -6,10 +6,14 @@ import os
 import random
 import string
 import json
+import hashlib
+from datetime import datetime, timezone
 from math import isfinite
 from pathlib import Path
 from typing import Any
 
+from ..environment.sim_world import default_world_state, save_world_state
+from ..goals.intrinsic import GoalState
 from ..governance.values import ValueWeights
 from ..identity import create_identity
 from ..memory import ensure_memory_structure, update_score, write_profile
@@ -20,6 +24,7 @@ from ..life.skill_catalog import refresh_skill_catalog
 _PSYCHE_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
 _PSYCHE_DEFAULTS = {trait: 0.5 for trait in _PSYCHE_TRAITS}
 _DEFAULT_STARTER_PROFILE = "minimal"
+_BIRTH_SCHEMA_VERSION = 1
 _STARTER_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "starter_skills.yaml"
 _DEFAULT_STARTER_PROFILES: dict[str, list[str]] = {
     "minimal": ["addition", "subtraction", "multiplication"],
@@ -188,6 +193,47 @@ def _resolve_starter_skills(
     return ordered
 
 
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def _build_birth_snapshot(
+    *,
+    identity_payload: dict[str, Any],
+    psyche_payload: dict[str, Any],
+    values_payload: dict[str, Any],
+    goals_payload: dict[str, Any],
+    world_payload: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    initial_state = {
+        "identity": identity_payload,
+        "psyche": psyche_payload,
+        "values": values_payload,
+        "goals": goals_payload,
+        "world": world_payload,
+    }
+    canonical = json.dumps(initial_state, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    checksum = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    snapshot = {
+        "schema_version": _BIRTH_SCHEMA_VERSION,
+        "created_at": _now_iso(),
+        "initial_state_checksum": checksum,
+        "initial_state": initial_state,
+    }
+    return snapshot, checksum
+
+
 def birth(
     seed: int | None = None,
     home: Path | None = None,
@@ -260,3 +306,56 @@ def birth(
     # Initialize the psyche with validated traits and save its state
     psyche = Psyche(**initial_traits)
     psyche.save_state(path=home / "mem" / "psyche.json")
+
+    birth_time = _now_iso()
+    mem_dir = home / "mem"
+    values_defaults = ValueWeights().to_dict()
+    goals_init = GoalState().to_dict()
+    world_init = default_world_state()
+    save_world_state(world_init, path=mem_dir / "world_state.json")
+    _atomic_write_json(mem_dir / "world_effects.json", {"schema_version": 1, "events": []})
+
+    snapshot_payload, initial_checksum = _build_birth_snapshot(
+        identity_payload=identity.__dict__,
+        psyche_payload=json.loads((mem_dir / "psyche.json").read_text(encoding="utf-8")),
+        values_payload={"values": values_defaults},
+        goals_payload={"schema_version": 1, **goals_init},
+        world_payload={"schema_version": 1, **world_init},
+    )
+    _atomic_write_json(mem_dir / "initial_snapshot.json", snapshot_payload)
+
+    summary_text = (
+        f"Naissance: {identity.name} initialisé·e avec une psyché stable, "
+        "des objectifs intrinsèques équilibrés et un monde de départ prêt."
+    )
+    birth_certificate = {
+        "schema_version": _BIRTH_SCHEMA_VERSION,
+        "event_type": "birth_certificate",
+        "issued_at": birth_time,
+        "identity": {"id": identity.id, "name": identity.name, "soulseed": identity.soulseed},
+        "artifacts": {
+            "initial_snapshot": "mem/initial_snapshot.json",
+            "psyche_state": "mem/psyche.json",
+            "profile": "mem/profile.json",
+            "world_state": "mem/world_state.json",
+        },
+        "self_summary": {"title": "naissance", "text": summary_text},
+        "initial_state_checksum": initial_checksum,
+    }
+    _append_jsonl(mem_dir / "life_events.jsonl", birth_certificate)
+
+    biography_payload = {
+        "schema_version": _BIRTH_SCHEMA_VERSION,
+        "identity": {"id": identity.id, "name": identity.name},
+        "birth_certificate": birth_certificate,
+        "self_summaries": [
+            {
+                "schema_version": _BIRTH_SCHEMA_VERSION,
+                "title": "naissance",
+                "text": summary_text,
+                "created_at": birth_time,
+                "initial_state_checksum": initial_checksum,
+            }
+        ],
+    }
+    _atomic_write_json(mem_dir / "biography.json", biography_payload)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -30,7 +30,18 @@ def test_birth_creates_memory_files(tmp_path: Path) -> None:
     birth(home=tmp_path)
     mem = tmp_path / "mem"
     assert mem.is_dir()
-    for name in ["profile.json", "values.yaml", "episodic.jsonl", "skills.json", "skill_catalog.json"]:
+    for name in [
+        "profile.json",
+        "values.yaml",
+        "episodic.jsonl",
+        "skills.json",
+        "skill_catalog.json",
+        "initial_snapshot.json",
+        "life_events.jsonl",
+        "biography.json",
+        "world_state.json",
+        "world_effects.json",
+    ]:
         assert (mem / name).exists()
 
 
@@ -46,15 +57,37 @@ def test_birth_initializes_identity_profile_and_psyche(tmp_path: Path) -> None:
     psyche_data = json.loads(
         (tmp_path / "mem" / "psyche.json").read_text(encoding="utf-8")
     )
-    assert psyche_data == {
-        "curiosity": 0.5,
-        "patience": 0.5,
-        "playfulness": 0.5,
-        "optimism": 0.5,
-        "resilience": 0.5,
-        "energy": 100.0,
-        "last_mood": None,
-    }
+    assert psyche_data["curiosity"] == 0.5
+    assert psyche_data["patience"] == 0.5
+    assert psyche_data["playfulness"] == 0.5
+    assert psyche_data["optimism"] == 0.5
+    assert psyche_data["resilience"] == 0.5
+    assert psyche_data["energy"] == 100.0
+    assert psyche_data["last_mood"] is None
+    assert psyche_data["schema_version"] >= 1
+
+
+def test_birth_writes_auditable_snapshot_certificate_and_summary(tmp_path: Path) -> None:
+    birth(seed=7, home=tmp_path)
+    mem_dir = tmp_path / "mem"
+
+    snapshot = json.loads((mem_dir / "initial_snapshot.json").read_text(encoding="utf-8"))
+    assert snapshot["schema_version"] == 1
+    assert snapshot["initial_state_checksum"]
+    assert set(snapshot["initial_state"]) == {"identity", "psyche", "values", "goals", "world"}
+
+    life_events = (mem_dir / "life_events.jsonl").read_text(encoding="utf-8").splitlines()
+    assert life_events
+    birth_event = json.loads(life_events[-1])
+    assert birth_event["schema_version"] == 1
+    assert birth_event["event_type"] == "birth_certificate"
+    assert birth_event["initial_state_checksum"] == snapshot["initial_state_checksum"]
+    assert birth_event["self_summary"]["title"] == "naissance"
+
+    biography = json.loads((mem_dir / "biography.json").read_text(encoding="utf-8"))
+    assert biography["schema_version"] == 1
+    assert biography["birth_certificate"]["event_type"] == "birth_certificate"
+    assert biography["self_summaries"][0]["title"] == "naissance"
 
 
 def test_add_episode(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Provide an auditable initial state at organism creation that captures identity, psyche, values, goals and world to support traceability and audits.
- Record a persistent birth event and a first self-summary so the life-history is immediately available for downstream features (reports, narratives, world simulation).

### Description
- `birth()` now builds a canonical initial snapshot (`mem/initial_snapshot.json`) containing `identity`, `psyche`, `values`, `goals` and `world`, and includes `schema_version` and a SHA-256 `initial_state_checksum` for auditability.
- The world initial state is explicitly initialized and persisted to `mem/world_state.json` and an empty `mem/world_effects.json` is created.
- A `birth_certificate` event is appended to `mem/life_events.jsonl` referencing the snapshot and embedding the initial `self_summary` titled `naissance`.
- A small `biography` file (`mem/biography.json`) is written with `schema_version`, the `birth_certificate` and the initial self-summary; tests were updated accordingly.

### Testing
- Ran `pytest -q tests/test_memory.py::test_birth_creates_memory_files tests/test_memory.py::test_birth_initializes_identity_profile_and_psyche tests/test_memory.py::test_birth_writes_auditable_snapshot_certificate_and_summary` and the three tests passed (`3 passed`).
- Ran `pytest -q tests/test_end_to_end.py tests/test_lives.py tests/test_birth_starter_profiles.py` and those suites passed (`12 passed`, with warnings reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec2b8ea08832a9369f47ca4cb62d5)