### PR TITLE
Add audio perception pipeline with VAD segmentation and Whisper fallback

### DIFF
--- a/perception/audio/README.md
+++ b/perception/audio/README.md
@@ -1,0 +1,16 @@
+# Audio perception
+
+Pipeline audio continue qui:
+
+- capture le micro en continu (`MicrophoneCapture`),
+- applique un VAD énergétique (`EnergyVAD`) pour début/fin de parole,
+- segmente les blocs PCM en buffers de parole (`SegmentBuffer`),
+- transcrit localement via Whisper (`WhisperTranscriber`) avec timestamps.
+
+Événements émis:
+
+- `PerceptEvent(event_type="audio_meta")` : volume, bruit, confiance VAD, runtime STT,
+- `PerceptEvent(event_type="transcript")` : texte, segments horodatés, confiance, bornes temporelles.
+
+Le transcripteur prévoit un fallback GPU -> CPU (`tiny`) si CUDA indisponible
+ou si le chargement du modèle GPU échoue.

--- a/perception/audio/__init__.py
+++ b/perception/audio/__init__.py
@@ -1,0 +1,18 @@
+"""Audio perception stack with VAD, segmentation and local Whisper STT."""
+
+from .capture import AudioBlock, AudioBlockProvider, AudioCaptureError, MicrophoneCapture
+from .pipeline import AudioPerceptionPipeline
+from .transcribe import WhisperRuntime, WhisperTranscriber
+from .vad import EnergyVAD, SegmentBuffer
+
+__all__ = [
+    "AudioBlock",
+    "AudioBlockProvider",
+    "AudioCaptureError",
+    "AudioPerceptionPipeline",
+    "EnergyVAD",
+    "MicrophoneCapture",
+    "SegmentBuffer",
+    "WhisperRuntime",
+    "WhisperTranscriber",
+]

--- a/perception/audio/capture.py
+++ b/perception/audio/capture.py
@@ -1,0 +1,115 @@
+"""Microphone capture utilities for audio perception."""
+
+from __future__ import annotations
+
+import audioop
+from dataclasses import dataclass
+from queue import Empty, Queue
+from time import monotonic
+from typing import Protocol
+
+try:
+    import sounddevice as sd  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    sd = None
+
+
+class AudioCaptureError(RuntimeError):
+    """Raised when microphone capture is unavailable or fails."""
+
+
+@dataclass(frozen=True)
+class AudioBlock:
+    """One captured PCM block and lightweight energy metadata."""
+
+    pcm16: bytes
+    sample_rate: int
+    channels: int
+    started_at: float
+    duration_s: float
+    rms: float
+    peak: float
+
+
+class AudioBlockProvider(Protocol):
+    """Provider contract for continuous microphone blocks."""
+
+    def next_block(self, *, timeout: float = 0.05) -> AudioBlock | None:
+        """Return the next block or ``None`` when no data is available yet."""
+
+    def close(self) -> None:
+        """Release capture resources."""
+
+
+@dataclass
+class MicrophoneCapture:
+    """Continuous microphone capture based on ``sounddevice.RawInputStream``."""
+
+    sample_rate: int = 16_000
+    channels: int = 1
+    block_duration_ms: int = 30
+    _stream: object | None = None
+    _queue: Queue[tuple[bytes, float]] | None = None
+
+    def _ensure_started(self) -> None:
+        if self._stream is not None:
+            return
+        if sd is None:
+            raise AudioCaptureError("sounddevice is not installed")
+
+        block_size = max(1, int(self.sample_rate * self.block_duration_ms / 1000))
+        queue: Queue[tuple[bytes, float]] = Queue(maxsize=128)
+
+        def _callback(indata, _frames, _time_info, _status) -> None:
+            try:
+                queue.put_nowait((bytes(indata), monotonic()))
+            except Exception:
+                pass
+
+        stream = sd.RawInputStream(
+            samplerate=self.sample_rate,
+            channels=self.channels,
+            dtype="int16",
+            blocksize=block_size,
+            callback=_callback,
+        )
+        stream.start()
+        self._stream = stream
+        self._queue = queue
+
+    def next_block(self, *, timeout: float = 0.05) -> AudioBlock | None:
+        self._ensure_started()
+        assert self._queue is not None
+        try:
+            pcm16, captured_at = self._queue.get(timeout=timeout)
+        except Empty:
+            return None
+
+        sample_width = 2
+        frame_count = max(1, len(pcm16) // (sample_width * max(self.channels, 1)))
+        duration = frame_count / float(self.sample_rate)
+        started_at = captured_at - duration
+
+        rms = float(audioop.rms(pcm16, sample_width)) / 32768.0
+        peak = float(audioop.max(pcm16, sample_width)) / 32768.0
+        return AudioBlock(
+            pcm16=pcm16,
+            sample_rate=self.sample_rate,
+            channels=self.channels,
+            started_at=started_at,
+            duration_s=duration,
+            rms=max(0.0, min(1.0, rms)),
+            peak=max(0.0, min(1.0, peak)),
+        )
+
+    def close(self) -> None:
+        stream = self._stream
+        self._stream = None
+        self._queue = None
+        if stream is None:
+            return
+        try:
+            stream.stop()
+            stream.close()
+        except Exception:
+            pass

--- a/perception/audio/pipeline.py
+++ b/perception/audio/pipeline.py
@@ -1,0 +1,86 @@
+"""Audio perception pipeline: continuous capture, VAD, segment buffer and STT."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from singular.core.agent_runtime import PerceptEvent
+
+from .capture import AudioBlockProvider, MicrophoneCapture
+from .transcribe import WhisperTranscriber
+from .vad import EnergyVAD, SegmentBuffer
+
+
+@dataclass
+class AudioPerceptionPipeline:
+    """Collect audio blocks continuously and emit transcript/audio metadata events."""
+
+    source_name: str = "audio.pipeline"
+    capture: AudioBlockProvider = field(default_factory=MicrophoneCapture)
+    vad: EnergyVAD = field(default_factory=EnergyVAD)
+    transcriber: WhisperTranscriber = field(default_factory=WhisperTranscriber)
+    segment_buffer: SegmentBuffer = field(default_factory=SegmentBuffer)
+    _noise_floor: float = field(default=0.01, init=False, repr=False)
+    _speaking: bool = field(default=False, init=False, repr=False)
+
+    def collect(self) -> list[PerceptEvent]:
+        block = self.capture.next_block()
+        if block is None:
+            return []
+
+        is_speech, speech_started, speech_ended, vad_confidence = self.vad.process(
+            block,
+            noise_floor=self._noise_floor,
+        )
+
+        if not is_speech:
+            self._noise_floor = (self._noise_floor * 0.95) + (block.rms * 0.05)
+
+        if speech_started:
+            self._speaking = True
+            self.segment_buffer.flush()
+        if self._speaking:
+            self.segment_buffer.add(block)
+
+        events: list[PerceptEvent] = []
+        runtime = self.transcriber.runtime
+        events.append(
+            PerceptEvent(
+                event_type="audio_meta",
+                source=self.source_name,
+                payload={
+                    "volume": round(block.rms, 4),
+                    "peak": round(block.peak, 4),
+                    "noise": round(self._noise_floor, 4),
+                    "confidence": vad_confidence,
+                    "speech": is_speech,
+                    "runtime": runtime.__dict__,
+                },
+            )
+        )
+
+        if speech_ended and self._speaking:
+            self._speaking = False
+            segment = self.segment_buffer.flush()
+            if segment:
+                transcript = self.transcriber.transcribe(segment)
+                events.append(
+                    PerceptEvent(
+                        event_type="transcript",
+                        source=self.source_name,
+                        payload={
+                            "text": transcript.get("text", ""),
+                            "segments": transcript.get("segments", []),
+                            "confidence": transcript.get("confidence", 0.0),
+                            "status": transcript.get("status", "ok"),
+                            "runtime": transcript.get("runtime", runtime.__dict__),
+                            "start": round(segment[0].started_at, 3),
+                            "end": round(segment[-1].started_at + segment[-1].duration_s, 3),
+                        },
+                    )
+                )
+
+        return events
+
+    def close(self) -> None:
+        self.capture.close()

--- a/perception/audio/transcribe.py
+++ b/perception/audio/transcribe.py
@@ -1,0 +1,138 @@
+"""Local Whisper transcription with CPU fallback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .capture import AudioBlock
+
+
+@dataclass(frozen=True)
+class WhisperRuntime:
+    """Resolved runtime configuration for Whisper inference."""
+
+    device: str
+    model_size: str
+    backend: str
+    fallback_applied: bool = False
+
+
+@dataclass
+class WhisperTranscriber:
+    """Best-effort local Whisper transcriber with GPU->CPU fallback."""
+
+    prefer_gpu: bool = True
+    gpu_model_size: str = "small"
+    cpu_model_size: str = "tiny"
+    _runtime: WhisperRuntime | None = None
+    _model: Any = None
+
+    @property
+    def runtime(self) -> WhisperRuntime:
+        if self._runtime is None:
+            self._runtime = self._load_runtime()
+            self._model = self._load_model(self._runtime)
+        return self._runtime
+
+    def _load_runtime(self) -> WhisperRuntime:
+        gpu_available = self._gpu_available() if self.prefer_gpu else False
+        device = "cuda" if gpu_available else "cpu"
+        model_size = self.gpu_model_size if gpu_available else self.cpu_model_size
+        return WhisperRuntime(device=device, model_size=model_size, backend="whisper")
+
+    def _gpu_available(self) -> bool:
+        try:  # pragma: no cover - optional dependency
+            import torch  # type: ignore
+
+            return bool(torch.cuda.is_available())
+        except Exception:
+            return False
+
+    def _load_model(self, runtime: WhisperRuntime) -> Any:
+        try:  # pragma: no cover - optional dependency
+            import whisper  # type: ignore
+
+            return whisper.load_model(runtime.model_size, device=runtime.device)
+        except Exception:
+            if runtime.device == "cuda":
+                cpu_runtime = WhisperRuntime(
+                    device="cpu",
+                    model_size=self.cpu_model_size,
+                    backend="whisper",
+                    fallback_applied=True,
+                )
+                try:  # pragma: no cover - optional dependency
+                    import whisper  # type: ignore
+
+                    self._runtime = cpu_runtime
+                    return whisper.load_model(cpu_runtime.model_size, device=cpu_runtime.device)
+                except Exception:
+                    self._runtime = WhisperRuntime(
+                        device="cpu",
+                        model_size=self.cpu_model_size,
+                        backend="unavailable",
+                        fallback_applied=True,
+                    )
+                    return None
+            self._runtime = WhisperRuntime(
+                device="cpu",
+                model_size=self.cpu_model_size,
+                backend="unavailable",
+                fallback_applied=runtime.fallback_applied,
+            )
+            return None
+
+    def transcribe(self, blocks: list[AudioBlock]) -> dict[str, Any]:
+        runtime = self.runtime
+        if not blocks:
+            return {"text": "", "segments": [], "confidence": 0.0, "runtime": runtime.__dict__}
+
+        if self._model is None:
+            return {
+                "text": "",
+                "segments": [],
+                "confidence": 0.0,
+                "status": "unavailable",
+                "runtime": runtime.__dict__,
+            }
+
+        pcm = b"".join(block.pcm16 for block in blocks)
+        sample_rate = blocks[0].sample_rate
+
+        try:  # pragma: no cover - optional dependency
+            result = self._model.transcribe(pcm, language="fr", fp16=(runtime.device == "cuda"))
+        except Exception:
+            return {
+                "text": "",
+                "segments": [],
+                "confidence": 0.0,
+                "status": "error",
+                "runtime": runtime.__dict__,
+            }
+
+        text = str(result.get("text", "")).strip()
+        segments = []
+        confidences: list[float] = []
+        for item in result.get("segments", []):
+            conf = float(item.get("avg_logprob", 0.0))
+            norm_conf = max(0.0, min(1.0, (conf + 1.5) / 1.5))
+            confidences.append(norm_conf)
+            segments.append(
+                {
+                    "start": round(float(item.get("start", 0.0)), 3),
+                    "end": round(float(item.get("end", 0.0)), 3),
+                    "text": str(item.get("text", "")).strip(),
+                    "confidence": round(norm_conf, 4),
+                }
+            )
+
+        confidence = round(sum(confidences) / len(confidences), 4) if confidences else 0.0
+        return {
+            "text": text,
+            "segments": segments,
+            "confidence": confidence,
+            "sample_rate": sample_rate,
+            "runtime": runtime.__dict__,
+            "status": "ok",
+        }

--- a/perception/audio/vad.py
+++ b/perception/audio/vad.py
@@ -1,0 +1,64 @@
+"""Energy-based voice activity detection and speech segmentation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from .capture import AudioBlock
+
+
+@dataclass
+class EnergyVAD:
+    """Simple VAD using block RMS with speech start/stop hysteresis."""
+
+    start_threshold: float = 0.03
+    stop_threshold: float = 0.015
+    noise_boost: float = 2.8
+    min_speech_blocks: int = 2
+    silence_blocks_to_stop: int = 6
+    _speech_blocks: int = field(default=0, init=False, repr=False)
+    _silence_blocks: int = field(default=0, init=False, repr=False)
+    _speaking: bool = field(default=False, init=False, repr=False)
+
+    def process(self, block: AudioBlock, *, noise_floor: float) -> tuple[bool, bool, bool, float]:
+        """Return ``(is_speech, speech_started, speech_ended, confidence)``."""
+
+        adaptive_start = max(self.start_threshold, noise_floor * self.noise_boost)
+        adaptive_stop = max(self.stop_threshold, adaptive_start * 0.5)
+        energy = block.rms
+        is_speech = energy >= (adaptive_stop if self._speaking else adaptive_start)
+
+        speech_started = False
+        speech_ended = False
+        if is_speech:
+            self._speech_blocks += 1
+            self._silence_blocks = 0
+            if not self._speaking and self._speech_blocks >= self.min_speech_blocks:
+                self._speaking = True
+                speech_started = True
+        else:
+            self._silence_blocks += 1
+            self._speech_blocks = 0
+            if self._speaking and self._silence_blocks >= self.silence_blocks_to_stop:
+                self._speaking = False
+                speech_ended = True
+
+        confidence = 0.0
+        if adaptive_start > 0:
+            confidence = max(0.0, min(1.0, (energy - noise_floor) / adaptive_start))
+        return is_speech, speech_started, speech_ended, round(confidence, 4)
+
+
+@dataclass
+class SegmentBuffer:
+    """Accumulate blocks while speech is active and flush completed segments."""
+
+    _active: list[AudioBlock] = field(default_factory=list, init=False, repr=False)
+
+    def add(self, block: AudioBlock) -> None:
+        self._active.append(block)
+
+    def flush(self) -> list[AudioBlock]:
+        segment = self._active
+        self._active = []
+        return segment

--- a/tests/perception/test_audio_pipeline.py
+++ b/tests/perception/test_audio_pipeline.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from perception.audio.capture import AudioBlock, AudioBlockProvider
+from perception.audio.pipeline import AudioPerceptionPipeline
+from perception.audio.transcribe import WhisperRuntime
+
+
+@dataclass
+class StaticAudioProvider(AudioBlockProvider):
+    blocks: list[AudioBlock]
+
+    def next_block(self, *, timeout: float = 0.05) -> AudioBlock | None:
+        if not self.blocks:
+            return None
+        return self.blocks.pop(0)
+
+    def close(self) -> None:
+        return None
+
+
+class DummyTranscriber:
+    runtime = WhisperRuntime(device="cpu", model_size="tiny", backend="whisper", fallback_applied=True)
+
+    def transcribe(self, blocks):
+        start = blocks[0].started_at
+        end = blocks[-1].started_at + blocks[-1].duration_s
+        return {
+            "text": "bonjour le monde",
+            "segments": [{"start": 0.0, "end": round(end - start, 3), "text": "bonjour le monde", "confidence": 0.86}],
+            "confidence": 0.86,
+            "status": "ok",
+            "runtime": self.runtime.__dict__,
+        }
+
+
+def _block(rms: float, t: float) -> AudioBlock:
+    amp = int(max(0.0, min(1.0, rms)) * 32767)
+    sample = amp.to_bytes(2, byteorder="little", signed=True)
+    pcm = sample * 480
+    return AudioBlock(
+        pcm16=pcm,
+        sample_rate=16_000,
+        channels=1,
+        started_at=t,
+        duration_s=0.03,
+        rms=rms,
+        peak=rms,
+    )
+
+
+def test_audio_pipeline_emits_meta_and_transcript_events() -> None:
+    blocks = [
+        _block(0.005, 0.00),
+        _block(0.004, 0.03),
+        _block(0.09, 0.06),
+        _block(0.10, 0.09),
+        _block(0.11, 0.12),
+        _block(0.004, 0.15),
+        _block(0.004, 0.18),
+        _block(0.004, 0.21),
+        _block(0.004, 0.24),
+        _block(0.004, 0.27),
+        _block(0.004, 0.30),
+    ]
+
+    pipeline = AudioPerceptionPipeline(
+        capture=StaticAudioProvider(blocks=blocks),
+        transcriber=DummyTranscriber(),
+    )
+
+    produced = []
+    while True:
+        events = pipeline.collect()
+        if not events and not pipeline.capture.blocks:
+            break
+        produced.extend(events)
+
+    assert any(evt.event_type == "audio_meta" for evt in produced)
+    transcripts = [evt for evt in produced if evt.event_type == "transcript"]
+    assert len(transcripts) == 1
+    assert transcripts[0].payload["text"] == "bonjour le monde"
+    assert transcripts[0].payload["segments"][0]["start"] == 0.0
+
+
+def test_audio_meta_exposes_runtime_fallback_flags() -> None:
+    pipeline = AudioPerceptionPipeline(
+        capture=StaticAudioProvider(blocks=[_block(0.02, 1.0)]),
+        transcriber=DummyTranscriber(),
+    )
+
+    events = pipeline.collect()
+    assert len(events) == 1
+    assert events[0].event_type == "audio_meta"
+    assert events[0].payload["runtime"]["fallback_applied"] is True


### PR DESCRIPTION
### Motivation
- Add an audio perception stack to capture continuous microphone input, detect voice activity, buffer utterances and produce speech transcripts with timestamps.
- Provide robust local STT by preferring GPU models and falling back to a smaller CPU model when CUDA or model loading is unavailable.
- Emit compact runtime-friendly percepts for downstream processing: `PerceptEvent(event_type='audio_meta')` and `PerceptEvent(event_type='transcript')`.

### Description
- Introduced a new package `perception/audio/` implementing continuous microphone capture via `MicrophoneCapture` and a compact `AudioBlock` descriptor (`perception/audio/capture.py`).
- Implemented an energy-based VAD with start/stop hysteresis and a `SegmentBuffer` to accumulate utterance blocks (`perception/audio/vad.py`).
- Added `WhisperTranscriber` that detects GPU availability, loads a preferred GPU model and falls back to a smaller CPU model (`tiny`) or marks STT unavailable if loading fails (`perception/audio/transcribe.py`).
- Composed an `AudioPerceptionPipeline` that integrates capture, VAD, buffering and STT and emits `PerceptEvent` objects with `event_type` `"audio_meta"` (volume, noise, VAD confidence, runtime) and `"transcript"` (text, per-segment timestamps, confidence, start/end) (`perception/audio/pipeline.py`).
- Added package exports and docs (`perception/audio/__init__.py`, `perception/audio/README.md`) and unit tests validating VAD-driven segmentation, transcript emission and runtime fallback metadata (`tests/perception/test_audio_pipeline.py`).

### Testing
- Ran `pytest -q tests/perception/test_audio_pipeline.py` which succeeded (`2 passed`) with a single deprecation warning for `audioop`.
- Ran `pytest -q tests/perception/test_vision_pipeline.py tests/perception/test_audio_pipeline.py` which succeeded (`5 passed`) with the same deprecation warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfad384410832ab0beb84727aa0356)