### PR TITLE
Add central runtime module for perception/mind/action orchestration

### DIFF
--- a/src/singular/core/__init__.py
+++ b/src/singular/core/__init__.py
@@ -1,0 +1,29 @@
+"""Core runtime primitives for ports and orchestration."""
+
+from singular.core.agent_runtime import (
+    DEFAULT_SCHEMA_VERSION,
+    ActionPort,
+    ActionRequest,
+    ActionResult,
+    AgentRuntime,
+    Intent,
+    MindPort,
+    PerceptEvent,
+    PerceptionPort,
+    RuntimeEvent,
+    RuntimeEventBus,
+)
+
+__all__ = [
+    "DEFAULT_SCHEMA_VERSION",
+    "ActionPort",
+    "ActionRequest",
+    "ActionResult",
+    "AgentRuntime",
+    "Intent",
+    "MindPort",
+    "PerceptEvent",
+    "PerceptionPort",
+    "RuntimeEvent",
+    "RuntimeEventBus",
+]

--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -1,0 +1,188 @@
+"""Central runtime orchestration for perception, mind and action ports."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Protocol
+from uuid import uuid4
+
+DEFAULT_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class PerceptEvent:
+    """Structured perception signal captured by the runtime."""
+
+    event_type: str
+    payload: dict[str, Any]
+    source: str
+    schema_version: str = DEFAULT_SCHEMA_VERSION
+    observed_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+@dataclass(frozen=True)
+class Intent:
+    """Objective proposed by the mind layer."""
+
+    goal: str
+    rationale: str = ""
+    mood: str = "neutral"
+    memory_refs: tuple[str, ...] = ()
+    confidence: float = 0.0
+    schema_version: str = DEFAULT_SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class ActionRequest:
+    """Action demanded by the runtime and sent to the action port."""
+
+    action_type: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+    intent_goal: str = ""
+    schema_version: str = DEFAULT_SCHEMA_VERSION
+    requested_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    """Execution result and audit metadata for an action."""
+
+    action_type: str
+    success: bool
+    message: str = ""
+    error: str | None = None
+    audit: dict[str, Any] = field(default_factory=dict)
+    schema_version: str = DEFAULT_SCHEMA_VERSION
+    completed_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+
+
+@dataclass(frozen=True)
+class RuntimeEvent:
+    """Envelope emitted on the internal runtime event bus."""
+
+    topic: str
+    payload: Any
+    schema_version: str = DEFAULT_SCHEMA_VERSION
+    event_id: str = field(default_factory=lambda: uuid4().hex)
+    emitted_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+EventHandler = Callable[[RuntimeEvent], None]
+
+
+class RuntimeEventBus:
+    """In-memory pub/sub bus with topic-based subscriptions."""
+
+    def __init__(self, *, schema_version: str = DEFAULT_SCHEMA_VERSION) -> None:
+        self.schema_version = schema_version
+        self._subscribers: dict[str, list[EventHandler]] = defaultdict(list)
+
+    def subscribe(self, topic: str, handler: EventHandler) -> None:
+        handlers = self._subscribers[topic]
+        if handler not in handlers:
+            handlers.append(handler)
+
+    def publish(self, topic: str, payload: Any) -> RuntimeEvent:
+        event = RuntimeEvent(
+            topic=topic,
+            payload=payload,
+            schema_version=self.schema_version,
+        )
+        for handler in list(self._subscribers.get(topic, [])):
+            handler(event)
+        return event
+
+
+class PerceptionPort(Protocol):
+    """Port producing structured perception events."""
+
+    def collect(self) -> list[PerceptEvent]:
+        """Return new percepts for the current runtime step."""
+
+
+class MindPort(Protocol):
+    """Port transforming perception into intent and action requests."""
+
+    def propose_intent(self, percept: PerceptEvent) -> Intent | None:
+        """Propose a goal based on one percept."""
+
+    def propose_action(self, intent: Intent, percept: PerceptEvent) -> ActionRequest | None:
+        """Translate one intent into an executable action request."""
+
+
+class ActionPort(Protocol):
+    """Port executing authorized actions."""
+
+    def execute(self, request: ActionRequest) -> ActionResult:
+        """Execute one action request and return audited output."""
+
+
+class AgentRuntime:
+    """Central runtime orchestrating perception, mind and action ports."""
+
+    def __init__(
+        self,
+        *,
+        perception: PerceptionPort,
+        mind: MindPort,
+        action: ActionPort,
+        event_bus: RuntimeEventBus | None = None,
+        schema_version: str = DEFAULT_SCHEMA_VERSION,
+    ) -> None:
+        self.perception = perception
+        self.mind = mind
+        self.action = action
+        self.schema_version = schema_version
+        self.event_bus = event_bus or RuntimeEventBus(schema_version=schema_version)
+
+    def step(self) -> list[ActionResult]:
+        """Run one full runtime step.
+
+        Flow:
+        1. collect perception events,
+        2. let the mind propose intent/action,
+        3. execute allowed actions,
+        4. publish all lifecycle events on the internal bus.
+        """
+
+        percepts = self.perception.collect()
+        results: list[ActionResult] = []
+        for percept in percepts:
+            self._ensure_schema_version(percept.schema_version)
+            self.event_bus.publish("perception.received", percept)
+
+            intent = self.mind.propose_intent(percept)
+            if intent is None:
+                self.event_bus.publish("mind.intent.skipped", {"percept": percept})
+                continue
+            self._ensure_schema_version(intent.schema_version)
+            self.event_bus.publish("mind.intent.proposed", intent)
+
+            request = self.mind.propose_action(intent, percept)
+            if request is None:
+                self.event_bus.publish("action.request.skipped", {"intent": intent})
+                continue
+            self._ensure_schema_version(request.schema_version)
+            self.event_bus.publish("action.requested", request)
+
+            result = self.action.execute(request)
+            self._ensure_schema_version(result.schema_version)
+            self.event_bus.publish("action.completed", result)
+            results.append(result)
+
+        return results
+
+    def _ensure_schema_version(self, candidate: str) -> None:
+        if candidate != self.schema_version:
+            raise ValueError(
+                "Schema version mismatch: "
+                f"runtime={self.schema_version} candidate={candidate}"
+            )

--- a/tests/test_core_agent_runtime.py
+++ b/tests/test_core_agent_runtime.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pytest
+
+from singular.core.agent_runtime import (
+    ActionRequest,
+    ActionResult,
+    AgentRuntime,
+    Intent,
+    PerceptEvent,
+    RuntimeEvent,
+    RuntimeEventBus,
+)
+
+
+class _PerceptionStub:
+    def collect(self) -> list[PerceptEvent]:
+        return [
+            PerceptEvent(
+                event_type="vision",
+                source="camera",
+                payload={"object": "door"},
+            )
+        ]
+
+
+class _MindStub:
+    def propose_intent(self, percept: PerceptEvent) -> Intent | None:
+        return Intent(goal=f"inspect:{percept.event_type}", confidence=0.9)
+
+    def propose_action(self, intent: Intent, percept: PerceptEvent) -> ActionRequest | None:
+        return ActionRequest(
+            action_type="os.notify",
+            parameters={"goal": intent.goal, "source": percept.source},
+            intent_goal=intent.goal,
+        )
+
+
+class _ActionStub:
+    def execute(self, request: ActionRequest) -> ActionResult:
+        return ActionResult(
+            action_type=request.action_type,
+            success=True,
+            message="done",
+            audit={"intent_goal": request.intent_goal},
+        )
+
+
+def test_agent_runtime_step_orchestrates_ports_and_events() -> None:
+    bus = RuntimeEventBus()
+    seen_topics: list[str] = []
+    seen_events: list[RuntimeEvent] = []
+
+    for topic in (
+        "perception.received",
+        "mind.intent.proposed",
+        "action.requested",
+        "action.completed",
+    ):
+        bus.subscribe(topic, lambda event, *, _topic=topic: seen_topics.append(_topic))
+        bus.subscribe(topic, lambda event: seen_events.append(event))
+
+    runtime = AgentRuntime(
+        perception=_PerceptionStub(),
+        mind=_MindStub(),
+        action=_ActionStub(),
+        event_bus=bus,
+    )
+
+    results = runtime.step()
+
+    assert len(results) == 1
+    assert results[0].success is True
+    assert seen_topics == [
+        "perception.received",
+        "mind.intent.proposed",
+        "action.requested",
+        "action.completed",
+    ]
+    assert all(event.schema_version == runtime.schema_version for event in seen_events)
+
+
+def test_agent_runtime_rejects_schema_version_mismatch() -> None:
+    class _BadPerception:
+        def collect(self) -> list[PerceptEvent]:
+            return [
+                PerceptEvent(
+                    event_type="os.event",
+                    source="kernel",
+                    payload={"event": "wake"},
+                    schema_version="2.0",
+                )
+            ]
+
+    runtime = AgentRuntime(
+        perception=_BadPerception(),
+        mind=_MindStub(),
+        action=_ActionStub(),
+    )
+
+    with pytest.raises(ValueError, match="Schema version mismatch"):
+        runtime.step()


### PR DESCRIPTION
### Motivation
- Centraliser l'orchestration entre perception, raisonnement (mind) et exécution d'actions pour standardiser les échanges et faciliter l'évolution des ports. 
- Fournir des DTOs versionnés pour éviter les régressions de schéma lors de mutations du format des messages. 

### Description
- Ajout de `src/singular/core/agent_runtime.py` qui expose `AgentRuntime` orchestrant les ports `PerceptionPort`, `MindPort` et `ActionPort` via la méthode `step()` (collecte → proposition d'intent → requête d'action → exécution). 
- Définition des dataclasses partagées `PerceptEvent`, `Intent`, `ActionRequest` et `ActionResult` incluant `schema_version` et horodatages pour audit et compatibilité. 
- Implémentation d'un bus d'événements interne `RuntimeEventBus` et d'une enveloppe `RuntimeEvent` avec publication des topics lifecycle (`perception.received`, `mind.intent.proposed`, `action.requested`, `action.completed`). 
- Export des API runtime via `src/singular/core/__init__.py` et ajout de tests unitaires ciblés dans `tests/test_core_agent_runtime.py`. 

### Testing
- Exécution des tests unitaires ciblés avec `pytest -q tests/test_core_agent_runtime.py` qui a réussi avec `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa4c95c10832a8d873c14e4843a13)