### PR TITLE
Handle nested provider import errors explicitly

### DIFF
--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -200,8 +200,13 @@ def _load_provider_contract(name: str) -> LLMProviderContract | None:
                 cost_estimate=cost_estimate,
                 max_retries=retries,
             )
-    except ModuleNotFoundError:
-        pass
+    except ModuleNotFoundError as exc:
+        if exc.name == module_name:
+            pass
+        else:
+            raise ProviderMisconfiguredError(
+                f"Provider '{name}' imports missing dependency '{exc.name}'"
+            ) from exc
 
     for ep in entry_points(group="singular.llm"):
         if ep.name != name:

--- a/tests/providers/test_llm_provider_loader.py
+++ b/tests/providers/test_llm_provider_loader.py
@@ -1,0 +1,16 @@
+import pytest
+
+from singular.providers import ProviderMisconfiguredError, _load_provider_contract
+
+
+def test_load_provider_contract_raises_explicit_error_when_dependency_is_missing(monkeypatch):
+    module_name = "singular.providers.llm_broken"
+
+    def fake_import_module(imported_name):
+        assert imported_name == module_name
+        raise ModuleNotFoundError("No module named 'missing_dependency'", name="missing_dependency")
+
+    monkeypatch.setattr("singular.providers.import_module", fake_import_module)
+
+    with pytest.raises(ProviderMisconfiguredError, match="missing dependency 'missing_dependency'"):
+        _load_provider_contract("broken")


### PR DESCRIPTION
### Motivation
- The provider loader suppressed all `ModuleNotFoundError` exceptions, hiding cases where a provider module exists but fails due to a missing internal dependency. 
- Make failures from misconfigured providers explicit so callers can surface configuration errors instead of silently falling back.

### Description
- Update `_load_provider_contract` in `src/singular/providers/__init__.py` to catch `ModuleNotFoundError as exc` and only ignore it when `exc.name == module_name`, otherwise raise a `ProviderMisconfiguredError` with the missing dependency name. 
- Add `tests/providers/test_llm_provider_loader.py` which monkeypatches `import_module` to raise `ModuleNotFoundError` for an internal dependency and asserts that `_load_provider_contract` raises `ProviderMisconfiguredError` with an explicit message. 

### Testing
- Ran `pytest -q tests/providers/test_llm_provider_loader.py tests/providers/test_llm_fallback_chain.py tests/providers/test_llm_entry_point.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded0896a30832aa7e07ae4e93c9165)