### PR TITLE
Improve lives create bootstrap UX and registry load behavior

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -398,7 +398,7 @@ def _preparse_environment(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--root", type=Path)
     parser.add_argument("--home", type=Path)
     parser.add_argument("--life")
-    args, _ = parser.parse_known_args(argv)
+    args, remaining = parser.parse_known_args(argv)
 
     if args.root:
         os.environ["SINGULAR_ROOT"] = str(args.root)
@@ -408,8 +408,21 @@ def _preparse_environment(argv: list[str] | None) -> argparse.Namespace:
     from . import lives as life_module
 
     life_name = _extract_talk_life_alias(argv) or args.life
+    command = next((token for token in remaining if not token.startswith("-")), None)
+    subcommand = None
+    if command is not None:
+        command_index = remaining.index(command)
+        subcommand = next(
+            (token for token in remaining[command_index + 1 :] if not token.startswith("-")),
+            None,
+        )
+    is_creation_bootstrap_command = command == "birth" or (
+        command == "lives" and subcommand == "create"
+    )
     needs_resolution = life_name is not None or (
-        args.home is None and "SINGULAR_HOME" not in os.environ
+        not is_creation_bootstrap_command
+        and args.home is None
+        and "SINGULAR_HOME" not in os.environ
     )
     if needs_resolution:
         life_dir = life_module.resolve_life(life_name)
@@ -1353,8 +1366,10 @@ def main(argv: list[str] | None = None) -> int:
         elif args.lives_command == "create":
             name = args.name or "New life"
             metadata = bootstrap_life(name, seed=args.seed)
+            registry_root = get_registry_root()
             os.environ["SINGULAR_HOME"] = str(metadata.path)
             print(f"Vie créée: {metadata.name} ({metadata.slug}) → {metadata.path}")
+            print(f"Registre de vies utilisé: {registry_root}")
         elif args.lives_command == "use":
             life_dir = resolve_life(args.name)
             if life_dir is None:

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -343,7 +343,10 @@ def load_registry() -> dict[str, Any]:
     try:
         with path.open(encoding="utf-8") as fh:
             payload = json.load(fh)
-    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+    except FileNotFoundError:
+        _LOGGER.debug("Life registry missing at %s (bootstrap mode).", path)
+        return default_registry
+    except (json.JSONDecodeError, OSError) as exc:
         _LOGGER.warning("Failed to load life registry from %s: %s", path, exc)
         return default_registry
 

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import logging
 
 import pytest
 
@@ -184,6 +185,38 @@ def test_birth_prints_registry_root_used(
     out = capsys.readouterr().out
     assert "Registre de vies utilisé:" in out
     assert str(root.resolve()) in out
+
+
+def test_lives_create_prints_registry_root_used(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "registry-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+    out = capsys.readouterr().out
+    assert "Registre de vies utilisé:" in out
+    assert str(root.resolve()) in out
+
+
+def test_lives_create_first_run_has_no_missing_registry_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    root = tmp_path / "fresh-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    caplog.set_level(logging.WARNING, logger="singular.lives")
+
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+    capsys.readouterr()
+
+    assert "Failed to load life registry" not in caplog.text
 
 
 def test_lives_archive_memorial_clone_guided_commands(

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -151,6 +152,18 @@ def test_load_registry_returns_default_for_empty_file(
 
     assert registry == {"active": None, "lives": {}}
     assert "Failed to load life registry" in caplog.text
+
+
+def test_load_registry_missing_file_is_bootstrap_without_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    caplog.set_level(logging.WARNING, logger="singular.lives")
+
+    registry = load_registry()
+
+    assert registry == {"active": None, "lives": {}}
+    assert "Failed to load life registry" not in caplog.text
 
 
 def test_load_registry_returns_default_for_invalid_json(


### PR DESCRIPTION
### Motivation

- Afficher explicitement le root du registre quand on crée une vie afin d'aligner le comportement de `lives create` avec `birth` et rassurer l'utilisateur sur le registre utilisé.
- Éviter des lectures/résolutions redondantes du registre au démarrage d'une commande de bootstrap pour diminuer le travail I/O inutile et les messages trompeurs.
- Traiter l'absence du fichier `registry.json` comme un cas normal de bootstrap (pas d'avertissement) et réserver les warnings aux JSON invalides ou erreurs I/O réelles.

### Description

- `load_registry`: retire le `warning` sur `FileNotFoundError` et logge en `debug` le cas manquant, en maintenant le `warning` pour `JSONDecodeError`/`OSError` et renvoie la valeur par défaut (`{'active': None, 'lives': {}}`).
- `_preparse_environment` (CLI): améliore la détection de la commande et du sous-commande à partir des tokens restants et évite la résolution de la vie active lors des commandes de bootstrap (`birth` et `lives create`).
- `lives create` (CLI): affiche désormais le root du registre utilisé avec `Registre de vies utilisé: ...` (même comportement que pour `birth`).
- Tests: ajout/ajustement de tests dans `tests/test_cli_lives.py` et `tests/test_lives.py` pour vérifier l'absence d'un warning sur fichier manquant au premier run et la présence du message `Registre de vies utilisé` pour `lives create`.

### Testing

- Exécuté `pytest -q tests/test_cli_lives.py tests/test_lives.py` et tous les tests ciblés ont réussi (27 passed).
- Les nouveaux tests vérifient l'absence de message d'avertissement pour fichier manque et la présence de la ligne `Registre de vies utilisé:` pour `lives create` et ont passé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee810f7d4832aa1aca08f8b12c842)