### PR TITLE
Rebuild memory layer service when SINGULAR_HOME changes

### DIFF
--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -22,6 +22,7 @@ from .events import Event, EventBus
 from .memory_layers import MemoryLayerService, build_backend
 
 _MEMORY_LAYER_SERVICE: MemoryLayerService | None = None
+_MEMORY_LAYER_SERVICE_ROOT: Path | None = None
 
 
 def get_base_dir() -> Path:
@@ -135,13 +136,15 @@ def ensure_memory_structure(mem_dir: Path | str | None = None) -> None:
 
 
 def get_memory_layer_service() -> MemoryLayerService:
-    """Return the singleton memory layer service."""
+    """Return the memory layer service for the current memory root."""
 
-    global _MEMORY_LAYER_SERVICE
-    if _MEMORY_LAYER_SERVICE is None:
+    global _MEMORY_LAYER_SERVICE, _MEMORY_LAYER_SERVICE_ROOT
+    root = get_memory_layers_dir().resolve()
+    if _MEMORY_LAYER_SERVICE is None or _MEMORY_LAYER_SERVICE_ROOT != root:
         _MEMORY_LAYER_SERVICE = MemoryLayerService(
-            build_backend(root=get_memory_layers_dir())
+            build_backend(root=root)
         )
+        _MEMORY_LAYER_SERVICE_ROOT = root
     return _MEMORY_LAYER_SERVICE
 
 

--- a/tests/test_memory_layers.py
+++ b/tests/test_memory_layers.py
@@ -56,3 +56,35 @@ def test_add_episode_enriches_semantic_memory(tmp_path, monkeypatch):
     texts = [entry["text"] for entry in lines]
     assert "lives in paris" in texts
     assert "coffee" in texts
+
+
+def test_memory_layer_service_rebuilds_when_root_changes(tmp_path, monkeypatch):
+    from singular import memory
+
+    home_a = tmp_path / "home-a"
+    home_b = tmp_path / "home-b"
+
+    monkeypatch.setenv("SINGULAR_HOME", str(home_a))
+    service_a = memory.get_memory_layer_service()
+    memory.add_episode({"event": "root-a", "summary": "alpha"})
+
+    monkeypatch.setenv("SINGULAR_HOME", str(home_b))
+    service_b = memory.get_memory_layer_service()
+    memory.add_episode({"event": "root-b", "summary": "beta"})
+
+    assert service_a is not service_b
+
+    short_a = home_a / "mem" / "layers" / "short_term.jsonl"
+    short_b = home_b / "mem" / "layers" / "short_term.jsonl"
+
+    lines_a = short_a.read_text(encoding="utf-8").splitlines()
+    lines_b = short_b.read_text(encoding="utf-8").splitlines()
+
+    payloads_a = [json.loads(line) for line in lines_a if line]
+    payloads_b = [json.loads(line) for line in lines_b if line]
+
+    assert len(payloads_a) == 1
+    assert payloads_a[0]["text"] == "alpha"
+
+    assert len(payloads_b) == 1
+    assert payloads_b[0]["text"] == "beta"


### PR DESCRIPTION
### Motivation
- Éviter le singleton « aveugle » qui conserve une instance de `MemoryLayerService` liée à un ancien `SINGULAR_HOME` lorsque le répertoire mémoire change.

### Description
- Implémentation de l’Option A: ajout d’un cache ` _MEMORY_LAYER_SERVICE_ROOT: Path | None` pour mémoriser le `root` utilisé lors de l’initialisation du service.
- `get_memory_layer_service()` résout maintenant `root = get_memory_layers_dir().resolve()` et reconstruit le `MemoryLayerService` si l’instance est absente ou si `root` a changé.
- Le backend est construit avec `build_backend(root=root)` et `_MEMORY_LAYER_SERVICE_ROOT` est mis à jour après reconstruction.
- Ajout du test `test_memory_layer_service_rebuilds_when_root_changes` dans `tests/test_memory_layers.py` qui change `SINGULAR_HOME`, récupère les services, ajoute des épisodes et vérifie que chaque root reçoit ses propres fichiers et que les instances sont distinctes.

### Testing
- Exécution de `pytest -q tests/test_memory_layers.py` qui a réussi avec `4 passed in 0.17s`.
- Le nouveau test confirme que les écritures ne fuient pas entre deux `SINGULAR_HOME` successifs et que le service est recréé comme attendu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded18e4610832ab07f6c3e5be9f684)