### PR TITLE
Centralise la configuration de rétention et ajoute reporting de politique

### DIFF
--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -10,6 +10,8 @@ import logging
 import os
 from typing import Any, Mapping
 
+from ..storage_retention import apply_runs_retention, load_retention_config
+
 from ..psyche import Psyche
 from ..memory import add_episode, add_procedural_memory
 from typing import Callable, Dict
@@ -18,8 +20,6 @@ from typing import Callable, Dict
 _BASE_DIR = Path(os.environ.get("SINGULAR_HOME", "."))
 # Directory where run logs are stored
 RUNS_DIR = _BASE_DIR / "runs"
-# Number of run logs to retain
-MAX_RUN_LOGS = int(os.environ.get("SINGULAR_RUNS_KEEP", "20"))
 EVENT_SCHEMA_VERSION = 1
 USAGE_REPUTATION_SCHEMA_VERSION = 1
 DEFAULT_REPUTATION_UPDATE_EVERY = int(os.environ.get("SINGULAR_REPUTATION_UPDATE_EVERY", "5"))
@@ -82,25 +82,19 @@ def _ensure_dir(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
-def _enforce_retention(root: Path, keep: int = MAX_RUN_LOGS) -> None:
-    """Remove oldest log files beyond the retention limit."""
-    logs = sorted(
-        root.glob("*.jsonl"),
-        key=lambda p: (p.stat().st_mtime, p.name),
-        reverse=True,
-    )
-    for old in logs[keep:]:
-        try:
-            old.unlink()
-        except FileNotFoundError:  # pragma: no cover - race condition
-            pass
-    # Clean up any leftover temporary files
+def _enforce_retention(root: Path) -> None:
+    """Apply retention policy to run logs and temporary files."""
+
+    config = load_retention_config(base_dir=_BASE_DIR)
+    apply_runs_retention(runs_dir=root, config=config)
+
+    # Clean up any leftover temporary files with the same count limit as runs.
     tmps = sorted(
         root.glob("*.jsonl.tmp"),
         key=lambda p: (p.stat().st_mtime, p.name),
         reverse=True,
     )
-    for old in tmps[keep:]:
+    for old in tmps[config.max_runs:]:
         try:
             old.unlink()
         except FileNotFoundError:  # pragma: no cover - race condition

--- a/src/singular/storage_retention.py
+++ b/src/singular/storage_retention.py
@@ -1,0 +1,219 @@
+"""Unified storage retention configuration and policy reporting.
+
+This module centralizes retention knobs for run artifacts and memory JSONL files.
+Configuration is resolved with the following precedence:
+1. Environment variables (``SINGULAR_RETENTION_*``)
+2. Persisted configuration file (JSON)
+3. Built-in defaults
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import json
+import os
+from typing import Any, Mapping
+
+_DEFAULT_PERSISTED_CONFIG_RELATIVE_PATH = Path("mem") / "retention_policy.json"
+_BYTES_PER_MB = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class RetentionConfig:
+    """Resolved retention limits for all persistent stores."""
+
+    max_runs: int = 20
+    max_run_age_days: int = 30
+    max_total_runs_size_mb: int = 512
+    max_episodic_lines: int = 20_000
+    max_episodic_days: int = 90
+    max_generations_lines: int = 50_000
+    max_generations_days: int = 365
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Decision record for one artifact considered by retention."""
+
+    target: str
+    category: str
+    action: str
+    reason: str
+    size_mb: float | None = None
+    age_days: float | None = None
+
+
+@dataclass(frozen=True)
+class PolicyReport:
+    """Collection of retention decisions for traceability."""
+
+    generated_at: str
+    scope: str
+    config: RetentionConfig
+    decisions: tuple[PolicyDecision, ...] = field(default_factory=tuple)
+
+    @property
+    def summary(self) -> dict[str, int]:
+        counts = {"keep": 0, "archive": 0, "delete": 0}
+        for decision in self.decisions:
+            counts[decision.action] = counts.get(decision.action, 0) + 1
+        return counts
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def persisted_retention_config_path(base_dir: Path | None = None) -> Path:
+    root = Path(base_dir) if base_dir is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    return root / _DEFAULT_PERSISTED_CONFIG_RELATIVE_PATH
+
+
+def load_persisted_retention_config(path: Path | None = None) -> Mapping[str, Any]:
+    """Load persisted retention config from JSON.
+
+    Expected shape:
+    {
+      "retention": {"max_runs": 20, ...}
+    }
+    """
+
+    config_path = path or persisted_retention_config_path()
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, Mapping):
+        return {}
+    retention = payload.get("retention", payload)
+    return retention if isinstance(retention, Mapping) else {}
+
+
+def load_retention_config(
+    *,
+    base_dir: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    persisted_path: Path | None = None,
+) -> RetentionConfig:
+    """Resolve retention configuration from env, persisted config, then defaults."""
+
+    env = dict(os.environ if environ is None else environ)
+    persisted = load_persisted_retention_config(
+        persisted_path or persisted_retention_config_path(base_dir)
+    )
+
+    defaults = RetentionConfig()
+
+    def pick(name: str, legacy_env: str | None = None) -> int:
+        env_name = f"SINGULAR_RETENTION_{name.upper()}"
+        if env_name in env:
+            return _coerce_positive_int(env[env_name], getattr(defaults, name))
+        if legacy_env and legacy_env in env:
+            return _coerce_positive_int(env[legacy_env], getattr(defaults, name))
+        if name in persisted:
+            return _coerce_positive_int(persisted[name], getattr(defaults, name))
+        return getattr(defaults, name)
+
+    return RetentionConfig(
+        max_runs=pick("max_runs", legacy_env="SINGULAR_RUNS_KEEP"),
+        max_run_age_days=pick("max_run_age_days"),
+        max_total_runs_size_mb=pick("max_total_runs_size_mb"),
+        max_episodic_lines=pick("max_episodic_lines"),
+        max_episodic_days=pick("max_episodic_days"),
+        max_generations_lines=pick("max_generations_lines"),
+        max_generations_days=pick("max_generations_days"),
+    )
+
+
+def build_runs_policy_report(
+    *,
+    runs_dir: Path,
+    config: RetentionConfig,
+    now: datetime | None = None,
+) -> PolicyReport:
+    """Build retention decisions for run JSONL logs in ``runs_dir``."""
+
+    ref_now = now or _now_utc()
+    candidates = []
+    for file in runs_dir.glob("*.jsonl"):
+        try:
+            stat = file.stat()
+        except OSError:
+            continue
+        mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+        age_days = (ref_now - mtime).total_seconds() / 86400
+        size = stat.st_size
+        candidates.append((file, mtime, age_days, size))
+
+    candidates.sort(key=lambda row: (row[1], row[0].name), reverse=True)
+
+    decisions: list[PolicyDecision] = []
+    running_size = 0
+    for index, (file, _mtime, age_days, size) in enumerate(candidates):
+        size_mb = size / _BYTES_PER_MB
+        action = "keep"
+        reason = "within_policy"
+        if index >= config.max_runs:
+            action = "delete"
+            reason = "max_runs"
+        elif age_days > config.max_run_age_days:
+            action = "archive"
+            reason = "max_run_age_days"
+        elif (running_size + size) / _BYTES_PER_MB > config.max_total_runs_size_mb:
+            action = "archive"
+            reason = "max_total_runs_size_mb"
+
+        if action == "keep":
+            running_size += size
+
+        decisions.append(
+            PolicyDecision(
+                target=str(file),
+                category="runs",
+                action=action,
+                reason=reason,
+                size_mb=round(size_mb, 4),
+                age_days=round(age_days, 4),
+            )
+        )
+
+    return PolicyReport(
+        generated_at=ref_now.isoformat(),
+        scope="runs",
+        config=config,
+        decisions=tuple(decisions),
+    )
+
+
+def apply_runs_retention(
+    *,
+    runs_dir: Path,
+    config: RetentionConfig,
+    now: datetime | None = None,
+) -> PolicyReport:
+    """Apply retention policy to run JSONL logs and return decision report.
+
+    Files marked as ``delete`` are removed immediately.
+    Files marked as ``archive`` are currently kept in place and reported so a
+    future archiver can move/compress them deterministically.
+    """
+
+    report = build_runs_policy_report(runs_dir=runs_dir, config=config, now=now)
+    for decision in report.decisions:
+        if decision.action != "delete":
+            continue
+        try:
+            Path(decision.target).unlink()
+        except FileNotFoundError:
+            continue
+    return report

--- a/tests/test_storage_retention.py
+++ b/tests/test_storage_retention.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+
+from singular.storage_retention import (
+    apply_runs_retention,
+    build_runs_policy_report,
+    load_retention_config,
+)
+
+
+def test_load_retention_config_env_overrides_persisted(tmp_path, monkeypatch) -> None:
+    persisted = tmp_path / "mem" / "retention_policy.json"
+    persisted.parent.mkdir(parents=True)
+    persisted.write_text(
+        json.dumps(
+            {
+                "retention": {
+                    "max_runs": 9,
+                    "max_run_age_days": 88,
+                    "max_total_runs_size_mb": 111,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SINGULAR_RETENTION_MAX_RUNS", "3")
+
+    config = load_retention_config(base_dir=tmp_path)
+
+    assert config.max_runs == 3
+    assert config.max_run_age_days == 88
+    assert config.max_total_runs_size_mb == 111
+
+
+def test_load_retention_config_uses_legacy_runs_keep_env(monkeypatch) -> None:
+    monkeypatch.setenv("SINGULAR_RUNS_KEEP", "4")
+
+    config = load_retention_config()
+
+    assert config.max_runs == 4
+
+
+def test_build_policy_report_marks_delete_archive_and_keep(tmp_path) -> None:
+    now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    recent = tmp_path / "recent.jsonl"
+    old = tmp_path / "old.jsonl"
+    overflow = tmp_path / "overflow.jsonl"
+    recent.write_text("{}\n", encoding="utf-8")
+    old.write_text("{}\n", encoding="utf-8")
+    overflow.write_text("x" * (2 * 1024 * 1024), encoding="utf-8")
+
+    old_mtime = (now - timedelta(days=40)).timestamp()
+    recent_mtime = (now - timedelta(days=1)).timestamp()
+    overflow_mtime = (now - timedelta(days=2)).timestamp()
+    recent.touch()
+    old.touch()
+    overflow.touch()
+    # Deterministic ordering: recent, overflow, old
+    import os
+
+    os.utime(recent, (recent_mtime, recent_mtime))
+    os.utime(overflow, (overflow_mtime, overflow_mtime))
+    os.utime(old, (old_mtime, old_mtime))
+
+    config = load_retention_config(
+        environ={
+            "SINGULAR_RETENTION_MAX_RUNS": "2",
+            "SINGULAR_RETENTION_MAX_RUN_AGE_DAYS": "30",
+            "SINGULAR_RETENTION_MAX_TOTAL_RUNS_SIZE_MB": "1",
+        }
+    )
+
+    report = build_runs_policy_report(runs_dir=tmp_path, config=config, now=now)
+
+    by_name = {p.target.split("/")[-1]: p for p in report.decisions}
+    assert by_name["recent.jsonl"].action == "keep"
+    assert by_name["old.jsonl"].action == "delete"
+    assert by_name["overflow.jsonl"].action == "archive"
+
+
+def test_apply_runs_retention_deletes_decisions(tmp_path) -> None:
+    now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    a = tmp_path / "a.jsonl"
+    b = tmp_path / "b.jsonl"
+    a.write_text("{}\n", encoding="utf-8")
+    b.write_text("{}\n", encoding="utf-8")
+
+    # Ensure one file is older so it gets deleted by max_runs=1
+    import os
+
+    os.utime(a, (now.timestamp(), now.timestamp()))
+    older = (now - timedelta(days=1)).timestamp()
+    os.utime(b, (older, older))
+
+    config = load_retention_config(environ={"SINGULAR_RETENTION_MAX_RUNS": "1"})
+    report = apply_runs_retention(runs_dir=tmp_path, config=config, now=now)
+
+    assert (tmp_path / "a.jsonl").exists()
+    assert not (tmp_path / "b.jsonl").exists()
+    assert report.summary["delete"] == 1


### PR DESCRIPTION
### Motivation
- Fournir une source unique et explicite de paramètres de rétention pour les artefacts persistants (runs, mem JSONL) avec des valeurs par défaut robustes et une résolution prévisible.
- Permettre le traçage des décisions de rétention (conserver / archiver / supprimer) via un rapport structuré pour audit et actions ultérieures.

### Description
- Ajout du module `src/singular/storage_retention.py` exposant `RetentionConfig`, `PolicyDecision`, `PolicyReport`, la résolution de configuration (précedence: variables d’environnement `SINGULAR_RETENTION_*`, fichier JSON persistant `mem/retention_policy.json`, puis defaults) et les helpers `build_runs_policy_report` / `apply_runs_retention`.
- Intégration dans la logique de rotation des logs de `RunLogger` (`src/singular/runs/logger.py`) pour utiliser `load_retention_config` et `apply_runs_retention` au lieu d’un seuil fixe uniquement basé sur `SINGULAR_RUNS_KEEP`.
- Les décisions `delete` sont appliquées immédiatement tandis que les décisions `archive` sont rapportées pour un archivage externe futur (aucun déplacement/compression automatique dans ce changement).
- Ajout de tests `tests/test_storage_retention.py` couvrant la priorité env > config persistée, compatibilité legacy `SINGULAR_RUNS_KEEP`, comportements `keep`/`archive`/`delete` et l’application des suppressions, et adaptation mineure des tests existants utilisés (`tests/test_runs_retention.py`).

### Testing
- Exécution des tests ciblés avec `pytest -q tests/test_storage_retention.py tests/test_runs_retention.py` qui ont tous réussi (`5 passed`) avec quelques warnings relatifs aux dates UTC dépréciées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df51e5c270832a8a1edcf04d90ef24)