### PR TITLE
Harden LifeMetadata payload validation and registry resilience

### DIFF
--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -58,21 +58,41 @@ class LifeMetadata:
     @classmethod
     def from_payload(cls, data: Dict[str, Any]) -> "LifeMetadata":
         """Build metadata from a registry payload."""
+        required_fields = ("name", "slug", "path", "created_at")
+        missing_fields = [field for field in required_fields if field not in data]
+        if missing_fields:
+            fields = ", ".join(missing_fields)
+            raise ValueError(f"invalid life metadata payload: missing required field(s): {fields}")
+
+        invalid_fields = [
+            field
+            for field in required_fields
+            if not isinstance(data.get(field), str) or not data.get(field, "").strip()
+        ]
+        if invalid_fields:
+            fields = ", ".join(invalid_fields)
+            raise ValueError(f"invalid life metadata payload: required field(s) must be non-empty strings: {fields}")
+
         proximity_score = data.get("proximity_score", 0.5)
         if not isinstance(proximity_score, (int, float)):
             proximity_score = 0.5
+        raw_lineage_depth = data.get("lineage_depth", 0)
+        try:
+            lineage_depth = max(0, int(raw_lineage_depth))
+        except (TypeError, ValueError):
+            lineage_depth = 0
         return cls(
-            name=str(data["name"]),
-            slug=str(data["slug"]),
+            name=data["name"].strip(),
+            slug=data["slug"].strip(),
             path=Path(data["path"]),
-            created_at=str(data["created_at"]),
+            created_at=data["created_at"].strip(),
             status=str(data.get("status", "active")),
             parents=tuple(str(item) for item in data.get("parents", []) if isinstance(item, str)),
             children=tuple(str(item) for item in data.get("children", []) if isinstance(item, str)),
             allies=tuple(str(item) for item in data.get("allies", []) if isinstance(item, str)),
             rivals=tuple(str(item) for item in data.get("rivals", []) if isinstance(item, str)),
             proximity_score=max(0.0, min(1.0, float(proximity_score))),
-            lineage_depth=max(0, int(data.get("lineage_depth", 0))),
+            lineage_depth=lineage_depth,
         )
 
 
@@ -339,7 +359,8 @@ def load_registry() -> dict[str, Any]:
     for slug, data in lives_payload.items():
         try:
             lives[slug] = LifeMetadata.from_payload(data)
-        except KeyError:
+        except (TypeError, ValueError) as exc:
+            _LOGGER.warning("Skipping invalid life entry '%s' in %s: %s", slug, path, exc)
             continue
 
     active = payload.get("active")

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from singular.lives import (
+    LifeMetadata,
     ally_lives,
     bootstrap_life,
     clone_life,
@@ -147,6 +148,64 @@ def test_load_registry_handles_partial_payload(
     registry = load_registry()
 
     assert registry == {"active": None, "lives": {}}
+
+
+def test_life_metadata_from_payload_raises_for_missing_required_fields() -> None:
+    with pytest.raises(ValueError, match="missing required field"):
+        LifeMetadata.from_payload(
+            {
+                "slug": "alpha",
+                "path": "/tmp/life-alpha",
+                "created_at": "2026-01-01T00:00:00+00:00",
+            }
+        )
+
+
+def test_life_metadata_from_payload_raises_for_bad_required_types() -> None:
+    with pytest.raises(ValueError, match="non-empty strings"):
+        LifeMetadata.from_payload(
+            {
+                "name": "Alpha",
+                "slug": "alpha",
+                "path": 123,
+                "created_at": "2026-01-01T00:00:00+00:00",
+            }
+        )
+
+
+def test_load_registry_skips_invalid_entries_with_logging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    registry_path = tmp_path / "lives" / "registry.json"
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "active": "alpha",
+                "lives": {
+                    "alpha": {
+                        "name": "Alpha",
+                        "slug": "alpha",
+                        "path": str(tmp_path / "lives" / "alpha"),
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    },
+                    "broken": {
+                        "name": "Broken",
+                        "slug": "broken",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    },
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    registry = load_registry()
+
+    assert set(registry["lives"]) == {"alpha"}
+    assert registry["active"] == "alpha"
+    assert "Skipping invalid life entry 'broken'" in caplog.text
 
 
 def test_relations_support_allies_rivals_children_and_proximity(


### PR DESCRIPTION
### Motivation
- Prevent crashes and unclear errors when registry payloads are malformed by validating required `LifeMetadata` fields (`name`, `slug`, `path`, `created_at`).
- Ensure the caller can ignore invalid entries safely while retaining observability via logs.

### Description
- Add explicit required-field checks in `LifeMetadata.from_payload` and raise contextual `ValueError` when fields are missing or not non-empty strings. (`src/singular/lives.py`)
- Coerce `lineage_depth` defensively with a safe fallback and normalize `name`, `slug`, and `created_at` via `strip()`; keep tolerant parsing for optional fields like `proximity_score`. (`src/singular/lives.py`)
- Update `load_registry` to catch `(TypeError, ValueError)` from `from_payload`, skip invalid entries, and emit a warning log describing the skipped slug and source path. (`src/singular/lives.py`)
- Add tests that assert `from_payload` raises for missing required fields and bad types, and that `load_registry` skips invalid entries while logging the event. (`tests/test_lives.py`)

### Testing
- Ran `pytest -q tests/test_lives.py` which executed the updated test suite. 
- Result: all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded4a07934832a9e1a97e5a4359b02)