### PR TITLE
Refactoriser le front du dashboard : extraire CSS/JS et servir assets statiques

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -11,6 +11,7 @@ import os
 import sys
 from pathlib import Path
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi.staticfiles import StaticFiles
 from singular.lives import get_registry_root, load_registry, set_life_status
 from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
@@ -46,6 +47,8 @@ def create_app(
     app = FastAPI()
     actions = DashboardActionService(home=base_dir)
     templates_dir = Path(__file__).parent / "templates"
+    static_dir = Path(__file__).parent / "static"
+    app.mount("/static", StaticFiles(directory=static_dir), name="dashboard-static")
 
     def _render_template(name: str, replacements: dict[str, str] | None = None) -> str:
         template = (templates_dir / name).read_text(encoding="utf-8")

--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -1,0 +1,116 @@
+    :root {
+      color-scheme: light;
+      font-family: Inter, system-ui, -apple-system, sans-serif;
+    }
+    body { margin: 20px; background:#f8fafc; color:#101828; }
+    nav { margin-bottom: 16px; }
+    nav a { text-decoration:none; font-weight:600; color:#175cd3; }
+    nav a:hover { text-decoration:underline; }
+    section { margin-bottom: 24px; }
+    h1, h2 { margin-bottom:8px; }
+    .intro-box {
+      background:#ecf3ff;
+      border:1px solid #b2ccff;
+      border-radius:10px;
+      padding:12px;
+      margin:12px 0 16px;
+    }
+    .intro-steps { margin:8px 0 0 18px; padding:0; }
+    .intro-steps li { margin:4px 0; }
+    .cards-grid {
+      display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+      gap:12px;
+      margin:10px 0;
+    }
+    .card {
+      border:1px solid #d0d5dd;
+      border-radius:10px;
+      padding:10px;
+      background:#f8fafc;
+    }
+    .card-label { color:#344054; font-size:0.9rem; margin-bottom:4px; }
+    .card-value { font-size:1.1rem; font-weight:700; color:#101828; }
+    .status-good { background:#dcfae6; color:#067647; }
+    .status-warn { background:#fff4e5; color:#b54708; }
+    .status-bad { background:#fee4e2; color:#b42318; }
+    .status-muted { background:#f2f4f7; color:#475467; }
+    .sparkline {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      letter-spacing: 1px;
+      font-size: 0.95rem;
+    }
+    .panel {
+      border:1px solid #d0d5dd;
+      border-radius:10px;
+      padding:12px;
+      background:#fff;
+      box-shadow:0 1px 2px rgba(16,24,40,0.04);
+    }
+    .section-help {
+      color:#344054;
+      margin:0 0 10px;
+      font-size:0.95rem;
+    }
+    table th { background:#f2f4f7; }
+    table td, table th { vertical-align:top; }
+    .technical-toggle { margin-top:8px; }
+    pre {
+      max-height:220px;
+      overflow:auto;
+      border:1px solid #ccc;
+      padding:8px;
+      border-radius:8px;
+      background:#fcfcfd;
+    }
+
+/* Reusable UI component conventions */
+:root {
+  --panel-border:#d0d5dd;
+  --badge-success-bg:#d1fadf;
+  --badge-danger-bg:#fde2e1;
+  --badge-warning-bg:#ffe7c2;
+  --badge-info-bg:#d9ecff;
+}
+
+.ui-card,.card { border:1px solid var(--panel-border); border-radius:10px; padding:10px; background:#f8fafc; }
+.ui-panel,.panel { border:1px solid var(--panel-border); border-radius:10px; padding:12px; background:#fff; box-shadow:0 1px 2px rgba(16,24,40,0.04); }
+.badge { display:inline-block; padding:2px 8px; border-radius:999px; margin-right:4px; }
+.badge-success { background:var(--badge-success-bg); }
+.badge-danger { background:var(--badge-danger-bg); }
+.badge-warning { background:var(--badge-warning-bg); }
+.badge-info { background:var(--badge-info-bg); }
+.table-base { border:1px solid #d0d5dd; border-collapse:collapse; width:100%; }
+.table-base th, .table-base td { border:1px solid #d0d5dd; }
+.table-state-empty td { color:#475467; font-style:italic; }
+.empty-state { border:1px dashed #d0d5dd; border-radius:8px; padding:12px; color:#475467; background:#fcfcfd; }
+
+.heading-reset-top { margin-top:0; }
+.heading-tight-bottom { margin-bottom:6px; }
+.list-tight-top { margin-top:6px; }
+.list-reset-top { margin-top:0; }
+.table-spacing-top { margin-top:8px; }
+.panel-spaced-bottom { margin-bottom:12px; }
+.timeline-strip { display:flex; gap:8px; overflow:auto; white-space:nowrap; }
+.timeline-top-gap { margin-top:8px; }
+.diff-preview { padding:12px; border:1px solid #ccc; }
+.toolbar-wrap { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+.filters-wrap { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+.stats-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; margin-top:8px; }
+.panel-compact { padding:8px; }
+.panel-bordered { border-color:#ddd; }
+.list-compact { margin:8px 0 0 18px; padding:0; }
+.panel-hidden { display:none !important; }
+.panel-top-gap { margin-top:12px; }
+.content-top-gap { margin-top:8px; }
+.text-muted-small { font-size:0.9rem; color:#475467; }
+.actions-panel { display:flex; flex-direction:column; gap:8px; max-width:680px; }
+.live-events-box { max-height:240px; overflow:auto; border:1px solid #ccc; padding:8px; }
+.fallback-box { margin-top:8px; padding:8px; border-radius:8px; }
+.timeline-item { display:inline-flex; gap:4px; }
+.timeline-button { padding:6px; }
+.timeline-link { align-self:center; }
+.diff-added { color:#0a7f2e; }
+.diff-removed { color:#b42318; }
+.diff-hunk { color:#175cd3; }
+

--- a/src/singular/dashboard/static/dashboard.js
+++ b/src/singular/dashboard/static/dashboard.js
@@ -1,0 +1,325 @@
+// Dashboard module state & constants
+const HOST_SENSORS_THRESHOLD={cpuWarn:85,cpuCritical:95,ramWarn:80,ramCritical:92,tempWarn:75,tempCritical:85,diskCritical:95};
+const BADGE_TONE={
+  success:'badge-success',
+  danger:'badge-danger',
+  warning:'badge-warning',
+  info:'badge-info',
+};
+
+const ws=new WebSocket(`ws://${location.host}/ws`);
+const livesTableState={sortBy:'score',sortOrder:'desc'};
+const liveState={paused:false,autoScroll:true,events:[]};
+const scopeState={currentLifeOnly:false};
+
+const setStatusTone=(el,tone)=>{el.classList.remove('status-good','status-warn','status-bad');if(tone==='good'){el.classList.add('status-good');}if(tone==='warn'){el.classList.add('status-warn');}if(tone==='bad'){el.classList.add('status-bad');}};
+const withScope=(url)=>{const u=new URL(url,window.location.origin);if(scopeState.currentLifeOnly){u.searchParams.set('current_life_only','true');}return `${u.pathname}${u.search}`;};
+const renderDailySkills=(dailySkills)=>{
+  const frequency=dailySkills?.frequency_totals||{};
+  const progression=dailySkills?.progression_pipeline||{};
+  const topSkills=dailySkills?.top_skills||[];
+  document.getElementById('daily-skill-uses-24h').textContent=String(frequency.uses_24h||0);
+  document.getElementById('daily-skill-uses-7d').textContent=String(frequency.uses_7d||0);
+  document.getElementById('daily-skill-top').textContent=String(topSkills[0]?.skill||'n/a');
+  document.getElementById('daily-skill-progression').textContent=`${progression.learned||0}→${progression.used||0}→${progression.improved||0}`;
+  const body=document.getElementById('daily-skills-table-body');
+  body.innerHTML='';
+  for(const item of topSkills){
+    const tr=document.createElement('tr');
+    const successRate=item.success_rate===null||item.success_rate===undefined?'n/a':`${(Number(item.success_rate)*100).toFixed(1)}%`;
+    const frequencyCell=`${item.frequency?.uses_24h||0}/${item.frequency?.uses_7d||0}`;
+    const tasks=(item.associated_tasks||[]).join(', ')||'n/a';
+    tr.innerHTML=`<td>${item.skill||'n/a'}</td><td>${frequencyCell}</td><td>${successRate}</td><td>${item.last_used_at||'n/a'}</td><td>${tasks}</td><td>${item.trend||'stable'}</td>`;
+    body.appendChild(tr);
+  }
+  if(!topSkills.length){
+    const tr=document.createElement('tr');
+    tr.innerHTML="<td colspan='6'>Aucune compétence quotidienne détectée.</td>";
+    body.appendChild(tr);
+  }
+};
+const hostRisk=(name,value)=>{
+  if(value===null||value===undefined||Number.isNaN(Number(value))){return 'unsupported';}
+  const v=Number(value);
+  if(name==='cpu'){if(v>=HOST_SENSORS_THRESHOLD.cpuCritical){return 'critical';}if(v>=HOST_SENSORS_THRESHOLD.cpuWarn){return 'warn';}return 'ok';}
+  if(name==='ram'){if(v>=HOST_SENSORS_THRESHOLD.ramCritical){return 'critical';}if(v>=HOST_SENSORS_THRESHOLD.ramWarn){return 'warn';}return 'ok';}
+  if(name==='temperature'){if(v>=HOST_SENSORS_THRESHOLD.tempCritical){return 'critical';}if(v>=HOST_SENSORS_THRESHOLD.tempWarn){return 'warn';}return 'ok';}
+  if(name==='disk'){if(v>=HOST_SENSORS_THRESHOLD.diskCritical){return 'critical';}return 'ok';}
+  return 'unsupported';
+};
+const sparkline=(values)=>{
+  if(!values.length){return '·';}
+  const ticks='▁▂▃▄▅▆▇█';
+  const min=Math.min(...values);
+  const max=Math.max(...values);
+  if(max-min<0.0001){return '▅'.repeat(values.length);}
+  return values.map(v=>ticks[Math.min(ticks.length-1,Math.max(0,Math.round(((v-min)/(max-min))*(ticks.length-1))))]).join('');
+};
+const toneByRisk=(el,risk)=>{
+  el.classList.remove('status-good','status-warn','status-bad','status-muted');
+  if(risk==='ok'){el.classList.add('status-good');return;}
+  if(risk==='warn'){el.classList.add('status-warn');return;}
+  if(risk==='critical'){el.classList.add('status-bad');return;}
+  el.classList.add('status-muted');
+};
+const extractHostMetrics=(record)=>{
+  if(record&&typeof record.host_metrics==='object'&&record.host_metrics){return record.host_metrics;}
+  if(record&&typeof record.signals==='object'&&record.signals&&typeof record.signals.host_metrics==='object'){return record.signals.host_metrics;}
+  if(record&&typeof record.payload==='object'&&record.payload&&typeof record.payload.host_metrics==='object'){return record.payload.host_metrics;}
+  return null;
+};
+const renderHostMetrics=(records)=>{
+  const metricDef=[
+    {key:'cpu',label:'host-cpu',trend:'host-cpu-trend',raw:'cpu_percent',suffix:'%'},
+    {key:'ram',label:'host-ram',trend:'host-ram-trend',raw:'ram_used_percent',suffix:'%'},
+    {key:'temperature',label:'host-temp',trend:'host-temp-trend',raw:'host_temperature_c',suffix:'°C'},
+    {key:'disk',label:'host-disk',trend:'host-disk-trend',raw:'disk_used_percent',suffix:'%'},
+  ];
+  const hist={cpu:[],ram:[],temperature:[],disk:[]};
+  let latestAdaptation=null;
+  for(const record of (records||[]).slice(-160)){
+    const host=extractHostMetrics(record);
+    if(host){
+      for(const def of metricDef){
+        const val=host[def.raw];
+        if(typeof val==='number'&&!Number.isNaN(val)){hist[def.key].push(Number(val));}
+      }
+    }
+    const event=record?.event;
+    let adaptation=null;
+    if(event==='orchestrator.adaptation'&&record?.payload&&typeof record.payload==='object'){adaptation=record.payload;}
+    else if(record?.adaptation&&typeof record.adaptation==='object'){adaptation=record.adaptation;}
+    if(adaptation){latestAdaptation={ts:record?.ts||null,payload:adaptation};}
+  }
+  const riskWeight={unsupported:-1,ok:0,warn:1,critical:2};
+  let global='ok';
+  let unsupportedCount=0;
+  for(const def of metricDef){
+    const values=hist[def.key];
+    const latest=values.length?values[values.length-1]:null;
+    const risk=hostRisk(def.key,latest);
+    if(riskWeight[risk]>riskWeight[global]){global=risk;}
+    if(risk==='unsupported'){unsupportedCount+=1;}
+    const el=document.getElementById(def.label);
+    const trendEl=document.getElementById(def.trend);
+    el.textContent=latest===null?'non supporté':`${latest.toFixed(1)}${def.suffix} · ${risk}`;
+    trendEl.textContent=sparkline(values.slice(-12));
+    toneByRisk(el,risk);
+  }
+  if(unsupportedCount===metricDef.length){global='unsupported';}
+  const globalEl=document.getElementById('host-global');
+  globalEl.textContent=global;
+  toneByRisk(globalEl,global);
+  document.getElementById('host-fallback').classList.toggle('panel-hidden',unsupportedCount===0);
+  const adaptationEl=document.getElementById('host-adaptation');
+  if(latestAdaptation){
+    const rules=Array.isArray(latestAdaptation.payload?.triggered_rules)?latestAdaptation.payload.triggered_rules:[];
+    adaptationEl.textContent=`Dernière adaptation capteur: ${latestAdaptation.ts||'n/a'} · règles=${rules.join(', ')||'n/a'} · prudent=${latestAdaptation.payload?.safe_mode===true?'oui':'non'}`;
+  }else{
+    adaptationEl.textContent='Dernière adaptation capteur: aucune adaptation trouvée';
+  }
+};
+
+const loadContext=()=>fetch('/dashboard/context').then(r=>r.json()).then(ctx=>{
+  document.getElementById('ctx-root').textContent=ctx.singular_root||'n/a';
+  document.getElementById('ctx-home').textContent=ctx.singular_home||'n/a';
+  document.getElementById('ctx-lives-count').textContent=String(ctx.registry_lives_count||0);
+  const policy=ctx.policy||{};
+  const autonomy=policy.autonomy||{};
+  const permissions=policy.permissions||{};
+  document.getElementById('ctx-policy-version').textContent=String(policy.version??'n/a');
+  document.getElementById('ctx-policy-autonomy').textContent=`safe_mode=${autonomy.safe_mode?'on':'off'} · quota=${autonomy.mutation_quota_per_window??'n/a'}/${autonomy.mutation_quota_window_seconds??'n/a'}s`;
+  document.getElementById('ctx-policy-permissions').textContent=`auto=${(permissions.modifiable_paths||[]).length} · review=${(permissions.review_required_paths||[]).length} · forbidden=${(permissions.forbidden_paths||[]).length}`;
+  const impactList=document.getElementById('ctx-policy-impact');
+  impactList.innerHTML='';
+  for(const item of (ctx.policy_impact||[])){const li=document.createElement('li');li.textContent=String(item);impactList.appendChild(li);}
+  if(!(ctx.policy_impact||[]).length){const li=document.createElement('li');li.textContent='Aucun impact disponible.';impactList.appendChild(li);}
+  const lifecycle=ctx.skills_lifecycle||{};
+  document.getElementById('kpi-skills-active').textContent=String(lifecycle.active||0);
+  document.getElementById('kpi-skills-dormant').textContent=String(lifecycle.dormant||0);
+  document.getElementById('kpi-skills-archived').textContent=String(lifecycle.archived||0);
+});
+
+const loadEco=()=>Promise.all([fetch(withScope('/ecosystem')).then(r=>r.json()),fetch(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc')).then(r=>r.json())]).then(([eco,lives])=>{
+  const summary=eco.summary||{};
+  const total=Number(summary.total_organisms||0);
+  const alive=Number(summary.alive_organisms||0);
+  const dead=Math.max(total-alive,0);
+  document.getElementById('eco-total-lives').textContent=String(total);
+  document.getElementById('eco-alive-lives').textContent=String(alive);
+  document.getElementById('eco-dead-lives').textContent=String(dead);
+
+  const rows=lives.table||[];
+  const selected=rows.find(row=>row.selected_life===true);
+  document.getElementById('eco-selected-life').textContent=selected?.life||'Aucune';
+  const latestRow=rows.find(row=>row.last_activity);
+  document.getElementById('eco-last-activity').textContent=latestRow?.last_activity||'n/a';
+
+  const organisms=eco.organisms||{};
+  const list=document.getElementById('organisms-list');
+  list.innerHTML='';
+  for(const [name,payload] of Object.entries(organisms)){
+    const li=document.createElement('li');
+    const status=payload.status||'alive';
+    const energy=payload.energy??'n/a';
+    const resources=payload.resources??'n/a';
+    li.textContent=`${name} · statut=${status} · énergie=${energy} · ressources=${resources}`;
+    list.appendChild(li);
+  }
+  if(Object.keys(organisms).length===0){
+    const li=document.createElement('li');li.textContent='Aucun organisme détecté.';list.appendChild(li);
+  }
+  document.getElementById('raw-eco-json').textContent=JSON.stringify(eco,null,2);
+});
+
+
+const loadQuests=()=>fetch('/quests').then(r=>r.json()).then(data=>{document.getElementById('quests').textContent=JSON.stringify(data,null,2);});
+const loadHostVitals=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(data=>{renderHostMetrics(data?.records||[]);}).catch(()=>{renderHostMetrics([]);});
+// Cockpit domain
+const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=>{
+  const statusBox=document.getElementById('cockpit-status');
+  statusBox.textContent=`Statut global: ${d.global_status||'unknown'}`;
+  if(d.global_status==='stable'){setStatusTone(statusBox,'good');}
+  else if(d.global_status==='warning'){setStatusTone(statusBox,'warn');}
+  else if(d.global_status==='critical'){setStatusTone(statusBox,'bad');}
+
+  const healthValue=d.health_score===null?'n/a':Number(d.health_score).toFixed(1);
+  const trend=d.trend||'n/a';
+  const accepted=d.accepted_mutation_rate===null?'n/a':`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
+  const alertsCount=(d.critical_alerts||[]).length;
+  const autonomy=d.autonomy_metrics||{};
+  const decisionQuality=autonomy.decision_quality||{};
+  const fmtPct=(value)=>value===null||value===undefined?'n/a':`${(Number(value)*100).toFixed(1)}%`;
+  const fmtNum=(value,suffix='')=>value===null||value===undefined?'n/a':`${Number(value).toFixed(2)}${suffix}`;
+
+  document.getElementById('kpi-health').textContent=healthValue;
+  document.getElementById('kpi-trend').textContent=trend;
+  document.getElementById('kpi-accepted').textContent=accepted;
+  document.getElementById('kpi-alerts').textContent=String(alertsCount);
+  document.getElementById('kpi-next-action').textContent=d.next_action||'n/a';
+  document.getElementById('kpi-autonomy-proactive').textContent=fmtPct(autonomy.proactive_initiative_rate);
+  document.getElementById('kpi-autonomy-stability').textContent=fmtPct(autonomy.long_term_stability);
+  document.getElementById('kpi-autonomy-decision').textContent=`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`;
+  document.getElementById('kpi-autonomy-latency').textContent=fmtNum(autonomy.perception_to_action_latency_ms,' ms');
+  document.getElementById('kpi-autonomy-cost').textContent=fmtNum(autonomy.resource_cost_per_gain);
+  const vital=d.vital_timeline||{};
+  const skillLifecycle=d.skills_lifecycle||{};
+  const vitalMetrics=d.vital_metrics||{};
+  const objectives=vitalMetrics.active_objectives||{};
+  const trajectory=d.trajectory||{};
+  const trajectoryObjectives=trajectory.objectives||{};
+  const trajectoryCounts=trajectoryObjectives.counts||{};
+  const priorityChanges=trajectory.priority_changes||[];
+  const objectiveLinks=trajectory.objective_narrative_links||[];
+  const energyResources=vitalMetrics.energy_resources||{};
+  const codeGeneration=vitalMetrics.code_generation||{};
+  const risks=vitalMetrics.risks||[];
+  document.getElementById('kpi-vital-age').textContent=String(vital.age??0);
+  document.getElementById('kpi-vital-risk').textContent=String(vital.risk_level||'n/a');
+  document.getElementById('kpi-vital-terminal').textContent=vital.terminal===true?'oui':'non';
+  document.getElementById('kpi-vital-causes').textContent=(vital.causes||[]).join(', ')||'n/a';
+  document.getElementById('kpi-circadian-phase').textContent=String((vitalMetrics.circadian_cycle||{}).phase||'n/a');
+  document.getElementById('kpi-active-objectives-count').textContent=String(objectives.count||0);
+  document.getElementById('kpi-quests-progress').textContent=`${objectives.count||0} actifs`;
+  document.getElementById('kpi-energy-total').textContent=fmtNum(energyResources.total_energy);
+  document.getElementById('kpi-resources-total').textContent=fmtNum(energyResources.total_resources);
+  document.getElementById('kpi-code-progression').textContent=String(codeGeneration.progression||'n/a');
+  document.getElementById('kpi-code-risks').textContent=risks.length?risks.join(', '):String(codeGeneration.risk_level||'n/a');
+  document.getElementById('kpi-skills-active').textContent=String(skillLifecycle.active||0);
+  document.getElementById('kpi-skills-dormant').textContent=String(skillLifecycle.dormant||0);
+  document.getElementById('kpi-skills-archived').textContent=String(skillLifecycle.archived||0);
+  renderDailySkills(d.daily_skills||{});
+  const objectivesList=document.getElementById('kpi-active-objectives-list');
+  objectivesList.innerHTML='';
+  for(const item of (objectives.items||[])){
+    const li=document.createElement('li');
+    li.textContent=String(item.name||item.id||'objectif');
+    objectivesList.appendChild(li);
+  }
+  if(!(objectives.items||[]).length){const li=document.createElement('li');li.textContent='Aucun objectif actif';objectivesList.appendChild(li);}
+  document.getElementById('kpi-trajectory-in-progress').textContent=String(trajectoryCounts.in_progress||0);
+  document.getElementById('kpi-trajectory-abandoned').textContent=String(trajectoryCounts.abandoned||0);
+  document.getElementById('kpi-trajectory-completed').textContent=String(trajectoryCounts.completed||0);
+  document.getElementById('kpi-trajectory-priority-count').textContent=String(priorityChanges.length||0);
+  document.getElementById('kpi-trajectory-links-count').textContent=String(objectiveLinks.length||0);
+  const priorityList=document.getElementById('kpi-priority-changes-list');
+  priorityList.innerHTML='';
+  for(const change of priorityChanges.slice(-5).reverse()){
+    const li=document.createElement('li');
+    li.textContent=`${change.objective||'objectif'} · ${change.from??'n/a'} → ${change.to??'n/a'} (${change.at||'n/a'})`;
+    priorityList.appendChild(li);
+  }
+  if(!priorityChanges.length){const li=document.createElement('li');li.textContent='Aucun changement détecté';priorityList.appendChild(li);}
+  const linksList=document.getElementById('kpi-objective-links-list');
+  linksList.innerHTML='';
+  for(const link of objectiveLinks.slice(-5).reverse()){
+    const li=document.createElement('li');
+    li.textContent=`${link.objective||'objectif'} ↔ ${link.event||'événement'} (${link.at||'n/a'})`;
+    linksList.appendChild(li);
+  }
+  if(!objectiveLinks.length){const li=document.createElement('li');li.textContent='Aucun lien narratif détecté';linksList.appendChild(li);}
+  setStatusTone(document.getElementById('kpi-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
+
+  const notable=d.last_notable_mutation;
+  if(notable){
+    const acceptedBadge=notable.accepted===true?'acceptée':(notable.accepted===false?'refusée':'n/a');
+    document.getElementById('kpi-notable-summary').textContent=`${notable.timestamp||'n/a'} · ${notable.life||'n/a'} · ${notable.operator||'n/a'} · ${acceptedBadge} · Δ=${notable.impact_delta??'n/a'}`;
+  } else {
+    document.getElementById('kpi-notable-summary').textContent='Aucune mutation notable';
+  }
+
+  const actionsEl=document.getElementById('kpi-actions');
+  actionsEl.innerHTML='';
+  for(const action of (d.suggested_actions||[])){
+    const li=document.createElement('li');
+    li.textContent=String(action);
+    actionsEl.appendChild(li);
+  }
+  if((d.suggested_actions||[]).length===0){
+    const li=document.createElement('li');li.textContent='Aucune action suggérée';actionsEl.appendChild(li);
+  }
+  document.getElementById('raw-cockpit-json').textContent=JSON.stringify(d,null,2);
+});
+
+const paintDiff=(raw)=>{const escaped=String(raw||'').replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');return escaped.split('\n').map(line=>{if(line.startsWith('+')){return `<span class='diff-added'>${line}</span>`;}if(line.startsWith('-')){return `<span class='diff-removed'>${line}</span>`;}if(line.startsWith('@@')){return `<span class='diff-hunk'>${line}</span>`;}return line;}).join('\n');};
+const showMutationDetail=(runId,index)=>fetch(`/api/runs/${runId}/mutations/${index}`).then(r=>r.json()).then(d=>{document.getElementById('timeline-summary').textContent=d.human_summary||d.decision_reason||'Aucun résumé disponible.';document.getElementById('timeline-impact').textContent=JSON.stringify(d.impact,null,2);document.getElementById('timeline-diff').innerHTML=paintDiff(d.diff)||'Aucun diff.';});
+const runAction=(action,payload)=>{const token=document.getElementById('action-token')?.value||'';const q=new URLSearchParams();if(token){q.set('token',token);}if(payload){q.set('payload',JSON.stringify(payload));}return fetch(`/api/actions/${action}?${q.toString()}`).then(async r=>{if(!r.ok){throw new Error(`HTTP ${r.status}`);}return r.json();}).then(data=>{document.getElementById('action-result').textContent=JSON.stringify(data,null,2);loadEco();loadCockpit();loadTimeline();}).catch(err=>{document.getElementById('action-result').textContent=`Erreur action ${action}: ${err.message}`;});};
+document.getElementById('act-birth').onclick=()=>runAction('birth',{name:document.getElementById('action-life-name').value||'Nouvelle vie'});
+document.getElementById('act-talk').onclick=()=>runAction('talk',{prompt:document.getElementById('action-prompt').value||''});
+document.getElementById('act-loop').onclick=()=>runAction('loop',{budget_seconds:Number(document.getElementById('action-budget').value||0)});
+document.getElementById('act-report').onclick=()=>runAction('report',{});
+document.getElementById('act-lives-list').onclick=()=>runAction('lives_list',{});
+document.getElementById('act-lives-use').onclick=()=>runAction('lives_use',{name:document.getElementById('action-life-name').value||''});
+document.getElementById('act-archive').onclick=()=>runAction('archive',{name:document.getElementById('action-life-name').value||''});
+document.getElementById('act-memorial').onclick=()=>runAction('memorial',{name:document.getElementById('action-life-name').value||'',message:'Merci pour ce cycle de vie.'});
+document.getElementById('act-clone').onclick=()=>runAction('clone',{name:document.getElementById('action-life-name').value||'',new_name:`${document.getElementById('action-life-name').value||'Vie'} clone`});
+const badge=(label,tone)=>`<span class='badge ${tone}'>${label}</span>`;
+const renderLivesBuckets=(rows)=>{const activeInRegistry=(rows||[]).filter(row=>row.is_registry_active_life===true);const extinctInRuns=(rows||[]).filter(row=>row.extinction_seen_in_runs===true);const aliveList=document.getElementById('alive-lives');const deadList=document.getElementById('dead-lives');document.getElementById('alive-count').textContent=String(activeInRegistry.length);document.getElementById('dead-count').textContent=String(extinctInRuns.length);aliveList.innerHTML='';deadList.innerHTML='';for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||'n/a';aliveList.appendChild(li);}for(const row of extinctInRuns){const li=document.createElement('li');li.textContent=row.life||'n/a';deadList.appendChild(li);}if(!activeInRegistry.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);}if(!extinctInRuns.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);}};
+const renderLivesTable=(rows)=>{const body=document.getElementById('lives-table-body');body.innerHTML='';for(const row of rows||[]){const tr=document.createElement('tr');const score=row.current_health_score===null||row.current_health_score===undefined?'n/a':Number(row.current_health_score).toFixed(1);const stability=row.stability===null||row.stability===undefined?'n/a':`${(Number(row.stability)*100).toFixed(1)}%`;const lastActivity=row.last_activity||'n/a';let badges='';if(row.selected_life){badges+=badge('Vie sélectionnée',BADGE_TONE.success);}else{badges+=badge('Vie non sélectionnée',BADGE_TONE.danger);}if(row.is_registry_active_life){badges+=badge('Vie active dans le registre',BADGE_TONE.success);}else{badges+=badge(`Statut registre: ${row.life_status||'n/a'}`,BADGE_TONE.danger);}if(row.run_terminated){badges+=badge('Run terminé',BADGE_TONE.warning);}if(row.extinction_seen_in_runs){badges+=badge('Extinction détectée',BADGE_TONE.danger);}if(row.has_recent_activity){badges+=badge('Activité récente',BADGE_TONE.info);}if(row.trend==='dégradation'){badges+=badge('dégradation',BADGE_TONE.warning);}if((row.alerts_count||0)>0){badges+=badge(`${row.alerts_count} alertes`,BADGE_TONE.danger);}tr.innerHTML=`<td>${row.life||'n/a'}</td><td>${score}</td><td>${row.trend||'n/a'}</td><td>${stability}</td><td>${lastActivity}</td><td>${row.iterations??0}</td><td>${badges}</td>`;body.appendChild(tr);}if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}};
+const renderUnattachedRuns=(payload)=>{const panel=document.getElementById('unattached-runs-panel');const list=document.getElementById('unattached-runs-list');const runs=(payload?.runs)||[];const runsCount=Number(payload?.runs_count||0);const recordsCount=Number(payload?.records_count||0);document.getElementById('unattached-runs-count').textContent=String(runsCount);document.getElementById('unattached-records-count').textContent=String(recordsCount);list.innerHTML='';if(!runsCount){panel.classList.add('panel-hidden');return;}panel.classList.remove('panel-hidden');for(const item of runs){const li=document.createElement('li');li.textContent=`${item.run_id||'unknown'} · ${item.records_count||0} enregistrements`;list.appendChild(li);}};
+const renderGenealogyTree=(payload)=>{const nodes=payload?.nodes||[];const treeEl=document.getElementById('genealogy-tree');const socialEl=document.getElementById('social-network-tree');const conflictsEl=document.getElementById('active-conflicts');if(!nodes.length){treeEl.textContent='Aucune lignée enregistrée.';socialEl.textContent='Aucun réseau social.';conflictsEl.textContent='Aucun conflit.';return;}const bySlug=new Map(nodes.map(node=>[node.slug,node]));const children=new Map();for(const node of nodes){children.set(node.slug,[]);}for(const node of nodes){for(const parent of (node.parents||[])){if(children.has(parent)){children.get(parent).push(node.slug);}}}const roots=nodes.filter(node=>(node.parents||[]).length===0).map(node=>node.slug);const lines=[];const visit=(slug,depth)=>{const node=bySlug.get(slug);if(!node){return;}const marker=node.active?'★':'•';const status=node.status==='extinct'?'✝':'✓';lines.push(`${'  '.repeat(depth)}${marker} ${node.name} (${node.slug}) [${status}]`);for(const child of (children.get(slug)||[])){visit(child,depth+1);}};for(const root of roots){visit(root,0);}const detached=nodes.filter(node=>!roots.includes(node.slug)&&!(node.parents||[]).every(parent=>bySlug.has(parent)));for(const node of detached){lines.push(`• ${node.name} (${node.slug}) [orphan]`);}treeEl.textContent=lines.join('\n');const socialLines=[];for(const node of nodes){const allies=(node.allies||[]).join(', ')||'-';const rivals=(node.rivals||[]).join(', ')||'-';socialLines.push(`${node.slug} | proximité=${Number(node.proximity_score||0.5).toFixed(2)} | alliés: ${allies} | rivaux: ${rivals}`);}socialEl.textContent=socialLines.join('\n');const conflicts=payload?.active_conflicts||[];conflictsEl.textContent=conflicts.length?conflicts.map(c=>`${c.life_a} ⚔ ${c.life_b}`).join('\n'):'Aucun conflit actif.';};
+const loadGenealogy=()=>fetch('/lives/genealogy').then(r=>r.json()).then(renderGenealogyTree).catch(()=>{document.getElementById('genealogy-tree').textContent='Impossible de charger la généalogie.';});
+// Lives board domain
+const loadLivesBoard=()=>{const q=new URLSearchParams();q.set('sort_by',livesTableState.sortBy);q.set('sort_order',livesTableState.sortOrder);if(document.getElementById('filter-active').checked){q.set('active_only','true');}if(document.getElementById('filter-degrading').checked){q.set('degrading_only','true');}if(document.getElementById('filter-dead').checked){q.set('dead_only','true');}const timeWindow=document.getElementById('filter-time-window').value||'all';q.set('time_window',timeWindow);const compareLives=(document.getElementById('filter-compare-lives').value||'').trim();if(compareLives){q.set('compare_lives',compareLives);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}return fetch(`/lives/comparison?${q.toString()}`).then(r=>r.json()).then(d=>{renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})));renderLivesTable(d.table||[]);renderUnattachedRuns(d.unattached_runs);});};
+for(const button of document.querySelectorAll('#lives-table [data-sort]')){button.onclick=()=>{const next=button.getAttribute('data-sort');if(livesTableState.sortBy===next){livesTableState.sortOrder=livesTableState.sortOrder==='desc'?'asc':'desc';}else{livesTableState.sortBy=next;livesTableState.sortOrder='desc';}loadLivesBoard();};}
+document.getElementById('filter-active').onchange=()=>loadLivesBoard();
+document.getElementById('filter-degrading').onchange=()=>loadLivesBoard();
+document.getElementById('filter-dead').onchange=()=>loadLivesBoard();
+document.getElementById('filter-time-window').onchange=()=>loadLivesBoard();
+document.getElementById('filter-compare-lives').onchange=()=>loadLivesBoard();
+const renderLiveEvents=()=>{const pre=document.getElementById('live-events');const rows=liveState.events.map(item=>`${item.ts||'n/a'} | ${item.run_id||'n/a'} | ${item.event||'unknown'}`);pre.textContent=rows.join('\n');if(liveState.autoScroll){pre.scrollTop=pre.scrollHeight;}};
+const updateLiveStatus=()=>{document.getElementById('live-status').textContent=liveState.paused?'Pause activée':'Lecture en direct';document.getElementById('live-toggle').textContent=liveState.paused?'Reprendre':'Pause';};
+document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};
+document.getElementById('live-autoscroll').onchange=e=>{liveState.autoScroll=Boolean(e.target.checked);if(liveState.autoScroll){renderLiveEvents();}};
+// Timeline domain
+const loadTimeline=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=scopeState.currentLifeOnly?'&current_life_only=true':'';return fetch(`/api/runs/${meta.run}/timeline?page=1&page_size=120${q}`).then(r=>r.json());}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.className='timeline-item';const btn=document.createElement('button');btn.className='timeline-button';btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.className='timeline-link';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';}});
+// Reflections domain
+const loadReflections=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=new URLSearchParams();const objective=document.getElementById('reflection-objective').value;const mood=document.getElementById('reflection-mood').value;const success=document.getElementById('reflection-success').value;if(objective){q.set('objective',objective);}if(mood){q.set('mood',mood);}if(success){q.set('success',success);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}const suffix=q.toString()?`?${q.toString()}`:'';return fetch(`/api/runs/${meta.run}/consciousness${suffix}`).then(r=>r.ok?r.json():{run_id:meta.run,items:[]});}).then(data=>{const wrap=document.getElementById('reflections-timeline');const detail=document.getElementById('reflections-detail');wrap.innerHTML='';for(const item of data.items||[]){const row=document.createElement('div');row.className='timeline-item';const btn=document.createElement('button');btn.className='timeline-button';const mood=item.emotional_state?.mood||'n/a';const objective=item.objective||'n/a';btn.textContent=`${item.ts||'n/a'} · ${objective} · ${mood}`;btn.onclick=()=>{detail.textContent=JSON.stringify(item,null,2);};row.appendChild(btn);wrap.appendChild(row);}if(!(data.items||[]).length){detail.textContent='Aucune réflexion disponible pour ces filtres.';}});
+document.getElementById('reflection-apply').onclick=()=>loadReflections();
+
+// Module bootstrap
+loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();loadGenealogy();loadQuests();setInterval(()=>{loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();loadGenealogy();loadQuests();},500);
+loadHostVitals();setInterval(()=>{loadHostVitals();},1200);
+loadReflections();setInterval(()=>{loadReflections();},800);
+updateLiveStatus();
+ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);return;}if(m.type==='quests'){document.getElementById('quests').textContent=JSON.stringify(m.data,null,2);return;}if(typeof m.run_id==='string'&&typeof m.event==='string'){liveState.events.push({type:m.type,run_id:m.run_id,event:m.event,ts:m.ts||null});if(!liveState.paused){renderLiveEvents();}}};

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -1,73 +1,8 @@
 <html>
 <head>
   <title>Tableau de bord Singular</title>
-  <style>
-    :root {
-      color-scheme: light;
-      font-family: Inter, system-ui, -apple-system, sans-serif;
-    }
-    body { margin: 20px; background:#f8fafc; color:#101828; }
-    nav { margin-bottom: 16px; }
-    nav a { text-decoration:none; font-weight:600; color:#175cd3; }
-    nav a:hover { text-decoration:underline; }
-    section { margin-bottom: 24px; }
-    h1, h2 { margin-bottom:8px; }
-    .intro-box {
-      background:#ecf3ff;
-      border:1px solid #b2ccff;
-      border-radius:10px;
-      padding:12px;
-      margin:12px 0 16px;
-    }
-    .intro-steps { margin:8px 0 0 18px; padding:0; }
-    .intro-steps li { margin:4px 0; }
-    .cards-grid {
-      display:grid;
-      grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
-      gap:12px;
-      margin:10px 0;
-    }
-    .card {
-      border:1px solid #d0d5dd;
-      border-radius:10px;
-      padding:10px;
-      background:#f8fafc;
-    }
-    .card-label { color:#344054; font-size:0.9rem; margin-bottom:4px; }
-    .card-value { font-size:1.1rem; font-weight:700; color:#101828; }
-    .status-good { background:#dcfae6; color:#067647; }
-    .status-warn { background:#fff4e5; color:#b54708; }
-    .status-bad { background:#fee4e2; color:#b42318; }
-    .status-muted { background:#f2f4f7; color:#475467; }
-    .sparkline {
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-      letter-spacing: 1px;
-      font-size: 0.95rem;
-    }
-    .panel {
-      border:1px solid #d0d5dd;
-      border-radius:10px;
-      padding:12px;
-      background:#fff;
-      box-shadow:0 1px 2px rgba(16,24,40,0.04);
-    }
-    .section-help {
-      color:#344054;
-      margin:0 0 10px;
-      font-size:0.95rem;
-    }
-    table th { background:#f2f4f7; }
-    table td, table th { vertical-align:top; }
-    .technical-toggle { margin-top:8px; }
-    pre {
-      max-height:220px;
-      overflow:auto;
-      border:1px solid #ccc;
-      padding:8px;
-      border-radius:8px;
-      background:#fcfcfd;
-    }
-  </style>
+    <link rel='stylesheet' href='/static/dashboard.css'/>
+
 </head>
 <body>
 <h1>Tableau de bord Singular</h1>
@@ -104,7 +39,7 @@
     <div class='card'><div class='card-label'>Prochaine action</div><div id='kpi-next-action' class='card-value'>n/a</div></div>
   </div>
   <div class='panel'>
-    <h3 style='margin-top:0;'>Santé hôte consolidée</h3>
+    <h3 class='heading-reset-top'>Santé hôte consolidée</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>CPU</div><div id='host-cpu' class='card-value'>n/a</div><div id='host-cpu-trend' class='sparkline'>·</div></div>
       <div class='card'><div class='card-label'>RAM</div><div id='host-ram' class='card-value'>n/a</div><div id='host-ram-trend' class='sparkline'>·</div></div>
@@ -112,8 +47,8 @@
       <div class='card'><div class='card-label'>Disque</div><div id='host-disk' class='card-value'>n/a</div><div id='host-disk-trend' class='sparkline'>·</div></div>
       <div class='card'><div class='card-label'>État global</div><div id='host-global' class='card-value'>n/a</div></div>
     </div>
-    <div id='host-adaptation' style='margin-top:8px;'>Dernière adaptation capteur: n/a</div>
-    <div id='host-fallback' class='status-muted' style='display:none;margin-top:8px;padding:8px;border-radius:8px;'>
+    <div id='host-adaptation' class='content-top-gap'>Dernière adaptation capteur: n/a</div>
+    <div id='host-fallback' class='status-muted panel-hidden fallback-box'>
       Certains capteurs hôte ne sont pas supportés sur cette plateforme (ou aucune donnée récente n’est disponible).
     </div>
   </div>
@@ -137,7 +72,7 @@
   </div>
 
   <div class='panel'>
-    <h3 style='margin-top:0;'>Synthèse des vies</h3>
+    <h3 class='heading-reset-top'>Synthèse des vies</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Vies totales</div><div id='eco-total-lives' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Vies vivantes</div><div id='eco-alive-lives' class='card-value'>0</div></div>
@@ -149,17 +84,17 @@
 
 
   <div class='panel'>
-    <h3 style='margin-top:0;'>Cycle circadien & objectifs actifs</h3>
+    <h3 class='heading-reset-top'>Cycle circadien & objectifs actifs</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Phase circadienne</div><div id='kpi-circadian-phase' class='card-value'>n/a</div></div>
       <div class='card'><div class='card-label'>Objectifs actifs</div><div id='kpi-active-objectives-count' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Progression quêtes</div><div id='kpi-quests-progress' class='card-value'>n/a</div></div>
     </div>
-    <ul id='kpi-active-objectives-list' style='margin-top:6px;'></ul>
+    <ul id='kpi-active-objectives-list' class='list-tight-top'></ul>
   </div>
 
   <div class='panel'>
-    <h3 style='margin-top:0;'>Trajectory des objectifs</h3>
+    <h3 class='heading-reset-top'>Trajectory des objectifs</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>En cours</div><div id='kpi-trajectory-in-progress' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Abandonnés</div><div id='kpi-trajectory-abandoned' class='card-value'>0</div></div>
@@ -167,14 +102,14 @@
       <div class='card'><div class='card-label'>Changements priorité</div><div id='kpi-trajectory-priority-count' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Liens narratifs</div><div id='kpi-trajectory-links-count' class='card-value'>0</div></div>
     </div>
-    <h4 style='margin-bottom:6px;'>Derniers changements de priorité</h4>
-    <ul id='kpi-priority-changes-list' style='margin-top:0;'></ul>
-    <h4 style='margin-bottom:6px;'>Liens objectifs ↔ événements majeurs</h4>
-    <ul id='kpi-objective-links-list' style='margin-top:0;'></ul>
+    <h4 class='heading-tight-bottom'>Derniers changements de priorité</h4>
+    <ul id='kpi-priority-changes-list' class='list-reset-top'></ul>
+    <h4 class='heading-tight-bottom'>Liens objectifs ↔ événements majeurs</h4>
+    <ul id='kpi-objective-links-list' class='list-reset-top'></ul>
   </div>
 
   <div class='panel'>
-    <h3 style='margin-top:0;'>Cycle de vie des skills</h3>
+    <h3 class='heading-reset-top'>Cycle de vie des skills</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Skills actives</div><div id='kpi-skills-active' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Skills dormantes</div><div id='kpi-skills-dormant' class='card-value'>0</div></div>
@@ -183,7 +118,7 @@
   </div>
 
   <div class='panel' id='competences-quotidien'>
-    <h3 style='margin-top:0;'>Compétences du quotidien</h3>
+    <h3 class='heading-reset-top'>Compétences du quotidien</h3>
     <p class='section-help'>Concentrez-vous sur les skills réellement utilisées et leur taux de réussite pour éviter les métriques “bruit”.</p>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Fréquence (24h)</div><div id='daily-skill-uses-24h' class='card-value'>0</div></div>
@@ -191,7 +126,7 @@
       <div class='card'><div class='card-label'>Top skill</div><div id='daily-skill-top' class='card-value'>n/a</div></div>
       <div class='card'><div class='card-label'>Progression apprise→utilisée→améliorée</div><div id='daily-skill-progression' class='card-value'>0→0→0</div></div>
     </div>
-    <table border='1' cellspacing='0' cellpadding='6' style='margin-top:8px;border-collapse:collapse;width:100%;'>
+    <table class='table-base table-spacing-top'>
       <thead><tr>
         <th>Compétence</th>
         <th>Fréquence 24h/7j</th>
@@ -205,7 +140,7 @@
   </div>
 
   <div class='panel'>
-    <h3 style='margin-top:0;'>Énergie / ressources & génération de code</h3>
+    <h3 class='heading-reset-top'>Énergie / ressources & génération de code</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Énergie totale</div><div id='kpi-energy-total' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Ressources totales</div><div id='kpi-resources-total' class='card-value'>0</div></div>
@@ -215,11 +150,11 @@
   </div>
 
   <div class='panel'>
-    <h3 style='margin-top:0;'>Dernière mutation notable</h3>
+    <h3 class='heading-reset-top'>Dernière mutation notable</h3>
     <p class='section-help'>Cette mutation est le meilleur “indice explicatif” de la trajectoire actuelle.</p>
     <div id='kpi-notable-summary'>Aucune mutation notable</div>
     <h4>Actions suggérées</h4>
-    <ul id='kpi-actions' style='margin-top:6px;'></ul>
+    <ul id='kpi-actions' class='list-tight-top'></ul>
     <details class='technical-toggle'>
       <summary><button type='button'>Voir détail technique</button></summary>
       <h4>Payload cockpit</h4>
@@ -235,8 +170,8 @@
 <section id="parametres">
   <h2>Paramètres</h2>
   <p class='section-help'>Section de diagnostic : utile surtout si vous suspectez un problème de configuration, de policy ou de registre.</p>
-  <div class='panel' style='margin-bottom:12px;'>
-    <h3 style='margin-top:0;'>Contexte registre</h3>
+  <div class='panel panel-spaced-bottom'>
+    <h3 class='heading-reset-top'>Contexte registre</h3>
     <div><strong>Registre courant (SINGULAR_ROOT)</strong> : <code id='ctx-root'>n/a</code></div>
     <div><strong>Vie courante (SINGULAR_HOME)</strong> : <code id='ctx-home'>n/a</code></div>
     <div><strong>Nombre de vies détectées</strong> : <span id='ctx-lives-count'>0</span></div>
@@ -257,17 +192,17 @@
 <section id="timeline-section">
   <h2>Timeline des événements</h2>
   <p class='section-help'>Objectif : passer du “quoi s’est passé” au “pourquoi cette décision”. Cliquez un événement de mutation pour inspecter impact + diff.</p>
-  <div id='timeline' style='display:flex;gap:8px;overflow:auto;white-space:nowrap;'></div>
+  <div id='timeline' class='timeline-strip'></div>
   <h3>Détail mutation</h3>
   <p id='timeline-summary'>Cliquez sur un événement de mutation.</p>
   <pre id='timeline-impact'></pre>
-  <pre id='timeline-diff' style='padding:12px;border:1px solid #ccc;'></pre>
+  <pre id='timeline-diff' class='diff-preview'></pre>
 </section>
 
 <section id="reflections-section">
   <h2>Timeline des réflexions</h2>
   <p class='section-help'>Filtrez par objectif/humeur/succès pour relier la qualité des décisions à l’état interne.</p>
-  <div style='display:flex;gap:8px;flex-wrap:wrap;align-items:center;'>
+  <div class='toolbar-wrap'>
     <label>Objectif
       <select id='reflection-objective'>
         <option value=''>Tous</option>
@@ -287,13 +222,13 @@
     </label>
     <button id='reflection-apply'>Appliquer filtres</button>
   </div>
-  <div id='reflections-timeline' style='display:flex;gap:8px;overflow:auto;white-space:nowrap;margin-top:8px;'></div>
-  <pre id='reflections-detail' style='margin-top:8px;'></pre>
+  <div id='reflections-timeline' class='timeline-strip timeline-top-gap'></div>
+  <pre id='reflections-detail' class='content-top-gap'></pre>
 </section>
 
 <section id="vies"><h2>Vies · Tableau comparatif</h2>
   <p class='section-help'>Comparez plusieurs vies sur la même fenêtre temporelle pour choisir la plus robuste, pas seulement la plus performante à court terme.</p>
-  <div style='display:flex;gap:12px;align-items:center;flex-wrap:wrap;'>
+  <div class='filters-wrap'>
     <label><input id='filter-active' type='checkbox'/> Statut registre: active</label>
     <label><input id='filter-degrading' type='checkbox'/> Seulement en dégradation</label>
     <label><input id='filter-dead' type='checkbox'/> Extinction détectée</label>
@@ -307,17 +242,17 @@
     </label>
     <label>Comparer vies (CSV) <input id='filter-compare-lives' placeholder='life-a,life-b'/></label>
   </div>
-  <div style='display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:12px;margin-top:8px;'>
-    <div style='border:1px solid #ddd;border-radius:8px;padding:8px;'>
+  <div class='stats-grid'>
+    <div class='panel panel-compact panel-bordered'>
       <strong>Vies actives dans le registre (<span id='alive-count'>0</span>)</strong>
-      <ul id='alive-lives' style='margin:8px 0 0 18px;padding:0;'></ul>
+      <ul id='alive-lives' class='list-compact'></ul>
     </div>
-    <div style='border:1px solid #ddd;border-radius:8px;padding:8px;'>
+    <div class='panel panel-compact panel-bordered'>
       <strong>Extinctions détectées dans les runs (<span id='dead-count'>0</span>)</strong>
-      <ul id='dead-lives' style='margin:8px 0 0 18px;padding:0;'></ul>
+      <ul id='dead-lives' class='list-compact'></ul>
     </div>
   </div>
-  <table id='lives-table' border='1' cellspacing='0' cellpadding='6' style='margin-top:8px;border-collapse:collapse;width:100%;'>
+  <table id='lives-table' class='table-base table-spacing-top'>
     <thead><tr>
       <th><button data-sort='life'>Vie</button></th>
       <th><button data-sort='score'>Score</button></th>
@@ -328,33 +263,33 @@
       <th>Badges</th>
     </tr></thead><tbody id='lives-table-body'></tbody>
   </table>
-  <div id='unattached-runs-panel' style='display:none;margin-top:12px;border:1px solid #ddd;border-radius:8px;padding:8px;'>
+  <div id='unattached-runs-panel' class='panel panel-hidden panel-top-gap panel-bordered panel-compact'>
     <strong>Runs non rattachés (<span id='unattached-runs-count'>0</span>)</strong>
-    <div style='font-size:0.9rem;color:#475467;'>Enregistrements sans vie explicite: <span id='unattached-records-count'>0</span></div>
-    <ul id='unattached-runs-list' style='margin:8px 0 0 18px;padding:0;'></ul>
+    <div class='text-muted-small'>Enregistrements sans vie explicite: <span id='unattached-records-count'>0</span></div>
+    <ul id='unattached-runs-list' class='list-compact'></ul>
   </div>
-  <div class='panel' style='margin-top:12px;'>
-    <h3 style='margin-top:0;'>Arbre généalogique (simplifié)</h3>
+  <div class='panel panel-top-gap'>
+    <h3 class='heading-reset-top'>Arbre généalogique (simplifié)</h3>
     <pre id='genealogy-tree'>Chargement…</pre>
-    <div style='margin-top:8px;'><strong>Réseau social</strong><pre id='social-network-tree'>Chargement…</pre></div>
-    <div style='margin-top:8px;'><strong>Conflits actifs</strong><pre id='active-conflicts'>Chargement…</pre></div>
+    <div class='content-top-gap'><strong>Réseau social</strong><pre id='social-network-tree'>Chargement…</pre></div>
+    <div class='content-top-gap'><strong>Conflits actifs</strong><pre id='active-conflicts'>Chargement…</pre></div>
   </div>
 </section>
 
 <section id="actions"><h2>Actions rapides</h2><pre id='action-result'>Aucune exécution</pre>
   <p class='section-help'>Utilisez cette section pour agir immédiatement sans quitter le dashboard (créer, parler, lancer une boucle, archiver).</p>
-  <div class='panel' style='display:flex;flex-direction:column;gap:8px;max-width:680px;'>
+  <div class='panel actions-panel'>
     <label>Jeton dashboard <input id='action-token' type='password' placeholder='optionnel'/></label>
     <label>Nom de vie (créer/utiliser) <input id='action-life-name' placeholder='Nouvelle vie'/></label>
     <label>Prompt de discussion <input id='action-prompt' placeholder='Prompt unique'/></label>
     <label>Budget boucle (s) <input id='action-budget' type='number' min='0.1' step='0.1' value='1.0'/></label>
-    <div style='display:flex;gap:8px;flex-wrap:wrap;'>
+    <div class='toolbar-wrap'>
       <button id='act-birth'>Créer vie</button><button id='act-talk'>Discuter</button><button id='act-loop'>Boucle</button>
       <button id='act-archive'>Archiver</button><button id='act-memorial'>Mémorial</button><button id='act-clone'>Cloner</button>
     </div>
     <details>
       <summary>Actions secondaires</summary>
-      <div style='display:flex;gap:8px;flex-wrap:wrap;margin-top:8px;'>
+      <div class='toolbar-wrap content-top-gap'>
         <button id='act-report'>Rapport</button><button id='act-lives-list'>Lister vies</button><button id='act-lives-use'>Utiliser vie</button>
       </div>
     </details>
@@ -363,326 +298,15 @@
 
 <section id="logs-live"><h2>Logs en direct</h2>
   <p class='section-help'>Flux opérationnel en temps réel. Si vous investiguez un incident, mettez en pause puis relisez les derniers événements.</p>
-  <div style='display:flex;gap:8px;align-items:center;flex-wrap:wrap;'>
+  <div class='toolbar-wrap'>
     <button id='live-toggle'>Pause</button>
     <label><input id='live-autoscroll' type='checkbox' checked/> Défilement automatique</label>
     <span id='live-status'>Lecture en direct</span>
   </div>
-  <pre id='live-events' style='max-height:240px;overflow:auto;border:1px solid #ccc;padding:8px;'></pre>
+  <pre id='live-events' class='live-events-box'></pre>
 </section>
 
-<script>
-const ws=new WebSocket(`ws://${location.host}/ws`);
-const livesTableState={sortBy:'score',sortOrder:'desc'};
-const liveState={paused:false,autoScroll:true,events:[]};
-const scopeState={currentLifeOnly:false};
+<script src='/static/dashboard.js'></script>
 
-const setStatusTone=(el,tone)=>{el.classList.remove('status-good','status-warn','status-bad');if(tone==='good'){el.classList.add('status-good');}if(tone==='warn'){el.classList.add('status-warn');}if(tone==='bad'){el.classList.add('status-bad');}};
-const withScope=(url)=>{const u=new URL(url,window.location.origin);if(scopeState.currentLifeOnly){u.searchParams.set('current_life_only','true');}return `${u.pathname}${u.search}`;};
-const renderDailySkills=(dailySkills)=>{
-  const frequency=dailySkills?.frequency_totals||{};
-  const progression=dailySkills?.progression_pipeline||{};
-  const topSkills=dailySkills?.top_skills||[];
-  document.getElementById('daily-skill-uses-24h').textContent=String(frequency.uses_24h||0);
-  document.getElementById('daily-skill-uses-7d').textContent=String(frequency.uses_7d||0);
-  document.getElementById('daily-skill-top').textContent=String(topSkills[0]?.skill||'n/a');
-  document.getElementById('daily-skill-progression').textContent=`${progression.learned||0}→${progression.used||0}→${progression.improved||0}`;
-  const body=document.getElementById('daily-skills-table-body');
-  body.innerHTML='';
-  for(const item of topSkills){
-    const tr=document.createElement('tr');
-    const successRate=item.success_rate===null||item.success_rate===undefined?'n/a':`${(Number(item.success_rate)*100).toFixed(1)}%`;
-    const frequencyCell=`${item.frequency?.uses_24h||0}/${item.frequency?.uses_7d||0}`;
-    const tasks=(item.associated_tasks||[]).join(', ')||'n/a';
-    tr.innerHTML=`<td>${item.skill||'n/a'}</td><td>${frequencyCell}</td><td>${successRate}</td><td>${item.last_used_at||'n/a'}</td><td>${tasks}</td><td>${item.trend||'stable'}</td>`;
-    body.appendChild(tr);
-  }
-  if(!topSkills.length){
-    const tr=document.createElement('tr');
-    tr.innerHTML="<td colspan='6'>Aucune compétence quotidienne détectée.</td>";
-    body.appendChild(tr);
-  }
-};
-const HOST_SENSORS_THRESHOLD={cpuWarn:85,cpuCritical:95,ramWarn:80,ramCritical:92,tempWarn:75,tempCritical:85,diskCritical:95};
-const hostRisk=(name,value)=>{
-  if(value===null||value===undefined||Number.isNaN(Number(value))){return 'unsupported';}
-  const v=Number(value);
-  if(name==='cpu'){if(v>=HOST_SENSORS_THRESHOLD.cpuCritical){return 'critical';}if(v>=HOST_SENSORS_THRESHOLD.cpuWarn){return 'warn';}return 'ok';}
-  if(name==='ram'){if(v>=HOST_SENSORS_THRESHOLD.ramCritical){return 'critical';}if(v>=HOST_SENSORS_THRESHOLD.ramWarn){return 'warn';}return 'ok';}
-  if(name==='temperature'){if(v>=HOST_SENSORS_THRESHOLD.tempCritical){return 'critical';}if(v>=HOST_SENSORS_THRESHOLD.tempWarn){return 'warn';}return 'ok';}
-  if(name==='disk'){if(v>=HOST_SENSORS_THRESHOLD.diskCritical){return 'critical';}return 'ok';}
-  return 'unsupported';
-};
-const sparkline=(values)=>{
-  if(!values.length){return '·';}
-  const ticks='▁▂▃▄▅▆▇█';
-  const min=Math.min(...values);
-  const max=Math.max(...values);
-  if(max-min<0.0001){return '▅'.repeat(values.length);}
-  return values.map(v=>ticks[Math.min(ticks.length-1,Math.max(0,Math.round(((v-min)/(max-min))*(ticks.length-1))))]).join('');
-};
-const toneByRisk=(el,risk)=>{
-  el.classList.remove('status-good','status-warn','status-bad','status-muted');
-  if(risk==='ok'){el.classList.add('status-good');return;}
-  if(risk==='warn'){el.classList.add('status-warn');return;}
-  if(risk==='critical'){el.classList.add('status-bad');return;}
-  el.classList.add('status-muted');
-};
-const extractHostMetrics=(record)=>{
-  if(record&&typeof record.host_metrics==='object'&&record.host_metrics){return record.host_metrics;}
-  if(record&&typeof record.signals==='object'&&record.signals&&typeof record.signals.host_metrics==='object'){return record.signals.host_metrics;}
-  if(record&&typeof record.payload==='object'&&record.payload&&typeof record.payload.host_metrics==='object'){return record.payload.host_metrics;}
-  return null;
-};
-const renderHostMetrics=(records)=>{
-  const metricDef=[
-    {key:'cpu',label:'host-cpu',trend:'host-cpu-trend',raw:'cpu_percent',suffix:'%'},
-    {key:'ram',label:'host-ram',trend:'host-ram-trend',raw:'ram_used_percent',suffix:'%'},
-    {key:'temperature',label:'host-temp',trend:'host-temp-trend',raw:'host_temperature_c',suffix:'°C'},
-    {key:'disk',label:'host-disk',trend:'host-disk-trend',raw:'disk_used_percent',suffix:'%'},
-  ];
-  const hist={cpu:[],ram:[],temperature:[],disk:[]};
-  let latestAdaptation=null;
-  for(const record of (records||[]).slice(-160)){
-    const host=extractHostMetrics(record);
-    if(host){
-      for(const def of metricDef){
-        const val=host[def.raw];
-        if(typeof val==='number'&&!Number.isNaN(val)){hist[def.key].push(Number(val));}
-      }
-    }
-    const event=record?.event;
-    let adaptation=null;
-    if(event==='orchestrator.adaptation'&&record?.payload&&typeof record.payload==='object'){adaptation=record.payload;}
-    else if(record?.adaptation&&typeof record.adaptation==='object'){adaptation=record.adaptation;}
-    if(adaptation){latestAdaptation={ts:record?.ts||null,payload:adaptation};}
-  }
-  const riskWeight={unsupported:-1,ok:0,warn:1,critical:2};
-  let global='ok';
-  let unsupportedCount=0;
-  for(const def of metricDef){
-    const values=hist[def.key];
-    const latest=values.length?values[values.length-1]:null;
-    const risk=hostRisk(def.key,latest);
-    if(riskWeight[risk]>riskWeight[global]){global=risk;}
-    if(risk==='unsupported'){unsupportedCount+=1;}
-    const el=document.getElementById(def.label);
-    const trendEl=document.getElementById(def.trend);
-    el.textContent=latest===null?'non supporté':`${latest.toFixed(1)}${def.suffix} · ${risk}`;
-    trendEl.textContent=sparkline(values.slice(-12));
-    toneByRisk(el,risk);
-  }
-  if(unsupportedCount===metricDef.length){global='unsupported';}
-  const globalEl=document.getElementById('host-global');
-  globalEl.textContent=global;
-  toneByRisk(globalEl,global);
-  document.getElementById('host-fallback').style.display=unsupportedCount>0?'block':'none';
-  const adaptationEl=document.getElementById('host-adaptation');
-  if(latestAdaptation){
-    const rules=Array.isArray(latestAdaptation.payload?.triggered_rules)?latestAdaptation.payload.triggered_rules:[];
-    adaptationEl.textContent=`Dernière adaptation capteur: ${latestAdaptation.ts||'n/a'} · règles=${rules.join(', ')||'n/a'} · prudent=${latestAdaptation.payload?.safe_mode===true?'oui':'non'}`;
-  }else{
-    adaptationEl.textContent='Dernière adaptation capteur: aucune adaptation trouvée';
-  }
-};
-
-const loadContext=()=>fetch('/dashboard/context').then(r=>r.json()).then(ctx=>{
-  document.getElementById('ctx-root').textContent=ctx.singular_root||'n/a';
-  document.getElementById('ctx-home').textContent=ctx.singular_home||'n/a';
-  document.getElementById('ctx-lives-count').textContent=String(ctx.registry_lives_count||0);
-  const policy=ctx.policy||{};
-  const autonomy=policy.autonomy||{};
-  const permissions=policy.permissions||{};
-  document.getElementById('ctx-policy-version').textContent=String(policy.version??'n/a');
-  document.getElementById('ctx-policy-autonomy').textContent=`safe_mode=${autonomy.safe_mode?'on':'off'} · quota=${autonomy.mutation_quota_per_window??'n/a'}/${autonomy.mutation_quota_window_seconds??'n/a'}s`;
-  document.getElementById('ctx-policy-permissions').textContent=`auto=${(permissions.modifiable_paths||[]).length} · review=${(permissions.review_required_paths||[]).length} · forbidden=${(permissions.forbidden_paths||[]).length}`;
-  const impactList=document.getElementById('ctx-policy-impact');
-  impactList.innerHTML='';
-  for(const item of (ctx.policy_impact||[])){const li=document.createElement('li');li.textContent=String(item);impactList.appendChild(li);}
-  if(!(ctx.policy_impact||[]).length){const li=document.createElement('li');li.textContent='Aucun impact disponible.';impactList.appendChild(li);}
-  const lifecycle=ctx.skills_lifecycle||{};
-  document.getElementById('kpi-skills-active').textContent=String(lifecycle.active||0);
-  document.getElementById('kpi-skills-dormant').textContent=String(lifecycle.dormant||0);
-  document.getElementById('kpi-skills-archived').textContent=String(lifecycle.archived||0);
-});
-
-const loadEco=()=>Promise.all([fetch(withScope('/ecosystem')).then(r=>r.json()),fetch(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc')).then(r=>r.json())]).then(([eco,lives])=>{
-  const summary=eco.summary||{};
-  const total=Number(summary.total_organisms||0);
-  const alive=Number(summary.alive_organisms||0);
-  const dead=Math.max(total-alive,0);
-  document.getElementById('eco-total-lives').textContent=String(total);
-  document.getElementById('eco-alive-lives').textContent=String(alive);
-  document.getElementById('eco-dead-lives').textContent=String(dead);
-
-  const rows=lives.table||[];
-  const selected=rows.find(row=>row.selected_life===true);
-  document.getElementById('eco-selected-life').textContent=selected?.life||'Aucune';
-  const latestRow=rows.find(row=>row.last_activity);
-  document.getElementById('eco-last-activity').textContent=latestRow?.last_activity||'n/a';
-
-  const organisms=eco.organisms||{};
-  const list=document.getElementById('organisms-list');
-  list.innerHTML='';
-  for(const [name,payload] of Object.entries(organisms)){
-    const li=document.createElement('li');
-    const status=payload.status||'alive';
-    const energy=payload.energy??'n/a';
-    const resources=payload.resources??'n/a';
-    li.textContent=`${name} · statut=${status} · énergie=${energy} · ressources=${resources}`;
-    list.appendChild(li);
-  }
-  if(Object.keys(organisms).length===0){
-    const li=document.createElement('li');li.textContent='Aucun organisme détecté.';list.appendChild(li);
-  }
-  document.getElementById('raw-eco-json').textContent=JSON.stringify(eco,null,2);
-});
-
-
-const loadQuests=()=>fetch('/quests').then(r=>r.json()).then(data=>{document.getElementById('quests').textContent=JSON.stringify(data,null,2);});
-const loadHostVitals=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(data=>{renderHostMetrics(data?.records||[]);}).catch(()=>{renderHostMetrics([]);});
-const loadCockpit=()=>fetch(withScope('/api/cockpit')).then(r=>r.json()).then(d=>{
-  const statusBox=document.getElementById('cockpit-status');
-  statusBox.textContent=`Statut global: ${d.global_status||'unknown'}`;
-  if(d.global_status==='stable'){setStatusTone(statusBox,'good');}
-  else if(d.global_status==='warning'){setStatusTone(statusBox,'warn');}
-  else if(d.global_status==='critical'){setStatusTone(statusBox,'bad');}
-
-  const healthValue=d.health_score===null?'n/a':Number(d.health_score).toFixed(1);
-  const trend=d.trend||'n/a';
-  const accepted=d.accepted_mutation_rate===null?'n/a':`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
-  const alertsCount=(d.critical_alerts||[]).length;
-  const autonomy=d.autonomy_metrics||{};
-  const decisionQuality=autonomy.decision_quality||{};
-  const fmtPct=(value)=>value===null||value===undefined?'n/a':`${(Number(value)*100).toFixed(1)}%`;
-  const fmtNum=(value,suffix='')=>value===null||value===undefined?'n/a':`${Number(value).toFixed(2)}${suffix}`;
-
-  document.getElementById('kpi-health').textContent=healthValue;
-  document.getElementById('kpi-trend').textContent=trend;
-  document.getElementById('kpi-accepted').textContent=accepted;
-  document.getElementById('kpi-alerts').textContent=String(alertsCount);
-  document.getElementById('kpi-next-action').textContent=d.next_action||'n/a';
-  document.getElementById('kpi-autonomy-proactive').textContent=fmtPct(autonomy.proactive_initiative_rate);
-  document.getElementById('kpi-autonomy-stability').textContent=fmtPct(autonomy.long_term_stability);
-  document.getElementById('kpi-autonomy-decision').textContent=`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`;
-  document.getElementById('kpi-autonomy-latency').textContent=fmtNum(autonomy.perception_to_action_latency_ms,' ms');
-  document.getElementById('kpi-autonomy-cost').textContent=fmtNum(autonomy.resource_cost_per_gain);
-  const vital=d.vital_timeline||{};
-  const skillLifecycle=d.skills_lifecycle||{};
-  const vitalMetrics=d.vital_metrics||{};
-  const objectives=vitalMetrics.active_objectives||{};
-  const trajectory=d.trajectory||{};
-  const trajectoryObjectives=trajectory.objectives||{};
-  const trajectoryCounts=trajectoryObjectives.counts||{};
-  const priorityChanges=trajectory.priority_changes||[];
-  const objectiveLinks=trajectory.objective_narrative_links||[];
-  const energyResources=vitalMetrics.energy_resources||{};
-  const codeGeneration=vitalMetrics.code_generation||{};
-  const risks=vitalMetrics.risks||[];
-  document.getElementById('kpi-vital-age').textContent=String(vital.age??0);
-  document.getElementById('kpi-vital-risk').textContent=String(vital.risk_level||'n/a');
-  document.getElementById('kpi-vital-terminal').textContent=vital.terminal===true?'oui':'non';
-  document.getElementById('kpi-vital-causes').textContent=(vital.causes||[]).join(', ')||'n/a';
-  document.getElementById('kpi-circadian-phase').textContent=String((vitalMetrics.circadian_cycle||{}).phase||'n/a');
-  document.getElementById('kpi-active-objectives-count').textContent=String(objectives.count||0);
-  document.getElementById('kpi-quests-progress').textContent=`${objectives.count||0} actifs`;
-  document.getElementById('kpi-energy-total').textContent=fmtNum(energyResources.total_energy);
-  document.getElementById('kpi-resources-total').textContent=fmtNum(energyResources.total_resources);
-  document.getElementById('kpi-code-progression').textContent=String(codeGeneration.progression||'n/a');
-  document.getElementById('kpi-code-risks').textContent=risks.length?risks.join(', '):String(codeGeneration.risk_level||'n/a');
-  document.getElementById('kpi-skills-active').textContent=String(skillLifecycle.active||0);
-  document.getElementById('kpi-skills-dormant').textContent=String(skillLifecycle.dormant||0);
-  document.getElementById('kpi-skills-archived').textContent=String(skillLifecycle.archived||0);
-  renderDailySkills(d.daily_skills||{});
-  const objectivesList=document.getElementById('kpi-active-objectives-list');
-  objectivesList.innerHTML='';
-  for(const item of (objectives.items||[])){
-    const li=document.createElement('li');
-    li.textContent=String(item.name||item.id||'objectif');
-    objectivesList.appendChild(li);
-  }
-  if(!(objectives.items||[]).length){const li=document.createElement('li');li.textContent='Aucun objectif actif';objectivesList.appendChild(li);}
-  document.getElementById('kpi-trajectory-in-progress').textContent=String(trajectoryCounts.in_progress||0);
-  document.getElementById('kpi-trajectory-abandoned').textContent=String(trajectoryCounts.abandoned||0);
-  document.getElementById('kpi-trajectory-completed').textContent=String(trajectoryCounts.completed||0);
-  document.getElementById('kpi-trajectory-priority-count').textContent=String(priorityChanges.length||0);
-  document.getElementById('kpi-trajectory-links-count').textContent=String(objectiveLinks.length||0);
-  const priorityList=document.getElementById('kpi-priority-changes-list');
-  priorityList.innerHTML='';
-  for(const change of priorityChanges.slice(-5).reverse()){
-    const li=document.createElement('li');
-    li.textContent=`${change.objective||'objectif'} · ${change.from??'n/a'} → ${change.to??'n/a'} (${change.at||'n/a'})`;
-    priorityList.appendChild(li);
-  }
-  if(!priorityChanges.length){const li=document.createElement('li');li.textContent='Aucun changement détecté';priorityList.appendChild(li);}
-  const linksList=document.getElementById('kpi-objective-links-list');
-  linksList.innerHTML='';
-  for(const link of objectiveLinks.slice(-5).reverse()){
-    const li=document.createElement('li');
-    li.textContent=`${link.objective||'objectif'} ↔ ${link.event||'événement'} (${link.at||'n/a'})`;
-    linksList.appendChild(li);
-  }
-  if(!objectiveLinks.length){const li=document.createElement('li');li.textContent='Aucun lien narratif détecté';linksList.appendChild(li);}
-  setStatusTone(document.getElementById('kpi-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
-
-  const notable=d.last_notable_mutation;
-  if(notable){
-    const acceptedBadge=notable.accepted===true?'acceptée':(notable.accepted===false?'refusée':'n/a');
-    document.getElementById('kpi-notable-summary').textContent=`${notable.timestamp||'n/a'} · ${notable.life||'n/a'} · ${notable.operator||'n/a'} · ${acceptedBadge} · Δ=${notable.impact_delta??'n/a'}`;
-  } else {
-    document.getElementById('kpi-notable-summary').textContent='Aucune mutation notable';
-  }
-
-  const actionsEl=document.getElementById('kpi-actions');
-  actionsEl.innerHTML='';
-  for(const action of (d.suggested_actions||[])){
-    const li=document.createElement('li');
-    li.textContent=String(action);
-    actionsEl.appendChild(li);
-  }
-  if((d.suggested_actions||[]).length===0){
-    const li=document.createElement('li');li.textContent='Aucune action suggérée';actionsEl.appendChild(li);
-  }
-  document.getElementById('raw-cockpit-json').textContent=JSON.stringify(d,null,2);
-});
-
-const paintDiff=(raw)=>{const escaped=String(raw||'').replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');return escaped.split('\n').map(line=>{if(line.startsWith('+')){return `<span style="color:#0a7f2e;">${line}</span>`;}if(line.startsWith('-')){return `<span style="color:#b42318;">${line}</span>`;}if(line.startsWith('@@')){return `<span style="color:#175cd3;">${line}</span>`;}return line;}).join('\n');};
-const showMutationDetail=(runId,index)=>fetch(`/api/runs/${runId}/mutations/${index}`).then(r=>r.json()).then(d=>{document.getElementById('timeline-summary').textContent=d.human_summary||d.decision_reason||'Aucun résumé disponible.';document.getElementById('timeline-impact').textContent=JSON.stringify(d.impact,null,2);document.getElementById('timeline-diff').innerHTML=paintDiff(d.diff)||'Aucun diff.';});
-const runAction=(action,payload)=>{const token=document.getElementById('action-token')?.value||'';const q=new URLSearchParams();if(token){q.set('token',token);}if(payload){q.set('payload',JSON.stringify(payload));}return fetch(`/api/actions/${action}?${q.toString()}`).then(async r=>{if(!r.ok){throw new Error(`HTTP ${r.status}`);}return r.json();}).then(data=>{document.getElementById('action-result').textContent=JSON.stringify(data,null,2);loadEco();loadCockpit();loadTimeline();}).catch(err=>{document.getElementById('action-result').textContent=`Erreur action ${action}: ${err.message}`;});};
-document.getElementById('act-birth').onclick=()=>runAction('birth',{name:document.getElementById('action-life-name').value||'Nouvelle vie'});
-document.getElementById('act-talk').onclick=()=>runAction('talk',{prompt:document.getElementById('action-prompt').value||''});
-document.getElementById('act-loop').onclick=()=>runAction('loop',{budget_seconds:Number(document.getElementById('action-budget').value||0)});
-document.getElementById('act-report').onclick=()=>runAction('report',{});
-document.getElementById('act-lives-list').onclick=()=>runAction('lives_list',{});
-document.getElementById('act-lives-use').onclick=()=>runAction('lives_use',{name:document.getElementById('action-life-name').value||''});
-document.getElementById('act-archive').onclick=()=>runAction('archive',{name:document.getElementById('action-life-name').value||''});
-document.getElementById('act-memorial').onclick=()=>runAction('memorial',{name:document.getElementById('action-life-name').value||'',message:'Merci pour ce cycle de vie.'});
-document.getElementById('act-clone').onclick=()=>runAction('clone',{name:document.getElementById('action-life-name').value||'',new_name:`${document.getElementById('action-life-name').value||'Vie'} clone`});
-const badge=(label,bg)=>`<span style="display:inline-block;padding:2px 8px;border-radius:999px;background:${bg};margin-right:4px;">${label}</span>`;
-const renderLivesBuckets=(rows)=>{const activeInRegistry=(rows||[]).filter(row=>row.is_registry_active_life===true);const extinctInRuns=(rows||[]).filter(row=>row.extinction_seen_in_runs===true);const aliveList=document.getElementById('alive-lives');const deadList=document.getElementById('dead-lives');document.getElementById('alive-count').textContent=String(activeInRegistry.length);document.getElementById('dead-count').textContent=String(extinctInRuns.length);aliveList.innerHTML='';deadList.innerHTML='';for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||'n/a';aliveList.appendChild(li);}for(const row of extinctInRuns){const li=document.createElement('li');li.textContent=row.life||'n/a';deadList.appendChild(li);}if(!activeInRegistry.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);}if(!extinctInRuns.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);}};
-const renderLivesTable=(rows)=>{const body=document.getElementById('lives-table-body');body.innerHTML='';for(const row of rows||[]){const tr=document.createElement('tr');const score=row.current_health_score===null||row.current_health_score===undefined?'n/a':Number(row.current_health_score).toFixed(1);const stability=row.stability===null||row.stability===undefined?'n/a':`${(Number(row.stability)*100).toFixed(1)}%`;const lastActivity=row.last_activity||'n/a';let badges='';if(row.selected_life){badges+=badge('Vie sélectionnée','#d1fadf');}else{badges+=badge('Vie non sélectionnée','#fde2e1');}if(row.is_registry_active_life){badges+=badge('Vie active dans le registre','#d1fadf');}else{badges+=badge(`Statut registre: ${row.life_status||'n/a'}`,'#fde2e1');}if(row.run_terminated){badges+=badge('Run terminé','#ffe7c2');}if(row.extinction_seen_in_runs){badges+=badge('Extinction détectée','#fecdca');}if(row.has_recent_activity){badges+=badge('Activité récente','#d9ecff');}if(row.trend==='dégradation'){badges+=badge('dégradation','#ffe7c2');}if((row.alerts_count||0)>0){badges+=badge(`${row.alerts_count} alertes`,'#fecdca');}tr.innerHTML=`<td>${row.life||'n/a'}</td><td>${score}</td><td>${row.trend||'n/a'}</td><td>${stability}</td><td>${lastActivity}</td><td>${row.iterations??0}</td><td>${badges}</td>`;body.appendChild(tr);}if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}};
-const renderUnattachedRuns=(payload)=>{const panel=document.getElementById('unattached-runs-panel');const list=document.getElementById('unattached-runs-list');const runs=(payload?.runs)||[];const runsCount=Number(payload?.runs_count||0);const recordsCount=Number(payload?.records_count||0);document.getElementById('unattached-runs-count').textContent=String(runsCount);document.getElementById('unattached-records-count').textContent=String(recordsCount);list.innerHTML='';if(!runsCount){panel.style.display='none';return;}panel.style.display='block';for(const item of runs){const li=document.createElement('li');li.textContent=`${item.run_id||'unknown'} · ${item.records_count||0} enregistrements`;list.appendChild(li);}};
-const renderGenealogyTree=(payload)=>{const nodes=payload?.nodes||[];const treeEl=document.getElementById('genealogy-tree');const socialEl=document.getElementById('social-network-tree');const conflictsEl=document.getElementById('active-conflicts');if(!nodes.length){treeEl.textContent='Aucune lignée enregistrée.';socialEl.textContent='Aucun réseau social.';conflictsEl.textContent='Aucun conflit.';return;}const bySlug=new Map(nodes.map(node=>[node.slug,node]));const children=new Map();for(const node of nodes){children.set(node.slug,[]);}for(const node of nodes){for(const parent of (node.parents||[])){if(children.has(parent)){children.get(parent).push(node.slug);}}}const roots=nodes.filter(node=>(node.parents||[]).length===0).map(node=>node.slug);const lines=[];const visit=(slug,depth)=>{const node=bySlug.get(slug);if(!node){return;}const marker=node.active?'★':'•';const status=node.status==='extinct'?'✝':'✓';lines.push(`${'  '.repeat(depth)}${marker} ${node.name} (${node.slug}) [${status}]`);for(const child of (children.get(slug)||[])){visit(child,depth+1);}};for(const root of roots){visit(root,0);}const detached=nodes.filter(node=>!roots.includes(node.slug)&&!(node.parents||[]).every(parent=>bySlug.has(parent)));for(const node of detached){lines.push(`• ${node.name} (${node.slug}) [orphan]`);}treeEl.textContent=lines.join('\n');const socialLines=[];for(const node of nodes){const allies=(node.allies||[]).join(', ')||'-';const rivals=(node.rivals||[]).join(', ')||'-';socialLines.push(`${node.slug} | proximité=${Number(node.proximity_score||0.5).toFixed(2)} | alliés: ${allies} | rivaux: ${rivals}`);}socialEl.textContent=socialLines.join('\n');const conflicts=payload?.active_conflicts||[];conflictsEl.textContent=conflicts.length?conflicts.map(c=>`${c.life_a} ⚔ ${c.life_b}`).join('\n'):'Aucun conflit actif.';};
-const loadGenealogy=()=>fetch('/lives/genealogy').then(r=>r.json()).then(renderGenealogyTree).catch(()=>{document.getElementById('genealogy-tree').textContent='Impossible de charger la généalogie.';});
-const loadLivesBoard=()=>{const q=new URLSearchParams();q.set('sort_by',livesTableState.sortBy);q.set('sort_order',livesTableState.sortOrder);if(document.getElementById('filter-active').checked){q.set('active_only','true');}if(document.getElementById('filter-degrading').checked){q.set('degrading_only','true');}if(document.getElementById('filter-dead').checked){q.set('dead_only','true');}const timeWindow=document.getElementById('filter-time-window').value||'all';q.set('time_window',timeWindow);const compareLives=(document.getElementById('filter-compare-lives').value||'').trim();if(compareLives){q.set('compare_lives',compareLives);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}return fetch(`/lives/comparison?${q.toString()}`).then(r=>r.json()).then(d=>{renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})));renderLivesTable(d.table||[]);renderUnattachedRuns(d.unattached_runs);});};
-for(const button of document.querySelectorAll('#lives-table [data-sort]')){button.onclick=()=>{const next=button.getAttribute('data-sort');if(livesTableState.sortBy===next){livesTableState.sortOrder=livesTableState.sortOrder==='desc'?'asc':'desc';}else{livesTableState.sortBy=next;livesTableState.sortOrder='desc';}loadLivesBoard();};}
-document.getElementById('filter-active').onchange=()=>loadLivesBoard();
-document.getElementById('filter-degrading').onchange=()=>loadLivesBoard();
-document.getElementById('filter-dead').onchange=()=>loadLivesBoard();
-document.getElementById('filter-time-window').onchange=()=>loadLivesBoard();
-document.getElementById('filter-compare-lives').onchange=()=>loadLivesBoard();
-const renderLiveEvents=()=>{const pre=document.getElementById('live-events');const rows=liveState.events.map(item=>`${item.ts||'n/a'} | ${item.run_id||'n/a'} | ${item.event||'unknown'}`);pre.textContent=rows.join('\n');if(liveState.autoScroll){pre.scrollTop=pre.scrollHeight;}};
-const updateLiveStatus=()=>{document.getElementById('live-status').textContent=liveState.paused?'Pause activée':'Lecture en direct';document.getElementById('live-toggle').textContent=liveState.paused?'Reprendre':'Pause';};
-document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};
-document.getElementById('live-autoscroll').onchange=e=>{liveState.autoScroll=Boolean(e.target.checked);if(liveState.autoScroll){renderLiveEvents();}};
-const loadTimeline=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=scopeState.currentLifeOnly?'&current_life_only=true':'';return fetch(`/api/runs/${meta.run}/timeline?page=1&page_size=120${q}`).then(r=>r.json());}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;btn.style.padding='6px';row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.style.alignSelf='center';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';}});
-const loadReflections=()=>fetch(withScope('/runs/latest')).then(r=>r.json()).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=new URLSearchParams();const objective=document.getElementById('reflection-objective').value;const mood=document.getElementById('reflection-mood').value;const success=document.getElementById('reflection-success').value;if(objective){q.set('objective',objective);}if(mood){q.set('mood',mood);}if(success){q.set('success',success);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}const suffix=q.toString()?`?${q.toString()}`:'';return fetch(`/api/runs/${meta.run}/consciousness${suffix}`).then(r=>r.ok?r.json():{run_id:meta.run,items:[]});}).then(data=>{const wrap=document.getElementById('reflections-timeline');const detail=document.getElementById('reflections-detail');wrap.innerHTML='';for(const item of data.items||[]){const row=document.createElement('div');row.style.display='inline-flex';row.style.gap='4px';const btn=document.createElement('button');const mood=item.emotional_state?.mood||'n/a';const objective=item.objective||'n/a';btn.textContent=`${item.ts||'n/a'} · ${objective} · ${mood}`;btn.style.padding='6px';btn.onclick=()=>{detail.textContent=JSON.stringify(item,null,2);};row.appendChild(btn);wrap.appendChild(row);}if(!(data.items||[]).length){detail.textContent='Aucune réflexion disponible pour ces filtres.';}});
-document.getElementById('reflection-apply').onclick=()=>loadReflections();
-loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();loadGenealogy();loadQuests();setInterval(()=>{loadContext();loadEco();loadCockpit();loadTimeline();loadLivesBoard();loadGenealogy();loadQuests();},500);
-loadHostVitals();setInterval(()=>{loadHostVitals();},1200);
-loadReflections();setInterval(()=>{loadReflections();},800);
-updateLiveStatus();
-ws.onmessage=e=>{const m=JSON.parse(e.data);if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);return;}if(m.type==='quests'){document.getElementById('quests').textContent=JSON.stringify(m.data,null,2);return;}if(typeof m.run_id==='string'&&typeof m.event==='string'){liveState.events.push({type:m.type,run_id:m.run_id,event:m.event,ts:m.ts||null});if(!liveState.paused){renderLiveEvents();}}};
-</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Rendre la couche UI plus modulaire et maintenable en retirant les blocs inline CSS/JS du template et en exposant des assets statiques.
- Organiser la logique côté client par domaines fonctionnels pour faciliter les évolutions et les tests (`cockpit`, `timeline`, `lives`, `reflections`, métriques hôte).
- Introduire une convention de composants visuels réutilisables (cartes, panneaux, badges, tables, états vides) pour uniformiser le rendu et réduire le styling ad-hoc inline.

### Description
- Extraction des styles inline vers `src/singular/dashboard/static/dashboard.css` et remplacement de blocs `<style>` par `<link rel='stylesheet' href='/static/dashboard.css'/>` dans le template `src/singular/dashboard/templates/dashboard.html`.
- Extraction du script inline vers `src/singular/dashboard/static/dashboard.js`, regroupement des constantes/états en tête de module et structuration du JS en domaines exposant les points d'entrée `loadCockpit`, `loadTimeline`, `loadLivesBoard`, `loadReflections`, et `renderHostMetrics`.
- Remplacement des attributs `style="..."` dans le HTML et du styling injecté par JS par des classes CSS utilitaires et des composants (`card`/`panel`/`badge`/`table-base`/`empty-state`), et adaptation du JS pour utiliser ces classes plutôt que manipulations d'affichage inline.
- Mise à jour de l'application FastAPI (`create_app`) pour monter le dossier statique et servir les assets via `app.mount("/static", StaticFiles(directory=static_dir), name="dashboard-static")` afin que le template charge les fichiers externes.

### Testing
- `python -m compileall src/singular/dashboard/__init__.py` a été exécuté et a compilé sans erreur.
- `node --check src/singular/dashboard/static/dashboard.js` a été exécuté et a validé la syntaxe du fichier JS.
- Recherche de résidus d'attributs `style=` via `rg -n "style="` sur les fichiers modifiés a été effectuée et n'a pas trouvé d'usages restants ciblés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ded6c06ff8832aa8714e16af8562a7)