### PR TITLE
Expose public JSONL append API for cross-module use

### DIFF
--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from .governance.policy import MutationGovernancePolicy
-from .memory import _append_jsonl_line
+from .memory import append_jsonl_line_safe
 
 _REGISTRY_DIRNAME = "lives"
 _REGISTRY_FILENAME = "registry.json"
@@ -151,7 +151,7 @@ def _log_legacy_transfer(
     reason: str,
     payload: dict[str, Any] | None = None,
 ) -> None:
-    _append_jsonl_line(
+    append_jsonl_line_safe(
         _legacy_transfers_journal_path(),
         {
             "ts": _now_iso(),

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -120,6 +120,20 @@ def _append_jsonl_line(path: Path, payload: dict[str, Any]) -> None:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
+def append_jsonl_line_safe(
+    path: Path | str,
+    payload: Mapping[str, Any],
+) -> None:
+    """Append one JSON object as JSONL with durable cross-platform locking.
+
+    This public API should be used by other modules when they need a locked
+    append operation. It preserves the existing lock+append behavior while
+    exposing a stable cross-module contract.
+    """
+
+    _append_jsonl_line(Path(path), dict(payload))
+
+
 def ensure_memory_structure(mem_dir: Path | str | None = None) -> None:
     """Create the memory directory structure if it does not exist."""
     if mem_dir is None:

--- a/src/singular/sensors/host_metrics_store.py
+++ b/src/singular/sensors/host_metrics_store.py
@@ -8,7 +8,7 @@ from typing import Any
 import json
 import os
 
-from singular.memory import _append_jsonl_line, get_mem_dir
+from singular.memory import append_jsonl_line_safe, get_mem_dir
 
 _DEFAULT_RETENTION_SAMPLES = 2000
 _DEFAULT_WINDOWS = (5, 20, 60)
@@ -72,7 +72,7 @@ def append_host_metrics_sample(metrics: dict[str, Any]) -> None:
         "ts": _utc_now_iso(),
         "metrics": {key: _safe_float(metrics.get(key)) for key in _METRICS_KEYS},
     }
-    _append_jsonl_line(path, payload)
+    append_jsonl_line_safe(path, payload)
     _trim_retention(path=path, retention=_retention_samples())
 
 


### PR DESCRIPTION
### Motivation

- Fournir une API publique et stable pour l’opération d’append JSONL verrouillée afin d’éviter l’usage d’une fonction interne entre modules.
- Forcer le transit de tous les appels cross-module vers cette API publique tout en conservant la logique existante de verrouillage et durabilité.

### Description

- Ajout de la fonction publique `append_jsonl_line_safe(path: Path | str, payload: Mapping[str, Any])` dans `src/singular/memory.py` qui délègue à l’implémentation existante `_append_jsonl_line` et expose une signature stable et une docstring.
- Remplacement de l’import privé `from .memory import _append_jsonl_line` par `from .memory import append_jsonl_line_safe` dans `src/singular/lives.py` et migration des appels concernés pour utiliser la nouvelle API.
- Migration de l’import et des appels dans `src/singular/sensors/host_metrics_store.py` pour utiliser `append_jsonl_line_safe` au lieu de l’appel interne.
- La logique de création de répertoire, lock cross-plateforme et écriture atomique/durabilité est inchangée puisque la nouvelle API délègue à l’implémentation existante.

### Testing

- Exécution de la vérification de compilation `python -m compileall -q src/singular/memory.py src/singular/lives.py src/singular/sensors/host_metrics_store.py` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded3f7bde4832aacdc2e61eb451e50)