### PR TITLE
Dashboard: démarrage avec registre vide et message d’onboarding

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -1173,7 +1173,6 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     elif args.command == "dashboard":
-        _ensure_active_life(resolve_life, args.life)
         from .dashboard import run as dashboard_run
 
         dashboard_run()

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -68,6 +68,23 @@ def create_app(
                 lives_paths.append(path)
         return lives_paths
 
+    def _registry_overview() -> dict[str, object]:
+        registry = load_registry()
+        raw_lives = registry.get("lives")
+        lives = raw_lives if isinstance(raw_lives, dict) else {}
+        active = registry.get("active")
+        active_valid = isinstance(active, str) and active in lives
+        is_empty = not lives and active is None
+        onboarding_message = "Aucune vie, créez-en une." if is_empty else None
+        return {
+            "lives": lives,
+            "lives_count": len(lives),
+            "active": active,
+            "active_valid": active_valid,
+            "is_empty": is_empty,
+            "onboarding_message": onboarding_message,
+        }
+
     def _runs_dirs(current_life_only: bool = False) -> list[Path]:
         if runs_path is not None:
             return [runs_path]
@@ -991,10 +1008,20 @@ def create_app(
     @app.get("/dashboard/context")
     def read_dashboard_context() -> dict[str, object]:
         policy = load_runtime_policy()
+        registry_state = _registry_overview()
         return {
             "singular_root": str(registry_root),
             "singular_home": str(base_dir),
-            "registry_lives_count": len(_registry_lives_paths()),
+            "registry_lives_count": registry_state["lives_count"],
+            "registry_state": {
+                "active": registry_state["active"],
+                "active_valid": registry_state["active_valid"],
+                "is_empty": registry_state["is_empty"],
+            },
+            "onboarding": {
+                "required": bool(registry_state["is_empty"]),
+                "message": registry_state["onboarding_message"],
+            },
             "policy": policy.to_payload(),
             "policy_impact": policy.impact_summary(),
             "skills_lifecycle": _skill_lifecycle_summary(),
@@ -1331,10 +1358,15 @@ def create_app(
             reverse=reverse,
         )
 
+        registry_state = _registry_overview()
         return {
             "lives": comparison,
             "table": lives_rows,
             "unattached_runs": unattached,
+            "onboarding": {
+                "required": bool(registry_state["is_empty"]),
+                "message": registry_state["onboarding_message"],
+            },
             "filters": {
                 "sort_by": sort_by,
                 "sort_order": "desc" if reverse else "asc",
@@ -1356,7 +1388,14 @@ def create_app(
         social_edges: list[dict[str, str]] = []
         conflicts: list[dict[str, str]] = []
         if not isinstance(lives, dict):
-            return {"active": active, "nodes": nodes, "edges": edges, "social_edges": social_edges, "active_conflicts": conflicts}
+            return {
+                "active": active,
+                "nodes": nodes,
+                "edges": edges,
+                "social_edges": social_edges,
+                "active_conflicts": conflicts,
+                "onboarding": {"required": active is None, "message": "Aucune vie, créez-en une." if active is None else None},
+            }
 
         for slug, meta in sorted(lives.items()):
             name = getattr(meta, "name", slug)
@@ -1408,6 +1447,10 @@ def create_app(
             "edges": edges,
             "social_edges": social_edges,
             "active_conflicts": [{"life_a": a, "life_b": b} for a, b in sorted(unique_conflicts)],
+            "onboarding": {
+                "required": not nodes and active is None,
+                "message": "Aucune vie, créez-en une." if not nodes and active is None else None,
+            },
         }
 
     @app.get("/mutations/top")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -36,6 +36,46 @@ def test_dashboard_endpoints(tmp_path: Path, monkeypatch) -> None:
     assert "skills_lifecycle" in context
 
 
+def test_dashboard_starts_with_empty_registry_and_exposes_onboarding(tmp_path: Path, monkeypatch) -> None:
+    root = tmp_path / "empty-root"
+    root.mkdir()
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    runs_dir = tmp_path / "runs"
+    psyche_file = tmp_path / "psyche.json"
+    psyche_file.write_text(json.dumps({"mood": "idle"}), encoding="utf-8")
+
+    app = create_app(runs_dir=runs_dir, psyche_file=psyche_file)
+    client = TestClient(app)
+
+    index_response = client.get("/")
+    assert index_response.status_code == 200
+
+    context = client.get("/dashboard/context")
+    assert context.status_code == 200
+    context_payload = context.json()
+    assert context_payload["registry_lives_count"] == 0
+    assert context_payload["registry_state"] == {
+        "active": None,
+        "active_valid": False,
+        "is_empty": True,
+    }
+    assert context_payload["onboarding"] == {
+        "required": True,
+        "message": "Aucune vie, créez-en une.",
+    }
+
+    comparison = client.get("/lives/comparison")
+    assert comparison.status_code == 200
+    comparison_payload = comparison.json()
+    assert comparison_payload["table"] == []
+    assert comparison_payload["onboarding"] == {
+        "required": True,
+        "message": "Aucune vie, créez-en une.",
+    }
+
+
 def test_dashboard_quests_endpoint(tmp_path: Path, monkeypatch) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Permettre le lancement du tableau de bord même lorsqu’il n’y a pas de vie active ni d’entrées dans le registre, afin d’afficher une interface d’accueil et inviter à créer une vie.
- Éviter l’échec ou le comportement bloquant côté CLI qui empêchait d’ouvrir le dashboard sans life active.

### Description
- Retiré l’appel bloquant `_ensure_active_life(resolve_life, args.life)` dans la branche CLI `dashboard` pour autoriser `singular dashboard` sans précondition. (`src/singular/cli.py`)
- Ajouté un helper `_registry_overview()` qui centralise la détection d’un registre vide et prépare un message d’onboarding. (`src/singular/dashboard/__init__.py`)
- Exposé un payload d’onboarding dans les réponses API clés (`/dashboard/context`, `/lives/comparison`, `/lives/genealogy`) contenant `required` et `message` (ex. "Aucune vie, créez-en une."). (`src/singular/dashboard/__init__.py`)
- Ajouté un test `test_dashboard_starts_with_empty_registry_and_exposes_onboarding` qui vérifie que l’application démarre et que les endpoints renvoient l’état de registre vide et le message d’onboarding. (`tests/test_dashboard.py`)

### Testing
- `python -m compileall -q src/singular/cli.py src/singular/dashboard/__init__.py tests/test_dashboard.py` a réussi. 
- `pytest -q tests/test_dashboard.py` a été lancé mais la collecte a échoué dans cet environnement à cause d’une dépendance manquante `fastapi.staticfiles` (erreur : `ModuleNotFoundError: No module named 'fastapi.staticfiles'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee5cff338832a8d4c21460b6f55d6)