### PR TITLE
Handle extinction as terminal shutdown: autopsy, biography, stop signal, registry update, and event

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -13,10 +13,11 @@ import heapq
 import hashlib
 import os
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Dict, Iterable, Mapping
 
-from singular.cognition.reflect import ActionHypothesis, reflect_action
+from singular.cognition.reflect import ActionHypothesis, ReflectionDecision, reflect_action
 from singular.beliefs.store import BeliefStore
 from singular.beliefs.meta_learning import (
     extract_run_features,
@@ -40,6 +41,7 @@ from singular.environment.reputation import ReputationSystem
 from singular.environment.world_resources import CompetitorIntent, WorldResourcePool
 from singular.goals import IntrinsicGoals
 from singular.resource_manager import ResourceManager
+from singular.lives import load_registry, set_life_status
 
 from . import sandbox
 from .death import DeathMonitor
@@ -141,6 +143,97 @@ ACTION_TYPE_FROM_LOOP_EVENT: dict[str, str] = {
 CHECKPOINT_VERSION = 1
 HEALTH_HISTORY_FINE_WINDOW = 500
 HEALTH_HISTORY_AGGREGATE_EVERY = 10
+
+
+def _resolve_current_life_slug() -> str | None:
+    """Resolve current life slug from ``SINGULAR_HOME`` and the lives registry."""
+
+    life_home = Path(os.environ.get("SINGULAR_HOME", ".")).resolve()
+    registry = load_registry()
+    lives = registry.get("lives", {})
+    if not isinstance(lives, dict):
+        return None
+    for slug, metadata in lives.items():
+        life_path = getattr(metadata, "path", None)
+        if life_path is None:
+            continue
+        try:
+            if Path(life_path).resolve() == life_home:
+                return str(slug)
+        except OSError:
+            continue
+    return None
+
+
+def _write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _build_final_biography(*, reason: str, state: Checkpoint, psyche: Psyche) -> dict[str, object]:
+    mood = getattr(getattr(psyche, "last_mood", None), "value", None)
+    if mood is None and getattr(psyche, "last_mood", None) is not None:
+        mood = str(getattr(psyche, "last_mood"))
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "periods": [
+            {
+                "name": "émergence",
+                "start_iteration": 0,
+                "end_iteration": min(state.iteration, 10),
+            },
+            {
+                "name": "exploration",
+                "start_iteration": min(state.iteration, 11),
+                "end_iteration": max(state.iteration - 1, 0),
+            },
+            {
+                "name": "crépuscule",
+                "start_iteration": state.iteration,
+                "end_iteration": state.iteration,
+            },
+        ],
+        "turning_points": [
+            f"Extinction déclenchée à l'itération {state.iteration}: {reason}",
+        ],
+        "regrets_and_pride": {
+            "regrets": [f"Cause terminale: {reason}"],
+            "pride": [f"Dernière humeur observée: {mood or 'inconnue'}"],
+        },
+    }
+
+
+def _build_autopsy_report(
+    *,
+    reason: str,
+    state: Checkpoint,
+    health_snapshot: Mapping[str, float | int] | None,
+    reflection: ReflectionDecision,
+    psyche: Psyche,
+) -> dict[str, object]:
+    technical_causes = [f"monitor:{reason}"]
+    if health_snapshot:
+        health_score = health_snapshot.get("health_score")
+        if isinstance(health_score, (int, float)):
+            technical_causes.append(f"health_score={float(health_score):.3f}")
+    behavioral_causes = [f"decision_reason:{reflection.decision_reason}"]
+    mutation_policy = getattr(psyche, "mutation_policy", None)
+    if callable(mutation_policy):
+        try:
+            behavioral_causes.append(f"mutation_policy:{mutation_policy()}")
+        except TypeError:
+            pass
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "iteration": state.iteration,
+        "technical_causes": technical_causes,
+        "behavioral_causes": behavioral_causes,
+    }
 
 
 def _aggregate_health_bucket(
@@ -1380,18 +1473,61 @@ def run(
                 state.iteration, psyche, mutated_score <= base_score, org.resources
             )
             if dead:
-                logger.log_death(reason or "unknown", age=state.iteration)
+                death_reason = reason or "unknown"
+                logger.log_death(death_reason, age=state.iteration)
                 logger.log_interaction(
                     INTERACTION_EXTINCTION,
                     organism=org_name,
-                    reason=reason or "unknown",
+                    reason=death_reason,
                     alive=False,
                 )
-                org.energy = max(org.energy, 1.0)
-                org.resources = max(org.resources, 1.0)
-                org.monitor = DeathMonitor()
+                mem_dir = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem"
+                autopsy_payload = _build_autopsy_report(
+                    reason=death_reason,
+                    state=state,
+                    health_snapshot=health_snapshot.to_dict(),
+                    reflection=reflection,
+                    psyche=psyche,
+                )
+                autopsy_path = mem_dir / "autopsy.json"
+                _write_json(autopsy_path, autopsy_payload)
+
+                biography_payload = _build_final_biography(
+                    reason=death_reason,
+                    state=state,
+                    psyche=psyche,
+                )
+                biography_path = mem_dir / "biography.final.json"
+                _write_json(biography_path, biography_payload)
+
+                stop_payload = {
+                    "stop": True,
+                    "reason": "life_extinction_detected",
+                    "life": org_name,
+                    "requested_at": datetime.now(timezone.utc).isoformat(),
+                }
+                _write_json(mem_dir / "orchestrator.stop.json", stop_payload)
+
+                life_slug = _resolve_current_life_slug()
+                if life_slug:
+                    set_life_status(life_slug, "extinct")
+
+                event_bus.publish(
+                    "life.terminated",
+                    {
+                        "life": life_slug or org_name,
+                        "status": "extinct",
+                        "reason": death_reason,
+                        "iteration": state.iteration,
+                        "autopsy_path": str(autopsy_path),
+                        "biography_path": str(biography_path),
+                        "orchestrator_stop_path": str(mem_dir / "orchestrator.stop.json"),
+                    },
+                    payload_version=1,
+                )
+                save_checkpoint(checkpoint_path, state)
                 tick_count += 1
-                continue
+                break
 
             # Remove organisms with depleted stores
             to_remove = [

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -113,6 +113,7 @@ class OrchestratorService:
         self.base_dir = base_dir or get_base_dir()
         self.mem_dir = get_mem_dir()
         self.state_path = self.mem_dir / "orchestrator_state.json"
+        self.stop_signal_path = self.mem_dir / "orchestrator.stop.json"
         self.checkpoint_path = self.base_dir / "life_checkpoint.json"
         self.skills_dir = self.base_dir / "skills"
         self.resources_path = self.base_dir / "resources.json"
@@ -680,6 +681,10 @@ class OrchestratorService:
 
         try:
             while self._running:
+                if self.stop_signal_path.exists():
+                    log.info("orchestrator stop requested via %s", self.stop_signal_path)
+                    self._running = False
+                    break
                 self.tick()
                 if self._external_stimulus_detected():
                     continue

--- a/tests/test_death.py
+++ b/tests/test_death.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import singular.life.loop as life_loop
 from singular.life.loop import run
 from singular.life.death import DeathMonitor
+from singular.events import EventBus
 
 
 def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
@@ -86,7 +87,7 @@ def test_death_by_age(tmp_path: Path, monkeypatch):
 
     assert state.iteration >= 2
     log = _read_log(tmp_path)
-    assert log[-1]["event"] == "death"
+    assert any(entry.get("event") == "death" for entry in log)
     episodes = episodic.read_text().splitlines()
     assert any(json.loads(line)["event"] == "death" for line in episodes)
 
@@ -110,7 +111,7 @@ def test_death_by_failures(tmp_path: Path, monkeypatch):
 
     assert state.iteration >= 2
     log = _read_log(tmp_path)
-    assert log[-1]["event"] == "death"
+    assert any(entry.get("event") == "death" for entry in log)
 
 
 def test_death_by_traits(tmp_path: Path, monkeypatch):
@@ -151,4 +152,70 @@ def test_death_by_traits(tmp_path: Path, monkeypatch):
 
     assert state.iteration == 1
     log = _read_log(tmp_path)
-    assert log[-1]["event"] == "death"
+    assert any(entry.get("event") == "death" for entry in log)
+
+
+def test_extinction_generates_terminal_artifacts_and_status(tmp_path: Path, monkeypatch):
+    skills_dir, ckpt = _setup(tmp_path)
+    _patch_logger(monkeypatch, tmp_path)
+    _patch_memory(monkeypatch, tmp_path)
+
+    life_home = tmp_path / "life-home"
+    (life_home / "mem").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life_home))
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+
+    registry_dir = tmp_path / "lives"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    (registry_dir / "registry.json").write_text(
+        json.dumps(
+            {
+                "active": "life-a",
+                "lives": {
+                    "life-a": {
+                        "name": "Life A",
+                        "slug": "life-a",
+                        "path": str(life_home),
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "status": "active",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    bus = EventBus()
+    terminal_events: list[dict[str, object]] = []
+    bus.subscribe("life.terminated", lambda event: terminal_events.append(event.payload))
+
+    monitor = DeathMonitor(max_age=1, max_failures=99, min_trait=0.0)
+    run(
+        skills_dir,
+        ckpt,
+        budget_seconds=10.0,
+        rng=random.Random(0),
+        run_id="loop",
+        operators={"inc": _inc_operator},
+        mortality=monitor,
+        event_bus=bus,
+    )
+
+    autopsy = json.loads((life_home / "mem" / "autopsy.json").read_text(encoding="utf-8"))
+    assert autopsy["technical_causes"]
+    assert autopsy["behavioral_causes"]
+
+    biography = json.loads((life_home / "mem" / "biography.final.json").read_text(encoding="utf-8"))
+    assert biography["periods"]
+    assert biography["turning_points"]
+    assert biography["regrets_and_pride"]["regrets"]
+    assert biography["regrets_and_pride"]["pride"]
+
+    stop_signal = json.loads((life_home / "mem" / "orchestrator.stop.json").read_text(encoding="utf-8"))
+    assert stop_signal["stop"] is True
+
+    updated_registry = json.loads((registry_dir / "registry.json").read_text(encoding="utf-8"))
+    assert updated_registry["lives"]["life-a"]["status"] == "extinct"
+
+    assert terminal_events
+    assert terminal_events[-1]["status"] == "extinct"

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -250,6 +250,23 @@ routines:
     assert routine_tasks[0]["priority"] > 90
 
 
+def test_orchestrator_run_forever_stops_on_stop_signal(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "mem").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+
+    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+    service.stop_signal_path.write_text('{"stop": true}', encoding="utf-8")
+
+    called = {"tick": 0}
+    monkeypatch.setattr(service, "tick", lambda: called.__setitem__("tick", called["tick"] + 1))
+
+    service.run_forever()
+
+    assert called["tick"] == 0
+
+
 def test_orchestrator_introspection_refreshes_self_narrative(monkeypatch, tmp_path: Path) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)


### PR DESCRIPTION
### Motivation
- When an organism dies the system should perform an explicit terminal shutdown flow that records technical and behavioural causes, produces a compact final biography, marks the life as extinct in the registry and notifies downstream systems that the life terminated.

### Description
- Added lifecycle terminal handling in `run` (life loop) so that on death the loop writes `mem/autopsy.json`, `mem/biography.final.json` and `mem/orchestrator.stop.json`, publishes a `life.terminated` event and stops the run instead of silently continuing; this includes helper functions ` _resolve_current_life_slug`, `_write_json`, `_build_final_biography` and `_build_autopsy_report` in `src/singular/life/loop.py`.
- Mark the registry entry for the current life as `extinct` by calling `set_life_status` when a matching life slug is found (uses `load_registry` to resolve slug).
- Make `OrchestratorService.run_forever()` respect a stop-signal file by checking for `mem/orchestrator.stop.json` and exiting cleanly if present (`src/singular/orchestrator/service.py`).
- Tests updated and added: `tests/test_death.py` relaxed death assertions and added `test_extinction_generates_terminal_artifacts_and_status`, and `tests/test_orchestrator_service.py` adds `test_orchestrator_run_forever_stops_on_stop_signal`.

### Testing
- Ran `pytest -q tests/test_death.py tests/test_orchestrator_service.py` and all tests passed (`14 passed, 46 warnings`).
- New/updated tests verify generation of autopsy and biography files, creation of `orchestrator.stop.json`, registry status update to `extinct`, emission of the `life.terminated` event, and orchestrator stop-on-signal behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec3ad5b4c832a8b7f0cca86b7d387)