### PR TITLE
Add action policy engine with allowlist, risk, dry-run and human confirmation

### DIFF
--- a/security/__init__.py
+++ b/security/__init__.py
@@ -1,0 +1,9 @@
+"""Security primitives for action authorization."""
+
+from .policy_engine import (
+    ActionPolicyEngine,
+    PolicyDecision,
+    PolicyRule,
+)
+
+__all__ = ["ActionPolicyEngine", "PolicyDecision", "PolicyRule"]

--- a/security/policy_engine.py
+++ b/security/policy_engine.py
@@ -1,0 +1,171 @@
+"""Policy engine authorizing action requests before execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    """Allowlist rule for one class of actions."""
+
+    rule_id: str
+    applications: frozenset[str] = frozenset({"*"})
+    windows: frozenset[str] = frozenset({"*"})
+    screen_zones: frozenset[str] = frozenset({"*"})
+    action_types: frozenset[str] = frozenset({"*"})
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Output of the policy engine for one action request."""
+
+    allowed: bool
+    blocked: bool
+    reason: str
+    rule_id: str | None
+    risk_level: str
+    dry_run: bool
+    requires_human_confirmation: bool
+
+
+class ActionPolicyEngine:
+    """Authorize action requests using allowlists and risk gates."""
+
+    def __init__(
+        self,
+        *,
+        rules: list[PolicyRule] | None = None,
+        risk_thresholds: dict[str, float] | None = None,
+        dry_run: bool = False,
+        require_human_confirmation_for_critical: bool = True,
+        confirmation_callback: Callable[[Any], bool] | None = None,
+        decision_logger: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        self.rules = rules or [PolicyRule(rule_id="allow_all")]
+        self.risk_thresholds = risk_thresholds or {"low": 0.3, "medium": 0.7}
+        self.dry_run = dry_run
+        self.require_human_confirmation_for_critical = (
+            require_human_confirmation_for_critical
+        )
+        self.confirmation_callback = confirmation_callback
+        self.decision_logger = decision_logger
+
+    def evaluate(self, request: Any) -> PolicyDecision:
+        """Evaluate one action request and return a decision."""
+
+        risk_score = self._risk_score(request)
+        risk_level = self._risk_level(risk_score)
+        matching_rule = self._find_matching_rule(request)
+
+        if matching_rule is None:
+            decision = PolicyDecision(
+                allowed=False,
+                blocked=True,
+                reason="action_not_allowlisted",
+                rule_id=None,
+                risk_level=risk_level,
+                dry_run=self.dry_run,
+                requires_human_confirmation=False,
+            )
+            self._log_decision(request, decision)
+            return decision
+
+        is_critical = self._is_critical(request, risk_level)
+        requires_confirmation = (
+            self.require_human_confirmation_for_critical and is_critical
+        )
+        if requires_confirmation:
+            is_confirmed = bool(
+                self.confirmation_callback(request) if self.confirmation_callback else False
+            )
+            if not is_confirmed:
+                decision = PolicyDecision(
+                    allowed=False,
+                    blocked=True,
+                    reason="critical_action_requires_human_confirmation",
+                    rule_id=matching_rule.rule_id,
+                    risk_level=risk_level,
+                    dry_run=self.dry_run,
+                    requires_human_confirmation=True,
+                )
+                self._log_decision(request, decision)
+                return decision
+
+        decision = PolicyDecision(
+            allowed=True,
+            blocked=False,
+            reason="dry_run" if self.dry_run else "allowed_by_rule",
+            rule_id=matching_rule.rule_id,
+            risk_level=risk_level,
+            dry_run=self.dry_run,
+            requires_human_confirmation=requires_confirmation,
+        )
+        self._log_decision(request, decision)
+        return decision
+
+    def _find_matching_rule(self, request: Any) -> PolicyRule | None:
+        action_type = str(getattr(request, "action_type", ""))
+        parameters = getattr(request, "parameters", {}) or {}
+        application = str(parameters.get("application", ""))
+        window = str(parameters.get("window", ""))
+        screen_zone = str(parameters.get("screen_zone", ""))
+
+        for rule in self.rules:
+            if not self._in_allowlist(action_type, rule.action_types):
+                continue
+            if not self._in_allowlist(application, rule.applications):
+                continue
+            if not self._in_allowlist(window, rule.windows):
+                continue
+            if not self._in_allowlist(screen_zone, rule.screen_zones):
+                continue
+            return rule
+
+        return None
+
+    @staticmethod
+    def _in_allowlist(value: str, allowlist: frozenset[str]) -> bool:
+        return "*" in allowlist or value in allowlist
+
+    def _risk_score(self, request: Any) -> float:
+        parameters = getattr(request, "parameters", {}) or {}
+        score = parameters.get("risk_score", 0.0)
+        try:
+            return float(score)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _risk_level(self, score: float) -> str:
+        low_ceiling = float(self.risk_thresholds.get("low", 0.3))
+        medium_ceiling = float(self.risk_thresholds.get("medium", 0.7))
+
+        if score <= low_ceiling:
+            return "low"
+        if score <= medium_ceiling:
+            return "medium"
+        return "high"
+
+    @staticmethod
+    def _is_critical(request: Any, risk_level: str) -> bool:
+        parameters = getattr(request, "parameters", {}) or {}
+        if bool(parameters.get("critical", False)):
+            return True
+        return risk_level == "high"
+
+    def _log_decision(self, request: Any, decision: PolicyDecision) -> None:
+        if self.decision_logger is None:
+            return
+
+        payload = {
+            "action_type": str(getattr(request, "action_type", "")),
+            "allowed": decision.allowed,
+            "blocked": decision.blocked,
+            "reason": decision.reason,
+            "rule_id": decision.rule_id,
+            "risk_level": decision.risk_level,
+            "dry_run": decision.dry_run,
+            "requires_human_confirmation": decision.requires_human_confirmation,
+        }
+        self.decision_logger(payload)

--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -6,6 +6,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable, Protocol
+
+from security.policy_engine import ActionPolicyEngine
 from uuid import uuid4
 
 DEFAULT_SCHEMA_VERSION = "1.0"
@@ -135,6 +137,7 @@ class AgentRuntime:
         mind: MindPort,
         action: ActionPort,
         event_bus: RuntimeEventBus | None = None,
+        policy_engine: ActionPolicyEngine | None = None,
         schema_version: str = DEFAULT_SCHEMA_VERSION,
     ) -> None:
         self.perception = perception
@@ -142,6 +145,7 @@ class AgentRuntime:
         self.action = action
         self.schema_version = schema_version
         self.event_bus = event_bus or RuntimeEventBus(schema_version=schema_version)
+        self.policy_engine = policy_engine or ActionPolicyEngine()
 
     def step(self) -> list[ActionResult]:
         """Run one full runtime step.
@@ -173,8 +177,80 @@ class AgentRuntime:
             self._ensure_schema_version(request.schema_version)
             self.event_bus.publish("action.requested", request)
 
+            decision = self.policy_engine.evaluate(request)
+            self.event_bus.publish(
+                "action.policy.decision",
+                {
+                    "request": request,
+                    "allowed": decision.allowed,
+                    "blocked": decision.blocked,
+                    "reason": decision.reason,
+                    "rule_id": decision.rule_id,
+                    "risk_level": decision.risk_level,
+                    "dry_run": decision.dry_run,
+                },
+            )
+            if decision.blocked:
+                result = ActionResult(
+                    action_type=request.action_type,
+                    success=False,
+                    message="blocked by policy engine",
+                    error=decision.reason,
+                    audit={
+                        "policy": {
+                            "allowed": decision.allowed,
+                            "blocked": decision.blocked,
+                            "reason": decision.reason,
+                            "rule_id": decision.rule_id,
+                            "risk_level": decision.risk_level,
+                            "dry_run": decision.dry_run,
+                        }
+                    },
+                )
+                self.event_bus.publish("action.blocked", result)
+                results.append(result)
+                continue
+
+            if decision.dry_run:
+                result = ActionResult(
+                    action_type=request.action_type,
+                    success=True,
+                    message="simulated (dry-run)",
+                    audit={
+                        "policy": {
+                            "allowed": decision.allowed,
+                            "blocked": decision.blocked,
+                            "reason": decision.reason,
+                            "rule_id": decision.rule_id,
+                            "risk_level": decision.risk_level,
+                            "dry_run": decision.dry_run,
+                        }
+                    },
+                )
+                self.event_bus.publish("action.simulated", result)
+                results.append(result)
+                continue
+
             result = self.action.execute(request)
             self._ensure_schema_version(result.schema_version)
+            enriched_audit = dict(result.audit)
+            enriched_audit["policy"] = {
+                "allowed": decision.allowed,
+                "blocked": decision.blocked,
+                "reason": decision.reason,
+                "rule_id": decision.rule_id,
+                "risk_level": decision.risk_level,
+                "dry_run": decision.dry_run,
+            }
+            result = ActionResult(
+                action_type=result.action_type,
+                success=result.success,
+                message=result.message,
+                error=result.error,
+                audit=enriched_audit,
+                schema_version=result.schema_version,
+                completed_at=result.completed_at,
+            )
             self.event_bus.publish("action.completed", result)
             results.append(result)
 

--- a/tests/test_core_agent_runtime.py
+++ b/tests/test_core_agent_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from security.policy_engine import ActionPolicyEngine, PolicyRule
 from singular.core.agent_runtime import (
     ActionRequest,
     ActionResult,
@@ -31,7 +32,13 @@ class _MindStub:
     def propose_action(self, intent: Intent, percept: PerceptEvent) -> ActionRequest | None:
         return ActionRequest(
             action_type="os.notify",
-            parameters={"goal": intent.goal, "source": percept.source},
+            parameters={
+                "goal": intent.goal,
+                "source": percept.source,
+                "application": "terminal",
+                "window": "main",
+                "screen_zone": "center",
+            },
             intent_goal=intent.goal,
         )
 
@@ -44,6 +51,7 @@ class _ActionStub:
             message="done",
             audit={"intent_goal": request.intent_goal},
         )
+
 
 
 def test_agent_runtime_step_orchestrates_ports_and_events() -> None:
@@ -78,6 +86,8 @@ def test_agent_runtime_step_orchestrates_ports_and_events() -> None:
         "action.completed",
     ]
     assert all(event.schema_version == runtime.schema_version for event in seen_events)
+    assert results[0].audit["policy"]["allowed"] is True
+
 
 
 def test_agent_runtime_rejects_schema_version_mismatch() -> None:
@@ -100,3 +110,99 @@ def test_agent_runtime_rejects_schema_version_mismatch() -> None:
 
     with pytest.raises(ValueError, match="Schema version mismatch"):
         runtime.step()
+
+
+
+def test_agent_runtime_blocks_action_not_allowlisted() -> None:
+    decisions: list[dict[str, object]] = []
+    runtime = AgentRuntime(
+        perception=_PerceptionStub(),
+        mind=_MindStub(),
+        action=_ActionStub(),
+        policy_engine=ActionPolicyEngine(
+            rules=[
+                PolicyRule(
+                    rule_id="allow_browser_only",
+                    applications=frozenset({"browser"}),
+                    windows=frozenset({"*"}),
+                    screen_zones=frozenset({"*"}),
+                    action_types=frozenset({"os.notify"}),
+                )
+            ],
+            decision_logger=decisions.append,
+        ),
+    )
+
+    results = runtime.step()
+
+    assert len(results) == 1
+    assert results[0].success is False
+    assert results[0].error == "action_not_allowlisted"
+    assert decisions[-1]["blocked"] is True
+    assert decisions[-1]["reason"] == "action_not_allowlisted"
+
+
+
+def test_agent_runtime_simulates_dry_run_without_executing_action_port() -> None:
+    class _ActionSpy(_ActionStub):
+        def __init__(self) -> None:
+            self.called = False
+
+        def execute(self, request: ActionRequest) -> ActionResult:
+            self.called = True
+            return super().execute(request)
+
+    action_spy = _ActionSpy()
+    runtime = AgentRuntime(
+        perception=_PerceptionStub(),
+        mind=_MindStub(),
+        action=action_spy,
+        policy_engine=ActionPolicyEngine(dry_run=True),
+    )
+
+    results = runtime.step()
+
+    assert len(results) == 1
+    assert results[0].success is True
+    assert results[0].message == "simulated (dry-run)"
+    assert action_spy.called is False
+
+
+
+def test_agent_runtime_requires_human_confirmation_for_critical_actions() -> None:
+    class _CriticalMind(_MindStub):
+        def propose_action(self, intent: Intent, percept: PerceptEvent) -> ActionRequest | None:
+            return ActionRequest(
+                action_type="os.notify",
+                parameters={
+                    "application": "terminal",
+                    "window": "main",
+                    "screen_zone": "center",
+                    "risk_score": 0.95,
+                    "critical": True,
+                },
+                intent_goal=intent.goal,
+            )
+
+    runtime = AgentRuntime(
+        perception=_PerceptionStub(),
+        mind=_CriticalMind(),
+        action=_ActionStub(),
+        policy_engine=ActionPolicyEngine(
+            rules=[
+                PolicyRule(
+                    rule_id="allow_terminal_notify",
+                    applications=frozenset({"terminal"}),
+                    windows=frozenset({"main"}),
+                    screen_zones=frozenset({"center"}),
+                    action_types=frozenset({"os.notify"}),
+                )
+            ]
+        ),
+    )
+
+    results = runtime.step()
+
+    assert len(results) == 1
+    assert results[0].success is False
+    assert results[0].error == "critical_action_requires_human_confirmation"


### PR DESCRIPTION
### Motivation
- Centraliser l’autorisation des `ActionRequest` afin d’empêcher l’exécution d’actions non autorisées ou à risque élevé.
- Introduire une classification de risque et un mode `dry-run` pour simuler actions sans effet réel.
- Forcer une confirmation humaine pour les actions critiques afin de réduire les opérations dangereuses.

### Description
- Ajout du module `security/policy_engine.py` définissant `PolicyRule`, `PolicyDecision` et `ActionPolicyEngine` avec allowlists (application/window/screen_zone/action_type), seuils de risque configurables, `dry_run`, callback de confirmation et journalisation des décisions.
- Exposition du module via `security/__init__.py` et intégration du moteur dans le runtime en acceptant `policy_engine` dans `AgentRuntime` (fichier `src/singular/core/agent_runtime.py`).
- Avant exécution, chaque `ActionRequest` est évaluée avec publication d’un événement `action.policy.decision`, blocage générant un `ActionResult` avec `error` et audit enrichi, et simulation traitée via `dry_run` sans appeler le port d’action.
- Tests étendus dans `tests/test_core_agent_runtime.py` pour couvrir le chemin nominal enrichi d’audit, le blocage par allowlist, la simulation `dry-run` et l’exigence de confirmation humaine pour actions critiques.

### Testing
- Exécution des tests ciblés avec `pytest -q tests/test_core_agent_runtime.py` a réussi et a retourné `5 passed`.
- Les nouveaux tests valident le logging des décisions, le blocage attendu et l’absence d’appel au port d’action en mode `dry_run`.
- Aucun test automatisé n’a échoué lors de la validation locale sur ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa609186c832aa50e7fc98dddb401)