### PR TITLE
Add safe-point retention execution with dry-run and frequency throttling

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -121,6 +121,49 @@ def _looks_like_dev_repo_root(path: Path) -> bool:
     return (path / "pyproject.toml").exists() and (path / "src" / "singular").is_dir()
 
 
+def _run_retention_at_safe_point(*, dry_run: bool = False, enforce_minimum_interval: bool = True) -> int:
+    """Run storage retention service and print a concise summary."""
+
+    from .storage_retention import run_retention_service
+
+    base_dir = Path(os.environ.get("SINGULAR_HOME", "."))
+    outcome = run_retention_service(
+        base_dir=base_dir,
+        dry_run=dry_run,
+        enforce_minimum_interval=enforce_minimum_interval,
+    )
+    report = outcome.report
+    if not outcome.executed:
+        reason = outcome.skipped_reason or "skipped"
+        print(
+            "Retention ignorée "
+            f"({reason}, min_interval={outcome.minimum_interval_minutes} min)."
+        )
+        return 0
+    if report is None:
+        print("Retention exécutée (aucun rapport).")
+        return 0
+    summary = report.summary
+    planned_or_deleted = summary.get("delete", 0)
+    action_word = "planned_delete" if dry_run else "deleted"
+    print(
+        "Retention exécutée "
+        f"(scope={report.scope}, keep={summary.get('keep', 0)}, "
+        f"{action_word}={planned_or_deleted})."
+    )
+    if dry_run:
+        planned = [d for d in report.decisions if d.action == "delete"]
+        if not planned:
+            print("Aucune suppression planifiée.")
+        for decision in planned:
+            print(
+                " - would_delete "
+                f"run_id={decision.run_id or '-'} target={decision.target} "
+                f"reason={decision.reason}"
+            )
+    return 0
+
+
 def _in_path(target: Path, env_path: str | None = None) -> bool:
     """Return True when *target* is present in PATH."""
 
@@ -891,6 +934,23 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Active les phases sans exécuter la mutation",
     )
+    retention_parser = subparsers.add_parser(
+        "retention",
+        help="Inspecte ou exécute la purge de rétention",
+    )
+    retention_subparsers = retention_parser.add_subparsers(
+        dest="retention_command",
+        required=True,
+    )
+    retention_run = retention_subparsers.add_parser(
+        "run",
+        help="Exécute la rétention des runs",
+    )
+    retention_run.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Affiche les suppressions prévues sans écrire",
+    )
     doctor_parser = subparsers.add_parser(
         "doctor", help="Diagnose CLI installation and PATH"
     )
@@ -1164,6 +1224,7 @@ def main(argv: list[str] | None = None) -> int:
         from .runs.loop import loop as loop_run
 
         life_dir = _ensure_active_life(resolve_life, args.life)
+        _run_retention_at_safe_point()
         skills_dir = args.skills_dir or life_dir / "skills"
         checkpoint = args.checkpoint or life_dir / "life_checkpoint.json"
         loop_run(
@@ -1252,6 +1313,7 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "dashboard":
         from .dashboard import run as dashboard_run
 
+        _run_retention_at_safe_point()
         dashboard_run()
     elif args.command == "rollback":
         from .runs.generations import rollback_generation
@@ -1309,6 +1371,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.orchestrate_command == "run":
             from .orchestrator import run_orchestrator_daemon
 
+            _run_retention_at_safe_point()
             return run_orchestrator_daemon(
                 veille_seconds=args.veille_seconds,
                 action_seconds=args.action_seconds,
@@ -1319,6 +1382,14 @@ def main(argv: list[str] | None = None) -> int:
                 lifecycle_config_path=args.lifecycle_config,
                 dry_run=args.dry_run,
                 safe_mode=args.safe_mode,
+            )
+
+    elif args.command == "retention":
+        _ensure_active_life(resolve_life, args.life)
+        if args.retention_command == "run":
+            return _run_retention_at_safe_point(
+                dry_run=bool(args.dry_run),
+                enforce_minimum_interval=not bool(args.dry_run),
             )
 
     elif args.command == "doctor":

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -10,7 +10,7 @@ import logging
 import os
 from typing import Any, Mapping
 
-from ..storage_retention import apply_runs_retention, load_retention_config
+from ..storage_retention import run_retention_service
 
 from ..psyche import Psyche
 from ..memory import add_episode, add_procedural_memory
@@ -85,20 +85,7 @@ def _ensure_dir(path: Path) -> None:
 def _enforce_retention(root: Path) -> None:
     """Apply retention policy to run logs and temporary files."""
 
-    config = load_retention_config(base_dir=_BASE_DIR)
-    apply_runs_retention(runs_dir=root, config=config)
-
-    # Clean up any leftover temporary files with the same count limit as runs.
-    tmps = sorted(
-        root.glob("*.jsonl.tmp"),
-        key=lambda p: (p.stat().st_mtime, p.name),
-        reverse=True,
-    )
-    for old in tmps[config.max_runs:]:
-        try:
-            old.unlink()
-        except FileNotFoundError:  # pragma: no cover - race condition
-            pass
+    run_retention_service(base_dir=_BASE_DIR, runs_dir=root)
 
 
 @dataclass
@@ -121,7 +108,6 @@ class RunLogger:
     def __post_init__(self) -> None:
         self.root = Path(self.root)
         self.root.mkdir(parents=True, exist_ok=True)
-        _enforce_retention(self.root)
 
         self.run_dir = self.root / self.run_id
         self.run_dir.mkdir(parents=True, exist_ok=True)

--- a/src/singular/storage_retention.py
+++ b/src/singular/storage_retention.py
@@ -69,6 +69,18 @@ class PolicyReport:
         return counts
 
 
+@dataclass(frozen=True)
+class RetentionRunOutcome:
+    """Outcome returned by the retention service entry point."""
+
+    executed: bool
+    dry_run: bool
+    report: PolicyReport | None
+    skipped_reason: str | None = None
+    minimum_interval_minutes: int = 0
+    last_executed_at: str | None = None
+
+
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -134,6 +146,30 @@ def _is_active_run(runs_dir: Path, run_id: str) -> bool:
 def _retention_log_path(runs_dir: Path) -> Path:
     base_dir = runs_dir.parent
     return base_dir / _RETENTION_LOG_RELATIVE_PATH
+
+
+def _retention_state_path(base_dir: Path) -> Path:
+    return base_dir / "mem" / "retention_state.json"
+
+
+def _load_retention_state(base_dir: Path) -> Mapping[str, Any]:
+    state_path = _retention_state_path(base_dir)
+    try:
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, Mapping):
+        return {}
+    return payload
+
+
+def _persist_retention_state(base_dir: Path, *, last_full_run_at: str) -> None:
+    state_path = _retention_state_path(base_dir)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"last_full_run_at": last_full_run_at}, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
 
 
 def _safe_delete_path(target: Path) -> tuple[bool, str]:
@@ -361,3 +397,82 @@ def apply_runs_retention(
             with_lock=True,
         )
     return report
+
+
+def run_retention_service(
+    *,
+    base_dir: Path | None = None,
+    runs_dir: Path | None = None,
+    dry_run: bool = False,
+    now: datetime | None = None,
+    minimum_interval_minutes: int | None = None,
+    enforce_minimum_interval: bool = True,
+) -> RetentionRunOutcome:
+    """Execute unified run-retention service with optional throttling.
+
+    ``dry_run=True`` computes and returns the report without deleting files or
+    writing retention state.
+    """
+
+    root = Path(base_dir) if base_dir is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    target_runs_dir = Path(runs_dir) if runs_dir is not None else root / "runs"
+    ref_now = now or _now_utc()
+    config = load_retention_config(base_dir=root)
+
+    min_interval = _coerce_positive_int(
+        os.environ.get("SINGULAR_RETENTION_MIN_INTERVAL_MINUTES", "15"),
+        15,
+    )
+    if minimum_interval_minutes is not None:
+        min_interval = _coerce_positive_int(minimum_interval_minutes, min_interval)
+    state = _load_retention_state(root)
+    last_run_raw = state.get("last_full_run_at")
+    last_run_at: datetime | None = None
+    if isinstance(last_run_raw, str):
+        try:
+            last_run_at = datetime.fromisoformat(last_run_raw)
+        except ValueError:
+            last_run_at = None
+
+    if (
+        enforce_minimum_interval
+        and not dry_run
+        and min_interval > 0
+        and last_run_at is not None
+        and ref_now < (last_run_at + timedelta(minutes=min_interval))
+    ):
+        return RetentionRunOutcome(
+            executed=False,
+            dry_run=False,
+            report=None,
+            skipped_reason="minimum_interval_not_elapsed",
+            minimum_interval_minutes=min_interval,
+            last_executed_at=last_run_at.isoformat(),
+        )
+
+    report = (
+        build_runs_policy_report(runs_dir=target_runs_dir, config=config, now=ref_now)
+        if dry_run
+        else apply_runs_retention(runs_dir=target_runs_dir, config=config, now=ref_now)
+    )
+
+    if not dry_run:
+        tmps = sorted(
+            target_runs_dir.glob("*.jsonl.tmp"),
+            key=lambda p: (p.stat().st_mtime, p.name),
+            reverse=True,
+        )
+        for old in tmps[config.max_runs :]:
+            try:
+                old.unlink()
+            except FileNotFoundError:  # pragma: no cover - race condition
+                pass
+        _persist_retention_state(root, last_full_run_at=ref_now.isoformat())
+
+    return RetentionRunOutcome(
+        executed=True,
+        dry_run=dry_run,
+        report=report,
+        minimum_interval_minutes=min_interval,
+        last_executed_at=(last_run_at.isoformat() if last_run_at is not None else None),
+    )

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -150,6 +150,38 @@ def test_status_supports_subcommand_format_and_verbose(
     assert captured["output_format"] == "table"
 
 
+def test_cli_loop_runs_startup_retention(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    root = tmp_path / "loop-root"
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    called: dict[str, object] = {"retention": 0}
+
+    def fake_run_retention_service(**kwargs):
+        called["retention"] = int(called["retention"]) + 1
+
+        class _Outcome:
+            executed = True
+            report = None
+            skipped_reason = None
+            minimum_interval_minutes = 15
+
+        return _Outcome()
+
+    def fake_loop_run(**kwargs):
+        called["loop"] = kwargs
+
+    monkeypatch.setattr("singular.storage_retention.run_retention_service", fake_run_retention_service)
+    monkeypatch.setattr("singular.runs.loop.loop", fake_loop_run)
+
+    code = main(["--root", str(root), "loop", "--budget-seconds", "0.1"])
+
+    assert code == 0
+    assert called["retention"] == 1
+    assert "loop" in called
+
+
 def test_cli_root_context_message_when_switching_registry_root(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_cli_retention.py
+++ b/tests/test_cli_retention.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from singular.cli import main
+
+
+def test_cli_retention_run_dry_run_dispatches(monkeypatch, tmp_path, capsys) -> None:
+    root = tmp_path / "root"
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    captured: dict[str, object] = {}
+
+    class _Report:
+        scope = "runs"
+        decisions = ()
+
+        @property
+        def summary(self) -> dict[str, int]:
+            return {"keep": 1, "delete": 0, "archive": 0}
+
+    class _Outcome:
+        executed = True
+        report = _Report()
+        skipped_reason = None
+        minimum_interval_minutes = 15
+
+    def fake_run_retention_service(**kwargs):
+        captured.update(kwargs)
+        return _Outcome()
+
+    monkeypatch.setattr("singular.storage_retention.run_retention_service", fake_run_retention_service)
+
+    code = main(["--root", str(root), "retention", "run", "--dry-run"])
+
+    assert code == 0
+    assert captured["dry_run"] is True
+    assert captured["enforce_minimum_interval"] is False
+    out = capsys.readouterr().out
+    assert "planned_delete=0" in out
+
+
+def test_cli_orchestrate_runs_startup_retention(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "root"
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    called: dict[str, int] = {"retention": 0}
+
+    class _Outcome:
+        executed = True
+        report = None
+        skipped_reason = None
+        minimum_interval_minutes = 15
+
+    def fake_run_retention_service(**kwargs):
+        called["retention"] += 1
+        return _Outcome()
+
+    def fake_run_orchestrator_daemon(**kwargs):
+        called["orchestrator"] = 1
+        return 0
+
+    monkeypatch.setattr("singular.storage_retention.run_retention_service", fake_run_retention_service)
+    monkeypatch.setattr(
+        "singular.orchestrator.run_orchestrator_daemon",
+        fake_run_orchestrator_daemon,
+    )
+
+    code = main(["--root", str(root), "orchestrate", "run"])
+
+    assert code == 0
+    assert called["retention"] == 1
+    assert called["orchestrator"] == 1

--- a/tests/test_storage_retention.py
+++ b/tests/test_storage_retention.py
@@ -7,6 +7,7 @@ from singular.storage_retention import (
     apply_runs_retention,
     build_runs_policy_report,
     load_retention_config,
+    run_retention_service,
 )
 
 
@@ -151,3 +152,61 @@ def test_apply_runs_retention_protects_active_run(tmp_path) -> None:
     assert run_old.exists()
     old_decision = next(d for d in report.decisions if d.run_id == "old")
     assert old_decision.reason == "active_run_protected"
+
+
+def test_run_retention_service_dry_run_does_not_delete(tmp_path, monkeypatch) -> None:
+    now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    recent = runs_dir / "recent.jsonl"
+    old = runs_dir / "old.jsonl"
+    recent.write_text("{}\n", encoding="utf-8")
+    old.write_text("{}\n", encoding="utf-8")
+
+    import os
+
+    os.utime(recent, (now.timestamp(), now.timestamp()))
+    older = (now - timedelta(days=1)).timestamp()
+    os.utime(old, (older, older))
+    monkeypatch.setenv("SINGULAR_RETENTION_MAX_RUNS", "1")
+
+    outcome = run_retention_service(
+        base_dir=tmp_path,
+        runs_dir=runs_dir,
+        dry_run=True,
+        now=now,
+        minimum_interval_minutes=30,
+    )
+
+    assert outcome.executed is True
+    assert outcome.report is not None
+    assert recent.exists()
+    assert old.exists()
+    assert any(
+        decision.target.endswith("old.jsonl") and decision.action == "delete"
+        for decision in outcome.report.decisions
+    )
+    assert not (tmp_path / "mem" / "retention_state.json").exists()
+
+
+def test_run_retention_service_respects_minimum_interval(tmp_path) -> None:
+    now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "a.jsonl").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "mem").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "mem" / "retention_state.json").write_text(
+        json.dumps({"last_full_run_at": (now - timedelta(minutes=5)).isoformat()}),
+        encoding="utf-8",
+    )
+
+    outcome = run_retention_service(
+        base_dir=tmp_path,
+        runs_dir=runs_dir,
+        now=now,
+        minimum_interval_minutes=30,
+    )
+
+    assert outcome.executed is False
+    assert outcome.report is None
+    assert outcome.skipped_reason == "minimum_interval_not_elapsed"


### PR DESCRIPTION
### Motivation
- Reduce retention overhead by running purge logic at safe points (after logs flushed/closed and at the startup of long-lived CLI commands) instead of eagerly on logger initialization.
- Provide an explicit CLI entry for manual retention runs and a `--dry-run` mode so planned deletions can be inspected without writing.
- Prevent frequent costly full purges by persisting the last full-run time and skipping runs that occur sooner than a configurable minimum interval.

### Description
- Introduce a unified entrypoint `run_retention_service(...)` in `src/singular/storage_retention.py` that supports normal execution, `dry_run=True` (builds a `PolicyReport` without deleting files), and minimum-interval throttling persisted to `mem/retention_state.json` with an env override `SINGULAR_RETENTION_MIN_INTERVAL_MINUTES` and a function return type `RetentionRunOutcome`.
- Move internal tmp cleanup and retention state persistence into `run_retention_service` and keep end-of-run retention call in `RunLogger.close()` after file flush/close, while removing eager retention at logger initialization (`src/singular/runs/logger.py`).
- Wire retention to safe CLI lifecycle points: run at startup of long-running commands `loop`, `orchestrate run`, and `dashboard`, and add an explicit `singular retention run [--dry-run]` command with a concise summary printer (`src/singular/cli.py`).
- Add tests covering `run_retention_service` dry-run behavior, minimum-interval skipping, and CLI dispatch/invocation (`tests/test_storage_retention.py`, `tests/test_cli_retention.py`, and CLI startup test adjustments).

### Testing
- Ran targeted pytest: `pytest -q tests/test_storage_retention.py tests/test_cli_retention.py tests/test_cli_orchestrate.py tests/test_cli_lives.py::test_cli_loop_runs_startup_retention` and all tests passed (`14 passed`).
- Added unit tests: `test_run_retention_service_dry_run_does_not_delete`, `test_run_retention_service_respects_minimum_interval`, `test_cli_retention_run_dry_run_dispatches`, and CLI startup retention tests, which succeeded in the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df59ffd768832aa1a2384a4c867d64)