### PR TITLE
Add audit logging with correlation IDs, automatic redaction, and offline replay tool

### DIFF
--- a/observability/__init__.py
+++ b/observability/__init__.py
@@ -1,0 +1,5 @@
+"""Observability utilities for audit and replay workflows."""
+
+from .audit_log import AuditLogStore, filter_session, read_audit_events, redact_sensitive_data
+
+__all__ = ["AuditLogStore", "filter_session", "read_audit_events", "redact_sensitive_data"]

--- a/observability/audit_log.py
+++ b/observability/audit_log.py
@@ -1,0 +1,217 @@
+"""Audit logging with correlation identifiers and sensitive data redaction.
+
+This module stores JSONL audit events with explicit correlation between
+``event_id``, ``intent_id``, and ``action_id`` so sessions can be replayed
+offline for diagnostics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+import hashlib
+import json
+import os
+import re
+import uuid
+
+_SENSITIVE_KEY_PATTERN = re.compile(
+    r"(pass(word)?|secret|token|api[_-]?key|authorization|cookie|session|private[_-]?key|"
+    r"credential|ssn|email|phone|address|iban|card|cvv|pwd)",
+    re.IGNORECASE,
+)
+
+_EMAIL_PATTERN = re.compile(r"([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]+\.[A-Za-z]{2,})")
+_LONG_TOKEN_PATTERN = re.compile(r"\b[A-Za-z0-9_\-]{20,}\b")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def _stable_fingerprint(value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8", errors="ignore")).hexdigest()
+    return f"sha256:{digest[:12]}"
+
+
+def _redact_string(value: str) -> str:
+    redacted = _EMAIL_PATTERN.sub("<redacted:email>", value)
+
+    def _replace_token(match: re.Match[str]) -> str:
+        token = match.group(0)
+        if token.isdigit() and len(token) < 20:
+            return token
+        return f"<redacted:token:{_stable_fingerprint(token)}>"
+
+    redacted = _LONG_TOKEN_PATTERN.sub(_replace_token, redacted)
+    return redacted
+
+
+def redact_sensitive_data(value: Any, key: str | None = None) -> Any:
+    """Recursively redact sensitive information in mappings, lists and strings."""
+
+    if key and _SENSITIVE_KEY_PATTERN.search(key):
+        marker = "<redacted>"
+        if isinstance(value, str) and value:
+            marker = f"<redacted:{_stable_fingerprint(value)}>"
+        return marker
+
+    if isinstance(value, Mapping):
+        return {str(k): redact_sensitive_data(v, str(k)) for k, v in value.items()}
+
+    if isinstance(value, list):
+        return [redact_sensitive_data(item) for item in value]
+
+    if isinstance(value, tuple):
+        return tuple(redact_sensitive_data(item) for item in value)
+
+    if isinstance(value, str):
+        return _redact_string(value)
+
+    return value
+
+
+@dataclass
+class AuditLogStore:
+    """JSONL-backed audit log with lineage correlation fields."""
+
+    root: Path | str | None = None
+    filename: str = "audit_events.jsonl"
+
+    def __post_init__(self) -> None:
+        base = Path(self.root) if self.root is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+        self.path = base / "mem" / self.filename
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _append(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        record = redact_sensitive_data(dict(payload))
+        with self.path.open("a", encoding="utf-8") as output:
+            output.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return record
+
+    def log(
+        self,
+        *,
+        session_id: str,
+        category: str,
+        data: Mapping[str, Any],
+        event_id: str | None = None,
+        intent_id: str | None = None,
+        action_id: str | None = None,
+        timestamp: str | None = None,
+    ) -> dict[str, Any]:
+        """Append a generic audit event with full correlation lineage."""
+
+        event_identifier = event_id or uuid.uuid4().hex
+        payload = {
+            "ts": timestamp or _now_iso(),
+            "session_id": session_id,
+            "category": category,
+            "event_id": event_identifier,
+            "intent_id": intent_id,
+            "action_id": action_id,
+            "data": dict(data),
+        }
+        return self._append(payload)
+
+    def log_decision(
+        self,
+        *,
+        session_id: str,
+        decision: Mapping[str, Any],
+        event_id: str | None = None,
+        intent_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self.log(
+            session_id=session_id,
+            category="decision",
+            data=dict(decision),
+            event_id=event_id,
+            intent_id=intent_id,
+        )
+
+    def log_prompt(
+        self,
+        *,
+        session_id: str,
+        prompt: Mapping[str, Any],
+        event_id: str,
+        intent_id: str,
+    ) -> dict[str, Any]:
+        return self.log(
+            session_id=session_id,
+            category="prompt",
+            data=dict(prompt),
+            event_id=event_id,
+            intent_id=intent_id,
+        )
+
+    def log_action(
+        self,
+        *,
+        session_id: str,
+        action: Mapping[str, Any],
+        event_id: str,
+        intent_id: str,
+        action_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self.log(
+            session_id=session_id,
+            category="action",
+            data=dict(action),
+            event_id=event_id,
+            intent_id=intent_id,
+            action_id=action_id or uuid.uuid4().hex,
+        )
+
+    def log_result(
+        self,
+        *,
+        session_id: str,
+        result: Mapping[str, Any],
+        event_id: str,
+        intent_id: str,
+        action_id: str,
+    ) -> dict[str, Any]:
+        return self.log(
+            session_id=session_id,
+            category="result",
+            data=dict(result),
+            event_id=event_id,
+            intent_id=intent_id,
+            action_id=action_id,
+        )
+
+
+def read_audit_events(path: Path | str) -> list[dict[str, Any]]:
+    """Read a JSONL audit file, skipping invalid lines."""
+
+    events: list[dict[str, Any]] = []
+    with Path(path).open(encoding="utf-8") as stream:
+        for line in stream:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                events.append(parsed)
+    return events
+
+
+def filter_session(events: Iterable[Mapping[str, Any]], session_id: str) -> list[dict[str, Any]]:
+    """Return only records for ``session_id`` preserving order."""
+
+    return [dict(event) for event in events if event.get("session_id") == session_id]
+
+
+__all__ = [
+    "AuditLogStore",
+    "filter_session",
+    "read_audit_events",
+    "redact_sensitive_data",
+]

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from observability.audit_log import AuditLogStore, read_audit_events
+
+
+def test_audit_log_persists_correlated_records_and_redacts_sensitive_data(tmp_path: Path) -> None:
+    store = AuditLogStore(root=tmp_path)
+
+    decision = store.log_decision(
+        session_id="session-1",
+        event_id="evt-1",
+        intent_id="intent-1",
+        decision={"policy": "allow", "api_key": "super-secret-key"},
+    )
+    assert decision["event_id"] == "evt-1"
+    assert decision["intent_id"] == "intent-1"
+    assert decision["data"]["api_key"].startswith("<redacted:")
+
+    action = store.log_action(
+        session_id="session-1",
+        event_id="evt-1",
+        intent_id="intent-1",
+        action={"tool": "shell", "prompt": "Contact me at ops@example.com"},
+        action_id="act-1",
+    )
+    assert action["action_id"] == "act-1"
+    assert action["data"]["prompt"] == "Contact me at <redacted:email>"
+
+    store.log_result(
+        session_id="session-1",
+        event_id="evt-1",
+        intent_id="intent-1",
+        action_id="act-1",
+        result={"ok": True, "token": "abcdefghijklmnopqrstuvwxyz123456"},
+    )
+
+    events = read_audit_events(tmp_path / "mem" / "audit_events.jsonl")
+    assert len(events) == 3
+    assert {event["category"] for event in events} == {"decision", "action", "result"}
+    assert all(event["event_id"] == "evt-1" for event in events)
+

--- a/tests/test_replay_session.py
+++ b/tests/test_replay_session.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from tools.replay_session import main
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as file:
+        for row in rows:
+            file.write(json.dumps(row) + "\n")
+
+
+def test_replay_session_returns_zero_when_lineage_is_consistent(tmp_path: Path, capsys) -> None:
+    log_path = tmp_path / "audit.jsonl"
+    _write_jsonl(
+        log_path,
+        [
+            {
+                "ts": "2026-04-15T10:00:00Z",
+                "session_id": "s1",
+                "category": "decision",
+                "event_id": "evt-1",
+                "intent_id": "intent-1",
+                "action_id": None,
+                "data": {"choice": "proceed"},
+            },
+            {
+                "ts": "2026-04-15T10:00:01Z",
+                "session_id": "s1",
+                "category": "action",
+                "event_id": "evt-1",
+                "intent_id": "intent-1",
+                "action_id": "act-1",
+                "data": {"tool": "shell"},
+            },
+            {
+                "ts": "2026-04-15T10:00:02Z",
+                "session_id": "s1",
+                "category": "result",
+                "event_id": "evt-1",
+                "intent_id": "intent-1",
+                "action_id": "act-1",
+                "data": {"ok": True},
+            },
+        ],
+    )
+
+    code = main([str(log_path), "--session-id", "s1"])
+    output = capsys.readouterr().out
+
+    assert code == 0
+    assert "No lineage/correlation issue detected." in output
+
+
+def test_replay_session_detects_missing_result(tmp_path: Path) -> None:
+    log_path = tmp_path / "audit.jsonl"
+    _write_jsonl(
+        log_path,
+        [
+            {
+                "ts": "2026-04-15T10:00:00Z",
+                "session_id": "s1",
+                "category": "decision",
+                "event_id": "evt-1",
+                "intent_id": "intent-1",
+                "action_id": None,
+                "data": {"choice": "proceed"},
+            },
+            {
+                "ts": "2026-04-15T10:00:01Z",
+                "session_id": "s1",
+                "category": "action",
+                "event_id": "evt-1",
+                "intent_id": "intent-1",
+                "action_id": "act-1",
+                "data": {"tool": "shell"},
+            },
+        ],
+    )
+
+    code = main([str(log_path), "--session-id", "s1"])
+    assert code == 3
+

--- a/tools/replay_session.py
+++ b/tools/replay_session.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Replay an offline audit session for diagnostics without live system access."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+import argparse
+import json
+import sys
+
+from observability.audit_log import filter_session, read_audit_events
+
+
+def _load(path: Path, session_id: str) -> list[dict[str, Any]]:
+    events = read_audit_events(path)
+    if session_id:
+        events = filter_session(events, session_id)
+    return sorted(events, key=lambda row: str(row.get("ts", "")))
+
+
+def _lineage_report(events: list[dict[str, Any]]) -> list[str]:
+    issues: list[str] = []
+    by_event: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    by_action: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+
+    for row in events:
+        event_id = str(row.get("event_id") or "")
+        action_id = str(row.get("action_id") or "")
+        if event_id:
+            by_event[event_id].append(row)
+            if action_id:
+                by_action[(event_id, action_id)].append(row)
+
+    for event_id, rows in by_event.items():
+        categories = {str(item.get("category")) for item in rows}
+        if "decision" not in categories:
+            issues.append(f"event_id={event_id}: missing decision")
+        if "action" in categories and "result" not in categories:
+            issues.append(f"event_id={event_id}: action without result")
+
+    for (event_id, action_id), rows in by_action.items():
+        categories = {str(item.get("category")) for item in rows}
+        if "action" not in categories:
+            issues.append(f"event_id={event_id}, action_id={action_id}: result without action")
+
+    return sorted(set(issues))
+
+
+def _print_timeline(events: list[dict[str, Any]], verbose: bool) -> None:
+    for index, row in enumerate(events, start=1):
+        ts = row.get("ts", "?")
+        category = row.get("category", "?")
+        event_id = row.get("event_id", "-")
+        intent_id = row.get("intent_id", "-")
+        action_id = row.get("action_id", "-")
+        print(f"[{index:04d}] {ts} | {category:<8} | event={event_id} intent={intent_id} action={action_id}")
+        if verbose:
+            print(json.dumps(row.get("data", {}), ensure_ascii=False, indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("audit_log", type=Path, help="Path to audit_events.jsonl")
+    parser.add_argument("--session-id", default="", help="Replay only one session")
+    parser.add_argument("--verbose", action="store_true", help="Print full payloads")
+    args = parser.parse_args(argv)
+
+    if not args.audit_log.exists():
+        print(f"error: audit file not found: {args.audit_log}", file=sys.stderr)
+        return 2
+
+    events = _load(args.audit_log, args.session_id)
+    if not events:
+        if args.session_id:
+            print(f"No events found for session_id={args.session_id}")
+        else:
+            print("No events found")
+        return 1
+
+    _print_timeline(events, verbose=args.verbose)
+
+    issues = _lineage_report(events)
+    print("\n=== Diagnostics ===")
+    if issues:
+        for issue in issues:
+            print(f"- {issue}")
+        return 3
+
+    print("- No lineage/correlation issue detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide an auditable, timestamped JSONL trail for decisions, prompts, actions and results with explicit lineage so sessions can be inspected offline.
- Ensure sensitive data is never persisted in cleartext by applying deterministic redaction to keys and token/email-like values before writing.
- Offer a non-live diagnostic tool to replay recorded sessions and detect common integrity/lineage issues for debugging.

### Description
- Add `observability/audit_log.py` implementing `AuditLogStore` which writes timestamped JSONL events with correlation fields `event_id`, `intent_id`, and `action_id`, and a `read_audit_events` + `filter_session` API.
- Implement automatic redaction in `redact_sensitive_data` using key-based and pattern-based checks (emails, long tokens) plus stable fingerprints for non-reversible markers.
- Add `tools/replay_session.py` to print a session timeline and run lineage diagnostics (e.g. missing decision, action without result, result without action) without needing live services.
- Export observability helpers in `observability/__init__.py` and add tests `tests/test_audit_log.py` and `tests/test_replay_session.py` that validate correlation, redaction, timeline output and diagnostic exit codes.

### Testing
- Ran `pytest -q tests/test_audit_log.py tests/test_replay_session.py` which executed the new unit tests and produced a successful run (`3 passed`).
- The tests verify that `AuditLogStore` persists correlated records, that sensitive fields are redacted, and that `tools/replay_session.py` detects lineage inconsistencies as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfaa79a490832a87a0033280a22b8b)