### PR TITLE
Add retention status/config subcommands and dashboard retention card

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -164,6 +164,80 @@ def _run_retention_at_safe_point(*, dry_run: bool = False, enforce_minimum_inter
     return 0
 
 
+def _retention_status() -> int:
+    """Display retention usage, thresholds and latest purge summary."""
+
+    from .storage_retention import retention_status_snapshot
+
+    base_dir = Path(os.environ.get("SINGULAR_HOME", "."))
+    status = retention_status_snapshot(base_dir=base_dir)
+    usage = status.get("usage", {})
+    runs_usage = usage.get("runs", {})
+    mem_usage = usage.get("mem", {})
+    lives_usage = usage.get("lives", {})
+    thresholds = status.get("thresholds", {})
+    threshold_flags = status.get("active_thresholds", {})
+    last_purge = status.get("last_purge", {})
+    purge_summary = last_purge.get("summary", {}) if isinstance(last_purge, dict) else {}
+
+    print("Retention status")
+    print(
+        "Usage: "
+        f"runs={runs_usage.get('size_mb', 0):.2f}MB, "
+        f"mem={mem_usage.get('size_mb', 0):.2f}MB, "
+        f"lives={lives_usage.get('size_mb', 0):.2f}MB"
+    )
+    print(
+        "Last purge: "
+        f"at={last_purge.get('at') or 'never'}, "
+        f"freed_mb={purge_summary.get('freed_mb', 0)}, "
+        f"deleted={purge_summary.get('deleted', 0)}, "
+        f"archived={purge_summary.get('archived', 0)}"
+    )
+    print(
+        "Thresholds: "
+        f"max_runs={thresholds.get('max_runs')}, "
+        f"max_run_age_days={thresholds.get('max_run_age_days')}, "
+        f"max_total_runs_size_mb={thresholds.get('max_total_runs_size_mb')}"
+    )
+    exceeded = [name for name, value in threshold_flags.items() if value]
+    print(
+        "Exceeded: "
+        + (", ".join(sorted(exceeded)) if exceeded else "none")
+    )
+
+    def _print_entries(label: str, entries: Any) -> None:
+        print(f"{label}:")
+        if not isinstance(entries, list) or not entries:
+            print(" - (empty)")
+            return
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            print(
+                " - "
+                f"{entry.get('kind', 'item')} {entry.get('name', '?')} "
+                f"({entry.get('size_mb', 0):.4f}MB)"
+            )
+
+    _print_entries("runs details", runs_usage.get("entries"))
+    _print_entries("mem details", mem_usage.get("entries"))
+    _print_entries("lives details", lives_usage.get("entries"))
+    return 0
+
+
+def _retention_config_show() -> int:
+    """Print currently active retention thresholds."""
+
+    from .storage_retention import retention_status_snapshot
+
+    base_dir = Path(os.environ.get("SINGULAR_HOME", "."))
+    status = retention_status_snapshot(base_dir=base_dir)
+    thresholds = status.get("thresholds", {})
+    print(json.dumps({"retention": thresholds}, ensure_ascii=False, indent=2))
+    return 0
+
+
 def _in_path(target: Path, env_path: str | None = None) -> bool:
     """Return True when *target* is present in PATH."""
 
@@ -951,6 +1025,22 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Affiche les suppressions prévues sans écrire",
     )
+    retention_subparsers.add_parser(
+        "status",
+        help="Affiche l'usage stockage, les seuils et la dernière purge",
+    )
+    retention_config = retention_subparsers.add_parser(
+        "config",
+        help="Inspecte la configuration de rétention active",
+    )
+    retention_config_subparsers = retention_config.add_subparsers(
+        dest="retention_config_command",
+        required=True,
+    )
+    retention_config_subparsers.add_parser(
+        "show",
+        help="Affiche les seuils actifs",
+    )
     doctor_parser = subparsers.add_parser(
         "doctor", help="Diagnose CLI installation and PATH"
     )
@@ -1391,6 +1481,10 @@ def main(argv: list[str] | None = None) -> int:
                 dry_run=bool(args.dry_run),
                 enforce_minimum_interval=not bool(args.dry_run),
             )
+        if args.retention_command == "status":
+            return _retention_status()
+        if args.retention_command == "config" and args.retention_config_command == "show":
+            return _retention_config_show()
 
     elif args.command == "doctor":
         _doctor(fix=args.fix)

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -16,6 +16,7 @@ from singular.lives import get_registry_root, load_registry, set_life_status
 from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
 from singular.memory import read_skills
+from singular.storage_retention import retention_status_snapshot
 
 from singular.dashboard.actions import DashboardActionService
 from singular.governance.policy import load_runtime_policy
@@ -1009,6 +1010,7 @@ def create_app(
     def read_dashboard_context() -> dict[str, object]:
         policy = load_runtime_policy()
         registry_state = _registry_overview()
+        retention = retention_status_snapshot(base_dir=base_dir)
         return {
             "singular_root": str(registry_root),
             "singular_home": str(base_dir),
@@ -1025,7 +1027,13 @@ def create_app(
             "policy": policy.to_payload(),
             "policy_impact": policy.impact_summary(),
             "skills_lifecycle": _skill_lifecycle_summary(),
+            "retention": retention,
         }
+
+    @app.get("/api/retention/status")
+    def read_retention_status() -> dict[str, object]:
+        payload = retention_status_snapshot(base_dir=base_dir)
+        return dict(payload)
 
     @app.get("/timeline")
     def read_timeline(

--- a/src/singular/dashboard/static/dashboard.js
+++ b/src/singular/dashboard/static/dashboard.js
@@ -22,6 +22,7 @@ const schedulerConfig={
   backoff:{baseMs:1500,maxMs:30000,multiplier:2},
   frequencies:{
     context:7000,
+    retention:7000,
     cockpit:5000,
     ecosystem:5000,
     timeline:4000,
@@ -34,6 +35,7 @@ const schedulerConfig={
 };
 const schedulerLabelIds={
   context:'parametres',
+  retention:'cockpit',
   cockpit:'cockpit',
   ecosystem:'cockpit',
   timeline:'timeline-section',
@@ -341,6 +343,25 @@ const loadContext=()=>fetchJson('/dashboard/context').then(ctx=>{
   document.getElementById('kpi-skills-archived').textContent=String(lifecycle.archived||0);
 });
 
+const loadRetentionStatus=()=>fetchJson('/api/retention/status').then(payload=>{
+  const usage=payload?.usage||{};
+  const runs=usage?.runs||{};
+  const mem=usage?.mem||{};
+  const lives=usage?.lives||{};
+  const lastPurge=payload?.last_purge||{};
+  const summary=lastPurge?.summary||{};
+  const thresholds=payload?.thresholds||{};
+  const activeThresholds=payload?.active_thresholds||{};
+  const exceeded=Object.entries(activeThresholds).filter(([,active])=>Boolean(active)).map(([key])=>key);
+
+  document.getElementById('kpi-retention-usage').textContent=`${Number(runs.size_mb||0).toFixed(2)}MB / ${Number(mem.size_mb||0).toFixed(2)}MB / ${Number(lives.size_mb||0).toFixed(2)}MB`;
+  document.getElementById('kpi-retention-last-purge').textContent=String(lastPurge?.at||'jamais');
+  document.getElementById('kpi-retention-freed').textContent=`${Number(summary.freed_mb||0).toFixed(2)}MB`;
+  document.getElementById('kpi-retention-items').textContent=`${summary.deleted||0} / ${summary.archived||0}`;
+  const thresholdLabel=`runs≤${thresholds.max_runs??na()} · age≤${thresholds.max_run_age_days??na()}j · size≤${thresholds.max_total_runs_size_mb??na()}MB`;
+  document.getElementById('kpi-retention-thresholds').textContent=exceeded.length?`${thresholdLabel} · dépassement: ${exceeded.join(', ')}`:thresholdLabel;
+});
+
 const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJson(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc'))]).then(([eco,lives])=>{
   const summary=eco.summary||{};
   const total=Number(summary.total_organisms||0);
@@ -536,6 +557,7 @@ if(essentialBtn){essentialBtn.onclick=toggleEssentialMode;}
 // Module bootstrap
 bootstrapPauseControls();
 registerTask('context',loadContext,schedulerConfig.frequencies.context);
+registerTask('retention',loadRetentionStatus,schedulerConfig.frequencies.retention);
 registerTask('ecosystem',loadEco,schedulerConfig.frequencies.ecosystem);
 registerTask('cockpit',loadCockpit,schedulerConfig.frequencies.cockpit);
 registerTask('timeline',loadTimeline,schedulerConfig.frequencies.timeline);

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -143,6 +143,18 @@
     </div>
   </div>
 
+  <div class='panel'>
+    <h3 class='heading-reset-top'>Rétention stockage</h3>
+    <p class='section-help'>À utiliser pour suivre en continu l'espace, les seuils actifs et la dernière purge.</p>
+    <div class='cards-grid'>
+      <div class='card'><div class='card-label'>Runs / Mem / Lives</div><div id='kpi-retention-usage' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Dernière purge</div><div id='kpi-retention-last-purge' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Volume libéré</div><div id='kpi-retention-freed' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Éléments supprimés / archivés</div><div id='kpi-retention-items' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Seuils actifs</div><div id='kpi-retention-thresholds' class='card-value'>Chargement…</div></div>
+    </div>
+  </div>
+
   <div class='panel' id='competences-quotidien'>
     <h3 class='heading-reset-top'>Compétences du quotidien</h3>
     <p class='section-help'>À utiliser pour suivre les skills réellement utilisées et éviter les métriques bruit.</p>

--- a/src/singular/storage_retention.py
+++ b/src/singular/storage_retention.py
@@ -79,6 +79,7 @@ class RetentionRunOutcome:
     skipped_reason: str | None = None
     minimum_interval_minutes: int = 0
     last_executed_at: str | None = None
+    last_run_summary: Mapping[str, Any] | None = None
 
 
 def _now_utc() -> datetime:
@@ -163,11 +164,19 @@ def _load_retention_state(base_dir: Path) -> Mapping[str, Any]:
     return payload
 
 
-def _persist_retention_state(base_dir: Path, *, last_full_run_at: str) -> None:
+def _persist_retention_state(
+    base_dir: Path,
+    *,
+    last_full_run_at: str,
+    last_run_summary: Mapping[str, Any] | None = None,
+) -> None:
     state_path = _retention_state_path(base_dir)
     state_path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {"last_full_run_at": last_full_run_at}
+    if last_run_summary is not None:
+        payload["last_run_summary"] = dict(last_run_summary)
     state_path.write_text(
-        json.dumps({"last_full_run_at": last_full_run_at}, indent=2, ensure_ascii=False) + "\n",
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
 
@@ -456,6 +465,7 @@ def run_retention_service(
         else apply_runs_retention(runs_dir=target_runs_dir, config=config, now=ref_now)
     )
 
+    last_run_summary: Mapping[str, Any] | None = None
     if not dry_run:
         tmps = sorted(
             target_runs_dir.glob("*.jsonl.tmp"),
@@ -467,7 +477,25 @@ def run_retention_service(
                 old.unlink()
             except FileNotFoundError:  # pragma: no cover - race condition
                 pass
-        _persist_retention_state(root, last_full_run_at=ref_now.isoformat())
+        deleted_decisions = [
+            decision
+            for decision in report.decisions
+            if decision.action == "delete" and not decision.active
+        ]
+        freed_mb = round(sum(decision.size_mb or 0.0 for decision in deleted_decisions), 4)
+        counts = report.summary
+        last_run_summary = {
+            "scope": report.scope,
+            "freed_mb": freed_mb,
+            "deleted": len(deleted_decisions),
+            "archived": counts.get("archive", 0),
+            "planned_deletions": counts.get("delete", 0),
+        }
+        _persist_retention_state(
+            root,
+            last_full_run_at=ref_now.isoformat(),
+            last_run_summary=last_run_summary,
+        )
 
     return RetentionRunOutcome(
         executed=True,
@@ -475,4 +503,90 @@ def run_retention_service(
         report=report,
         minimum_interval_minutes=min_interval,
         last_executed_at=(last_run_at.isoformat() if last_run_at is not None else None),
+        last_run_summary=last_run_summary,
     )
+
+
+def _child_entries_size(path: Path) -> list[dict[str, Any]]:
+    if not path.exists() or not path.is_dir():
+        return []
+    entries: list[dict[str, Any]] = []
+    for child in sorted(path.iterdir(), key=lambda item: item.name):
+        child_size_bytes = _walk_total_size(child)
+        entries.append(
+            {
+                "name": child.name,
+                "path": str(child),
+                "kind": "dir" if child.is_dir() else "file",
+                "size_bytes": child_size_bytes,
+                "size_mb": round(child_size_bytes / _BYTES_PER_MB, 4),
+            }
+        )
+    entries.sort(key=lambda item: item["size_bytes"], reverse=True)
+    return entries
+
+
+def retention_status_snapshot(
+    *,
+    base_dir: Path | None = None,
+    runs_dir: Path | None = None,
+    now: datetime | None = None,
+) -> Mapping[str, Any]:
+    """Return a rich status payload used by CLI and dashboard monitoring."""
+
+    root = Path(base_dir) if base_dir is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    target_runs_dir = Path(runs_dir) if runs_dir is not None else root / "runs"
+    config = load_retention_config(base_dir=root)
+    report = build_runs_policy_report(runs_dir=target_runs_dir, config=config, now=now)
+    state = _load_retention_state(root)
+
+    runs_size_bytes = _walk_total_size(target_runs_dir)
+    mem_size_bytes = _walk_total_size(root / "mem")
+    lives_size_bytes = _walk_total_size(root / "lives")
+
+    run_count = len(report.decisions)
+    overdue_age = [
+        decision for decision in report.decisions if (decision.age_days or 0.0) > config.max_run_age_days
+    ]
+    exceeds = {
+        "max_runs": run_count > config.max_runs,
+        "max_total_runs_size_mb": (runs_size_bytes / _BYTES_PER_MB) > config.max_total_runs_size_mb,
+        "max_run_age_days": len(overdue_age) > 0,
+    }
+
+    return {
+        "scope": "runs",
+        "generated_at": report.generated_at,
+        "usage": {
+            "runs": {
+                "size_bytes": runs_size_bytes,
+                "size_mb": round(runs_size_bytes / _BYTES_PER_MB, 4),
+                "entries": _child_entries_size(target_runs_dir),
+            },
+            "mem": {
+                "size_bytes": mem_size_bytes,
+                "size_mb": round(mem_size_bytes / _BYTES_PER_MB, 4),
+                "entries": _child_entries_size(root / "mem"),
+            },
+            "lives": {
+                "size_bytes": lives_size_bytes,
+                "size_mb": round(lives_size_bytes / _BYTES_PER_MB, 4),
+                "entries": _child_entries_size(root / "lives"),
+            },
+        },
+        "thresholds": {
+            "max_runs": config.max_runs,
+            "max_run_age_days": config.max_run_age_days,
+            "max_total_runs_size_mb": config.max_total_runs_size_mb,
+            "max_episodic_lines": config.max_episodic_lines,
+            "max_episodic_days": config.max_episodic_days,
+            "max_generations_lines": config.max_generations_lines,
+            "max_generations_days": config.max_generations_days,
+        },
+        "active_thresholds": exceeds,
+        "policy_summary": report.summary,
+        "last_purge": {
+            "at": state.get("last_full_run_at"),
+            "summary": state.get("last_run_summary", {}),
+        },
+    }

--- a/tests/test_cli_retention.py
+++ b/tests/test_cli_retention.py
@@ -69,3 +69,47 @@ def test_cli_orchestrate_runs_startup_retention(monkeypatch, tmp_path) -> None:
     assert code == 0
     assert called["retention"] == 1
     assert called["orchestrator"] == 1
+
+
+def test_cli_retention_status_prints_usage(monkeypatch, tmp_path, capsys) -> None:
+    root = tmp_path / "root"
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    def fake_retention_status_snapshot(**kwargs):
+        return {
+            "usage": {
+                "runs": {"size_mb": 1.5, "entries": [{"kind": "file", "name": "a.jsonl", "size_mb": 1.5}]},
+                "mem": {"size_mb": 0.5, "entries": []},
+                "lives": {"size_mb": 2.0, "entries": []},
+            },
+            "thresholds": {"max_runs": 20, "max_run_age_days": 30, "max_total_runs_size_mb": 512},
+            "active_thresholds": {"max_runs": False, "max_total_runs_size_mb": True, "max_run_age_days": False},
+            "last_purge": {"at": "2026-04-15T12:00:00+00:00", "summary": {"freed_mb": 3.5, "deleted": 7, "archived": 1}},
+        }
+
+    monkeypatch.setattr("singular.storage_retention.retention_status_snapshot", fake_retention_status_snapshot)
+
+    code = main(["--root", str(root), "retention", "status"])
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "runs=1.50MB, mem=0.50MB, lives=2.00MB" in out
+    assert "freed_mb=3.5, deleted=7, archived=1" in out
+    assert "max_total_runs_size_mb" in out
+
+
+def test_cli_retention_config_show_prints_active_thresholds(monkeypatch, tmp_path, capsys) -> None:
+    root = tmp_path / "root"
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    def fake_retention_status_snapshot(**kwargs):
+        return {"thresholds": {"max_runs": 5, "max_run_age_days": 14, "max_total_runs_size_mb": 42}}
+
+    monkeypatch.setattr("singular.storage_retention.retention_status_snapshot", fake_retention_status_snapshot)
+
+    code = main(["--root", str(root), "retention", "config", "show"])
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert '"max_runs": 5' in out
+    assert '"max_run_age_days": 14' in out

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -34,6 +34,10 @@ def test_dashboard_endpoints(tmp_path: Path, monkeypatch) -> None:
     assert context["policy"]["version"] == 1
     assert isinstance(context["policy_impact"], list)
     assert "skills_lifecycle" in context
+    assert "retention" in context
+    retention = client.get("/api/retention/status").json()
+    assert "usage" in retention
+    assert "last_purge" in retention
 
 
 def test_dashboard_starts_with_empty_registry_and_exposes_onboarding(tmp_path: Path, monkeypatch) -> None:
@@ -258,6 +262,8 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     response = client.get("/")
     assert response.status_code == 200
     body = response.json()
+    assert "kpi-retention-usage" in body
+    assert "kpi-retention-thresholds" in body
     assert "Cockpit" in body
     assert "Prochaine action" in body
     assert "Métriques d’autonomie" in body

--- a/tests/test_storage_retention.py
+++ b/tests/test_storage_retention.py
@@ -7,6 +7,7 @@ from singular.storage_retention import (
     apply_runs_retention,
     build_runs_policy_report,
     load_retention_config,
+    retention_status_snapshot,
     run_retention_service,
 )
 
@@ -210,3 +211,60 @@ def test_run_retention_service_respects_minimum_interval(tmp_path) -> None:
     assert outcome.executed is False
     assert outcome.report is None
     assert outcome.skipped_reason == "minimum_interval_not_elapsed"
+
+
+def test_run_retention_service_persists_last_purge_summary(tmp_path, monkeypatch) -> None:
+    now = datetime(2026, 4, 15, tzinfo=timezone.utc)
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    recent = runs_dir / "recent.jsonl"
+    old = runs_dir / "old.jsonl"
+    recent.write_text("{}\n", encoding="utf-8")
+    old.write_text("{}\n", encoding="utf-8")
+
+    import os
+
+    os.utime(recent, (now.timestamp(), now.timestamp()))
+    older = (now - timedelta(days=1)).timestamp()
+    os.utime(old, (older, older))
+    monkeypatch.setenv("SINGULAR_RETENTION_MAX_RUNS", "1")
+
+    outcome = run_retention_service(base_dir=tmp_path, runs_dir=runs_dir, now=now)
+
+    assert outcome.executed is True
+    assert outcome.last_run_summary is not None
+    assert outcome.last_run_summary["deleted"] == 1
+    state = json.loads((tmp_path / "mem" / "retention_state.json").read_text(encoding="utf-8"))
+    assert state["last_run_summary"]["deleted"] == 1
+
+
+def test_retention_status_snapshot_reports_usage_and_thresholds(tmp_path, monkeypatch) -> None:
+    runs_dir = tmp_path / "runs"
+    mem_dir = tmp_path / "mem"
+    lives_dir = tmp_path / "lives"
+    runs_dir.mkdir()
+    mem_dir.mkdir()
+    lives_dir.mkdir()
+    (runs_dir / "a.jsonl").write_text("{}\n", encoding="utf-8")
+    (mem_dir / "events.jsonl").write_text("{}\n", encoding="utf-8")
+    (lives_dir / "alpha.json").write_text("{}\n", encoding="utf-8")
+    (mem_dir / "retention_state.json").write_text(
+        json.dumps(
+            {
+                "last_full_run_at": "2026-04-15T10:00:00+00:00",
+                "last_run_summary": {"freed_mb": 1.2, "deleted": 3, "archived": 0},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SINGULAR_RETENTION_MAX_RUNS", "1")
+    monkeypatch.setenv("SINGULAR_RETENTION_MAX_TOTAL_RUNS_SIZE_MB", "1")
+
+    payload = retention_status_snapshot(base_dir=tmp_path, now=datetime(2026, 4, 15, tzinfo=timezone.utc))
+
+    assert payload["usage"]["runs"]["size_mb"] >= 0
+    assert payload["usage"]["mem"]["size_mb"] >= 0
+    assert payload["usage"]["lives"]["size_mb"] >= 0
+    assert payload["thresholds"]["max_runs"] == 1
+    assert payload["thresholds"]["max_total_runs_size_mb"] == 1
+    assert payload["last_purge"]["summary"]["deleted"] == 3


### PR DESCRIPTION
### Motivation
- Provide observability and control over storage retention: show usage per area (`runs/`, `mem/`, `lives/`), surface active thresholds and overruns, and expose last purge metrics. 
- Make retention data available to operators both from CLI and via the web dashboard for continuous monitoring.

### Description
- Extend the retention service in `src/singular/storage_retention.py` to persist a `last_run_summary` and compute a reusable snapshot via `retention_status_snapshot(...)`, and add `_child_entries_size` to report per-entry sizes.  `run_retention_service` now records freed MB and deleted/archived counts into `retention_state.json` when a full run executes.
- Add CLI subcommands in `src/singular/cli.py`: `singular retention status` (prints usage, per-entry sizes, thresholds and last purge summary) and `singular retention config show` (prints active thresholds), and wire them into the dispatcher with helper functions `_retention_status` and `_retention_config_show`.
- Surface retention in the dashboard by injecting the snapshot into `/dashboard/context`, adding a new endpoint `GET /api/retention/status` in `src/singular/dashboard/__init__.py`, adding a dedicated "Rétention stockage" card in `src/singular/dashboard/templates/dashboard.html`, and adding JS polling/renderer in `src/singular/dashboard/static/dashboard.js` with a scheduler task for continuous refresh.
- Update and add unit tests under `tests/` to cover CLI commands, retention state persistence and snapshot, and dashboard endpoint/card presence (`tests/test_cli_retention.py`, `tests/test_storage_retention.py`, `tests/test_dashboard.py`).

### Testing
- Ran `pytest -q tests/test_cli_retention.py tests/test_storage_retention.py` and the two-test-suite run passed: all tests succeeded (14 passed). 
- Attempting to run the dashboard tests together in this environment (`pytest -q tests/test_cli_retention.py tests/test_storage_retention.py tests/test_dashboard.py`) triggered an import error for `fastapi.staticfiles` due to the lightweight `fastapi_stub` test environment; the dashboard endpoint and UI updates are exercised by the added dashboard tests but full run may require the real `fastapi` package or extending the stub to include `staticfiles`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5be8c854832a84b779df8c621c1f)