### PR TITLE
docs: documenter les nouveaux paramètres de rétention et la migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,8 +428,8 @@ SINGULAR_HOME=/chemin/personnel singular lives create
 # ou
 singular --home /chemin/personnel lives create
 
-# Ajuster la rétention des journaux
-SINGULAR_RUNS_KEEP=50 singular report --format json
+# Ajuster la rétention (priorité env > fichier mem/retention_policy.json > défauts)
+SINGULAR_RETENTION_MAX_RUNS=50 singular retention status
 
 # Utiliser l'API OpenAI
 OPENAI_API_KEY=sk-... singular talk --prompt "Salut"
@@ -468,7 +468,53 @@ Rollback atomique vers une génération stable :
 singular rollback --generation 42
 ```
 
-Politique de conservation/archivage/purge : `docs/generations_registry.md`.
+### Rétention des artefacts (nouveaux paramètres)
+
+La rétention est pilotée par 7 paramètres (`retention config show`) :
+
+- `max_runs` (défaut: `20`)
+- `max_run_age_days` (défaut: `30`)
+- `max_total_runs_size_mb` (défaut: `512`)
+- `max_episodic_lines` (défaut: `20000`)
+- `max_episodic_days` (défaut: `90`)
+- `max_generations_lines` (défaut: `50000`)
+- `max_generations_days` (défaut: `365`)
+
+Ordre de résolution des valeurs: variables d’environnement `SINGULAR_RETENTION_*`,
+puis `mem/retention_policy.json`, puis défauts intégrés.
+
+Garanties (suppression automatique) :
+
+- un run actif (verrou `.active.lock` ou fichier temporaire `.jsonl.tmp`) n’est jamais supprimé ;
+- les données `lives/` ne sont jamais supprimées par `singular retention run` ;
+- les snapshots/registre de générations ne sont pas supprimés automatiquement par ce service ;
+- `--dry-run` n’écrit rien et ne supprime rien.
+
+Commandes de contrôle :
+
+```bash
+# Voir les seuils effectivement actifs
+singular retention config show
+
+# Voir usage, dépassements et dernière purge
+singular retention status
+
+# Simuler les suppressions (fortement recommandé)
+singular retention run --dry-run
+
+# Appliquer la purge réelle
+singular retention run
+```
+
+### Migration (utilisateurs existants)
+
+1. **Audit initial** : exécutez `singular retention status`.
+2. **Activation progressive** : définissez d’abord des seuils permissifs (ex. `MAX_RUNS` élevé), puis resserrez par étapes.
+3. **Dry-run obligatoire en pratique** : lancez `singular retention run --dry-run` avant toute purge réelle.
+4. **Purge réelle** : exécutez `singular retention run` uniquement après validation de la liste `would_delete`.
+5. **Compatibilité legacy** : remplacez `SINGULAR_RUNS_KEEP` par `SINGULAR_RETENTION_MAX_RUNS` dans vos scripts CI/shell.
+
+Politique de conservation/archivage/purge détaillée : `docs/generations_registry.md`.
 
 Schéma JSON (`schema_version: 1`) :
 

--- a/docs/generations_registry.md
+++ b/docs/generations_registry.md
@@ -29,9 +29,72 @@ singular rollback --generation <id>
 Le rollback est autorisé uniquement pour une génération stable (`stable=true`, i.e. acceptée),
 et restaure atomiquement le fichier de skill depuis le snapshot.
 
-## Politique de conservation / archivage / purge
+## Rétention: paramètres, défauts, garanties
 
-- Le registre `mem/generations.jsonl` est conservé comme journal d’audit principal.
-- Les snapshots `runs/<run_id>/generations/` peuvent être archivés après 30 jours.
-- Après vérification d’archivage, les snapshots des générations rejetées peuvent être purgés en priorité.
-- Les générations acceptées gardent au moins un snapshot restaurable par run actif.
+La politique de rétention unifiée expose les paramètres suivants :
+
+- `max_runs` (défaut: `20`)
+- `max_run_age_days` (défaut: `30`)
+- `max_total_runs_size_mb` (défaut: `512`)
+- `max_episodic_lines` (défaut: `20000`)
+- `max_episodic_days` (défaut: `90`)
+- `max_generations_lines` (défaut: `50000`)
+- `max_generations_days` (défaut: `365`)
+
+Résolution des paramètres (priorité décroissante) :
+
+1. variables d’environnement `SINGULAR_RETENTION_*`;
+2. fichier `mem/retention_policy.json`;
+3. valeurs par défaut intégrées.
+
+Exemples de variables d’environnement :
+
+```bash
+SINGULAR_RETENTION_MAX_RUNS=50
+SINGULAR_RETENTION_MAX_RUN_AGE_DAYS=14
+SINGULAR_RETENTION_MAX_TOTAL_RUNS_SIZE_MB=1024
+```
+
+### Garanties (ce qui n’est jamais supprimé automatiquement)
+
+- un run actif est toujours protégé (`.active.lock` ou `.jsonl.tmp`);
+- `lives/` n’est pas ciblé par la purge `retention run`;
+- `mem/generations.jsonl` n’est pas supprimé automatiquement par la rétention des runs;
+- les snapshots de générations (`runs/<run_id>/generations/`) ne sont pas purgés par défaut par ce service;
+- en mode `--dry-run`, aucune suppression ni écriture d’état n’est effectuée.
+
+## Commandes de contrôle
+
+```bash
+# Afficher les seuils actifs (après résolution env/fichier/défauts)
+singular retention config show
+
+# Afficher usage stockage, dépassements et dernière purge
+singular retention status
+
+# Simuler sans supprimer
+singular retention run --dry-run
+
+# Exécuter la purge réelle
+singular retention run
+```
+
+Notes opérationnelles :
+
+- la purge réelle est throttlée (intervalle minimal, 15 min par défaut) ;
+- la dernière exécution est journalisée dans `mem/retention_state.json`;
+- les décisions sont tracées dans `mem/retention.log.jsonl`.
+
+## Migration (utilisateurs existants)
+
+Recommandation de migration progressive :
+
+1. **Mesurer avant d’agir** : `singular retention status`.
+2. **Configurer sans risque** : définir d’abord des seuils permissifs.
+3. **Toujours valider en simulation** : `singular retention run --dry-run`.
+4. **Purger ensuite seulement** : `singular retention run` après revue des `would_delete`.
+5. **Mettre à jour les scripts legacy** :
+   - ancien: `SINGULAR_RUNS_KEEP=...`
+   - nouveau: `SINGULAR_RETENTION_MAX_RUNS=...`
+
+Cette approche évite une purge inattendue lors de la première activation sur un environnement historique.


### PR DESCRIPTION
### Motivation

- Clarifier l'utilisation du nouveau service de rétention en exposant les paramètres de configuration, leurs valeurs par défaut, les garanties de non-suppression et les commandes CLI associées afin d'éviter des purges inattendues. 
- Fournir une procédure de migration progressive pour les utilisateurs existants (activation graduelle et utilisation de `--dry-run`) afin de sécuriser l'activation sur des environnements historiques.

### Description

- Mise à jour de `README.md` : remplacement de l'exemple legacy `SINGULAR_RUNS_KEEP` par la variable `SINGULAR_RETENTION_MAX_RUNS` et ajout d'une section détaillant les 7 paramètres de rétention, leur ordre de résolution (env > `mem/retention_policy.json` > défauts), les garanties et les commandes de contrôle (`retention config show`, `retention status`, `retention run --dry-run`, `retention run`).
- Refond de `docs/generations_registry.md` : ajout d'une section `Rétention: paramètres, défauts, garanties` qui liste les paramètres, valeurs par défaut, exemples de variables d'environnement, garanties (ce qui n’est jamais supprimé automatiquement), notes opérationnelles (throttling, fichiers d'état/log) et une section de migration recommandée.
- Documentation alignée sur l'implémentation existante dans `src/singular/storage_retention.py` et la CLI (`singular retention ...`) pour rendre explicites les comportements observés en production.

### Testing

- Aucun test automatisé n'a été exécuté pour ce changement (modifications de documentation uniquement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5ff2a170832ab6991e51a5f0f70c)