### PR TITLE
Handle invalid JSONL lines in status run parsing

### DIFF
--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -203,6 +203,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "success_rate": None,
         "mutation_success_rate": None,
         "mutation_count": 0,
+        "invalid_lines": 0,
         "health": None,
         "alerts": [],
         "mood": None,
@@ -249,6 +250,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "impact": summarize_environmental_impact(host_aggregates),
     }
     all_records: list[dict[str, object]] = []
+    invalid_lines = 0
     runs_dir = Path(RUNS_DIR)
     files = sorted(runs_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
     if files:
@@ -258,13 +260,20 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                 for line in fh:
                     line = line.strip()
                     if line:
-                        all_records.append(json.loads(line))
+                        try:
+                            all_records.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            invalid_lines += 1
         records = []
         with latest.open(encoding="utf-8") as fh:
             for line in fh:
                 line = line.strip()
                 if line:
-                    records.append(json.loads(line))
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        invalid_lines += 1
+        payload["invalid_lines"] = invalid_lines
         payload["daily_skills"] = build_daily_skills_snapshot(records=all_records)
         if records:
             last = records[-1]


### PR DESCRIPTION
### Motivation
- Prevent malformed lines in `runs/*.jsonl` from raising `JSONDecodeError` and aborting the global status computation. 
- Provide visibility into how many lines were skipped while keeping status generation resilient.

### Description
- Wrap `json.loads(line)` in `try/except json.JSONDecodeError` when building `all_records` from `runs/*.jsonl` to ignore invalid lines. 
- Apply the same `try/except` protection when reading the latest run into `records` and increment an `invalid_lines` counter for each skipped line. 
- Expose the `invalid_lines` counter in the status `payload` (added to `payload` and initialized/updated in `status()` in `src/singular/organisms/status.py`).

### Testing
- Ran `python -m compileall src/singular/organisms/status.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69decef16bf8832a85272054df487ce8)