### PR TITLE
Use a local Random instance in birth handler

### DIFF
--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -289,12 +289,11 @@ def birth(
 
     refresh_skill_catalog(skills_dir=skills_dir, mem_dir=home / "mem")
 
-    if seed is not None:
-        random.seed(seed)
+    rng = random.Random(seed)
 
     # Generate a random name and soulseed for the new identity
-    name = f"organism-{random.randint(0, 999999):06d}"
-    soulseed = "".join(random.choices(string.ascii_lowercase + string.digits, k=16))
+    name = f"organism-{rng.randint(0, 999999):06d}"
+    soulseed = "".join(rng.choices(string.ascii_lowercase + string.digits, k=16))
 
     # Create the identity file and persist a base profile
     identity = create_identity(name, soulseed, path=home / "id.json")


### PR DESCRIPTION
### Motivation
- Garantir la reproductibilité locale dans `birth` sans modifier l'état RNG global lorsqu'un `seed` est fourni.

### Description
- Remplace l'appel global `random.seed(seed)` par une instance locale `rng = random.Random(seed)` et utilise `rng.randint(...)` et `rng.choices(...)` pour générer `name` et `soulseed` dans `src/singular/organisms/birth.py`.

### Testing
- Exécuté `python -m compileall src/singular/organisms/birth.py` et la compilation a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded10d7cdc832a8ac96ee190d1520a)