### PR TITLE
Extend run retention to purge run directories safely

### DIFF
--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -125,6 +125,11 @@ class RunLogger:
 
         self.run_dir = self.root / self.run_id
         self.run_dir.mkdir(parents=True, exist_ok=True)
+        self._active_lock_path = self.run_dir / ".active.lock"
+        self._active_lock_path.write_text(
+            json.dumps({"run_id": self.run_id, "started_at": datetime.utcnow().isoformat(timespec="seconds")}),
+            encoding="utf-8",
+        )
         self.events_path = self.run_dir / "events.jsonl"
         self._events_file = self.events_path.open("a", encoding="utf-8")
         self.consciousness_path = self.run_dir / "consciousness.jsonl"
@@ -474,6 +479,10 @@ class RunLogger:
             os.fsync(self._file.fileno())
             self._file.close()
             os.replace(self.tmp_path, self.path)
+            try:
+                self._active_lock_path.unlink()
+            except FileNotFoundError:
+                pass
             _enforce_retention(self.root)
 
     def __enter__(self) -> RunLogger:  # pragma: no cover - trivial

--- a/src/singular/storage_retention.py
+++ b/src/singular/storage_retention.py
@@ -14,9 +14,14 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import json
 import os
+import shutil
+import time
 from typing import Any, Mapping
 
+from .io_utils import append_jsonl_line
+
 _DEFAULT_PERSISTED_CONFIG_RELATIVE_PATH = Path("mem") / "retention_policy.json"
+_RETENTION_LOG_RELATIVE_PATH = Path("mem") / "retention.log.jsonl"
 _BYTES_PER_MB = 1024 * 1024
 
 
@@ -43,6 +48,8 @@ class PolicyDecision:
     reason: str
     size_mb: float | None = None
     age_days: float | None = None
+    run_id: str | None = None
+    active: bool = False
 
 
 @dataclass(frozen=True)
@@ -72,6 +79,83 @@ def _coerce_positive_int(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed > 0 else default
+
+
+def _walk_total_size(path: Path) -> int:
+    if not path.exists():
+        return 0
+    if path.is_file():
+        try:
+            return path.stat().st_size
+        except OSError:
+            return 0
+    total = 0
+    for file in path.rglob("*"):
+        if not file.is_file():
+            continue
+        try:
+            total += file.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _latest_mtime(path: Path) -> datetime | None:
+    if not path.exists():
+        return None
+    timestamps: list[float] = []
+    try:
+        timestamps.append(path.stat().st_mtime)
+    except OSError:
+        return None
+    if path.is_dir():
+        for file in path.rglob("*"):
+            try:
+                timestamps.append(file.stat().st_mtime)
+            except OSError:
+                continue
+    if not timestamps:
+        return None
+    return datetime.fromtimestamp(max(timestamps), tz=timezone.utc)
+
+
+def _run_id_from_legacy_file(path: Path) -> str:
+    stem = path.stem
+    return stem.rsplit("-", 1)[0] if "-" in stem else stem
+
+
+def _is_active_run(runs_dir: Path, run_id: str) -> bool:
+    run_dir = runs_dir / run_id
+    if (run_dir / ".active.lock").exists():
+        return True
+    return any(runs_dir.glob(f"{run_id}-*.jsonl.tmp"))
+
+
+def _retention_log_path(runs_dir: Path) -> Path:
+    base_dir = runs_dir.parent
+    return base_dir / _RETENTION_LOG_RELATIVE_PATH
+
+
+def _safe_delete_path(target: Path) -> tuple[bool, str]:
+    if not target.exists():
+        return True, "missing"
+    tombstone = target.with_name(f".purge-{target.name}-{time.time_ns()}")
+    try:
+        os.replace(target, tombstone)
+    except FileNotFoundError:
+        return True, "missing"
+    except OSError as exc:
+        return False, f"rename_failed:{exc.__class__.__name__}"
+    try:
+        if tombstone.is_dir():
+            shutil.rmtree(tombstone, ignore_errors=False)
+        else:
+            tombstone.unlink()
+    except FileNotFoundError:
+        return True, "missing"
+    except OSError as exc:
+        return False, f"remove_failed:{exc.__class__.__name__}"
+    return True, "deleted"
 
 
 def persisted_retention_config_path(base_dir: Path | None = None) -> Path:
@@ -144,48 +228,77 @@ def build_runs_policy_report(
     """Build retention decisions for run JSONL logs in ``runs_dir``."""
 
     ref_now = now or _now_utc()
-    candidates = []
-    for file in runs_dir.glob("*.jsonl"):
-        try:
-            stat = file.stat()
-        except OSError:
-            continue
-        mtime = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
-        age_days = (ref_now - mtime).total_seconds() / 86400
-        size = stat.st_size
-        candidates.append((file, mtime, age_days, size))
+    grouped: dict[str, list[Path]] = {}
+    for run_dir in runs_dir.iterdir() if runs_dir.exists() else []:
+        if run_dir.is_dir():
+            grouped.setdefault(run_dir.name, []).append(run_dir)
+    for legacy_file in runs_dir.glob("*.jsonl"):
+        grouped.setdefault(_run_id_from_legacy_file(legacy_file), []).append(legacy_file)
 
-    candidates.sort(key=lambda row: (row[1], row[0].name), reverse=True)
+    candidates: list[tuple[str, Path, datetime, float, int, bool]] = []
+    for run_id, artifacts in grouped.items():
+        mtimes = [mtime for artifact in artifacts if (mtime := _latest_mtime(artifact)) is not None]
+        if not mtimes:
+            continue
+        latest_mtime = max(mtimes)
+        age_days = (ref_now - latest_mtime).total_seconds() / 86400
+        size = sum(_walk_total_size(artifact) for artifact in artifacts)
+        primary = runs_dir / run_id if (runs_dir / run_id).exists() else artifacts[0]
+        candidates.append((run_id, primary, latest_mtime, age_days, size, _is_active_run(runs_dir, run_id)))
+
+    candidates.sort(key=lambda row: (row[2], row[0]), reverse=True)
 
     decisions: list[PolicyDecision] = []
+    kept_count = 0
+    kept_candidates: list[tuple[int, int]] = []
     running_size = 0
-    for index, (file, _mtime, age_days, size) in enumerate(candidates):
+    for index, (run_id, target, _mtime, age_days, size, active) in enumerate(candidates):
         size_mb = size / _BYTES_PER_MB
         action = "keep"
         reason = "within_policy"
-        if index >= config.max_runs:
+        if active:
+            reason = "active_run_protected"
+        elif kept_count >= config.max_runs:
             action = "delete"
             reason = "max_runs"
         elif age_days > config.max_run_age_days:
-            action = "archive"
+            action = "delete"
             reason = "max_run_age_days"
-        elif (running_size + size) / _BYTES_PER_MB > config.max_total_runs_size_mb:
-            action = "archive"
-            reason = "max_total_runs_size_mb"
-
-        if action == "keep":
+        else:
+            kept_count += 1
             running_size += size
 
         decisions.append(
             PolicyDecision(
-                target=str(file),
+                target=str(target),
                 category="runs",
                 action=action,
                 reason=reason,
                 size_mb=round(size_mb, 4),
                 age_days=round(age_days, 4),
+                run_id=run_id,
+                active=active,
             )
         )
+        if action == "keep" and not active:
+            kept_candidates.append((index, size))
+
+    if running_size / _BYTES_PER_MB > config.max_total_runs_size_mb:
+        for index, size in sorted(kept_candidates, key=lambda row: row[0], reverse=True):
+            if running_size / _BYTES_PER_MB <= config.max_total_runs_size_mb:
+                break
+            decision = decisions[index]
+            decisions[index] = PolicyDecision(
+                target=decision.target,
+                category=decision.category,
+                action="delete",
+                reason="max_total_runs_size_mb",
+                size_mb=decision.size_mb,
+                age_days=decision.age_days,
+                run_id=decision.run_id,
+                active=decision.active,
+            )
+            running_size -= size
 
     return PolicyReport(
         generated_at=ref_now.isoformat(),
@@ -209,11 +322,42 @@ def apply_runs_retention(
     """
 
     report = build_runs_policy_report(runs_dir=runs_dir, config=config, now=now)
+    retention_log = _retention_log_path(runs_dir)
+    by_run: dict[str, list[Path]] = {}
+    for run_dir in runs_dir.iterdir() if runs_dir.exists() else []:
+        if run_dir.is_dir():
+            by_run.setdefault(run_dir.name, []).append(run_dir)
+    for legacy_file in runs_dir.glob("*.jsonl"):
+        by_run.setdefault(_run_id_from_legacy_file(legacy_file), []).append(legacy_file)
+
     for decision in report.decisions:
-        if decision.action != "delete":
-            continue
-        try:
-            Path(decision.target).unlink()
-        except FileNotFoundError:
-            continue
+        delete_status = "skipped"
+        if decision.action == "delete" and not decision.active:
+            artifacts = by_run.get(decision.run_id or "", [Path(decision.target)])
+            deleted_all = True
+            statuses: list[str] = []
+            for artifact in artifacts:
+                ok, status = _safe_delete_path(artifact)
+                statuses.append(f"{artifact.name}:{status}")
+                deleted_all = deleted_all and ok
+            delete_status = "deleted" if deleted_all else "error"
+            if statuses:
+                delete_status = f"{delete_status}:{','.join(statuses)}"
+
+        append_jsonl_line(
+            retention_log,
+            {
+                "ts": _now_utc().isoformat(),
+                "scope": "runs",
+                "run_id": decision.run_id,
+                "target": decision.target,
+                "action": decision.action,
+                "reason": decision.reason,
+                "active": decision.active,
+                "size_mb": decision.size_mb,
+                "age_days": decision.age_days,
+                "delete_status": delete_status,
+            },
+            with_lock=True,
+        )
     return report

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -7,6 +7,7 @@ from singular.runs.explain import summarize_mutation
 
 def test_log_creation(tmp_path: Path) -> None:
     logger = RunLogger("test", root=tmp_path)
+    assert (tmp_path / "test" / ".active.lock").exists()
     summary = summarize_mutation(
         operator="op",
         impacted_file="skill.py",
@@ -47,6 +48,7 @@ def test_log_creation(tmp_path: Path) -> None:
     assert event["version"] == 1
     assert event["event_type"] == "mutation"
     assert event["payload"]["human_summary"] == summary
+    assert not (tmp_path / "test" / ".active.lock").exists()
 
 
 def test_resume_after_crash(tmp_path: Path) -> None:

--- a/tests/test_storage_retention.py
+++ b/tests/test_storage_retention.py
@@ -42,7 +42,7 @@ def test_load_retention_config_uses_legacy_runs_keep_env(monkeypatch) -> None:
     assert config.max_runs == 4
 
 
-def test_build_policy_report_marks_delete_archive_and_keep(tmp_path) -> None:
+def test_build_policy_report_marks_delete_and_keep(tmp_path) -> None:
     now = datetime(2026, 4, 15, tzinfo=timezone.utc)
     recent = tmp_path / "recent.jsonl"
     old = tmp_path / "old.jsonl"
@@ -77,7 +77,8 @@ def test_build_policy_report_marks_delete_archive_and_keep(tmp_path) -> None:
     by_name = {p.target.split("/")[-1]: p for p in report.decisions}
     assert by_name["recent.jsonl"].action == "keep"
     assert by_name["old.jsonl"].action == "delete"
-    assert by_name["overflow.jsonl"].action == "archive"
+    assert by_name["overflow.jsonl"].action == "delete"
+    assert by_name["overflow.jsonl"].reason == "max_total_runs_size_mb"
 
 
 def test_apply_runs_retention_deletes_decisions(tmp_path) -> None:
@@ -100,3 +101,53 @@ def test_apply_runs_retention_deletes_decisions(tmp_path) -> None:
     assert (tmp_path / "a.jsonl").exists()
     assert not (tmp_path / "b.jsonl").exists()
     assert report.summary["delete"] == 1
+
+
+def test_apply_runs_retention_deletes_run_directory_and_logs_decision(tmp_path) -> None:
+    now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    run_recent = tmp_path / "recent"
+    run_old = tmp_path / "old"
+    run_recent.mkdir()
+    run_old.mkdir()
+    (run_recent / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    (run_old / "events.jsonl").write_text("{}\n", encoding="utf-8")
+
+    import os
+
+    os.utime(run_recent / "events.jsonl", (now.timestamp(), now.timestamp()))
+    older = (now - timedelta(days=1)).timestamp()
+    os.utime(run_old / "events.jsonl", (older, older))
+
+    config = load_retention_config(environ={"SINGULAR_RETENTION_MAX_RUNS": "1"})
+    apply_runs_retention(runs_dir=tmp_path, config=config, now=now)
+
+    assert run_recent.exists()
+    assert not run_old.exists()
+    retention_log = tmp_path.parent / "mem" / "retention.log.jsonl"
+    lines = retention_log.read_text(encoding="utf-8").splitlines()
+    assert any(json.loads(line).get("run_id") == "old" for line in lines)
+
+
+def test_apply_runs_retention_protects_active_run(tmp_path) -> None:
+    now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    run_recent = tmp_path / "recent"
+    run_old = tmp_path / "old"
+    run_recent.mkdir()
+    run_old.mkdir()
+    (run_recent / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    (run_old / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    (run_old / ".active.lock").write_text("{}", encoding="utf-8")
+
+    import os
+
+    os.utime(run_recent / "events.jsonl", (now.timestamp(), now.timestamp()))
+    older = (now - timedelta(days=1)).timestamp()
+    os.utime(run_old / "events.jsonl", (older, older))
+
+    config = load_retention_config(environ={"SINGULAR_RETENTION_MAX_RUNS": "1"})
+    report = apply_runs_retention(runs_dir=tmp_path, config=config, now=now)
+
+    assert run_recent.exists()
+    assert run_old.exists()
+    old_decision = next(d for d in report.decisions if d.run_id == "old")
+    assert old_decision.reason == "active_run_protected"


### PR DESCRIPTION
### Motivation
- Expand retention to treat a run as a unit (not only legacy `*.jsonl` files) so `runs/<run_id>/` directories are considered for retention and purge.  
- Enforce the requested algorithm: list runs with metadata, sort newest→oldest, apply count/age thresholds first, then trim by total size.  
- Protect active runs from deletion and perform safe/atomic purge operations with traceable logging.  

### Description
- Replace per-file-only logic with run-aware grouping in `build_runs_policy_report` by merging `runs/*.jsonl` legacy files and `runs/<run_id>/` directories and computing each run's `mtime`, total `size` and `active` state.  
- Add helpers: `_walk_total_size`, `_latest_mtime`, `_run_id_from_legacy_file`, `_is_active_run`, `_retention_log_path` and `_safe_delete_path` to compute sizes/mtimes, detect active runs and perform tombstone-based safe deletes.  
- Update decision model to include `run_id` and `active` and implement retention ordering: protect active runs, apply `max_runs` and `max_run_age_days` as deletes, then enforce `max_total_runs_size_mb` by deleting oldest kept non-active runs.  
- Implement `apply_runs_retention` to remove run artifacts via `_safe_delete_path` and write a structured decision line to `mem/retention.log.jsonl` using `append_jsonl_line`.  
- Make `RunLogger` create `runs/<run_id>/.active.lock` on start and remove it on close so active runs are protected by retention.  
- Add and adjust tests to cover directory deletion, active-run protection, retention logging, and `.active.lock` lifecycle.  

### Testing
- Ran `pytest -q tests/test_storage_retention.py tests/test_runs_logger.py` and all tests passed (`12 passed`).  
- The changes include unit tests that assert deletion of run directories, protection of active runs, and presence of retention log entries, and these tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df56e6963c832aadcc7c1bd8b225ec)