### PR TITLE
Add inheritance policy and audited legacy transfers for cloned lives

### DIFF
--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -13,10 +13,12 @@ from pathlib import Path
 from typing import Any, Dict
 
 from .governance.policy import MutationGovernancePolicy
+from .memory import _append_jsonl_line
 
 _REGISTRY_DIRNAME = "lives"
 _REGISTRY_FILENAME = "registry.json"
 _RELATIONS_JOURNAL = "lives_relations.jsonl"
+_LEGACY_TRANSFERS_JOURNAL = "legacy_transfers.jsonl"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,6 +76,43 @@ class LifeMetadata:
         )
 
 
+@dataclass(frozen=True)
+class InheritancePolicy:
+    """Describe which artefacts can be transferred to a new life."""
+
+    memory_summary_max_entries: int = 25
+    sensitive_memory_keys: tuple[str, ...] = (
+        "password",
+        "secret",
+        "token",
+        "api_key",
+        "private_key",
+        "email",
+        "phone",
+        "address",
+        "hostname",
+        "cwd",
+        "path",
+        "username",
+        "user",
+    )
+    inherit_only_flagged_skills: bool = True
+    inheritable_skill_flag: str = "inheritable"
+    aggregate_lessons_limit: int = 10
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "memory_summary_max_entries": self.memory_summary_max_entries,
+            "sensitive_memory_keys": list(self.sensitive_memory_keys),
+            "inherit_only_flagged_skills": self.inherit_only_flagged_skills,
+            "inheritable_skill_flag": self.inheritable_skill_flag,
+            "aggregate_lessons_limit": self.aggregate_lessons_limit,
+        }
+
+
+DEFAULT_INHERITANCE_POLICY = InheritancePolicy()
+
+
 def _registry_path(root: Path | None = None) -> Path:
     root = root or get_registry_root()
     return root / _REGISTRY_DIRNAME / _REGISTRY_FILENAME
@@ -85,6 +124,10 @@ def _now_iso() -> str:
 
 def _relations_journal_path() -> Path:
     return get_registry_root() / "mem" / _RELATIONS_JOURNAL
+
+
+def _legacy_transfers_journal_path() -> Path:
+    return get_registry_root() / "mem" / _LEGACY_TRANSFERS_JOURNAL
 
 
 def _log_relations_event(event: str, *, actor: str, target: str | None = None, details: dict[str, Any] | None = None) -> None:
@@ -99,6 +142,153 @@ def _log_relations_event(event: str, *, actor: str, target: str | None = None, d
     }
     with journal.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def _log_legacy_transfer(
+    *,
+    source: str,
+    target: str,
+    reason: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    _append_jsonl_line(
+        _legacy_transfers_journal_path(),
+        {
+            "ts": _now_iso(),
+            "source": source,
+            "target": target,
+            "reason": reason,
+            "payload": payload or {},
+        },
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    try:
+        with path.open(encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                payload = json.loads(line)
+                if isinstance(payload, dict):
+                    records.append(payload)
+    except (OSError, json.JSONDecodeError):
+        return []
+    return records
+
+
+def _is_sensitive_record(record: dict[str, Any], policy: InheritancePolicy) -> bool:
+    lowered_keys = {str(key).lower() for key in record.keys()}
+    sensitive_tokens = tuple(token.lower() for token in policy.sensitive_memory_keys)
+    return any(any(token in key for token in sensitive_tokens) for key in lowered_keys)
+
+
+def _safe_memory_summary(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "event": record.get("event") or record.get("op") or record.get("kind") or "unknown",
+        "status": record.get("status") or ("success" if record.get("success") else "failure" if record.get("success") is False else "unknown"),
+        "mood": record.get("mood"),
+        "ts": record.get("ts"),
+    }
+
+
+def _aggregate_lessons(records: list[dict[str, Any]], limit: int) -> dict[str, Any]:
+    success_events: list[str] = []
+    failure_events: list[str] = []
+    for rec in records:
+        status = rec.get("status")
+        event = str(rec.get("event") or rec.get("op") or rec.get("kind") or "unknown")
+        if status == "success" or rec.get("success") is True:
+            success_events.append(event)
+        elif status == "failure" or rec.get("success") is False:
+            failure_events.append(event)
+    return {
+        "success_count": len(success_events),
+        "failure_count": len(failure_events),
+        "top_successes": success_events[-limit:],
+        "top_failures": failure_events[-limit:],
+    }
+
+
+def _apply_inheritance_policy(*, source: LifeMetadata, target: LifeMetadata, policy: InheritancePolicy) -> None:
+    source_mem = source.path / "mem"
+    target_mem = target.path / "mem"
+    target_mem.mkdir(parents=True, exist_ok=True)
+
+    source_episodes = _read_jsonl(source_mem / "episodic.jsonl")
+    non_sensitive = [rec for rec in source_episodes if not _is_sensitive_record(rec, policy)]
+    memory_summary = [_safe_memory_summary(rec) for rec in non_sensitive[-policy.memory_summary_max_entries :]]
+    (target_mem / "legacy_memory_summary.json").write_text(
+        json.dumps(memory_summary, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    _log_legacy_transfer(
+        source=source.slug,
+        target=target.slug,
+        reason="non_sensitive_memory_summary",
+        payload={"transferred_entries": len(memory_summary)},
+    )
+
+    source_skills = _read_json(source_mem / "skills.json")
+    skill_flag = policy.inheritable_skill_flag
+    inherited_skills = {
+        name: payload
+        for name, payload in source_skills.items()
+        if isinstance(payload, dict) and bool(payload.get(skill_flag))
+    }
+    (target_mem / "skills.json").write_text(
+        json.dumps(inherited_skills, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    target_skills_dir = target.path / "skills"
+    for skill_file in target_skills_dir.glob("*.py"):
+        if skill_file.stem not in inherited_skills:
+            skill_file.unlink(missing_ok=True)
+    _log_legacy_transfer(
+        source=source.slug,
+        target=target.slug,
+        reason="inheritable_skills_only",
+        payload={"transferred_skills": sorted(inherited_skills)},
+    )
+
+    lessons = _aggregate_lessons(non_sensitive, policy.aggregate_lessons_limit)
+    (target_mem / "legacy_lessons.json").write_text(
+        json.dumps(lessons, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    _log_legacy_transfer(
+        source=source.slug,
+        target=target.slug,
+        reason="aggregated_success_failure_lessons",
+        payload=lessons,
+    )
+
+    inheritance_payload = {
+        "inherited_from": source.slug,
+        "inherited_at": _now_iso(),
+        "inheritance_policy": policy.to_payload(),
+        "transfers": {
+            "memory_summary_path": "mem/legacy_memory_summary.json",
+            "skills_path": "mem/skills.json",
+            "lessons_path": "mem/legacy_lessons.json",
+        },
+    }
+    (target_mem / "inheritance_policy.json").write_text(
+        json.dumps(inheritance_payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
 
 
 def _govern_relation_operation(op_name: str) -> None:
@@ -468,6 +658,7 @@ def clone_life(name: str, *, new_name: str | None = None) -> LifeMetadata:
     clone_name = new_name or f"{source.name} clone"
     clone_meta = create_life(clone_name, parents=(source_slug,))
     shutil.copytree(source.path, clone_meta.path, dirs_exist_ok=True)
+    _apply_inheritance_policy(source=source, target=clone_meta, policy=DEFAULT_INHERITANCE_POLICY)
     registry = load_registry()
     lives: dict[str, LifeMetadata] = registry.get("lives", {})
     current = lives.get(clone_meta.slug)

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from singular.lives import (
     ally_lives,
     bootstrap_life,
+    clone_life,
     get_registry_root,
     list_relations,
     load_registry,
@@ -165,3 +167,68 @@ def test_relations_support_allies_rivals_children_and_proximity(
     assert payload["focus"]["rivals"] == []
     assert payload["focus"]["proximity_score"] == 0.83
     assert any(node["slug"] == alpha.slug for node in payload["social"]["nodes"])
+
+
+def test_clone_life_applies_inheritance_policy_and_logs_transfers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    source = bootstrap_life("Source", seed=5)
+    source_mem = source.path / "mem"
+    source_skills = source.path / "skills"
+    source_skills.mkdir(parents=True, exist_ok=True)
+    (source_skills / "kept.py").write_text("def run(context=None):\n    return {'ok': True}\n", encoding="utf-8")
+    (source_skills / "dropped.py").write_text("def run(context=None):\n    return {'ok': True}\n", encoding="utf-8")
+
+    (source_mem / "skills.json").write_text(
+        json.dumps(
+            {
+                "kept": {"score": 0.9, "inheritable": True},
+                "dropped": {"score": 0.2, "inheritable": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (source_mem / "episodic.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"event": "quest", "status": "success", "mood": "joy"}),
+                json.dumps({"event": "repair", "status": "failure", "token": "secret"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    clone = clone_life(source.slug, new_name="Source clone")
+    clone_mem = clone.path / "mem"
+    clone_skills = clone.path / "skills"
+
+    inherited_skills = json.loads((clone_mem / "skills.json").read_text(encoding="utf-8"))
+    assert list(inherited_skills) == ["kept"]
+    assert (clone_skills / "kept.py").exists()
+    assert not (clone_skills / "dropped.py").exists()
+
+    memory_summary = json.loads((clone_mem / "legacy_memory_summary.json").read_text(encoding="utf-8"))
+    assert len(memory_summary) == 1
+    assert memory_summary[0]["event"] == "quest"
+
+    lessons = json.loads((clone_mem / "legacy_lessons.json").read_text(encoding="utf-8"))
+    assert lessons["success_count"] == 1
+    assert lessons["failure_count"] == 0
+
+    inheritance = json.loads((clone_mem / "inheritance_policy.json").read_text(encoding="utf-8"))
+    assert "inheritance_policy" in inheritance
+    assert inheritance["inherited_from"] == source.slug
+
+    journal_path = tmp_path / "mem" / "legacy_transfers.jsonl"
+    assert journal_path.exists()
+    journal_lines = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(journal_lines) == 3
+    assert all(item["source"] == source.slug for item in journal_lines)
+    assert all(item["target"] == clone.slug for item in journal_lines)
+    assert {item["reason"] for item in journal_lines} == {
+        "non_sensitive_memory_summary",
+        "inheritable_skills_only",
+        "aggregated_success_failure_lessons",
+    }


### PR DESCRIPTION
### Motivation

- Provide a controlled inheritance mechanism when creating a new life so only non-sensitive summarized memories, explicitly marked inheritable skills, and aggregated lessons are transferred.  
- Ensure each transfer is auditable by tracing source/target/reason into a dedicated legacy transfers journal.  

### Description

- Add a first-class `InheritancePolicy` dataclass and `DEFAULT_INHERITANCE_POLICY` in `src/singular/lives.py` to encode transfer rules and limits.  
- Introduce a legacy transfers journal (`_LEGACY_TRANSFERS_JOURNAL`) and logging helper `_log_legacy_transfer` that appends audited records to `mem/legacy_transfers.jsonl`.  
- Implement helpers `_read_json`, `_read_jsonl`, `_is_sensitive_record`, `_safe_memory_summary`, `_aggregate_lessons` and the core `_apply_inheritance_policy` which: summarize non-sensitive episodic memory into `mem/legacy_memory_summary.json`, copy only skills flagged as inheritable into `mem/skills.json` while removing unmarked `.py` files in the clone, and write aggregated success/failure lessons to `mem/legacy_lessons.json` plus `mem/inheritance_policy.json`.  
- Hook the policy into the lifecycle by calling `_apply_inheritance_policy` from `clone_life` so the inheritance steps run automatically when cloning.  
- Add a regression test `test_clone_life_applies_inheritance_policy_and_logs_transfers` in `tests/test_lives.py` that validates transferred files and the three journal entries (`non_sensitive_memory_summary`, `inheritable_skills_only`, `aggregated_success_failure_lessons`).  

### Testing

- Ran `pytest -q tests/test_lives.py tests/test_cli_lives.py` and the test suite completed successfully.  
- The run produced `19 passed` for the executed tests and the new regression asserts (memory summary, skill filtering, lessons aggregation, and transfer journal) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dec808dae4832a924297fcfbe4c8bb)