### PR TITLE
Fix load_llm_client default fallback resolution and precedence tests

### DIFF
--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -227,9 +227,6 @@ def _load_provider_contract(name: str) -> LLMProviderContract | None:
 def load_llm_client(name: str | None) -> LLMProviderClient | None:
     """Load one provider or a configured fallback chain as :class:`LLMProviderClient`."""
 
-    if not name and not os.getenv("LLM_PROVIDER_FALLBACK"):
-        return None
-
     chain_names = _resolve_provider_chain(name)
     clients: list[LLMProviderClient] = []
     for chain_name in chain_names:

--- a/tests/providers/test_llm_fallback_chain.py
+++ b/tests/providers/test_llm_fallback_chain.py
@@ -1,21 +1,49 @@
 import pytest
 
-from singular.providers import FallbackLLMClient, ProviderUnavailableError, load_llm_client
+import singular.providers as providers
+from singular.providers import FallbackLLMClient, LLMProviderContract, ProviderUnavailableError, load_llm_client
 
 
-def test_load_llm_client_from_env_fallback_chain(monkeypatch):
-    monkeypatch.setenv("LLM_PROVIDER_FALLBACK", "dummy")
+def _dummy_contract(name: str) -> LLMProviderContract:
+    return LLMProviderContract(
+        name=name,
+        generate=lambda prompt, timeout=8.0: f"{name}:{prompt}",
+        embed=lambda text, timeout=8.0: [float(len(text)), timeout],
+        healthcheck=lambda: {"ok": True, "provider": name},
+        cost_estimate=lambda prompt, completion="": 0.0,
+    )
+
+
+def test_load_llm_client_none_without_env_uses_default_fallback_chain(monkeypatch):
+    monkeypatch.delenv("LLM_PROVIDER_FALLBACK", raising=False)
+    monkeypatch.setattr(providers, "DEFAULT_FALLBACK_CHAIN", ("dummy",))
+    monkeypatch.setattr(providers, "_load_provider_contract", lambda chain_name: _dummy_contract(chain_name))
+
     client = load_llm_client(None)
     assert client is not None
     assert client.name == "dummy"
-    assert client.generate_reply("hello") == "Echo: hello"
+    assert client.generate_reply("hello") == "dummy:hello"
 
 
-def test_load_llm_client_comma_chain_uses_order(monkeypatch):
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    client = load_llm_client("openai,dummy")
-    assert isinstance(client, FallbackLLMClient)
-    assert client.generate_reply("bonjour") == "Echo: bonjour"
+def test_load_llm_client_env_fallback_chain_has_priority_over_default(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER_FALLBACK", "dummy")
+    monkeypatch.setattr(providers, "DEFAULT_FALLBACK_CHAIN", ("local",))
+    monkeypatch.setattr(providers, "_load_provider_contract", lambda chain_name: _dummy_contract(chain_name))
+
+    client = load_llm_client(None)
+    assert client is not None
+    assert client.name == "dummy"
+    assert client.generate_reply("bonjour") == "dummy:bonjour"
+
+
+def test_load_llm_client_explicit_name_has_priority_over_env(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER_FALLBACK", "dummy")
+    monkeypatch.setattr(providers, "_load_provider_contract", lambda chain_name: _dummy_contract(chain_name))
+
+    client = load_llm_client("openai")
+    assert client is not None
+    assert client.name == "openai"
+    assert client.generate_reply("salut") == "openai:salut"
 
 
 def test_fallback_client_errors_when_chain_empty():


### PR DESCRIPTION
### Motivation
- Ensure provider resolution always delegates to `_resolve_provider_chain(name)` so the default fallback chain (`DEFAULT_FALLBACK_CHAIN`) is used when `name` is omitted.
- Clarify and enforce precedence rules between an explicit `name`, the environment `LLM_PROVIDER_FALLBACK`, and the default fallback chain.

### Description
- Removed the early-return guard in `load_llm_client` that returned `None` when `name` was falsy and `LLM_PROVIDER_FALLBACK` was unset, so resolution always calls `_resolve_provider_chain(name)` (`src/singular/providers/__init__.py`).
- Updated provider tests to use a dummy `LLMProviderContract` and to explicitly assert precedence: default chain used when `name=None` and no env, env `LLM_PROVIDER_FALLBACK` overrides default, and an explicit `name` overrides the env (`tests/providers/test_llm_fallback_chain.py`).
- Kept the existing `FallbackLLMClient` empty-chain error test unchanged.

### Testing
- Ran `pytest -q tests/providers/test_llm_fallback_chain.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69decfef8768832aa17a7fceaac15c7c)