### PR TITLE
Add sandboxed typed action runner with timeout, rate limit, cancel, and rollback

### DIFF
--- a/action/__init__.py
+++ b/action/__init__.py
@@ -1,0 +1,21 @@
+"""Action sandbox package."""
+
+from .sandbox_runner import (
+    ActionError,
+    ActionRateLimitError,
+    ActionTimeoutError,
+    CancellationError,
+    CircuitBreakerOpenError,
+    DefaultActionBackend,
+    SandboxRunner,
+)
+
+__all__ = [
+    "ActionError",
+    "ActionRateLimitError",
+    "ActionTimeoutError",
+    "CancellationError",
+    "CircuitBreakerOpenError",
+    "DefaultActionBackend",
+    "SandboxRunner",
+]

--- a/action/sandbox_runner.py
+++ b/action/sandbox_runner.py
@@ -1,0 +1,193 @@
+"""Controlled execution layer for UI-like agent actions.
+
+This module intentionally disallows arbitrary shell execution and only supports a
+small typed catalog of actions.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from dataclasses import dataclass, field
+from threading import Event
+from time import monotonic
+from typing import Any, Callable, Deque, Dict, Mapping, MutableMapping
+
+
+AllowedActionName = str
+Rollback = Callable[[], None]
+
+
+class ActionError(RuntimeError):
+    """Base error for sandboxed actions."""
+
+
+class ActionTimeoutError(ActionError):
+    """Raised when one action exceeds the timeout."""
+
+
+class ActionRateLimitError(ActionError):
+    """Raised when rate limits are exceeded."""
+
+
+class CancellationError(ActionError):
+    """Raised when execution has been cancelled."""
+
+
+class CircuitBreakerOpenError(ActionError):
+    """Raised when the runner is in open circuit-breaker state."""
+
+
+@dataclass(slots=True)
+class RunnerConfig:
+    timeout_s: float = 2.0
+    rate_limit_count: int = 20
+    rate_limit_window_s: float = 10.0
+    max_consecutive_failures: int = 3
+    circuit_open_s: float = 15.0
+
+
+class DefaultActionBackend:
+    """Thin backend contract.
+
+    Replace these methods with real integrations (desktop automation, webdriver,
+    etc.) in production.
+    """
+
+    def click(self, *, x: int, y: int, button: str = "left") -> dict[str, Any]:
+        return {"ok": True, "action": "click", "x": x, "y": y, "button": button}
+
+    def type(self, *, text: str, clear: bool = False) -> dict[str, Any]:
+        return {"ok": True, "action": "type", "chars": len(text), "clear": clear}
+
+    def hotkey(self, *, keys: list[str]) -> dict[str, Any]:
+        return {"ok": True, "action": "hotkey", "keys": keys}
+
+    def open_app(self, *, app: str, args: list[str] | None = None) -> dict[str, Any]:
+        return {"ok": True, "action": "open_app", "app": app, "args": args or []}
+
+    def read_clipboard(self) -> dict[str, Any]:
+        return {"ok": True, "action": "read_clipboard", "text": ""}
+
+
+@dataclass(slots=True)
+class SandboxRunner:
+    backend: DefaultActionBackend
+    config: RunnerConfig = field(default_factory=RunnerConfig)
+    _timestamps: Deque[float] = field(default_factory=deque, init=False)
+    _cancel_event: Event = field(default_factory=Event, init=False)
+    _consecutive_failures: int = field(default=0, init=False)
+    _circuit_open_until: float = field(default=0.0, init=False)
+    _rollbacks: list[Rollback] = field(default_factory=list, init=False)
+    _catalog: MutableMapping[AllowedActionName, Callable[..., Any]] = field(
+        default_factory=dict, init=False
+    )
+
+    def __post_init__(self) -> None:
+        self._catalog = {
+            "click": self.backend.click,
+            "type": self.backend.type,
+            "hotkey": self.backend.hotkey,
+            "open_app": self.backend.open_app,
+            "read_clipboard": self.backend.read_clipboard,
+        }
+
+    @property
+    def allowed_actions(self) -> tuple[str, ...]:
+        return tuple(self._catalog.keys())
+
+    def cancel(self) -> None:
+        self._cancel_event.set()
+
+    def reset_cancellation(self) -> None:
+        self._cancel_event.clear()
+
+    def run_action(self, action: str, params: Mapping[str, Any] | None = None) -> Any:
+        params = dict(params or {})
+        self._ensure_circuit_closed()
+        self._ensure_not_cancelled()
+        self._check_rate_limit()
+
+        handler = self._catalog.get(action)
+        if handler is None:
+            raise ActionError(
+                f"action '{action}' not allowed; allowed actions: {', '.join(self.allowed_actions)}"
+            )
+
+        start = monotonic()
+        try:
+            result = self._run_with_timeout(handler, params)
+            self._register_rollback(action, params)
+        except Exception:
+            self._record_failure()
+            self._rollback_best_effort()
+            raise
+
+        elapsed = monotonic() - start
+        if elapsed > self.config.timeout_s:
+            self._record_failure()
+            self._rollback_best_effort()
+            raise ActionTimeoutError(
+                f"action '{action}' exceeded strict timeout ({self.config.timeout_s}s)"
+            )
+
+        self._consecutive_failures = 0
+        return result
+
+    def run_plan(self, steps: list[Mapping[str, Any]]) -> list[Any]:
+        results: list[Any] = []
+        for step in steps:
+            action = str(step["action"])
+            params = dict(step.get("params") or {})
+            results.append(self.run_action(action, params))
+        return results
+
+    def _run_with_timeout(self, handler: Callable[..., Any], params: Dict[str, Any]) -> Any:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(handler, **params)
+            try:
+                return future.result(timeout=self.config.timeout_s)
+            except FutureTimeout as exc:
+                future.cancel()
+                raise ActionTimeoutError("action timed out") from exc
+
+    def _check_rate_limit(self) -> None:
+        now = monotonic()
+        window_start = now - self.config.rate_limit_window_s
+        while self._timestamps and self._timestamps[0] < window_start:
+            self._timestamps.popleft()
+
+        if len(self._timestamps) >= self.config.rate_limit_count:
+            raise ActionRateLimitError(
+                "rate limit reached: "
+                f"max {self.config.rate_limit_count} actions every {self.config.rate_limit_window_s}s"
+            )
+        self._timestamps.append(now)
+
+    def _ensure_not_cancelled(self) -> None:
+        if self._cancel_event.is_set():
+            raise CancellationError("runner cancelled")
+
+    def _ensure_circuit_closed(self) -> None:
+        now = monotonic()
+        if now < self._circuit_open_until:
+            raise CircuitBreakerOpenError("circuit breaker open")
+
+    def _record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self.config.max_consecutive_failures:
+            self._circuit_open_until = monotonic() + self.config.circuit_open_s
+
+    def _register_rollback(self, action: str, params: Mapping[str, Any]) -> None:
+        if action == "open_app":
+            self._rollbacks.append(lambda: self.backend.hotkey(keys=["alt", "f4"]))
+        elif action == "type" and params.get("clear"):
+            self._rollbacks.append(lambda: self.backend.hotkey(keys=["ctrl", "z"]))
+
+    def _rollback_best_effort(self) -> None:
+        while self._rollbacks:
+            rollback = self._rollbacks.pop()
+            try:
+                rollback()
+            except Exception:
+                continue

--- a/tests/test_action_sandbox_runner.py
+++ b/tests/test_action_sandbox_runner.py
@@ -1,0 +1,112 @@
+import time
+
+import pytest
+
+from action.sandbox_runner import (
+    ActionError,
+    ActionRateLimitError,
+    ActionTimeoutError,
+    CancellationError,
+    CircuitBreakerOpenError,
+    RunnerConfig,
+    SandboxRunner,
+)
+
+
+class SpyBackend:
+    def __init__(self):
+        self.calls = []
+
+    def click(self, **kwargs):
+        self.calls.append(("click", kwargs))
+        return {"ok": True}
+
+    def type(self, **kwargs):
+        self.calls.append(("type", kwargs))
+        return {"ok": True}
+
+    def hotkey(self, **kwargs):
+        self.calls.append(("hotkey", kwargs))
+        return {"ok": True}
+
+    def open_app(self, **kwargs):
+        self.calls.append(("open_app", kwargs))
+        return {"ok": True}
+
+    def read_clipboard(self):
+        self.calls.append(("read_clipboard", {}))
+        return {"ok": True, "text": "hello"}
+
+
+def test_only_catalog_actions_allowed():
+    runner = SandboxRunner(backend=SpyBackend())
+    with pytest.raises(ActionError):
+        runner.run_action("shell", {"cmd": "rm -rf /"})
+
+
+def test_timeout_is_enforced():
+    backend = SpyBackend()
+
+    def slow_click(**kwargs):
+        time.sleep(0.08)
+        return {"ok": True}
+
+    backend.click = slow_click
+    runner = SandboxRunner(backend=backend, config=RunnerConfig(timeout_s=0.02))
+
+    with pytest.raises(ActionTimeoutError):
+        runner.run_action("click", {"x": 1, "y": 2})
+
+
+def test_rate_limit_is_enforced():
+    runner = SandboxRunner(
+        backend=SpyBackend(),
+        config=RunnerConfig(rate_limit_count=1, rate_limit_window_s=1.0),
+    )
+    runner.run_action("read_clipboard")
+    with pytest.raises(ActionRateLimitError):
+        runner.run_action("read_clipboard")
+
+
+def test_cancellation_stops_execution():
+    runner = SandboxRunner(backend=SpyBackend())
+    runner.cancel()
+    with pytest.raises(CancellationError):
+        runner.run_action("read_clipboard")
+
+
+def test_circuit_breaker_opens_after_consecutive_failures():
+    backend = SpyBackend()
+
+    def broken_click(**kwargs):
+        raise RuntimeError("boom")
+
+    backend.click = broken_click
+    runner = SandboxRunner(
+        backend=backend,
+        config=RunnerConfig(max_consecutive_failures=2, circuit_open_s=30.0),
+    )
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError):
+            runner.run_action("click", {"x": 1, "y": 1})
+
+    with pytest.raises(CircuitBreakerOpenError):
+        runner.run_action("read_clipboard")
+
+
+def test_open_app_registers_rollback_on_failure():
+    backend = SpyBackend()
+
+    def broken_type(**kwargs):
+        raise RuntimeError("cannot type")
+
+    backend.type = broken_type
+
+    runner = SandboxRunner(backend=backend)
+    runner.run_action("open_app", {"app": "notepad"})
+
+    with pytest.raises(RuntimeError):
+        runner.run_action("type", {"text": "hello"})
+
+    assert ("hotkey", {"keys": ["alt", "f4"]}) in backend.calls


### PR DESCRIPTION
### Motivation
- Provide a controlled execution layer for UI-like agent actions to prevent arbitrary shell execution and unsafe side effects.
- Enforce strict per-action safety guarantees such as timeouts, rate limiting, cancellation and circuit-breaking to protect downstream systems.
- Offer best-effort logical rollbacks for actions that change external state to reduce impact of failures.

### Description
- Add a new `action` package with `sandbox_runner.py` implementing `RunnerConfig`, `DefaultActionBackend`, and `SandboxRunner` that executes a typed action catalog only (`click`, `type`, `hotkey`, `open_app`, `read_clipboard`).
- Enforce a strict per-action timeout via `_run_with_timeout`, a sliding-window rate limiter via `_check_rate_limit`, cancellation via `cancel()`/`_ensure_not_cancelled`, and a circuit-breaker opened after `max_consecutive_failures` via `_record_failure`/`_ensure_circuit_closed`.
- Record simple logical rollback hooks (for example `alt+f4` after `open_app` and `ctrl+z` for cleared `type`) and run best-effort rollbacks on failure via `_rollback_best_effort`.
- Export main symbols in `action/__init__.py` and add targeted tests in `tests/test_action_sandbox_runner.py` covering catalog restrictions, timeout, rate limiting, cancellation, circuit-breaker behavior, and rollback registration.

### Testing
- Ran `pytest -q tests/test_action_sandbox_runner.py` and all tests passed (`6 passed`).
- The new tests exercise `SandboxRunner` behaviors for allowed actions, timeouts, rate limits, cancellation, circuit-breaker opening, and rollback registration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa8e39414832aaffb439d5c7aae5e)