### PR TITLE
Unify life creation on `lives create` and deprecate `birth` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Contrairement aux chatbots classiques (qui ne changent pas leur cœur) ou aux si
 
 ```bash
 pip install -e .[yaml,dashboard,viz]
-singular birth --name Lumen
+singular lives create --name Lumen
 singular talk
 singular loop --budget-seconds 10
 singular status --format table
@@ -48,7 +48,7 @@ Si vous débutez, suivez **exactement** ces étapes :
 
 1. **Créer une vie**
    ```bash
-   singular birth --name Lumen
+   singular lives create --name Lumen
    ```
 2. **Envoyer un premier message**
    ```bash
@@ -95,17 +95,17 @@ Ce pack complète les skills arithmétiques historiques (`addition`, `subtractio
 
 ### Profils de naissance (traits initiaux)
 
-Le parser `birth` accepte des overrides bornés `[0,1]` pour les traits initiaux
+La commande `lives create` accepte des overrides bornés `[0,1]` pour les traits initiaux
 du psyche : `--curiosity`, `--patience`, `--playfulness`, `--optimism`,
 `--resilience`. Les valeurs sont persistées dans `mem/psyche.json`.
 
 ```bash
 # Profil prudent : stabilité, patience, faible prise de risque
-singular birth --name "Prudent" \
+singular lives create --name "Prudent" \
   --curiosity 0.20 --patience 0.90 --playfulness 0.15 --optimism 0.55 --resilience 0.90
 
 # Profil explorateur : curiosité et jeu plus élevés, patience plus basse
-singular birth --name "Explorateur" \
+singular lives create --name "Explorateur" \
   --curiosity 0.92 --patience 0.35 --playfulness 0.85 --optimism 0.75 --resilience 0.70
 ```
 
@@ -181,7 +181,7 @@ diffère du registre implicite précédent :
 Vous utilisez un autre registre de vies: ... (au lieu de ...).
 ```
 
-De plus, ``birth`` affiche explicitement le root de registre utilisé pour éviter
+De plus, ``lives create`` affiche explicitement le root de registre utilisé pour éviter
 toute ambiguïté.
 
 ## 🧹 Désinstallation
@@ -233,7 +233,7 @@ le fichier hybride dans `child/`.
 
 1. **Naissance**
    ```bash
-   singular birth --name Lumen
+   singular lives create --name Lumen
    ```
 
 ### ⏰ Horloge vitale
@@ -264,7 +264,7 @@ Si vous voulez un mode **autonome en continu** (au lieu d’exécuter `loop` à 
 
 1. **Préparer une vie active**
    ```bash
-   singular birth --name Lumen
+   singular lives create --name Lumen
    singular lives use lumen
    ```
 2. **Démarrer l’orchestrateur**
@@ -424,9 +424,9 @@ Exemples :
 
 ```bash
 # Choisir un dossier de données
-SINGULAR_HOME=/chemin/personnel singular birth
+SINGULAR_HOME=/chemin/personnel singular lives create
 # ou
-singular --home /chemin/personnel birth
+singular --home /chemin/personnel lives create
 
 # Ajuster la rétention des journaux
 SINGULAR_RUNS_KEEP=50 singular report --format json

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -22,6 +22,15 @@ from .root_config import (
 
 __all__ = ["main"]
 
+_BIRTH_ALIAS_ENV = "SINGULAR_ENABLE_BIRTH_ALIAS"
+
+
+def _birth_alias_enabled() -> bool:
+    """Return True when the deprecated ``birth`` alias is still enabled."""
+
+    raw = os.environ.get(_BIRTH_ALIAS_ENV, "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
 
 def _bounded_trait_value(raw: str) -> float:
     """Parse a psyche trait override constrained to ``[0, 1]``."""
@@ -440,8 +449,8 @@ def _ensure_active_life(
     life_dir = resolve(life_name)
     if life_dir is None:
         raise SystemExit(
-            "Aucune vie active. Utilisez `singular birth --name ...` ou "
-            "`singular lives create` pour créer une vie."
+            "Aucune vie active. Utilisez `singular lives create --name ...` pour créer "
+            "une vie (`birth` reste un alias temporaire déprécié)."
         )
     os.environ["SINGULAR_HOME"] = str(life_dir)
     return life_dir
@@ -556,6 +565,84 @@ def _print_registry_context_message_if_needed(
     )
 
 
+def _add_life_creation_arguments(parser: argparse.ArgumentParser) -> None:
+    """Attach shared life creation options to a parser."""
+
+    parser.add_argument(
+        "--name",
+        default="New life",
+        help="Human readable name for the life",
+    )
+    parser.add_argument(
+        "--curiosity",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    parser.add_argument(
+        "--patience",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    parser.add_argument(
+        "--playfulness",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    parser.add_argument(
+        "--optimism",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    parser.add_argument(
+        "--resilience",
+        type=_bounded_trait_value,
+        default=None,
+        help="Trait initial borné dans [0,1]",
+    )
+    parser.add_argument(
+        "--starter-profile",
+        default="minimal",
+        help="Profil de starter skills à appliquer (ex: minimal, assistant, ops, creative)",
+    )
+    parser.add_argument(
+        "--starter-skill",
+        action="append",
+        default=[],
+        help="Skill starter individuel à ajouter (option répétable)",
+    )
+
+
+def _create_life_with_bootstrap(
+    args: argparse.Namespace,
+    *,
+    bootstrap_life: Callable[..., Any],
+    get_registry_root: Callable[[], Path],
+) -> None:
+    """Create a life via ``bootstrap_life`` with shared CLI options."""
+
+    psyche_overrides = {
+        trait: getattr(args, trait)
+        for trait in ("curiosity", "patience", "playfulness", "optimism", "resilience")
+        if getattr(args, trait, None) is not None
+    }
+    name = args.name or "New life"
+    metadata = bootstrap_life(
+        name,
+        seed=args.seed,
+        psyche_overrides=psyche_overrides or None,
+        starter_profile=args.starter_profile,
+        starter_skills=args.starter_skill,
+    )
+    registry_root = get_registry_root()
+    os.environ["SINGULAR_HOME"] = str(metadata.path)
+    print(f"Vie créée: {metadata.name} ({metadata.slug}) → {metadata.path}")
+    print(f"Registre de vies utilisé: {registry_root}")
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the singular command line interface."""
 
@@ -619,56 +706,12 @@ def main(argv: list[str] | None = None) -> int:
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    birth_parser = subparsers.add_parser(
-        "birth",
-        help="Birth a new life (affiche aussi le root de registre utilisé)",
-    )
-    birth_parser.add_argument(
-        "--name",
-        default="New life",
-        help="Human readable name for the life",
-    )
-    birth_parser.add_argument(
-        "--curiosity",
-        type=_bounded_trait_value,
-        default=None,
-        help="Trait initial borné dans [0,1]",
-    )
-    birth_parser.add_argument(
-        "--patience",
-        type=_bounded_trait_value,
-        default=None,
-        help="Trait initial borné dans [0,1]",
-    )
-    birth_parser.add_argument(
-        "--playfulness",
-        type=_bounded_trait_value,
-        default=None,
-        help="Trait initial borné dans [0,1]",
-    )
-    birth_parser.add_argument(
-        "--optimism",
-        type=_bounded_trait_value,
-        default=None,
-        help="Trait initial borné dans [0,1]",
-    )
-    birth_parser.add_argument(
-        "--resilience",
-        type=_bounded_trait_value,
-        default=None,
-        help="Trait initial borné dans [0,1]",
-    )
-    birth_parser.add_argument(
-        "--starter-profile",
-        default="minimal",
-        help="Profil de starter skills à appliquer (ex: minimal, assistant, ops, creative)",
-    )
-    birth_parser.add_argument(
-        "--starter-skill",
-        action="append",
-        default=[],
-        help="Skill starter individuel à ajouter (option répétable)",
-    )
+    if _birth_alias_enabled():
+        birth_parser = subparsers.add_parser(
+            "birth",
+            help="Alias déprécié de `lives create` (migration recommandée)",
+        )
+        _add_life_creation_arguments(birth_parser)
 
     spawn_parser = subparsers.add_parser(
         "spawn", help="Create child organism from two parents"
@@ -902,11 +945,7 @@ def main(argv: list[str] | None = None) -> int:
     lives_subparsers = lives_parser.add_subparsers(dest="lives_command", required=True)
     lives_subparsers.add_parser("list", help="List registered lives")
     lives_create = lives_subparsers.add_parser("create", help="Create a new life")
-    lives_create.add_argument(
-        "--name",
-        default="New life",
-        help="Human readable name for the life",
-    )
+    _add_life_creation_arguments(lives_create)
     lives_use = lives_subparsers.add_parser("use", help="Activate an existing life")
     lives_use.add_argument("name", help="Slug or name of the life to activate")
     lives_delete = lives_subparsers.add_parser(
@@ -1094,29 +1133,16 @@ def main(argv: list[str] | None = None) -> int:
         os.environ["SINGULAR_SAFE_MODE"] = "1"
 
     if args.command == "birth":
-        psyche_overrides = {
-            trait: getattr(args, trait)
-            for trait in (
-                "curiosity",
-                "patience",
-                "playfulness",
-                "optimism",
-                "resilience",
-            )
-            if getattr(args, trait, None) is not None
-        }
-        name = args.name or "New life"
-        metadata = bootstrap_life(
-            name,
-            seed=args.seed,
-            psyche_overrides=psyche_overrides or None,
-            starter_profile=args.starter_profile,
-            starter_skills=args.starter_skill,
+        print(
+            "⚠️ `singular birth` est déprécié et sera supprimé après la période "
+            "de transition. Migrez vers `singular lives create --name ...`.",
+            file=sys.stderr,
         )
-        registry_root = get_registry_root()
-        os.environ["SINGULAR_HOME"] = str(metadata.path)
-        print(f"Vie créée: {metadata.name} ({metadata.slug}) → {metadata.path}")
-        print(f"Registre de vies utilisé: {registry_root}")
+        _create_life_with_bootstrap(
+            args,
+            bootstrap_life=bootstrap_life,
+            get_registry_root=get_registry_root,
+        )
 
     elif args.command == "spawn":
         from .organisms.spawn import spawn
@@ -1364,12 +1390,11 @@ def main(argv: list[str] | None = None) -> int:
                             f" (créée le {item['created_at']})"
                         )
         elif args.lives_command == "create":
-            name = args.name or "New life"
-            metadata = bootstrap_life(name, seed=args.seed)
-            registry_root = get_registry_root()
-            os.environ["SINGULAR_HOME"] = str(metadata.path)
-            print(f"Vie créée: {metadata.name} ({metadata.slug}) → {metadata.path}")
-            print(f"Registre de vies utilisé: {registry_root}")
+            _create_life_with_bootstrap(
+                args,
+                bootstrap_life=bootstrap_life,
+                get_registry_root=get_registry_root,
+            )
         elif args.lives_command == "use":
             life_dir = resolve_life(args.name)
             if life_dir is None:

--- a/tests/test_cli_birth.py
+++ b/tests/test_cli_birth.py
@@ -9,7 +9,12 @@ from singular.cli import main
 from singular.lives import load_registry
 
 
-def test_birth_persists_initial_psyche_overrides(
+@pytest.mark.parametrize(
+    "creation_command",
+    [["birth"], ["lives", "create"]],
+)
+def test_birth_alias_and_lives_create_persist_initial_psyche_overrides(
+    creation_command: list[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -21,7 +26,7 @@ def test_birth_persists_initial_psyche_overrides(
         [
             "--root",
             str(root),
-            "birth",
+            *creation_command,
             "--name",
             "Prudent",
             "--curiosity",
@@ -52,13 +57,24 @@ def test_birth_persists_initial_psyche_overrides(
     assert payload["resilience"] == 0.95
 
 
-def test_birth_rejects_out_of_range_psyche_override() -> None:
+@pytest.mark.parametrize(
+    "creation_command",
+    [["birth"], ["lives", "create"]],
+)
+def test_birth_alias_and_lives_create_reject_out_of_range_psyche_override(
+    creation_command: list[str],
+) -> None:
     with pytest.raises(SystemExit) as excinfo:
-        main(["birth", "--curiosity", "1.5"])
+        main([*creation_command, "--curiosity", "1.5"])
     assert excinfo.value.code == 2
 
 
-def test_birth_uses_minimal_starter_profile_by_default(
+@pytest.mark.parametrize(
+    "creation_command",
+    [["birth"], ["lives", "create"]],
+)
+def test_birth_alias_and_lives_create_use_minimal_starter_profile_by_default(
+    creation_command: list[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -66,7 +82,7 @@ def test_birth_uses_minimal_starter_profile_by_default(
     monkeypatch.delenv("SINGULAR_ROOT", raising=False)
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
 
-    main(["--root", str(root), "birth", "--name", "Minimal"])
+    main(["--root", str(root), *creation_command, "--name", "Minimal"])
 
     registry = load_registry()
     slug = registry["active"]
@@ -75,7 +91,12 @@ def test_birth_uses_minimal_starter_profile_by_default(
     assert skills == ["addition.py", "multiplication.py", "subtraction.py"]
 
 
-def test_birth_applies_explicit_starter_profile(
+@pytest.mark.parametrize(
+    "creation_command",
+    [["birth"], ["lives", "create"]],
+)
+def test_birth_alias_and_lives_create_apply_explicit_starter_profile(
+    creation_command: list[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -87,7 +108,7 @@ def test_birth_applies_explicit_starter_profile(
         [
             "--root",
             str(root),
-            "birth",
+            *creation_command,
             "--name",
             "Operator",
             "--starter-profile",
@@ -108,7 +129,12 @@ def test_birth_applies_explicit_starter_profile(
     ]
 
 
-def test_birth_unknown_profile_falls_back_to_minimal_and_adds_explicit_skills(
+@pytest.mark.parametrize(
+    "creation_command",
+    [["birth"], ["lives", "create"]],
+)
+def test_birth_alias_and_lives_create_unknown_profile_falls_back_to_minimal_and_adds_explicit_skills(
+    creation_command: list[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -120,7 +146,7 @@ def test_birth_unknown_profile_falls_back_to_minimal_and_adds_explicit_skills(
         [
             "--root",
             str(root),
-            "birth",
+            *creation_command,
             "--name",
             "Fallback",
             "--starter-profile",
@@ -135,3 +161,18 @@ def test_birth_unknown_profile_falls_back_to_minimal_and_adds_explicit_skills(
     life_home = Path(registry["lives"][slug].path)
     skills = sorted(path.name for path in (life_home / "skills").glob("*.py"))
     assert skills == ["addition.py", "multiplication.py", "subtraction.py", "summary.py"]
+
+
+def test_birth_prints_deprecation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "registry-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    main(["--root", str(root), "birth", "--name", "Legacy"])
+    stderr = capsys.readouterr().err
+    assert "déprécié" in stderr
+    assert "singular lives create --name" in stderr

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -172,7 +172,7 @@ def test_cli_root_context_message_when_switching_registry_root(
     assert str(root_a.resolve()) in second_out
 
 
-def test_birth_prints_registry_root_used(
+def test_birth_alias_prints_registry_root_used(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -185,6 +185,42 @@ def test_birth_prints_registry_root_used(
     out = capsys.readouterr().out
     assert "Registre de vies utilisé:" in out
     assert str(root.resolve()) in out
+
+
+def test_birth_is_removed_when_alias_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "registry-root"
+    monkeypatch.setenv("SINGULAR_ENABLE_BIRTH_ALIAS", "0")
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--root", str(root), "birth", "--name", "Gamma"])
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "invalid choice" in err
+    assert "birth" in err
+
+    main(
+        [
+            "--root",
+            str(root),
+            "lives",
+            "create",
+            "--name",
+            "Gamma",
+            "--curiosity",
+            "0.3",
+            "--starter-profile",
+            "ops",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "Vie créée:" in out
+    assert "Registre de vies utilisé:" in out
 
 
 def test_lives_create_prints_registry_root_used(


### PR DESCRIPTION
### Motivation
- Standardize the CLI surface so `lives create` is the canonical command for creating lives while preserving existing `birth` workflows during a transition period. 
- Surface a clear migration path and avoid breaking user scripts immediately by keeping `birth` as a controlled alias with a deprecation notice. 
- Provide a simple switch to remove the alias later via environment variable and update onboarding/docs to show only the canonical command. 

### Description
- Factorized life-creation options into `_add_life_creation_arguments` and centralized the bootstrap logic into `_create_life_with_bootstrap` so both creation entrypoints reuse the same implementation. 
- Made `lives create` the canonical creation command and attached creation options (`--name`, trait overrides, `--starter-profile`, `--starter-skill`, `--seed`) via the shared helpers. 
- Kept `birth` as a deprecated alias that calls the same implementation and emits a migration warning to `stderr`, and added `SINGULAR_ENABLE_BIRTH_ALIAS` (defaults to enabled) to disable the `birth` parser entry (post-transition removal can be enforced by setting this to `0`). 
- Updated the "no active life" help message to recommend `singular lives create --name ...` and updated onboarding/docs in `README.md` to expose `singular lives create` in examples. 
- Updated tests: parameterized creation tests to run both `birth` and `lives create` for parity, added a test asserting the deprecation warning on `birth`, and added a test validating that setting `SINGULAR_ENABLE_BIRTH_ALIAS=0` removes the `birth` command at parse time. 

### Testing
- Ran `pytest -q tests/test_cli_birth.py tests/test_cli_lives.py` and all tests passed: `23 passed in 1.59s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dee9880460832abfd449cf6a62a277)