### PR TITLE
Centralize durable IO utilities for memory and multi-agent protocol

### DIFF
--- a/src/singular/io_utils.py
+++ b/src/singular/io_utils.py
@@ -1,0 +1,87 @@
+"""Shared file I/O helpers with durability and cross-platform locking."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from typing import Any, Iterator
+import json
+import os
+import tempfile
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import fcntl
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+@contextmanager
+def _locked_file(path: Path) -> Iterator[None]:
+    """Acquire an exclusive sidecar lock for ``path``."""
+
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if os.name == "nt":
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def atomic_write_text(path: Path | str, data: str, fsync: bool = True) -> None:
+    """Atomically write text to ``path`` using a temporary sibling file."""
+
+    destination = Path(path)
+    _ensure_parent(destination)
+    tmp = tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=destination.parent, delete=False
+    )
+    try:
+        with tmp:
+            tmp.write(data)
+            tmp.flush()
+            if fsync:
+                os.fsync(tmp.fileno())
+        os.replace(tmp.name, destination)
+        if fsync and os.name != "nt":
+            dir_fd = os.open(destination.parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except FileNotFoundError:
+            pass
+
+
+def append_jsonl_line(
+    path: Path | str,
+    payload: dict[str, Any],
+    with_lock: bool = True,
+) -> None:
+    """Append one JSON object as JSONL with optional cross-platform locking."""
+
+    destination = Path(path)
+    _ensure_parent(destination)
+    line = json.dumps(payload, ensure_ascii=False) + "\n"
+    lock_context = _locked_file(destination) if with_lock else nullcontext()
+    with lock_context:
+        with destination.open("a", encoding="utf-8") as file:
+            file.write(line)
+            file.flush()
+            os.fsync(file.fileno())

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -10,15 +10,10 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 import json
 import os
-import tempfile
 from datetime import datetime, timedelta, timezone
 
-if os.name == "nt":
-    import msvcrt
-else:
-    import fcntl
-
 from .events import Event, EventBus
+from .io_utils import append_jsonl_line, atomic_write_text
 from .memory_layers import MemoryLayerService, build_backend
 
 _MEMORY_LAYER_SERVICE: MemoryLayerService | None = None
@@ -71,54 +66,18 @@ def get_psyche_file() -> Path:
     return get_mem_dir() / "psyche.json"
 
 
-def _ensure_dir(path: Path) -> None:
-    """Ensure the parent directory of ``path`` exists."""
-    path.parent.mkdir(parents=True, exist_ok=True)
 
 
 def _atomic_write_text(path: Path, data: str) -> None:
-    """Atomically write ``data`` to ``path``."""
-    _ensure_dir(path)
-    tmp = tempfile.NamedTemporaryFile(
-        "w", encoding="utf-8", dir=path.parent, delete=False
-    )
-    try:
-        with tmp:
-            tmp.write(data)
-            tmp.flush()
-            os.fsync(tmp.fileno())
-        os.replace(tmp.name, path)
-    finally:
-        try:
-            os.unlink(tmp.name)
-        except FileNotFoundError:
-            pass
+    """Backward-compatible alias for shared atomic text writes."""
+
+    atomic_write_text(path, data)
 
 
 def _append_jsonl_line(path: Path, payload: dict[str, Any]) -> None:
-    """Safely append one JSON line with cross-platform file locking."""
+    """Backward-compatible alias for shared locked JSONL appends."""
 
-    _ensure_dir(path)
-    line = json.dumps(payload, ensure_ascii=False) + "\n"
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    with lock_path.open("a+b") as lock_file:
-        if os.name == "nt":
-            lock_file.seek(0)
-            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
-        else:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        try:
-            with path.open("a", encoding="utf-8") as file:
-                file.write(line)
-                file.flush()
-                os.fsync(file.fileno())
-        finally:
-            if os.name == "nt":
-                lock_file.seek(0)
-                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
-            else:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-
+    append_jsonl_line(path, payload, with_lock=True)
 
 def append_jsonl_line_safe(
     path: Path | str,
@@ -131,7 +90,7 @@ def append_jsonl_line_safe(
     exposing a stable cross-module contract.
     """
 
-    _append_jsonl_line(Path(path), dict(payload))
+    append_jsonl_line(Path(path), dict(payload), with_lock=True)
 
 
 def ensure_memory_structure(mem_dir: Path | str | None = None) -> None:
@@ -186,7 +145,7 @@ def write_profile(profile: dict[str, Any], path: Path | str | None = None) -> No
     if path is None:
         path = get_profile_file()
     path = Path(path)
-    _atomic_write_text(path, json.dumps(profile))
+    atomic_write_text(path, json.dumps(profile))
 
 
 def update_trait(
@@ -240,7 +199,7 @@ def write_values(values: dict[str, Any], path: Path | str | None = None) -> None
         raise ImportError(
             "PyYAML is required to write values. Please install PyYAML."
         ) from exc
-    _atomic_write_text(path, yaml.safe_dump(values))
+    atomic_write_text(path, yaml.safe_dump(values))
 
 
 # ---------------------------------------------------------------------------
@@ -284,7 +243,7 @@ def add_episode(
     if path is None:
         path = get_episodic_file()
     path = Path(path)
-    _append_jsonl_line(path, episode)
+    append_jsonl_line(path, episode)
     try:
         get_memory_layer_service().ingest_episode(episode)
     except Exception:
@@ -326,7 +285,7 @@ def write_skills(skills: dict[str, Any], path: Path | str | None = None) -> None
     if path is None:
         path = get_skills_file()
     path = Path(path)
-    _atomic_write_text(path, json.dumps(skills))
+    atomic_write_text(path, json.dumps(skills))
 
 
 def update_score(
@@ -586,7 +545,7 @@ def write_psyche(state: dict[str, Any], path: Path | str | None = None) -> None:
     if path is None:
         path = get_psyche_file()
     path = Path(path)
-    _atomic_write_text(path, json.dumps(state))
+    atomic_write_text(path, json.dumps(state))
 
 
 _REGISTERED_MEMORY_BUS_IDS: set[int] = set()

--- a/src/singular/multiagent/protocol.py
+++ b/src/singular/multiagent/protocol.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Literal, Protocol
 import json
-import os
-import tempfile
 import time
 from collections import defaultdict, deque
 
@@ -18,12 +16,8 @@ from singular.events import (
     build_help_event_payload,
 )
 from singular.governance.policy import AUTH_AUTO, AUTH_FORCED, MutationGovernancePolicy
+from singular.io_utils import append_jsonl_line, atomic_write_text
 from singular.life import sandbox
-
-if os.name == "nt":
-    import msvcrt
-else:
-    import fcntl
 
 MESSAGE_SCHEMA_V1: dict[str, Any] = {
     "required": {"intent", "task", "evidence", "confidence"},
@@ -168,13 +162,13 @@ class FileQueueTransport:
         self.path = Path(path)
 
     def send(self, message: AgentMessage) -> None:
-        _append_jsonl_line(self.path, message.to_dict())
+        append_jsonl_line(self.path, message.to_dict())
 
     def receive(self) -> list[AgentMessage]:
         if not self.path.exists():
             return []
         payload = self.path.read_text(encoding="utf-8")
-        _atomic_write_text(self.path, "")
+        atomic_write_text(self.path, "")
         messages: list[AgentMessage] = []
         for line in payload.splitlines():
             if not line.strip():
@@ -211,7 +205,7 @@ class CollectiveMemory:
         return self.root / f"{self.namespace}.jsonl"
 
     def append(self, record: dict[str, Any]) -> None:
-        _append_jsonl_line(self._path, record)
+        append_jsonl_line(self._path, record)
 
     def read(self) -> list[dict[str, Any]]:
         if not self._path.exists():
@@ -508,42 +502,3 @@ class HelpExchangeCoordinator:
             requester_gain=requester_gain,
             helper_gain=helper_gain,
         )
-
-
-def _atomic_write_text(path: Path, data: str) -> None:
-    tmp = tempfile.NamedTemporaryFile(
-        "w", encoding="utf-8", dir=path.parent, delete=False
-    )
-    try:
-        with tmp:
-            tmp.write(data)
-            tmp.flush()
-        Path(tmp.name).replace(path)
-    finally:
-        try:
-            Path(tmp.name).unlink()
-        except FileNotFoundError:
-            pass
-
-
-def _append_jsonl_line(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    line = json.dumps(payload, ensure_ascii=False) + "\n"
-    lock_path = path.with_suffix(path.suffix + ".lock")
-    with lock_path.open("a+b") as lock_file:
-        if os.name == "nt":
-            lock_file.seek(0)
-            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
-        else:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        try:
-            with path.open("a", encoding="utf-8") as file:
-                file.write(line)
-                file.flush()
-                os.fsync(file.fileno())
-        finally:
-            if os.name == "nt":
-                lock_file.seek(0)
-                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
-            else:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from singular import memory
+from singular import io_utils
 from singular.resource_manager import ResourceManager
 
 
@@ -16,7 +17,7 @@ def test_write_profile_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     profile_path.parent.mkdir(parents=True, exist_ok=True)
     profile_path.write_text(json.dumps({"old": 1}), encoding="utf-8")
 
-    monkeypatch.setattr(memory.os, "replace", failing_replace)
+    monkeypatch.setattr(io_utils.os, "replace", failing_replace)
 
     with pytest.raises(RuntimeError):
         memory.write_profile({"new": 2}, path=profile_path)
@@ -31,7 +32,7 @@ def test_add_episode_uses_append_path_not_snapshot_replace(
     episode_path.parent.mkdir(parents=True, exist_ok=True)
     episode_path.write_text(json.dumps({"event": "old"}) + "\n", encoding="utf-8")
 
-    monkeypatch.setattr(memory.os, "replace", failing_replace)
+    monkeypatch.setattr(io_utils.os, "replace", failing_replace)
 
     memory.add_episode({"event": "new"}, path=episode_path)
 
@@ -48,7 +49,7 @@ def test_resource_manager_save_atomic(
     path.write_text(json.dumps({"energy": 1, "food": 2, "warmth": 3}), encoding="utf-8")
     rm = ResourceManager(path=path)
 
-    monkeypatch.setattr(memory.os, "replace", failing_replace)
+    monkeypatch.setattr(io_utils.os, "replace", failing_replace)
 
     rm.energy = 10
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
### Motivation
- Remove duplicated file I/O code and provide a single place for atomic writes and JSONL appends with consistent durability semantics.
- Harmonize durability behavior (`flush + fsync`, optional directory fsync on POSIX) and a cross-platform sidecar lock strategy for JSONL appends.
- Allow other modules to reuse the same locking/durability logic and reduce risk of inconsistent implementations.

### Description
- Add `src/singular/io_utils.py` exposing `atomic_write_text(path, data, fsync=True)` and `append_jsonl_line(path, payload, with_lock=True)` implementing temp-file replace semantics, optional fsync, directory fsync on POSIX, and sidecar `.lock` cross-platform locking.
- Migrate `src/singular/memory.py` to call `atomic_write_text` and `append_jsonl_line` and provide small backward-compatible wrappers `_atomic_write_text` and `_append_jsonl_line` so existing internal imports continue to work.
- Migrate `src/singular/multiagent/protocol.py` to use the shared functions and remove the duplicated local implementations.
- Update `tests/test_atomic_writes.py` to monkeypatch `io_utils.os.replace` (because `os.replace` is now centralized in `io_utils`).

### Testing
- Ran `pytest -q tests/test_memory.py tests/test_multiagent_protocol.py tests/test_atomic_writes.py` which completed with the IO-related tests passing and one unrelated failure in `test_birth_initializes_default_skills` (the failure is outside the scope of the IO changes).
- Ran a focused verification `pytest -q tests/test_multiagent_protocol.py tests/test_atomic_writes.py tests/test_memory.py -k 'add_episode or update_trait_score_and_note or values_helpers_without_yaml'` which passed (all selected tests green).
- Addressed initial import issues during rollout so tests can import the new shared helpers; overall IO-related test coverage is passing in the exercised suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded5266400832a97cad7273bbb507b)