### PR TITLE
Harden multiagent atomic-write durability and add fsync test

### DIFF
--- a/src/singular/multiagent/protocol.py
+++ b/src/singular/multiagent/protocol.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Literal, Protocol
 import json
+import os
+import tempfile
 import time
 from collections import defaultdict, deque
 
@@ -16,7 +18,7 @@ from singular.events import (
     build_help_event_payload,
 )
 from singular.governance.policy import AUTH_AUTO, AUTH_FORCED, MutationGovernancePolicy
-from singular.io_utils import append_jsonl_line, atomic_write_text
+from singular.io_utils import append_jsonl_line
 from singular.life import sandbox
 
 MESSAGE_SCHEMA_V1: dict[str, Any] = {
@@ -168,13 +170,39 @@ class FileQueueTransport:
         if not self.path.exists():
             return []
         payload = self.path.read_text(encoding="utf-8")
-        atomic_write_text(self.path, "")
+        _atomic_write_text(self.path, "")
         messages: list[AgentMessage] = []
         for line in payload.splitlines():
             if not line.strip():
                 continue
             messages.append(AgentMessage.from_dict(json.loads(line)))
         return messages
+
+
+def _atomic_write_text(path: Path, data: str) -> None:
+    """Atomically write text to ``path`` using a temporary sibling file."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    )
+    try:
+        with tmp:
+            tmp.write(data)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp.name, path)
+        if os.name != "nt":
+            dir_fd = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except FileNotFoundError:
+            pass
 
 
 def resolve_conflicts(messages: Iterable[AgentMessage]) -> dict[str, AgentMessage]:

--- a/tests/test_multiagent_protocol.py
+++ b/tests/test_multiagent_protocol.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 import json
 import multiprocessing as mp
 from pathlib import Path
+from unittest.mock import Mock
 
 from singular.multiagent import (
     AgentMessage,
@@ -15,6 +16,7 @@ from singular.multiagent import (
     resolve_conflicts,
     validate_message_schema,
 )
+from singular.multiagent import protocol as protocol_module
 from singular.governance.policy import MutationGovernancePolicy
 
 
@@ -290,3 +292,58 @@ def test_help_exchange_coordinator_emits_help_requested(tmp_path: Path) -> None:
     messages = transport.receive()
     assert len(messages) == 1
     assert messages[0].intent == "help.requested"
+
+
+def test_atomic_write_text_flushes_and_fsyncs_and_creates_parent(
+    tmp_path: Path, monkeypatch
+) -> None:
+    destination = tmp_path / "nested" / "queue" / "messages.jsonl"
+    fake_tmp_path = tmp_path / "tmp-write"
+    flush_mock = Mock()
+    fileno_mock = Mock(return_value=123)
+    write_mock = Mock()
+    unlink_calls: list[str] = []
+
+    class _FakeTempFile:
+        name = str(fake_tmp_path)
+
+        def write(self, data: str) -> None:
+            write_mock(data)
+
+        def flush(self) -> None:
+            flush_mock()
+
+        def fileno(self) -> int:
+            return fileno_mock()
+
+        def __enter__(self) -> "_FakeTempFile":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def _fake_named_tempfile(*args, **kwargs):
+        assert destination.parent.exists()
+        assert kwargs["dir"] == destination.parent
+        return _FakeTempFile()
+
+    fsync_mock = Mock()
+    replace_mock = Mock()
+
+    def _fake_unlink(path: str) -> None:
+        unlink_calls.append(path)
+        raise FileNotFoundError
+
+    monkeypatch.setattr(protocol_module.tempfile, "NamedTemporaryFile", _fake_named_tempfile)
+    monkeypatch.setattr(protocol_module.os, "fsync", fsync_mock)
+    monkeypatch.setattr(protocol_module.os, "replace", replace_mock)
+    monkeypatch.setattr(protocol_module.os, "unlink", _fake_unlink)
+
+    protocol_module._atomic_write_text(destination, "payload")
+
+    write_mock.assert_called_once_with("payload")
+    flush_mock.assert_called_once()
+    fileno_mock.assert_called_once()
+    fsync_mock.assert_any_call(123)
+    replace_mock.assert_called_once_with(str(fake_tmp_path), destination)
+    assert unlink_calls == [str(fake_tmp_path)]


### PR DESCRIPTION
### Motivation
- Ensure the FileQueueTransport atomic write path is durable by calling `os.fsync()` after `flush()` to persist temporary-file contents.
- Make the multi-agent atomic write behavior consistent with the shared helpers used by memory utilities by ensuring the parent directory exists before creating the temporary file.
- Add a focused unit test to validate the atomic write code path and its interactions with `flush`/`fsync` and file cleanup under mocked conditions.

### Description
- Added `os` and `tempfile` imports and introduced a local helper `def _atomic_write_text(path: Path, data: str) -> None:` in `src/singular/multiagent/protocol.py` that creates the parent directory, writes to a temporary sibling file, calls `flush()` then `os.fsync(tmp.fileno())`, atomically replaces the destination with `os.replace()`, performs a directory `fsync` on POSIX, and cleans up the temp file.
- Updated `FileQueueTransport.receive()` to use the new local `_atomic_write_text()` instead of the previously imported `atomic_write_text()` helper.
- Added a unit test `test_atomic_write_text_flushes_and_fsyncs_and_creates_parent` in `tests/test_multiagent_protocol.py` that monkeypatches `tempfile.NamedTemporaryFile`, `os.fsync`, `os.replace`, and `os.unlink` to assert that the parent directory is created before temp file creation and that `write`, `flush`, `fileno`, `fsync`, `replace`, and cleanup behavior occur as expected.

### Testing
- Ran the targeted test with `pytest -q tests/test_multiagent_protocol.py -k atomic_write_text_flushes_and_fsyncs_and_creates_parent`, which passed.
- Ran the full module tests with `pytest -q tests/test_multiagent_protocol.py`, and all tests passed (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded61f84b4832a8e02fc4d106f782b)