### PR TITLE
Fix f-string quote conflict in status quest output

### DIFF
--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -513,8 +513,8 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     print(f"Réseau social: {len(social.get('edges', []))} relations")
     print(f"Conflits actifs: {len(relationships.get('active_conflicts', []))}")
     quests = payload.get("quests") if isinstance(payload.get("quests"), dict) else {"active": [], "completed": []}
-    print(f"Quêtes actives: {len(quests.get("active", []))}")
-    print(f"Quêtes terminées: {len(quests.get("completed", []))}")
+    print(f"Quêtes actives: {len(quests.get('active', []))}")
+    print(f"Quêtes terminées: {len(quests.get('completed', []))}")
     lifecycle = payload.get("skills_lifecycle") if isinstance(payload.get("skills_lifecycle"), dict) else {}
     print(f"Skills actives: {lifecycle.get('active', 0)}")
     print(f"Skills dormantes: {lifecycle.get('dormant', 0)}")


### PR DESCRIPTION
### Motivation
- Corriger un conflit de guillemets dans la fonction `status()` lors de l'affichage des compteurs de quêtes pour éviter une erreur de parsing des f-strings.

### Description
- Remplacement des guillemets internes dans les appels `quests.get(...)` par des quotes simples dans `status()` pour les clés `'active'` et `'completed'` (`print(f"Quêtes actives: {len(quests.get('active', []))}")` et `print(f"Quêtes terminées: {len(quests.get('completed', []))}")`).

### Testing
- Exécution de `python -m py_compile src/singular/organisms/status.py` pour valider la syntaxe du fichier, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dece49ed68832a9763c53a4012450c)