### PR TITLE
Add OS perception pipeline with semantic context events

### DIFF
--- a/perception/os/README.md
+++ b/perception/os/README.md
@@ -1,0 +1,30 @@
+# perception.os
+
+Pipeline de perception OS orientée contexte:
+
+- fenêtre active (`application`, `title`),
+- état d'entrée utilisateur (position souris + activité clavier agrégée, sans keylogging brut),
+- notifications système capturables,
+- état hôte (réseau, batterie, charge CPU).
+
+## Événements produits
+
+`OSPerceptionPipeline.collect()` émet deux `PerceptEvent`:
+
+1. `os_state`: snapshot brut compact,
+2. `os_semantic`: événements dérivés (ex: `user.in_meeting`, `workspace.coding_active`).
+
+## Confidentialité
+
+- Aucun enregistrement de frappes clavier brutes.
+- Les notifications sont réduites à un aperçu (`body_preview`).
+- Le provider par défaut est **best effort** sans dépendances système obligatoires.
+
+## Extension
+
+Sous-classez `BestEffortOSSnapshotProvider` pour brancher des APIs natives (Windows/macOS/Linux)
+et fournir:
+
+- détection réelle de fenêtre active,
+- état clavier/idle robuste,
+- flux notifications natif.

--- a/perception/os/__init__.py
+++ b/perception/os/__init__.py
@@ -1,0 +1,26 @@
+"""OS perception stack: raw host/app/input signals + semantic context events."""
+
+from .capture import (
+    ActiveWindowState,
+    BestEffortOSSnapshotProvider,
+    HostState,
+    InputState,
+    NotificationRecord,
+    OSSnapshot,
+    OSSnapshotProvider,
+)
+from .pipeline import OSPerceptionPipeline
+from .semantics import OSSemanticInterpreter, SemanticRuleConfig
+
+__all__ = [
+    "ActiveWindowState",
+    "BestEffortOSSnapshotProvider",
+    "HostState",
+    "InputState",
+    "NotificationRecord",
+    "OSPerceptionPipeline",
+    "OSSemanticInterpreter",
+    "OSSnapshot",
+    "OSSnapshotProvider",
+    "SemanticRuleConfig",
+]

--- a/perception/os/capture.py
+++ b/perception/os/capture.py
@@ -1,0 +1,160 @@
+"""OS-level signal capture (best effort, privacy preserving)."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class NotificationRecord:
+    """Compact system notification record."""
+
+    app: str
+    title: str
+    body_preview: str
+    observed_at: str
+    priority: str = "normal"
+
+
+@dataclass(frozen=True)
+class ActiveWindowState:
+    """Foreground window metadata."""
+
+    app: str
+    title: str
+
+
+@dataclass(frozen=True)
+class InputState:
+    """Privacy-preserving user input state."""
+
+    mouse_x: int | None
+    mouse_y: int | None
+    keyboard_active: bool
+    idle_seconds: float
+
+
+@dataclass(frozen=True)
+class HostState:
+    """Host operating state summary."""
+
+    network_online: bool | None
+    network_type: str | None
+    battery_percent: float | None
+    battery_charging: bool | None
+    cpu_percent: float | None
+
+
+@dataclass(frozen=True)
+class OSSnapshot:
+    """Aggregated snapshot from OS sensors."""
+
+    observed_at: str
+    active_window: ActiveWindowState
+    input_state: InputState
+    notifications: list[NotificationRecord] = field(default_factory=list)
+    host_state: HostState = field(
+        default_factory=lambda: HostState(
+            network_online=None,
+            network_type=None,
+            battery_percent=None,
+            battery_charging=None,
+            cpu_percent=None,
+        )
+    )
+
+    def to_payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class OSSnapshotProvider(Protocol):
+    """Contract for OS snapshot providers."""
+
+    def collect_snapshot(self) -> OSSnapshot:
+        """Collect one OS snapshot."""
+
+
+class BestEffortOSSnapshotProvider:
+    """Portable provider that captures what is available without keylogging."""
+
+    source_name = "os.capture"
+
+    def __init__(self) -> None:
+        self._last_notifications: set[tuple[str, str, str]] = set()
+
+    def collect_snapshot(self) -> OSSnapshot:
+        observed_at = datetime.now(timezone.utc).isoformat()
+        return OSSnapshot(
+            observed_at=observed_at,
+            active_window=self._collect_active_window(),
+            input_state=self._collect_input_state(),
+            notifications=self._collect_notifications(observed_at=observed_at),
+            host_state=self._collect_host_state(),
+        )
+
+    def _collect_active_window(self) -> ActiveWindowState:
+        # Best-effort placeholders: real platform hooks can override this provider.
+        return ActiveWindowState(app="unknown", title="unknown")
+
+    def _collect_input_state(self) -> InputState:
+        mouse_x: int | None = None
+        mouse_y: int | None = None
+        try:
+            import pyautogui  # type: ignore[import-untyped]
+
+            point = pyautogui.position()
+            mouse_x, mouse_y = int(point.x), int(point.y)
+        except Exception:
+            pass
+
+        return InputState(
+            mouse_x=mouse_x,
+            mouse_y=mouse_y,
+            keyboard_active=False,
+            idle_seconds=0.0,
+        )
+
+    def _collect_notifications(self, *, observed_at: str) -> list[NotificationRecord]:
+        # No default OS backend to avoid hard deps. Integrators can subclass.
+        _ = observed_at
+        return []
+
+    def _collect_host_state(self) -> HostState:
+        cpu_percent: float | None = None
+        battery_percent: float | None = None
+        battery_charging: bool | None = None
+        network_online: bool | None = None
+        network_type: str | None = None
+
+        try:
+            import psutil  # type: ignore[import-untyped]
+
+            cpu_percent = float(psutil.cpu_percent(interval=0.0))
+            battery = psutil.sensors_battery()
+            if battery is not None:
+                battery_percent = float(battery.percent)
+                battery_charging = bool(battery.power_plugged)
+
+            interfaces = psutil.net_if_stats()
+            online = [name for name, stats in interfaces.items() if stats.isup]
+            network_online = bool(online)
+            if online:
+                lowered = {name.lower() for name in online}
+                if any("wi" in name or "wlan" in name for name in lowered):
+                    network_type = "wifi"
+                elif any("eth" in name or "en" in name for name in lowered):
+                    network_type = "ethernet"
+                else:
+                    network_type = "unknown"
+        except Exception:
+            pass
+
+        return HostState(
+            network_online=network_online,
+            network_type=network_type,
+            battery_percent=battery_percent,
+            battery_charging=battery_charging,
+            cpu_percent=cpu_percent,
+        )

--- a/perception/os/pipeline.py
+++ b/perception/os/pipeline.py
@@ -1,0 +1,44 @@
+"""OS perception pipeline producing raw and semantic events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from singular.core.agent_runtime import PerceptEvent
+
+from .capture import BestEffortOSSnapshotProvider, OSSnapshotProvider
+from .semantics import OSSemanticInterpreter
+
+
+@dataclass
+class OSPerceptionPipeline:
+    """Collect OS snapshots and derive semantic context events."""
+
+    source_name: str = "os.pipeline"
+    provider: OSSnapshotProvider = field(default_factory=BestEffortOSSnapshotProvider)
+    interpreter: OSSemanticInterpreter = field(default_factory=OSSemanticInterpreter)
+
+    def collect(self) -> list[PerceptEvent]:
+        snapshot = self.provider.collect_snapshot()
+        semantic_events = self.interpreter.derive(snapshot)
+
+        events = [
+            PerceptEvent(
+                event_type="os_state",
+                source=self.source_name,
+                payload=snapshot.to_payload(),
+            )
+        ]
+
+        events.append(
+            PerceptEvent(
+                event_type="os_semantic",
+                source=self.source_name,
+                payload={
+                    "observed_at": snapshot.observed_at,
+                    "events": semantic_events,
+                },
+            )
+        )
+
+        return events

--- a/perception/os/semantics.py
+++ b/perception/os/semantics.py
@@ -1,0 +1,100 @@
+"""Semantic event derivation from raw OS snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .capture import OSSnapshot
+
+
+@dataclass(frozen=True)
+class SemanticRuleConfig:
+    """Thresholds and keyword rules for semantic transformation."""
+
+    meeting_keywords: tuple[str, ...] = ("meet", "zoom", "teams", "calendar")
+    coding_keywords: tuple[str, ...] = ("code", "pycharm", "vscode", "terminal", "vim")
+    high_cpu_threshold: float = 85.0
+    low_battery_threshold: float = 20.0
+
+
+class OSSemanticInterpreter:
+    """Derive human-meaningful context events from OS snapshots."""
+
+    def __init__(self, config: SemanticRuleConfig | None = None) -> None:
+        self.config = config or SemanticRuleConfig()
+
+    def derive(self, snapshot: OSSnapshot) -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+
+        app = snapshot.active_window.app.lower()
+        title = snapshot.active_window.title.lower()
+        joined = f"{app} {title}"
+
+        if any(keyword in joined for keyword in self.config.meeting_keywords):
+            events.append(
+                {
+                    "type": "user.in_meeting",
+                    "confidence": 0.86,
+                    "reason": "active_window_keywords",
+                    "window": snapshot.active_window.title,
+                    "application": snapshot.active_window.app,
+                }
+            )
+
+        if any(keyword in joined for keyword in self.config.coding_keywords):
+            events.append(
+                {
+                    "type": "workspace.coding_active",
+                    "confidence": 0.82,
+                    "reason": "active_window_keywords",
+                    "window": snapshot.active_window.title,
+                    "application": snapshot.active_window.app,
+                }
+            )
+
+        cpu = snapshot.host_state.cpu_percent
+        if isinstance(cpu, (int, float)) and float(cpu) >= self.config.high_cpu_threshold:
+            events.append(
+                {
+                    "type": "host.cpu_high",
+                    "confidence": 0.9,
+                    "reason": "cpu_threshold",
+                    "cpu_percent": float(cpu),
+                    "threshold": self.config.high_cpu_threshold,
+                }
+            )
+
+        battery = snapshot.host_state.battery_percent
+        charging = snapshot.host_state.battery_charging
+        if (
+            isinstance(battery, (int, float))
+            and float(battery) <= self.config.low_battery_threshold
+            and charging is False
+        ):
+            events.append(
+                {
+                    "type": "host.battery_low",
+                    "confidence": 0.92,
+                    "reason": "battery_threshold",
+                    "battery_percent": float(battery),
+                    "charging": bool(charging),
+                    "threshold": self.config.low_battery_threshold,
+                }
+            )
+
+        if any("calendar" in n.app.lower() for n in snapshot.notifications):
+            events.append(
+                {
+                    "type": "user.calendar_prompt",
+                    "confidence": 0.74,
+                    "reason": "notification_source",
+                    "count": sum(
+                        1
+                        for n in snapshot.notifications
+                        if "calendar" in n.app.lower()
+                    ),
+                }
+            )
+
+        return events

--- a/tests/perception/test_os_pipeline.py
+++ b/tests/perception/test_os_pipeline.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from perception.os.capture import (
+    ActiveWindowState,
+    HostState,
+    InputState,
+    NotificationRecord,
+    OSSnapshot,
+    OSSnapshotProvider,
+)
+from perception.os.pipeline import OSPerceptionPipeline
+
+
+@dataclass
+class StaticSnapshotProvider(OSSnapshotProvider):
+    snapshot: OSSnapshot
+
+    def collect_snapshot(self) -> OSSnapshot:
+        return self.snapshot
+
+
+def test_os_pipeline_emits_raw_and_semantic_events() -> None:
+    snapshot = OSSnapshot(
+        observed_at="2026-04-15T00:00:00+00:00",
+        active_window=ActiveWindowState(app="Zoom", title="Weekly Engineering Meeting"),
+        input_state=InputState(mouse_x=120, mouse_y=88, keyboard_active=True, idle_seconds=1.5),
+        notifications=[
+            NotificationRecord(
+                app="Calendar",
+                title="Standup",
+                body_preview="in 2 minutes",
+                observed_at="2026-04-15T00:00:00+00:00",
+            )
+        ],
+        host_state=HostState(
+            network_online=True,
+            network_type="wifi",
+            battery_percent=14.0,
+            battery_charging=False,
+            cpu_percent=92.0,
+        ),
+    )
+
+    pipeline = OSPerceptionPipeline(provider=StaticSnapshotProvider(snapshot=snapshot))
+
+    events = pipeline.collect()
+
+    assert len(events) == 2
+    assert events[0].event_type == "os_state"
+    assert events[0].payload["active_window"]["app"] == "Zoom"
+
+    semantic = events[1]
+    assert semantic.event_type == "os_semantic"
+    semantic_types = {event["type"] for event in semantic.payload["events"]}
+    assert "user.in_meeting" in semantic_types
+    assert "host.cpu_high" in semantic_types
+    assert "host.battery_low" in semantic_types
+    assert "user.calendar_prompt" in semantic_types
+
+
+def test_os_pipeline_detects_coding_window() -> None:
+    snapshot = OSSnapshot(
+        observed_at="2026-04-15T00:00:00+00:00",
+        active_window=ActiveWindowState(app="Code", title="repo - main.py"),
+        input_state=InputState(mouse_x=None, mouse_y=None, keyboard_active=False, idle_seconds=30.0),
+        notifications=[],
+        host_state=HostState(
+            network_online=None,
+            network_type=None,
+            battery_percent=90.0,
+            battery_charging=True,
+            cpu_percent=15.0,
+        ),
+    )
+
+    pipeline = OSPerceptionPipeline(provider=StaticSnapshotProvider(snapshot=snapshot))
+
+    events = pipeline.collect()
+
+    semantic_types = {event["type"] for event in events[1].payload["events"]}
+    assert "workspace.coding_active" in semantic_types
+    assert "host.battery_low" not in semantic_types
+    assert "host.cpu_high" not in semantic_types


### PR DESCRIPTION
### Motivation
- Provide a lightweight, privacy-preserving OS sensor stack to capture foreground window, input state, notifications and host metrics for higher-level context derivation.
- Enable the runtime to reason about user context (e.g. in a meeting or actively coding) without raw keylogging or persisting full images.

### Description
- Add a new `perception/os` package with structured snapshot models (`OSSnapshot`, `ActiveWindowState`, `InputState`, `HostState`, `NotificationRecord`) in `perception/os/capture.py` and a default `BestEffortOSSnapshotProvider` that gathers available signals without hard runtime deps.
- Add `OSSemanticInterpreter` and `SemanticRuleConfig` in `perception/os/semantics.py` that derive semantic events like `user.in_meeting`, `workspace.coding_active`, `host.cpu_high`, `host.battery_low` and `user.calendar_prompt` from snapshots.
- Add `OSPerceptionPipeline` in `perception/os/pipeline.py` which emits two `PerceptEvent`s: `os_state` (raw compact snapshot) and `os_semantic` (derived events).
- Expose the package via `perception/os/__init__.py`, add documentation in `perception/os/README.md`, and include unit tests in `tests/perception/test_os_pipeline.py` covering raw + semantic emission and coding-window detection.

### Testing
- Ran `pytest -q tests/perception/test_os_pipeline.py`, which passed (`2 passed`).
- Ran `pytest -q tests/perception/test_audio_pipeline.py tests/perception/test_vision_pipeline.py tests/perception/test_os_pipeline.py`, which passed (`7 passed`) with a deprecation warning from an existing audio module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb11fe0fc832aa81b5687b668518a)