### PR TITLE
Add compact vision perception pipeline with frame sampling

### DIFF
--- a/perception/vision/README.md
+++ b/perception/vision/README.md
@@ -1,0 +1,22 @@
+# Vision perception
+
+Pipeline vision compacte qui:
+
+- capture caméra (`CameraCapture`) via OpenCV,
+- capture écran (`ScreenCapture`) ou fenêtre active (`ActiveWindowCapture`),
+- applique un prétraitement (`FramePreprocessor`: ROI + resize),
+- applique une stratégie de sampling (`FrameSamplingStrategy`, défaut `1.5 FPS`),
+- extrait des événements (`OcrTextExtractor`, `KeyObjectExtractor`, `UIStateChangeExtractor`),
+- émet des `PerceptEvent(event_type="vision")` compacts sans persistance d'images brutes.
+
+## Exemple rapide
+
+```python
+from perception.vision import VisionPerceptionPipeline
+
+pipeline = VisionPerceptionPipeline(source="window")
+percepts = pipeline.collect()
+```
+
+Le payload inclut des métadonnées compactes (`frame_fingerprint`, snippets OCR,
+objets clés, indicateur de changement d'état UI), pas les buffers image complets.

--- a/perception/vision/__init__.py
+++ b/perception/vision/__init__.py
@@ -1,0 +1,29 @@
+"""Vision perception stack producing compact :class:`PerceptEvent` objects.
+
+The package avoids persisting raw image buffers in events. It keeps transient
+frames in memory, then emits compact summaries (hashes, counts, labels, text
+snippets) under ``event_type='vision'``.
+"""
+
+from .capture import CameraCapture, ScreenCapture
+from .extractors import (
+    KeyObjectExtractor,
+    OcrTextExtractor,
+    UIStateChangeExtractor,
+    VisionEventExtractor,
+)
+from .pipeline import VisionPerceptionPipeline
+from .preprocess import FramePreprocessor, FrameSamplingStrategy, RegionOfInterest
+
+__all__ = [
+    "CameraCapture",
+    "FramePreprocessor",
+    "FrameSamplingStrategy",
+    "KeyObjectExtractor",
+    "OcrTextExtractor",
+    "RegionOfInterest",
+    "ScreenCapture",
+    "UIStateChangeExtractor",
+    "VisionEventExtractor",
+    "VisionPerceptionPipeline",
+]

--- a/perception/vision/capture.py
+++ b/perception/vision/capture.py
@@ -1,0 +1,99 @@
+"""Transient frame capture providers for camera, screen and active window."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None
+
+try:
+    import mss  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    mss = None
+
+try:
+    import pygetwindow as gw  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    gw = None
+
+
+class VisionCaptureError(RuntimeError):
+    """Raised when a capture source cannot be initialized or read."""
+
+
+@dataclass
+class CameraCapture:
+    """OpenCV-based camera frame capture."""
+
+    camera_index: int = 0
+
+    def grab_frame(self) -> Any:
+        if cv2 is None:
+            raise VisionCaptureError("opencv-python is not installed")
+
+        camera = cv2.VideoCapture(self.camera_index)
+        try:
+            ok, frame = camera.read()
+        finally:
+            camera.release()
+
+        if not ok:
+            raise VisionCaptureError(f"unable to read camera index={self.camera_index}")
+        return frame
+
+
+@dataclass
+class ScreenCapture:
+    """Capture display content via ``mss``."""
+
+    monitor_index: int = 1
+
+    def grab_frame(self) -> Any:
+        if mss is None:
+            raise VisionCaptureError("mss is not installed")
+
+        with mss.mss() as sct:
+            monitors = sct.monitors
+            if self.monitor_index >= len(monitors):
+                raise VisionCaptureError(
+                    f"monitor index out of range: {self.monitor_index} (available={len(monitors)-1})"
+                )
+            shot = sct.grab(monitors[self.monitor_index])
+        return shot
+
+
+@dataclass
+class ActiveWindowCapture:
+    """Capture only the currently active window when available."""
+
+    fallback_monitor_index: int = 1
+
+    def grab_frame(self) -> Any:
+        if mss is None:
+            raise VisionCaptureError("mss is not installed")
+
+        region: dict[str, int] | None = None
+        if gw is not None:
+            window = gw.getActiveWindow()
+            if window is not None:
+                region = {
+                    "left": max(int(window.left), 0),
+                    "top": max(int(window.top), 0),
+                    "width": max(int(window.width), 1),
+                    "height": max(int(window.height), 1),
+                }
+
+        with mss.mss() as sct:
+            if region is None:
+                monitors = sct.monitors
+                if self.fallback_monitor_index >= len(monitors):
+                    raise VisionCaptureError(
+                        "no active window and fallback monitor index is out of range"
+                    )
+                region = monitors[self.fallback_monitor_index]
+            shot = sct.grab(region)
+        return shot

--- a/perception/vision/extractors.py
+++ b/perception/vision/extractors.py
@@ -1,0 +1,100 @@
+"""Extract compact vision events from transient frames."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from hashlib import sha1
+from typing import Any, Protocol
+
+try:
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None
+
+try:
+    import pytesseract  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pytesseract = None
+
+
+class VisionEventExtractor(Protocol):
+    """Extractor contract returning compact metadata for one frame."""
+
+    def extract(self, frame: Any) -> dict[str, Any]:
+        """Return compact extracted features."""
+
+
+@dataclass
+class OcrTextExtractor:
+    """OCR extractor returning a short text snippet and confidence proxies."""
+
+    max_chars: int = 240
+
+    def extract(self, frame: Any) -> dict[str, Any]:
+        if pytesseract is None:
+            return {"available": False, "text": ""}
+        text = pytesseract.image_to_string(frame).strip()
+        snippet = " ".join(text.split())[: self.max_chars]
+        return {
+            "available": True,
+            "text": snippet,
+            "length": len(snippet),
+            "has_text": bool(snippet),
+        }
+
+
+@dataclass
+class KeyObjectExtractor:
+    """Lightweight object cue extractor based on contour count and motion edges."""
+
+    min_area: int = 900
+
+    def extract(self, frame: Any) -> dict[str, Any]:
+        if cv2 is None:
+            return {"available": False, "key_objects": []}
+
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+        edges = cv2.Canny(blurred, 80, 160)
+        contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+        boxes: list[dict[str, int]] = []
+        for contour in contours:
+            area = int(cv2.contourArea(contour))
+            if area < self.min_area:
+                continue
+            x, y, w, h = cv2.boundingRect(contour)
+            boxes.append({"x": int(x), "y": int(y), "w": int(w), "h": int(h), "area": area})
+
+        boxes = sorted(boxes, key=lambda item: item["area"], reverse=True)[:5]
+        return {
+            "available": True,
+            "count": len(boxes),
+            "key_objects": boxes,
+        }
+
+
+@dataclass
+class UIStateChangeExtractor:
+    """Detect meaningful UI state changes via frame fingerprint diffing."""
+
+    changed_threshold: float = 0.94
+    _previous_hash: str | None = field(default=None, init=False, repr=False)
+
+    def extract(self, frame: Any) -> dict[str, Any]:
+        payload = frame.tobytes() if hasattr(frame, "tobytes") else bytes(str(frame), "utf-8")
+        fingerprint = sha1(payload).hexdigest()[:16]
+
+        if self._previous_hash is None:
+            self._previous_hash = fingerprint
+            return {"changed": False, "change_ratio": 0.0, "ui_state": fingerprint}
+
+        similarity = SequenceMatcher(None, self._previous_hash, fingerprint).ratio()
+        changed = similarity < self.changed_threshold
+        self._previous_hash = fingerprint
+        return {
+            "changed": changed,
+            "change_ratio": round(1.0 - similarity, 4),
+            "ui_state": fingerprint,
+        }

--- a/perception/vision/pipeline.py
+++ b/perception/vision/pipeline.py
@@ -1,0 +1,68 @@
+"""Vision perception pipeline emitting compact ``PerceptEvent(type='vision')``."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from singular.core.agent_runtime import PerceptEvent
+
+from .capture import ActiveWindowCapture, CameraCapture, ScreenCapture, VisionCaptureError
+from .extractors import KeyObjectExtractor, OcrTextExtractor, UIStateChangeExtractor, VisionEventExtractor
+from .preprocess import FramePreprocessor, FrameSamplingStrategy
+
+
+@dataclass
+class VisionPerceptionPipeline:
+    """Capture, preprocess, extract and emit compact vision percepts."""
+
+    source: str = "screen"
+    source_name: str = "vision.pipeline"
+    sampling: FrameSamplingStrategy = field(default_factory=lambda: FrameSamplingStrategy(fps=1.5))
+    preprocessor: FramePreprocessor = field(default_factory=FramePreprocessor)
+    extractors: list[VisionEventExtractor] = field(
+        default_factory=lambda: [OcrTextExtractor(), KeyObjectExtractor(), UIStateChangeExtractor()]
+    )
+
+    def collect(self) -> list[PerceptEvent]:
+        """Collect at most one sampled frame and return compact vision events."""
+
+        if not self.sampling.should_sample():
+            return []
+
+        try:
+            frame = self._capture_frame()
+            processed = self.preprocessor.preprocess(frame)
+        except VisionCaptureError as exc:
+            return [
+                PerceptEvent(
+                    event_type="vision",
+                    source=self.source_name,
+                    payload={"status": "capture_error", "error": str(exc)},
+                )
+            ]
+
+        payload: dict[str, Any] = {
+            "status": "ok",
+            "source": self.source,
+            "frame_fingerprint": self.preprocessor.frame_fingerprint(processed),
+            "sampling_fps": self.sampling.fps,
+            "events": {},
+        }
+        for extractor in self.extractors:
+            payload["events"][extractor.__class__.__name__] = extractor.extract(processed)
+
+        return [
+            PerceptEvent(
+                event_type="vision",
+                source=self.source_name,
+                payload=payload,
+            )
+        ]
+
+    def _capture_frame(self) -> Any:
+        if self.source == "camera":
+            return CameraCapture().grab_frame()
+        if self.source == "window":
+            return ActiveWindowCapture().grab_frame()
+        return ScreenCapture().grab_frame()

--- a/perception/vision/preprocess.py
+++ b/perception/vision/preprocess.py
@@ -1,0 +1,80 @@
+"""Frame preprocessing and sampling utilities for vision perception."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from hashlib import sha1
+from time import monotonic
+from typing import Any
+
+try:
+    import cv2  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    cv2 = None
+
+
+@dataclass(frozen=True)
+class RegionOfInterest:
+    """Rectangular ROI in pixel coordinates."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass
+class FrameSamplingStrategy:
+    """Throttle frame processing to a bounded FPS budget."""
+
+    fps: float = 1.5
+    _last_sample_at: float | None = field(default=None, init=False, repr=False)
+
+    def should_sample(self, *, now: float | None = None) -> bool:
+        """Return ``True`` only when enough time elapsed since last sample."""
+
+        if self.fps <= 0:
+            return False
+        current = monotonic() if now is None else now
+        if self._last_sample_at is None:
+            self._last_sample_at = current
+            return True
+        min_interval = 1.0 / self.fps
+        if (current - self._last_sample_at) >= min_interval:
+            self._last_sample_at = current
+            return True
+        return False
+
+
+@dataclass
+class FramePreprocessor:
+    """Apply ROI cropping and resize in-memory before extraction."""
+
+    target_width: int = 640
+    target_height: int = 360
+    roi: RegionOfInterest | None = None
+
+    def preprocess(self, frame: Any) -> Any:
+        """Return processed frame (no persistence)."""
+
+        cropped = self._apply_roi(frame)
+        return self._resize(cropped)
+
+    def frame_fingerprint(self, frame: Any) -> str:
+        """Compute a compact stable frame fingerprint."""
+
+        payload = frame.tobytes() if hasattr(frame, "tobytes") else bytes(str(frame), "utf-8")
+        return sha1(payload).hexdigest()[:16]
+
+    def _apply_roi(self, frame: Any) -> Any:
+        if self.roi is None:
+            return frame
+        x, y, w, h = self.roi.x, self.roi.y, self.roi.width, self.roi.height
+        if hasattr(frame, "__getitem__"):
+            return frame[y : y + h, x : x + w]
+        return frame
+
+    def _resize(self, frame: Any) -> Any:
+        if cv2 is None or self.target_width <= 0 or self.target_height <= 0:
+            return frame
+        return cv2.resize(frame, (self.target_width, self.target_height))

--- a/tests/perception/test_vision_pipeline.py
+++ b/tests/perception/test_vision_pipeline.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from perception.vision.extractors import UIStateChangeExtractor
+from perception.vision.pipeline import VisionPerceptionPipeline
+from perception.vision.preprocess import FrameSamplingStrategy
+
+
+class DummyFrame:
+    def __init__(self, content: bytes) -> None:
+        self._content = content
+
+    def tobytes(self) -> bytes:
+        return self._content
+
+    def __getitem__(self, _item):
+        return self
+
+
+class _TestPipeline(VisionPerceptionPipeline):
+    def __init__(self, frame: DummyFrame, **kwargs):
+        super().__init__(**kwargs)
+        self._frame = frame
+
+    def _capture_frame(self):
+        return self._frame
+
+
+def test_sampling_strategy_throttles_to_configured_fps() -> None:
+    sampling = FrameSamplingStrategy(fps=2.0)
+
+    assert sampling.should_sample(now=0.0) is True
+    assert sampling.should_sample(now=0.5) is True
+    assert sampling.should_sample(now=0.7) is False
+    assert sampling.should_sample(now=1.0) is True
+
+
+def test_pipeline_emits_compact_vision_event_without_raw_image() -> None:
+    pipeline = _TestPipeline(
+        frame=DummyFrame(b"frame-1"),
+        source="window",
+    )
+
+    events = pipeline.collect()
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_type == "vision"
+    assert "frame_fingerprint" in event.payload
+    assert "events" in event.payload
+    assert "frame" not in event.payload
+    assert "raw_image" not in event.payload
+
+
+def test_ui_state_change_extractor_flags_changes() -> None:
+    extractor = UIStateChangeExtractor(changed_threshold=0.99)
+
+    first = extractor.extract(DummyFrame(b"state-a"))
+    second = extractor.extract(DummyFrame(b"state-a"))
+    third = extractor.extract(DummyFrame(b"state-b"))
+
+    assert first["changed"] is False
+    assert second["changed"] is False
+    assert third["changed"] is True


### PR DESCRIPTION
### Motivation
- Provide a lightweight vision perception stack that emits compact `PerceptEvent(event_type='vision')` summaries instead of persisting raw image buffers.
- Support multiple transient capture sources (camera, screen, active window) and reduce processing cost via FPS sampling and preprocessing (ROI + resize).

### Description
- Add `perception/vision/` package with modules: `capture.py` (camera/screen/active-window captures and `VisionCaptureError`), `preprocess.py` (ROI, `FramePreprocessor`, `FrameSamplingStrategy` with default `fps=1.5`), `extractors.py` (OCR `OcrTextExtractor`, simple object cues `KeyObjectExtractor`, UI change `UIStateChangeExtractor`), `pipeline.py` (`VisionPerceptionPipeline` that composes capture → preprocess → extract and emits compact `PerceptEvent` payloads), and `__init__.py` + `README.md` documenting usage.
- The pipeline emits compact payloads containing `frame_fingerprint`, sampling metadata and extractor outputs, and avoids storing raw image buffers in events.
- Capture and vision dependencies are optional and handled gracefully (degrades to compact `capture_error` events when unavailable).
- Added unit tests under `tests/perception/` covering sampling throttling, compact event shape, and UI state-change detection.

### Testing
- Ran `pytest -q tests/perception/test_vision_pipeline.py` which passed (`3 passed`).
- Ran `python -m compileall -q perception/vision tests/perception/test_vision_pipeline.py` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfabfda154832abdb8b7233fbdb5b2)