### PR TITLE
Amélioration UX dashboard : glossaire, labels KPI, statuts visuels et mode « Essentiel »

### DIFF
--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -268,3 +268,14 @@ button:hover {
   background: rgba(60, 45, 10, 0.5);
   color: #ffe0a5;
 }
+
+.nav-mode-toggle { margin-left: 12px; }
+.glossary { display: grid; grid-template-columns: minmax(110px, 160px) 1fr; gap: 6px 12px; margin: 8px 0 0; }
+.glossary dt { color: #d8e5ff; font-weight: 700; }
+.glossary dd { margin: 0; color: var(--text-secondary); }
+.kpi-label { text-decoration: underline dotted rgba(153, 168, 216, 0.8); text-underline-offset: 3px; cursor: help; }
+.status-legend { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 8px; }
+.status-pill { border: 1px solid var(--panel-border); border-radius: 999px; padding: 2px 10px; font-size: 0.82rem; font-weight: 600; }
+.status-with-icon::before { content: attr(data-status-icon); margin-right: 6px; }
+body.essential-mode .technical-only { display: none !important; }
+body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok); }

--- a/src/singular/dashboard/static/dashboard.js
+++ b/src/singular/dashboard/static/dashboard.js
@@ -7,6 +7,9 @@ const BADGE_TONE={
   info:'badge-info',
 };
 
+const MISSING_TEXT={notAvailable:'Non disponible',notMeasured:'Pas encore mesuré'};
+const na=()=>MISSING_TEXT.notAvailable;
+const nm=()=>MISSING_TEXT.notMeasured;
 const ws=new WebSocket(`ws://${location.host}/ws`);
 const livesTableState={sortBy:'score',sortOrder:'desc'};
 const liveState={paused:false,autoScroll:true,events:[]};
@@ -52,7 +55,7 @@ const staleTimeoutTasks=new Set();
 const PROLONGED_TIMEOUT_THRESHOLD=2;
 const fmtTimestamp=(value=new Date())=>{
   const d=value instanceof Date?value:new Date(value);
-  if(Number.isNaN(d.getTime())){return 'n/a';}
+  if(Number.isNaN(d.getTime())){return na();}
   return d.toLocaleString('fr-FR',{hour12:false});
 };
 const ensureUpdateLabel=(taskName)=>{
@@ -147,6 +150,12 @@ const bootstrapPauseControls=()=>{
 };
 
 const setStatusTone=(el,tone)=>{el.classList.remove('status-good','status-warn','status-bad');if(tone==='good'){el.classList.add('status-good');}if(tone==='warn'){el.classList.add('status-warn');}if(tone==='bad'){el.classList.add('status-bad');}};
+const applyStatusIndicator=(el,tone)=>{
+  if(!el){return;}
+  const icon=tone==='good'?'●':(tone==='warn'?'▲':(tone==='bad'?'■':'•'));
+  el.classList.add('status-with-icon');
+  el.dataset.statusIcon=icon;
+};
 const withScope=(url)=>{const u=new URL(url,window.location.origin);if(scopeState.currentLifeOnly){u.searchParams.set('current_life_only','true');}return `${u.pathname}${u.search}`;};
 const ensurePanelLayer=(panelId)=>{
   const panel=document.getElementById(panelId);
@@ -210,16 +219,16 @@ const renderDailySkills=(dailySkills)=>{
   const topSkills=dailySkills?.top_skills||[];
   document.getElementById('daily-skill-uses-24h').textContent=String(frequency.uses_24h||0);
   document.getElementById('daily-skill-uses-7d').textContent=String(frequency.uses_7d||0);
-  document.getElementById('daily-skill-top').textContent=String(topSkills[0]?.skill||'n/a');
+  document.getElementById('daily-skill-top').textContent=String(topSkills[0]?.skill||na());
   document.getElementById('daily-skill-progression').textContent=`${progression.learned||0}→${progression.used||0}→${progression.improved||0}`;
   const body=document.getElementById('daily-skills-table-body');
   body.innerHTML='';
   for(const item of topSkills){
     const tr=document.createElement('tr');
-    const successRate=item.success_rate===null||item.success_rate===undefined?'n/a':`${(Number(item.success_rate)*100).toFixed(1)}%`;
+    const successRate=item.success_rate===null||item.success_rate===undefined?na():`${(Number(item.success_rate)*100).toFixed(1)}%`;
     const frequencyCell=`${item.frequency?.uses_24h||0}/${item.frequency?.uses_7d||0}`;
-    const tasks=(item.associated_tasks||[]).join(', ')||'n/a';
-    tr.innerHTML=`<td>${item.skill||'n/a'}</td><td>${frequencyCell}</td><td>${successRate}</td><td>${item.last_used_at||'n/a'}</td><td>${tasks}</td><td>${item.trend||'stable'}</td>`;
+    const tasks=(item.associated_tasks||[]).join(', ')||na();
+    tr.innerHTML=`<td>${item.skill||na()}</td><td>${frequencyCell}</td><td>${successRate}</td><td>${item.last_used_at||na()}</td><td>${tasks}</td><td>${item.trend||'stable'}</td>`;
     body.appendChild(tr);
   }
   if(!topSkills.length){
@@ -292,7 +301,7 @@ const renderHostMetrics=(records)=>{
     if(risk==='unsupported'){unsupportedCount+=1;}
     const el=document.getElementById(def.label);
     const trendEl=document.getElementById(def.trend);
-    el.textContent=latest===null?'non supporté':`${latest.toFixed(1)}${def.suffix} · ${risk}`;
+    el.textContent=latest===null?na():`${latest.toFixed(1)}${def.suffix} · ${risk}`;
     trendEl.textContent=sparkline(values.slice(-12));
     toneByRisk(el,risk);
   }
@@ -300,11 +309,12 @@ const renderHostMetrics=(records)=>{
   const globalEl=document.getElementById('host-global');
   globalEl.textContent=global;
   toneByRisk(globalEl,global);
+  applyStatusIndicator(globalEl,global==='ok'?'good':(global==='warn'?'warn':(global==='critical'?'bad':null)));
   document.getElementById('host-fallback').classList.toggle('panel-hidden',unsupportedCount===0);
   const adaptationEl=document.getElementById('host-adaptation');
   if(latestAdaptation){
     const rules=Array.isArray(latestAdaptation.payload?.triggered_rules)?latestAdaptation.payload.triggered_rules:[];
-    adaptationEl.textContent=`Dernière adaptation capteur: ${latestAdaptation.ts||'n/a'} · règles=${rules.join(', ')||'n/a'} · prudent=${latestAdaptation.payload?.safe_mode===true?'oui':'non'}`;
+    adaptationEl.textContent=`Dernière adaptation capteur: ${latestAdaptation.ts||na()} · règles=${rules.join(', ')||na()} · prudent=${latestAdaptation.payload?.safe_mode===true?'oui':'non'}`;
   }else{
     adaptationEl.textContent='Dernière adaptation capteur: aucune adaptation trouvée';
   }
@@ -312,14 +322,14 @@ const renderHostMetrics=(records)=>{
 };
 
 const loadContext=()=>fetchJson('/dashboard/context').then(ctx=>{
-  document.getElementById('ctx-root').textContent=ctx.singular_root||'n/a';
-  document.getElementById('ctx-home').textContent=ctx.singular_home||'n/a';
+  document.getElementById('ctx-root').textContent=ctx.singular_root||na();
+  document.getElementById('ctx-home').textContent=ctx.singular_home||na();
   document.getElementById('ctx-lives-count').textContent=String(ctx.registry_lives_count||0);
   const policy=ctx.policy||{};
   const autonomy=policy.autonomy||{};
   const permissions=policy.permissions||{};
-  document.getElementById('ctx-policy-version').textContent=String(policy.version??'n/a');
-  document.getElementById('ctx-policy-autonomy').textContent=`safe_mode=${autonomy.safe_mode?'on':'off'} · quota=${autonomy.mutation_quota_per_window??'n/a'}/${autonomy.mutation_quota_window_seconds??'n/a'}s`;
+  document.getElementById('ctx-policy-version').textContent=String(policy.version??na());
+  document.getElementById('ctx-policy-autonomy').textContent=`safe_mode=${autonomy.safe_mode?'on':'off'} · quota=${autonomy.mutation_quota_per_window??na()}/${autonomy.mutation_quota_window_seconds??na()}s`;
   document.getElementById('ctx-policy-permissions').textContent=`auto=${(permissions.modifiable_paths||[]).length} · review=${(permissions.review_required_paths||[]).length} · forbidden=${(permissions.forbidden_paths||[]).length}`;
   const impactList=document.getElementById('ctx-policy-impact');
   impactList.innerHTML='';
@@ -344,7 +354,7 @@ const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJson(with
   const selected=rows.find(row=>row.selected_life===true);
   document.getElementById('eco-selected-life').textContent=selected?.life||'Aucune';
   const latestRow=rows.find(row=>row.last_activity);
-  document.getElementById('eco-last-activity').textContent=latestRow?.last_activity||'n/a';
+  document.getElementById('eco-last-activity').textContent=latestRow?.last_activity||na();
 
   const organisms=eco.organisms||{};
   const list=document.getElementById('organisms-list');
@@ -352,8 +362,8 @@ const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJson(with
   for(const [name,payload] of Object.entries(organisms)){
     const li=document.createElement('li');
     const status=payload.status||'alive';
-    const energy=payload.energy??'n/a';
-    const resources=payload.resources??'n/a';
+    const energy=payload.energy??na();
+    const resources=payload.resources??na();
     li.textContent=`${name} · statut=${status} · énergie=${energy} · ressources=${resources}`;
     list.appendChild(li);
   }
@@ -373,25 +383,25 @@ const loadHostVitals=()=>fetchJson(withScope('/runs/latest')).then(data=>{
 const loadCockpit=()=>fetchJson(withScope('/api/cockpit')).then(d=>{
   if(!d||typeof d!=='object'){setPanelState('cockpit','empty','Aucune donnée cockpit disponible.');return;}
   const statusBox=document.getElementById('cockpit-status');
-  statusBox.textContent=`Statut global: ${d.global_status||'unknown'}`;
-  if(d.global_status==='stable'){setStatusTone(statusBox,'good');}
-  else if(d.global_status==='warning'){setStatusTone(statusBox,'warn');}
-  else if(d.global_status==='critical'){setStatusTone(statusBox,'bad');}
+  statusBox.textContent=`Statut global: ${d.global_status||na()}`;
+  if(d.global_status==='stable'){setStatusTone(statusBox,'good');applyStatusIndicator(statusBox,'good');}
+  else if(d.global_status==='warning'){setStatusTone(statusBox,'warn');applyStatusIndicator(statusBox,'warn');}
+  else if(d.global_status==='critical'){setStatusTone(statusBox,'bad');applyStatusIndicator(statusBox,'bad');}
 
-  const healthValue=d.health_score===null?'n/a':Number(d.health_score).toFixed(1);
-  const trend=d.trend||'n/a';
-  const accepted=d.accepted_mutation_rate===null?'n/a':`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
+  const healthValue=d.health_score===null?na():Number(d.health_score).toFixed(1);
+  const trend=d.trend||na();
+  const accepted=d.accepted_mutation_rate===null?na():`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
   const alertsCount=(d.critical_alerts||[]).length;
   const autonomy=d.autonomy_metrics||{};
   const decisionQuality=autonomy.decision_quality||{};
-  const fmtPct=(value)=>value===null||value===undefined?'n/a':`${(Number(value)*100).toFixed(1)}%`;
-  const fmtNum=(value,suffix='')=>value===null||value===undefined?'n/a':`${Number(value).toFixed(2)}${suffix}`;
+  const fmtPct=(value)=>value===null||value===undefined?na():`${(Number(value)*100).toFixed(1)}%`;
+  const fmtNum=(value,suffix='')=>value===null||value===undefined?na():`${Number(value).toFixed(2)}${suffix}`;
 
   document.getElementById('kpi-health').textContent=healthValue;
   document.getElementById('kpi-trend').textContent=trend;
   document.getElementById('kpi-accepted').textContent=accepted;
   document.getElementById('kpi-alerts').textContent=String(alertsCount);
-  document.getElementById('kpi-next-action').textContent=d.next_action||'n/a';
+  document.getElementById('kpi-next-action').textContent=d.next_action||na();
   document.getElementById('kpi-autonomy-proactive').textContent=fmtPct(autonomy.proactive_initiative_rate);
   document.getElementById('kpi-autonomy-stability').textContent=fmtPct(autonomy.long_term_stability);
   document.getElementById('kpi-autonomy-decision').textContent=`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`;
@@ -410,16 +420,16 @@ const loadCockpit=()=>fetchJson(withScope('/api/cockpit')).then(d=>{
   const codeGeneration=vitalMetrics.code_generation||{};
   const risks=vitalMetrics.risks||[];
   document.getElementById('kpi-vital-age').textContent=String(vital.age??0);
-  document.getElementById('kpi-vital-risk').textContent=String(vital.risk_level||'n/a');
+  document.getElementById('kpi-vital-risk').textContent=String(vital.risk_level||na());
   document.getElementById('kpi-vital-terminal').textContent=vital.terminal===true?'oui':'non';
-  document.getElementById('kpi-vital-causes').textContent=(vital.causes||[]).join(', ')||'n/a';
-  document.getElementById('kpi-circadian-phase').textContent=String((vitalMetrics.circadian_cycle||{}).phase||'n/a');
+  document.getElementById('kpi-vital-causes').textContent=(vital.causes||[]).join(', ')||na();
+  document.getElementById('kpi-circadian-phase').textContent=String((vitalMetrics.circadian_cycle||{}).phase||na());
   document.getElementById('kpi-active-objectives-count').textContent=String(objectives.count||0);
   document.getElementById('kpi-quests-progress').textContent=`${objectives.count||0} actifs`;
   document.getElementById('kpi-energy-total').textContent=fmtNum(energyResources.total_energy);
   document.getElementById('kpi-resources-total').textContent=fmtNum(energyResources.total_resources);
-  document.getElementById('kpi-code-progression').textContent=String(codeGeneration.progression||'n/a');
-  document.getElementById('kpi-code-risks').textContent=risks.length?risks.join(', '):String(codeGeneration.risk_level||'n/a');
+  document.getElementById('kpi-code-progression').textContent=String(codeGeneration.progression||na());
+  document.getElementById('kpi-code-risks').textContent=risks.length?risks.join(', '):String(codeGeneration.risk_level||na());
   document.getElementById('kpi-skills-active').textContent=String(skillLifecycle.active||0);
   document.getElementById('kpi-skills-dormant').textContent=String(skillLifecycle.dormant||0);
   document.getElementById('kpi-skills-archived').textContent=String(skillLifecycle.archived||0);
@@ -441,7 +451,7 @@ const loadCockpit=()=>fetchJson(withScope('/api/cockpit')).then(d=>{
   priorityList.innerHTML='';
   for(const change of priorityChanges.slice(-5).reverse()){
     const li=document.createElement('li');
-    li.textContent=`${change.objective||'objectif'} · ${change.from??'n/a'} → ${change.to??'n/a'} (${change.at||'n/a'})`;
+    li.textContent=`${change.objective||'objectif'} · ${change.from??na()} → ${change.to??na()} (${change.at||na()})`;
     priorityList.appendChild(li);
   }
   if(!priorityChanges.length){const li=document.createElement('li');li.textContent='Aucun changement détecté';priorityList.appendChild(li);}
@@ -449,7 +459,7 @@ const loadCockpit=()=>fetchJson(withScope('/api/cockpit')).then(d=>{
   linksList.innerHTML='';
   for(const link of objectiveLinks.slice(-5).reverse()){
     const li=document.createElement('li');
-    li.textContent=`${link.objective||'objectif'} ↔ ${link.event||'événement'} (${link.at||'n/a'})`;
+    li.textContent=`${link.objective||'objectif'} ↔ ${link.event||'événement'} (${link.at||na()})`;
     linksList.appendChild(li);
   }
   if(!objectiveLinks.length){const li=document.createElement('li');li.textContent='Aucun lien narratif détecté';linksList.appendChild(li);}
@@ -457,8 +467,8 @@ const loadCockpit=()=>fetchJson(withScope('/api/cockpit')).then(d=>{
 
   const notable=d.last_notable_mutation;
   if(notable){
-    const acceptedBadge=notable.accepted===true?'acceptée':(notable.accepted===false?'refusée':'n/a');
-    document.getElementById('kpi-notable-summary').textContent=`${notable.timestamp||'n/a'} · ${notable.life||'n/a'} · ${notable.operator||'n/a'} · ${acceptedBadge} · Δ=${notable.impact_delta??'n/a'}`;
+    const acceptedBadge=notable.accepted===true?'acceptée':(notable.accepted===false?'refusée':na());
+    document.getElementById('kpi-notable-summary').textContent=`${notable.timestamp||na()} · ${notable.life||na()} · ${notable.operator||na()} · ${acceptedBadge} · Δ=${notable.impact_delta??na()}`;
   } else {
     document.getElementById('kpi-notable-summary').textContent='Aucune mutation notable';
   }
@@ -489,8 +499,8 @@ document.getElementById('act-archive').onclick=()=>runAction('archive',{name:doc
 document.getElementById('act-memorial').onclick=()=>runAction('memorial',{name:document.getElementById('action-life-name').value||'',message:'Merci pour ce cycle de vie.'});
 document.getElementById('act-clone').onclick=()=>runAction('clone',{name:document.getElementById('action-life-name').value||'',new_name:`${document.getElementById('action-life-name').value||'Vie'} clone`});
 const badge=(label,tone)=>`<span class='badge ${tone}'>${label}</span>`;
-const renderLivesBuckets=(rows)=>{const activeInRegistry=(rows||[]).filter(row=>row.is_registry_active_life===true);const extinctInRuns=(rows||[]).filter(row=>row.extinction_seen_in_runs===true);const aliveList=document.getElementById('alive-lives');const deadList=document.getElementById('dead-lives');document.getElementById('alive-count').textContent=String(activeInRegistry.length);document.getElementById('dead-count').textContent=String(extinctInRuns.length);aliveList.innerHTML='';deadList.innerHTML='';for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||'n/a';aliveList.appendChild(li);}for(const row of extinctInRuns){const li=document.createElement('li');li.textContent=row.life||'n/a';deadList.appendChild(li);}if(!activeInRegistry.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);}if(!extinctInRuns.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);}};
-const renderLivesTable=(rows)=>{const body=document.getElementById('lives-table-body');body.innerHTML='';for(const row of rows||[]){const tr=document.createElement('tr');const score=row.current_health_score===null||row.current_health_score===undefined?'n/a':Number(row.current_health_score).toFixed(1);const stability=row.stability===null||row.stability===undefined?'n/a':`${(Number(row.stability)*100).toFixed(1)}%`;const lastActivity=row.last_activity||'n/a';let badges='';if(row.selected_life){badges+=badge('Vie sélectionnée',BADGE_TONE.success);}else{badges+=badge('Vie non sélectionnée',BADGE_TONE.danger);}if(row.is_registry_active_life){badges+=badge('Vie active dans le registre',BADGE_TONE.success);}else{badges+=badge(`Statut registre: ${row.life_status||'n/a'}`,BADGE_TONE.danger);}if(row.run_terminated){badges+=badge('Run terminé',BADGE_TONE.warning);}if(row.extinction_seen_in_runs){badges+=badge('Extinction détectée',BADGE_TONE.danger);}if(row.has_recent_activity){badges+=badge('Activité récente',BADGE_TONE.info);}if(row.trend==='dégradation'){badges+=badge('dégradation',BADGE_TONE.warning);}if((row.alerts_count||0)>0){badges+=badge(`${row.alerts_count} alertes`,BADGE_TONE.danger);}tr.innerHTML=`<td>${row.life||'n/a'}</td><td>${score}</td><td>${row.trend||'n/a'}</td><td>${stability}</td><td>${lastActivity}</td><td>${row.iterations??0}</td><td>${badges}</td>`;body.appendChild(tr);}if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}};
+const renderLivesBuckets=(rows)=>{const activeInRegistry=(rows||[]).filter(row=>row.is_registry_active_life===true);const extinctInRuns=(rows||[]).filter(row=>row.extinction_seen_in_runs===true);const aliveList=document.getElementById('alive-lives');const deadList=document.getElementById('dead-lives');document.getElementById('alive-count').textContent=String(activeInRegistry.length);document.getElementById('dead-count').textContent=String(extinctInRuns.length);aliveList.innerHTML='';deadList.innerHTML='';for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||na();aliveList.appendChild(li);}for(const row of extinctInRuns){const li=document.createElement('li');li.textContent=row.life||na();deadList.appendChild(li);}if(!activeInRegistry.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);}if(!extinctInRuns.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);}};
+const renderLivesTable=(rows)=>{const body=document.getElementById('lives-table-body');body.innerHTML='';for(const row of rows||[]){const tr=document.createElement('tr');const score=row.current_health_score===null||row.current_health_score===undefined?na():Number(row.current_health_score).toFixed(1);const stability=row.stability===null||row.stability===undefined?na():`${(Number(row.stability)*100).toFixed(1)}%`;const lastActivity=row.last_activity||na();let badges='';if(row.selected_life){badges+=badge('Vie sélectionnée',BADGE_TONE.success);}else{badges+=badge('Vie non sélectionnée',BADGE_TONE.danger);}if(row.is_registry_active_life){badges+=badge('Vie active dans le registre',BADGE_TONE.success);}else{badges+=badge(`Statut registre: ${row.life_status||na()}`,BADGE_TONE.danger);}if(row.run_terminated){badges+=badge('Run terminé',BADGE_TONE.warning);}if(row.extinction_seen_in_runs){badges+=badge('Extinction détectée',BADGE_TONE.danger);}if(row.has_recent_activity){badges+=badge('Activité récente',BADGE_TONE.info);}if(row.trend==='dégradation'){badges+=badge('dégradation',BADGE_TONE.warning);}if((row.alerts_count||0)>0){badges+=badge(`${row.alerts_count} alertes`,BADGE_TONE.danger);}tr.innerHTML=`<td>${row.life||na()}</td><td>${score}</td><td>${row.trend||na()}</td><td>${stability}</td><td>${lastActivity}</td><td>${row.iterations??0}</td><td>${badges}</td>`;body.appendChild(tr);}if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}};
 const renderUnattachedRuns=(payload)=>{const panel=document.getElementById('unattached-runs-panel');const list=document.getElementById('unattached-runs-list');const runs=(payload?.runs)||[];const runsCount=Number(payload?.runs_count||0);const recordsCount=Number(payload?.records_count||0);document.getElementById('unattached-runs-count').textContent=String(runsCount);document.getElementById('unattached-records-count').textContent=String(recordsCount);list.innerHTML='';if(!runsCount){panel.classList.add('panel-hidden');return;}panel.classList.remove('panel-hidden');for(const item of runs){const li=document.createElement('li');li.textContent=`${item.run_id||'unknown'} · ${item.records_count||0} enregistrements`;list.appendChild(li);}};
 const renderGenealogyTree=(payload)=>{const nodes=payload?.nodes||[];const treeEl=document.getElementById('genealogy-tree');const socialEl=document.getElementById('social-network-tree');const conflictsEl=document.getElementById('active-conflicts');if(!nodes.length){treeEl.textContent='Aucune lignée enregistrée.';socialEl.textContent='Aucun réseau social.';conflictsEl.textContent='Aucun conflit.';return;}const bySlug=new Map(nodes.map(node=>[node.slug,node]));const children=new Map();for(const node of nodes){children.set(node.slug,[]);}for(const node of nodes){for(const parent of (node.parents||[])){if(children.has(parent)){children.get(parent).push(node.slug);}}}const roots=nodes.filter(node=>(node.parents||[]).length===0).map(node=>node.slug);const lines=[];const visit=(slug,depth)=>{const node=bySlug.get(slug);if(!node){return;}const marker=node.active?'★':'•';const status=node.status==='extinct'?'✝':'✓';lines.push(`${'  '.repeat(depth)}${marker} ${node.name} (${node.slug}) [${status}]`);for(const child of (children.get(slug)||[])){visit(child,depth+1);}};for(const root of roots){visit(root,0);}const detached=nodes.filter(node=>!roots.includes(node.slug)&&!(node.parents||[]).every(parent=>bySlug.has(parent)));for(const node of detached){lines.push(`• ${node.name} (${node.slug}) [orphan]`);}treeEl.textContent=lines.join('\n');const socialLines=[];for(const node of nodes){const allies=(node.allies||[]).join(', ')||'-';const rivals=(node.rivals||[]).join(', ')||'-';socialLines.push(`${node.slug} | proximité=${Number(node.proximity_score||0.5).toFixed(2)} | alliés: ${allies} | rivaux: ${rivals}`);}socialEl.textContent=socialLines.join('\n');const conflicts=payload?.active_conflicts||[];conflictsEl.textContent=conflicts.length?conflicts.map(c=>`${c.life_a} ⚔ ${c.life_b}`).join('\n'):'Aucun conflit actif.';};
 const loadGenealogy=()=>fetchJson('/lives/genealogy').then(renderGenealogyTree).catch(error=>{document.getElementById('genealogy-tree').textContent='Impossible de charger la généalogie.';throw error;});
@@ -502,15 +512,26 @@ document.getElementById('filter-degrading').onchange=()=>loadLivesBoard();
 document.getElementById('filter-dead').onchange=()=>loadLivesBoard();
 document.getElementById('filter-time-window').onchange=()=>loadLivesBoard();
 document.getElementById('filter-compare-lives').onchange=()=>loadLivesBoard();
-const renderLiveEvents=()=>{const pre=document.getElementById('live-events');const rows=liveState.events.map(item=>`${item.ts||'n/a'} | ${item.run_id||'n/a'} | ${item.event||'unknown'}`);pre.textContent=rows.join('\n');if(liveState.autoScroll){pre.scrollTop=pre.scrollHeight;}};
+const renderLiveEvents=()=>{const pre=document.getElementById('live-events');const rows=liveState.events.map(item=>`${item.ts||na()} | ${item.run_id||na()} | ${item.event||'unknown'}`);pre.textContent=rows.join('\n');if(liveState.autoScroll){pre.scrollTop=pre.scrollHeight;}};
 const updateLiveStatus=()=>{document.getElementById('live-status').textContent=liveState.paused?'Pause activée':'Lecture en direct';document.getElementById('live-toggle').textContent=liveState.paused?'Reprendre':'Pause';};
 document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};
 document.getElementById('live-autoscroll').onchange=e=>{liveState.autoScroll=Boolean(e.target.checked);if(liveState.autoScroll){renderLiveEvents();}};
 // Timeline domain
-const loadTimeline=()=>fetchJson(withScope('/runs/latest')).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=scopeState.currentLifeOnly?'&current_life_only=true':'';return fetchJson(`/api/runs/${meta.run}/timeline?page=1&page_size=120${q}`);}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.className='timeline-item';const btn=document.createElement('button');btn.className='timeline-button';btn.textContent=`${item.event} · ${item.timestamp||'n/a'}`;row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.className='timeline-link';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';setPanelState('timeline-section','empty','Aucun événement pour le run courant.');}});
+const loadTimeline=()=>fetchJson(withScope('/runs/latest')).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=scopeState.currentLifeOnly?'&current_life_only=true':'';return fetchJson(`/api/runs/${meta.run}/timeline?page=1&page_size=120${q}`);}).then(data=>{const wrap=document.getElementById('timeline');const summary=document.getElementById('timeline-summary');const impact=document.getElementById('timeline-impact');const diff=document.getElementById('timeline-diff');wrap.innerHTML='';let mutationIndex=0;for(const item of data.items||[]){const row=document.createElement('div');row.className='timeline-item';const btn=document.createElement('button');btn.className='timeline-button';btn.textContent=`${item.event} · ${item.timestamp||na()}`;row.appendChild(btn);if(item.event==='mutation'&&data.run_id){const currentIndex=mutationIndex;mutationIndex+=1;btn.onclick=()=>showMutationDetail(data.run_id,currentIndex);const link=document.createElement('a');link.href=`/runs/${data.run_id}/mutations/${currentIndex}`;link.textContent='Voir détail';link.className='timeline-link';row.appendChild(link);}wrap.appendChild(row);}if(!(data.items||[]).length){summary.textContent='Aucun événement de frise disponible.';impact.textContent='';diff.textContent='';setPanelState('timeline-section','empty','Aucun événement pour le run courant.');}});
 // Reflections domain
-const loadReflections=()=>fetchJson(withScope('/runs/latest')).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=new URLSearchParams();const objective=document.getElementById('reflection-objective').value;const mood=document.getElementById('reflection-mood').value;const success=document.getElementById('reflection-success').value;if(objective){q.set('objective',objective);}if(mood){q.set('mood',mood);}if(success){q.set('success',success);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}const suffix=q.toString()?`?${q.toString()}`:'';return fetchJson(`/api/runs/${meta.run}/consciousness${suffix}`);}).then(data=>{const wrap=document.getElementById('reflections-timeline');const detail=document.getElementById('reflections-detail');wrap.innerHTML='';for(const item of data.items||[]){const row=document.createElement('div');row.className='timeline-item';const btn=document.createElement('button');btn.className='timeline-button';const mood=item.emotional_state?.mood||'n/a';const objective=item.objective||'n/a';btn.textContent=`${item.ts||'n/a'} · ${objective} · ${mood}`;btn.onclick=()=>{detail.textContent=JSON.stringify(item,null,2);};row.appendChild(btn);wrap.appendChild(row);}if(!(data.items||[]).length){detail.textContent='Aucune réflexion disponible pour ces filtres.';setPanelState('reflections-section','empty','Aucune réflexion disponible. Essayez d’élargir les filtres.');}});
+const loadReflections=()=>fetchJson(withScope('/runs/latest')).then(meta=>{if(!meta.run){return {run_id:null,items:[]};}const q=new URLSearchParams();const objective=document.getElementById('reflection-objective').value;const mood=document.getElementById('reflection-mood').value;const success=document.getElementById('reflection-success').value;if(objective){q.set('objective',objective);}if(mood){q.set('mood',mood);}if(success){q.set('success',success);}if(scopeState.currentLifeOnly){q.set('current_life_only','true');}const suffix=q.toString()?`?${q.toString()}`:'';return fetchJson(`/api/runs/${meta.run}/consciousness${suffix}`);}).then(data=>{const wrap=document.getElementById('reflections-timeline');const detail=document.getElementById('reflections-detail');wrap.innerHTML='';for(const item of data.items||[]){const row=document.createElement('div');row.className='timeline-item';const btn=document.createElement('button');btn.className='timeline-button';const mood=item.emotional_state?.mood||na();const objective=item.objective||na();btn.textContent=`${item.ts||na()} · ${objective} · ${mood}`;btn.onclick=()=>{detail.textContent=JSON.stringify(item,null,2);};row.appendChild(btn);wrap.appendChild(row);}if(!(data.items||[]).length){detail.textContent='Aucune réflexion disponible pour ces filtres.';setPanelState('reflections-section','empty','Aucune réflexion disponible. Essayez d’élargir les filtres.');}});
 document.getElementById('reflection-apply').onclick=()=>loadReflections();
+
+const toggleEssentialMode=()=>{
+  document.body.classList.toggle('essential-mode');
+  const btn=document.getElementById('toggle-essential');
+  if(!btn){return;}
+  const isEssential=document.body.classList.contains('essential-mode');
+  btn.textContent=`Mode Essentiel : ${isEssential?'ON':'OFF'}`;
+  btn.setAttribute('aria-pressed',isEssential?'true':'false');
+};
+const essentialBtn=document.getElementById('toggle-essential');
+if(essentialBtn){essentialBtn.onclick=toggleEssentialMode;}
 
 // Module bootstrap
 bootstrapPauseControls();

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -12,90 +12,114 @@
   <a href="#competences-quotidien">Compétences du quotidien</a> ·
   <a href="#timeline-section">Timeline</a> ·
   <a href="#vies">Vies</a> ·
-  <a href="#logs-live">Logs</a> ·
-  <a href="#parametres">Paramètres</a>
+  <a href="#logs-live" class='technical-only'>Logs</a> ·
+  <a href="#parametres" class='technical-only'>Paramètres</a>
+  <button id='toggle-essential' class='nav-mode-toggle' type='button' aria-pressed='false'>Mode Essentiel : OFF</button>
 </nav>
 <div id='stale-data-banner' class='stale-banner panel-hidden' role='status' aria-live='polite'></div>
 <div class='intro-box'>
-  <strong>Guide de lecture rapide (humain)</strong>
+  <strong>Guide de lecture rapide</strong>
   <ol class='intro-steps'>
-    <li><strong>Cockpit</strong> : regardez d’abord le statut global, puis la prochaine action recommandée.</li>
-    <li><strong>Alertes et risques</strong> : vérifiez les zones en orange/rouge pour prioriser.</li>
-    <li><strong>Timeline</strong> : cliquez un événement pour comprendre le “pourquoi” d’une mutation.</li>
-    <li><strong>Vies</strong> : comparez les organismes pour décider quoi conserver, corriger ou archiver.</li>
+    <li><strong>Cockpit</strong> : vérifiez d’abord le statut global, puis la prochaine action recommandée.</li>
+    <li><strong>Risques</strong> : traitez en priorité les statuts <em>Alerte</em> et <em>Critique</em>.</li>
+    <li><strong>Timeline</strong> : ouvrez un événement pour comprendre la mutation et son impact.</li>
+    <li><strong>Vies</strong> : comparez les organismes avant de conserver, corriger ou archiver.</li>
   </ol>
+</div>
+
+<div class='panel'>
+  <h2 class='heading-reset-top'>Glossaire commun</h2>
+  <p class='section-help'>Ces définitions sont utilisées partout dans le dashboard pour garantir un vocabulaire cohérent.</p>
+  <dl class='glossary'>
+    <dt>Vie</dt><dd>Instance suivie dans le registre, avec historique, statut et métriques.</dd>
+    <dt>Organisme</dt><dd>Entité opérationnelle associée à une vie (énergie, ressources, décisions).</dd>
+    <dt>Mutation</dt><dd>Changement appliqué au système, accepté ou refusé selon son impact.</dd>
+    <dt>Run</dt><dd>Session d’exécution horodatée contenant événements, décisions et traces.</dd>
+    <dt>Extinction</dt><dd>Arrêt terminal détecté pour une vie dans les runs ou le registre.</dd>
+    <dt>Stabilité</dt><dd>Capacité à maintenir des performances cohérentes dans le temps.</dd>
+    <dt>Risque</dt><dd>Niveau de probabilité d’un incident ou d’une régression à court terme.</dd>
+  </dl>
 </div>
 
 <section id="cockpit">
   <h2>Cockpit</h2>
-  <p class='section-help'>Vue de synthèse : utilisez cette section pour décider en moins de 30 secondes si l’organisme est stable, en risque, ou en régression.</p>
-  <div id='cockpit-status' class='card card-value'>Statut global: n/a</div>
-  <p><strong>Qu’est-ce que ce score ?</strong> Le score de santé agrège stabilité sandbox, tendance récente et signal d’acceptation des mutations.</p>
+  <p class='section-help'>À utiliser pour décider en moins de 30 secondes si l’organisme est stable, en alerte, ou critique.</p>
+  <div class='status-legend'>
+    <span class='status-pill status-good'>● OK</span>
+    <span class='status-pill status-warn'>▲ Alerte</span>
+    <span class='status-pill status-bad'>■ Critique</span>
+  </div>
+  <div id='cockpit-status' class='card card-value'>Statut global: Non disponible</div>
+  <p><strong>Lecture du score santé :</strong> ce score combine stabilité, tendance récente et acceptation des mutations.</p>
 
   <div class='cards-grid'>
-    <div class='card'><div class='card-label'>Score de santé</div><div id='kpi-health' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>Tendance</div><div id='kpi-trend' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>Taux de mutations acceptées</div><div id='kpi-accepted' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>Alertes critiques</div><div id='kpi-alerts' class='card-value'>0</div></div>
-    <div class='card'><div class='card-label'>Prochaine action</div><div id='kpi-next-action' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Niveau global de santé de l’organisme'>Santé</div><div id='kpi-health' class='card-value'>Pas encore mesuré</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Évolution récente du système'>Tendance</div><div id='kpi-trend' class='card-value'>Non disponible</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Part des mutations validées'>Mutations acceptées</div><div id='kpi-accepted' class='card-value'>Pas encore mesuré</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Nombre d’alertes de niveau critique'>Alertes critiques</div><div id='kpi-alerts' class='card-value'>0</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Action prioritaire recommandée'>Prochaine action</div><div id='kpi-next-action' class='card-value'>Non disponible</div></div>
   </div>
   <div class='panel' id='host-vitals-panel'>
     <h3 class='heading-reset-top'>Santé hôte consolidée</h3>
+    <p class='section-help'>À utiliser pour vérifier rapidement si la plateforme hôte limite les performances.</p>
     <div class='cards-grid'>
-      <div class='card'><div class='card-label'>CPU</div><div id='host-cpu' class='card-value'>n/a</div><div id='host-cpu-trend' class='sparkline'>·</div></div>
-      <div class='card'><div class='card-label'>RAM</div><div id='host-ram' class='card-value'>n/a</div><div id='host-ram-trend' class='sparkline'>·</div></div>
-      <div class='card'><div class='card-label'>Température</div><div id='host-temp' class='card-value'>n/a</div><div id='host-temp-trend' class='sparkline'>·</div></div>
-      <div class='card'><div class='card-label'>Disque</div><div id='host-disk' class='card-value'>n/a</div><div id='host-disk-trend' class='sparkline'>·</div></div>
-      <div class='card'><div class='card-label'>État global</div><div id='host-global' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label kpi-label' title='Utilisation processeur'>CPU</div><div id='host-cpu' class='card-value'>Pas encore mesuré</div><div id='host-cpu-trend' class='sparkline'>·</div></div>
+      <div class='card'><div class='card-label kpi-label' title='Utilisation mémoire vive'>RAM</div><div id='host-ram' class='card-value'>Pas encore mesuré</div><div id='host-ram-trend' class='sparkline'>·</div></div>
+      <div class='card'><div class='card-label kpi-label' title='Température système'>Température</div><div id='host-temp' class='card-value'>Pas encore mesuré</div><div id='host-temp-trend' class='sparkline'>·</div></div>
+      <div class='card'><div class='card-label kpi-label' title='Utilisation disque'>Disque</div><div id='host-disk' class='card-value'>Pas encore mesuré</div><div id='host-disk-trend' class='sparkline'>·</div></div>
+      <div class='card'><div class='card-label kpi-label' title='État hôte consolidé'>État hôte</div><div id='host-global' class='card-value'>Non disponible</div></div>
     </div>
-    <div id='host-adaptation' class='content-top-gap'>Dernière adaptation capteur: n/a</div>
+    <div id='host-adaptation' class='content-top-gap'>Dernière adaptation capteur: Non disponible</div>
     <div id='host-fallback' class='status-muted panel-hidden fallback-box'>
       Certains capteurs hôte ne sont pas supportés sur cette plateforme (ou aucune donnée récente n’est disponible).
     </div>
   </div>
 
-  <h3>Métriques d’autonomie</h3>
-  <p class='section-help'>Ces indicateurs montrent si Singular agit seul de façon utile (et non juste active).</p>
+  <h3>Autonomie</h3>
+  <p class='section-help'>À utiliser pour suivre si Singular agit seul de façon utile, et pas seulement fréquente.</p>
   <div class='cards-grid'>
-    <div class='card'><div class='card-label'>Taux d’initiatives proactives</div><div id='kpi-autonomy-proactive' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>Stabilité long terme</div><div id='kpi-autonomy-stability' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>Qualité décisions (accept./régr.)</div><div id='kpi-autonomy-decision' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>Latence perception→action</div><div id='kpi-autonomy-latency' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>Coût ressources par gain</div><div id='kpi-autonomy-cost' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Part d’actions lancées sans demande explicite'>Initiatives</div><div id='kpi-autonomy-proactive' class='card-value'>Pas encore mesuré</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Robustesse observée sur la durée'>Stabilité long terme</div><div id='kpi-autonomy-stability' class='card-value'>Pas encore mesuré</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Qualité des décisions acceptées vs régressions'>Qualité décision</div><div id='kpi-autonomy-decision' class='card-value'>Pas encore mesuré</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Temps entre perception et action'>Latence P→A</div><div id='kpi-autonomy-latency' class='card-value'>Pas encore mesuré</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Consommation de ressources pour un gain utile'>Coût par gain</div><div id='kpi-autonomy-cost' class='card-value'>Pas encore mesuré</div></div>
   </div>
   <h3>Timeline vitale</h3>
-  <p class='section-help'>Âge + risque + causes terminales vous aident à estimer la probabilité d’une extinction à court terme.</p>
+  <p class='section-help'>À utiliser pour estimer le risque d’extinction à court terme.</p>
   <div class='cards-grid'>
-    <div class='card'><div class='card-label'>Âge</div><div id='kpi-vital-age' class='card-value'>0</div></div>
-    <div class='card'><div class='card-label'>Risque</div><div id='kpi-vital-risk' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>État terminal</div><div id='kpi-vital-terminal' class='card-value'>n/a</div></div>
-    <div class='card'><div class='card-label'>Causes</div><div id='kpi-vital-causes' class='card-value'>n/a</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Ancienneté de la vie'>Âge</div><div id='kpi-vital-age' class='card-value'>0</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Niveau de risque courant'>Risque</div><div id='kpi-vital-risk' class='card-value'>Non disponible</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Statut terminal détecté'>Terminal</div><div id='kpi-vital-terminal' class='card-value'>Non disponible</div></div>
+    <div class='card'><div class='card-label kpi-label' title='Causes terminales observées'>Causes</div><div id='kpi-vital-causes' class='card-value'>Non disponible</div></div>
   </div>
 
   <div class='panel'>
     <h3 class='heading-reset-top'>Synthèse des vies</h3>
+    <p class='section-help'>À utiliser pour piloter le portefeuille de vies actives et éteintes.</p>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Vies totales</div><div id='eco-total-lives' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Vies vivantes</div><div id='eco-alive-lives' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Vies mortes</div><div id='eco-dead-lives' class='card-value'>0</div></div>
-      <div class='card'><div class='card-label'>Vie sélectionnée</div><div id='eco-selected-life' class='card-value'>n/a</div></div>
-      <div class='card'><div class='card-label'>Dernière activité</div><div id='eco-last-activity' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label'>Vie sélectionnée</div><div id='eco-selected-life' class='card-value'>Non disponible</div></div>
+      <div class='card'><div class='card-label'>Dernière activité</div><div id='eco-last-activity' class='card-value'>Non disponible</div></div>
     </div>
   </div>
 
 
   <div class='panel'>
     <h3 class='heading-reset-top'>Cycle circadien & objectifs actifs</h3>
+    <p class='section-help'>À utiliser pour comprendre le rythme d’activité et la charge d’objectifs.</p>
     <div class='cards-grid'>
-      <div class='card'><div class='card-label'>Phase circadienne</div><div id='kpi-circadian-phase' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label'>Phase circadienne</div><div id='kpi-circadian-phase' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Objectifs actifs</div><div id='kpi-active-objectives-count' class='card-value'>0</div></div>
-      <div class='card'><div class='card-label'>Progression quêtes</div><div id='kpi-quests-progress' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label'>Progression quêtes</div><div id='kpi-quests-progress' class='card-value'>Non disponible</div></div>
     </div>
     <ul id='kpi-active-objectives-list' class='list-tight-top'></ul>
   </div>
 
   <div class='panel'>
     <h3 class='heading-reset-top'>Trajectory des objectifs</h3>
+    <p class='section-help'>À utiliser pour suivre les bascules de priorité et la cohérence narrative.</p>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>En cours</div><div id='kpi-trajectory-in-progress' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Abandonnés</div><div id='kpi-trajectory-abandoned' class='card-value'>0</div></div>
@@ -111,6 +135,7 @@
 
   <div class='panel'>
     <h3 class='heading-reset-top'>Cycle de vie des skills</h3>
+    <p class='section-help'>À utiliser pour garder un portefeuille de compétences actif et pertinent.</p>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Skills actives</div><div id='kpi-skills-active' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Skills dormantes</div><div id='kpi-skills-dormant' class='card-value'>0</div></div>
@@ -120,11 +145,11 @@
 
   <div class='panel' id='competences-quotidien'>
     <h3 class='heading-reset-top'>Compétences du quotidien</h3>
-    <p class='section-help'>Concentrez-vous sur les skills réellement utilisées et leur taux de réussite pour éviter les métriques “bruit”.</p>
+    <p class='section-help'>À utiliser pour suivre les skills réellement utilisées et éviter les métriques bruit.</p>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Fréquence (24h)</div><div id='daily-skill-uses-24h' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Fréquence (7j)</div><div id='daily-skill-uses-7d' class='card-value'>0</div></div>
-      <div class='card'><div class='card-label'>Top skill</div><div id='daily-skill-top' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label'>Top skill</div><div id='daily-skill-top' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Progression apprise→utilisée→améliorée</div><div id='daily-skill-progression' class='card-value'>0→0→0</div></div>
     </div>
     <table class='table-base table-spacing-top'>
@@ -142,21 +167,22 @@
 
   <div class='panel'>
     <h3 class='heading-reset-top'>Énergie / ressources & génération de code</h3>
+    <p class='section-help'>À utiliser pour arbitrer performance, coût et exposition au risque.</p>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Énergie totale</div><div id='kpi-energy-total' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Ressources totales</div><div id='kpi-resources-total' class='card-value'>0</div></div>
-      <div class='card'><div class='card-label'>Progression génération code</div><div id='kpi-code-progression' class='card-value'>n/a</div></div>
-      <div class='card'><div class='card-label'>Risques</div><div id='kpi-code-risks' class='card-value'>n/a</div></div>
+      <div class='card'><div class='card-label'>Progression génération code</div><div id='kpi-code-progression' class='card-value'>Non disponible</div></div>
+      <div class='card'><div class='card-label'>Risques</div><div id='kpi-code-risks' class='card-value'>Non disponible</div></div>
     </div>
   </div>
 
   <div class='panel'>
     <h3 class='heading-reset-top'>Dernière mutation notable</h3>
-    <p class='section-help'>Cette mutation est le meilleur “indice explicatif” de la trajectoire actuelle.</p>
+    <p class='section-help'>À utiliser pour relier la trajectoire actuelle à sa mutation la plus explicative.</p>
     <div id='kpi-notable-summary'>Aucune mutation notable</div>
     <h4>Actions suggérées</h4>
     <ul id='kpi-actions' class='list-tight-top'></ul>
-    <details class='technical-toggle'>
+    <details class='technical-toggle technical-only'>
       <summary><button type='button'>Voir détail technique</button></summary>
       <h4>Payload cockpit</h4>
       <pre id='raw-cockpit-json'></pre>
@@ -165,20 +191,20 @@
     </details>
   </div>
 
-  <p><strong>Pourquoi cette alerte ?</strong> Une alerte critique apparaît si la santé chute fortement, si la stabilité de sandbox baisse, ou si trop de mutations sont refusées.</p>
+  <p><strong>Pourquoi cette alerte ?</strong> Une alerte critique apparaît si la santé chute fortement, si la stabilité sandbox baisse, ou si trop de mutations sont refusées.</p>
 </section>
 
-<section id="parametres">
+<section id="parametres" class='technical-only'>
   <h2>Paramètres</h2>
-  <p class='section-help'>Section de diagnostic : utile surtout si vous suspectez un problème de configuration, de policy ou de registre.</p>
+  <p class='section-help'>À utiliser pour diagnostiquer une configuration, une policy ou un registre incohérent.</p>
   <div class='panel panel-spaced-bottom'>
     <h3 class='heading-reset-top'>Contexte registre</h3>
-    <div><strong>Registre courant (SINGULAR_ROOT)</strong> : <code id='ctx-root'>n/a</code></div>
-    <div><strong>Vie courante (SINGULAR_HOME)</strong> : <code id='ctx-home'>n/a</code></div>
+    <div><strong>Registre courant (SINGULAR_ROOT)</strong> : <code id='ctx-root'>Non disponible</code></div>
+    <div><strong>Vie courante (SINGULAR_HOME)</strong> : <code id='ctx-home'>Non disponible</code></div>
     <div><strong>Nombre de vies détectées</strong> : <span id='ctx-lives-count'>0</span></div>
-    <div><strong>Version politique</strong> : <span id='ctx-policy-version'>n/a</span></div>
-    <div><strong>Autonomie</strong> : <span id='ctx-policy-autonomy'>n/a</span></div>
-    <div><strong>Permissions</strong> : <span id='ctx-policy-permissions'>n/a</span></div>
+    <div><strong>Version politique</strong> : <span id='ctx-policy-version'>Non disponible</span></div>
+    <div><strong>Autonomie</strong> : <span id='ctx-policy-autonomy'>Non disponible</span></div>
+    <div><strong>Permissions</strong> : <span id='ctx-policy-permissions'>Non disponible</span></div>
   </div>
   <h3>Impact des politiques actives</h3>
   <ul id='ctx-policy-impact'><li>Chargement…</li></ul>
@@ -192,7 +218,7 @@
 
 <section id="timeline-section">
   <h2>Timeline des événements</h2>
-  <p class='section-help'>Objectif : passer du “quoi s’est passé” au “pourquoi cette décision”. Cliquez un événement de mutation pour inspecter impact + diff.</p>
+  <p class='section-help'>À utiliser pour passer du “quoi” au “pourquoi” sur chaque décision de mutation.</p>
   <div id='timeline' class='timeline-strip'></div>
   <h3>Détail mutation</h3>
   <p id='timeline-summary'>Cliquez sur un événement de mutation.</p>
@@ -200,9 +226,9 @@
   <pre id='timeline-diff' class='diff-preview'></pre>
 </section>
 
-<section id="reflections-section">
+<section id="reflections-section" class='technical-only'>
   <h2>Timeline des réflexions</h2>
-  <p class='section-help'>Filtrez par objectif/humeur/succès pour relier la qualité des décisions à l’état interne.</p>
+  <p class='section-help'>À utiliser pour corréler objectif, humeur et qualité de décision.</p>
   <div class='toolbar-wrap'>
     <label>Objectif
       <select id='reflection-objective'>
@@ -228,7 +254,7 @@
 </section>
 
 <section id="vies"><h2>Vies · Tableau comparatif</h2>
-  <p class='section-help'>Comparez plusieurs vies sur la même fenêtre temporelle pour choisir la plus robuste, pas seulement la plus performante à court terme.</p>
+  <p class='section-help'>À utiliser pour comparer la robustesse des vies sur une fenêtre temporelle identique.</p>
   <div class='filters-wrap'>
     <label><input id='filter-active' type='checkbox'/> Statut registre: active</label>
     <label><input id='filter-degrading' type='checkbox'/> Seulement en dégradation</label>
@@ -264,12 +290,12 @@
       <th>Badges</th>
     </tr></thead><tbody id='lives-table-body'></tbody>
   </table>
-  <div id='unattached-runs-panel' class='panel panel-hidden panel-top-gap panel-bordered panel-compact'>
+  <div id='unattached-runs-panel' class='panel panel-hidden panel-top-gap panel-bordered panel-compact technical-only'>
     <strong>Runs non rattachés (<span id='unattached-runs-count'>0</span>)</strong>
     <div class='text-muted-small'>Enregistrements sans vie explicite: <span id='unattached-records-count'>0</span></div>
     <ul id='unattached-runs-list' class='list-compact'></ul>
   </div>
-  <div class='panel panel-top-gap'>
+  <div class='panel panel-top-gap technical-only'>
     <h3 class='heading-reset-top'>Arbre généalogique (simplifié)</h3>
     <pre id='genealogy-tree'>Chargement…</pre>
     <div class='content-top-gap'><strong>Réseau social</strong><pre id='social-network-tree'>Chargement…</pre></div>
@@ -278,7 +304,7 @@
 </section>
 
 <section id="actions"><h2>Actions rapides</h2><pre id='action-result'>Aucune exécution</pre>
-  <p class='section-help'>Utilisez cette section pour agir immédiatement sans quitter le dashboard (créer, parler, lancer une boucle, archiver).</p>
+  <p class='section-help'>À utiliser pour exécuter une action immédiate sans quitter le dashboard.</p>
   <div class='panel actions-panel'>
     <label>Jeton dashboard <input id='action-token' type='password' placeholder='optionnel'/></label>
     <label>Nom de vie (créer/utiliser) <input id='action-life-name' placeholder='Nouvelle vie'/></label>
@@ -288,7 +314,7 @@
       <button id='act-birth'>Créer vie</button><button id='act-talk'>Discuter</button><button id='act-loop'>Boucle</button>
       <button id='act-archive'>Archiver</button><button id='act-memorial'>Mémorial</button><button id='act-clone'>Cloner</button>
     </div>
-    <details>
+    <details class='technical-only'>
       <summary>Actions secondaires</summary>
       <div class='toolbar-wrap content-top-gap'>
         <button id='act-report'>Rapport</button><button id='act-lives-list'>Lister vies</button><button id='act-lives-use'>Utiliser vie</button>
@@ -297,8 +323,8 @@
   </div>
 </section>
 
-<section id="logs-live"><h2>Logs en direct</h2>
-  <p class='section-help'>Flux opérationnel en temps réel. Si vous investiguez un incident, mettez en pause puis relisez les derniers événements.</p>
+<section id="logs-live" class='technical-only'><h2>Logs en direct</h2>
+  <p class='section-help'>À utiliser pour investiguer un incident via les derniers événements bruts.</p>
   <div class='toolbar-wrap'>
     <button id='live-toggle'>Pause</button>
     <label><input id='live-autoscroll' type='checkbox' checked/> Défilement automatique</label>


### PR DESCRIPTION
### Motivation
- Rendre le langage du dashboard cohérent en centralisant un glossaire et en uniformisant les libellés pour faciliter la lecture rapide. 
- Remplacer les marqueurs techniques (`n/a`) par des formulations compréhensibles par l’utilisateur et harmoniser le ton des aides contextuelles. 
- Ajouter des repères visuels standards pour le statut (OK / Alerte / Critique) et proposer une vue simplifiée (« Essentiel ») qui masque les sections purement techniques.

### Description
- Ajout d’un glossaire et d’un bouton toggle `Mode Essentiel` dans `src/singular/dashboard/templates/dashboard.html`, et balisage des sections techniques via la classe `technical-only` pour pouvoir les masquer en vue simplifiée.  
- Normalisation des libellés KPI et ajout d’info-bulles via des `title` courts (`kpi-label`) dans `dashboard.html` pour un format court + aide contextuelle.  
- Remplacement des placeholders visibles par l’utilisateur : introduction d’un objet `MISSING_TEXT` et des helpers `na()` / `nm()` dans `src/singular/dashboard/static/dashboard.js` et application de ces helpers dans les renderers dynamiques (cockpit, host, vies, timeline, etc.).  
- Ajout d’indicateurs visuels de statut (pills + icônes) et d’un helper `applyStatusIndicator` en JS, ainsi que de styles associés (`status-pill`, `status-with-icon`, règles pour `body.essential-mode`) dans `src/singular/dashboard/static/dashboard.css`.  

### Testing
- Exécution de la vérification de syntaxe JS : `node -c src/singular/dashboard/static/dashboard.js` a réussi.  
- Lancer `pytest -q` a échoué pendant la collecte des tests avec une erreur d’import : `ModuleNotFoundError: No module named 'fastapi.staticfiles'`, ce qui indique une dépendance manquante dans l’environnement de test (échec de collecte, tests non exécutés).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dedc6673fc832ab63df4923795f271)