### PR TITLE
feat(action): add ghost execution mode with QA gate for live actions

### DIFF
--- a/action/sandbox_runner.py
+++ b/action/sandbox_runner.py
@@ -11,11 +11,12 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
 from dataclasses import dataclass, field
 from threading import Event
 from time import monotonic
-from typing import Any, Callable, Deque, Dict, Mapping, MutableMapping
+from typing import Any, Callable, Deque, Dict, Literal, Mapping, MutableMapping
 
 
 AllowedActionName = str
 Rollback = Callable[[], None]
+RunnerMode = Literal["ghost", "live"]
 
 
 class ActionError(RuntimeError):
@@ -45,6 +46,8 @@ class RunnerConfig:
     rate_limit_window_s: float = 10.0
     max_consecutive_failures: int = 3
     circuit_open_s: float = 15.0
+    initial_mode: RunnerMode = "ghost"
+    require_qa_before_live: bool = True
 
 
 class DefaultActionBackend:
@@ -82,8 +85,12 @@ class SandboxRunner:
     _catalog: MutableMapping[AllowedActionName, Callable[..., Any]] = field(
         default_factory=dict, init=False
     )
+    _mode: RunnerMode = field(default="ghost", init=False)
+    _qa_completed: bool = field(default=False, init=False)
+    _ghost_log: list[dict[str, Any]] = field(default_factory=list, init=False)
 
     def __post_init__(self) -> None:
+        self._mode = self.config.initial_mode
         self._catalog = {
             "click": self.backend.click,
             "type": self.backend.type,
@@ -96,6 +103,29 @@ class SandboxRunner:
     def allowed_actions(self) -> tuple[str, ...]:
         return tuple(self._catalog.keys())
 
+    @property
+    def mode(self) -> RunnerMode:
+        return self._mode
+
+    @property
+    def ghost_log(self) -> tuple[dict[str, Any], ...]:
+        return tuple(self._ghost_log)
+
+    def run_qa_plan(self, steps: list[Mapping[str, Any]]) -> list[Any]:
+        previous_mode = self._mode
+        try:
+            self._mode = "ghost"
+            results = self.run_plan(steps)
+            self._qa_completed = True
+            return results
+        finally:
+            self._mode = previous_mode
+
+    def enable_live_mode(self) -> None:
+        if self.config.require_qa_before_live and not self._qa_completed:
+            raise ActionError("live mode requires a successful QA step in ghost mode")
+        self._mode = "live"
+
     def cancel(self) -> None:
         self._cancel_event.set()
 
@@ -104,6 +134,9 @@ class SandboxRunner:
 
     def run_action(self, action: str, params: Mapping[str, Any] | None = None) -> Any:
         params = dict(params or {})
+        if self._mode == "live" and self.config.require_qa_before_live and not self._qa_completed:
+            raise ActionError("live mode requires a successful QA step in ghost mode")
+
         self._ensure_circuit_closed()
         self._ensure_not_cancelled()
         self._check_rate_limit()
@@ -116,8 +149,11 @@ class SandboxRunner:
 
         start = monotonic()
         try:
-            result = self._run_with_timeout(handler, params)
-            self._register_rollback(action, params)
+            if self._mode == "ghost":
+                result = self._simulate_action(action, params)
+            else:
+                result = self._run_with_timeout(handler, params)
+                self._register_rollback(action, params)
         except Exception:
             self._record_failure()
             self._rollback_best_effort()
@@ -150,6 +186,17 @@ class SandboxRunner:
             except FutureTimeout as exc:
                 future.cancel()
                 raise ActionTimeoutError("action timed out") from exc
+
+    def _simulate_action(self, action: str, params: Mapping[str, Any]) -> dict[str, Any]:
+        simulated = {
+            "ok": True,
+            "simulated": True,
+            "action": action,
+            "params": dict(params),
+            "overlay": f"[ghost] would execute action '{action}' with params={dict(params)}",
+        }
+        self._ghost_log.append(simulated)
+        return simulated
 
     def _check_rate_limit(self) -> None:
         now = monotonic()

--- a/tests/test_action_sandbox_runner.py
+++ b/tests/test_action_sandbox_runner.py
@@ -39,7 +39,10 @@ class SpyBackend:
 
 
 def test_only_catalog_actions_allowed():
-    runner = SandboxRunner(backend=SpyBackend())
+    runner = SandboxRunner(
+        backend=SpyBackend(),
+        config=RunnerConfig(require_qa_before_live=False, initial_mode="live"),
+    )
     with pytest.raises(ActionError):
         runner.run_action("shell", {"cmd": "rm -rf /"})
 
@@ -52,7 +55,14 @@ def test_timeout_is_enforced():
         return {"ok": True}
 
     backend.click = slow_click
-    runner = SandboxRunner(backend=backend, config=RunnerConfig(timeout_s=0.02))
+    runner = SandboxRunner(
+        backend=backend,
+        config=RunnerConfig(
+            timeout_s=0.02,
+            require_qa_before_live=False,
+            initial_mode="live",
+        ),
+    )
 
     with pytest.raises(ActionTimeoutError):
         runner.run_action("click", {"x": 1, "y": 2})
@@ -61,7 +71,12 @@ def test_timeout_is_enforced():
 def test_rate_limit_is_enforced():
     runner = SandboxRunner(
         backend=SpyBackend(),
-        config=RunnerConfig(rate_limit_count=1, rate_limit_window_s=1.0),
+        config=RunnerConfig(
+            rate_limit_count=1,
+            rate_limit_window_s=1.0,
+            require_qa_before_live=False,
+            initial_mode="live",
+        ),
     )
     runner.run_action("read_clipboard")
     with pytest.raises(ActionRateLimitError):
@@ -69,7 +84,10 @@ def test_rate_limit_is_enforced():
 
 
 def test_cancellation_stops_execution():
-    runner = SandboxRunner(backend=SpyBackend())
+    runner = SandboxRunner(
+        backend=SpyBackend(),
+        config=RunnerConfig(require_qa_before_live=False, initial_mode="live"),
+    )
     runner.cancel()
     with pytest.raises(CancellationError):
         runner.run_action("read_clipboard")
@@ -84,7 +102,12 @@ def test_circuit_breaker_opens_after_consecutive_failures():
     backend.click = broken_click
     runner = SandboxRunner(
         backend=backend,
-        config=RunnerConfig(max_consecutive_failures=2, circuit_open_s=30.0),
+        config=RunnerConfig(
+            max_consecutive_failures=2,
+            circuit_open_s=30.0,
+            require_qa_before_live=False,
+            initial_mode="live",
+        ),
     )
 
     for _ in range(2):
@@ -103,10 +126,39 @@ def test_open_app_registers_rollback_on_failure():
 
     backend.type = broken_type
 
-    runner = SandboxRunner(backend=backend)
+    runner = SandboxRunner(
+        backend=backend,
+        config=RunnerConfig(require_qa_before_live=False, initial_mode="live"),
+    )
     runner.run_action("open_app", {"app": "notepad"})
 
     with pytest.raises(RuntimeError):
         runner.run_action("type", {"text": "hello"})
 
     assert ("hotkey", {"keys": ["alt", "f4"]}) in backend.calls
+
+
+def test_ghost_mode_simulates_and_logs_without_executing_backend():
+    backend = SpyBackend()
+    runner = SandboxRunner(backend=backend)
+
+    result = runner.run_action("click", {"x": 1, "y": 2})
+
+    assert result["simulated"] is True
+    assert result["overlay"].startswith("[ghost] would execute action 'click'")
+    assert backend.calls == []
+    assert runner.ghost_log[0]["action"] == "click"
+
+
+def test_live_mode_requires_qa_ghost_step_before_activation():
+    runner = SandboxRunner(backend=SpyBackend())
+
+    with pytest.raises(ActionError, match="requires a successful QA step"):
+        runner.enable_live_mode()
+
+    qa_results = runner.run_qa_plan([{"action": "read_clipboard"}])
+    assert qa_results[0]["simulated"] is True
+
+    runner.enable_live_mode()
+    live_result = runner.run_action("read_clipboard")
+    assert live_result["ok"] is True


### PR DESCRIPTION
### Motivation
- Provide a non‑destructive "ghost" execution mode that computes planned actions and shows what would be done (overlay/log) without calling real backends. 
- Make a QA step mandatory before enabling real (live) execution to reduce accidental side effects and enforce review.

### Description
- Added `RunnerMode = Literal["ghost","live"]` and two new `RunnerConfig` options: `initial_mode` and `require_qa_before_live` to control default mode and QA gating. 
- Extended `SandboxRunner` with `_mode`, `_qa_completed` and `_ghost_log` fields, a `_simulate_action()` method that returns a simulated overlay/log entry and appends to `ghost_log`, and properties `mode` and `ghost_log`. 
- Added `run_qa_plan(steps)` which forces execution in ghost mode and marks QA completed on success, and `enable_live_mode()` which enforces the QA gate before switching to live. 
- Protected `run_action()` to honor the ghost/live mode (simulate in ghost, execute backend in live), preserve existing rate limit/cancellation/circuit/timeout/rollback behavior, and updated tests to exercise both live and ghost workflows.

### Testing
- Ran the modified action sandbox tests with `pytest -q tests/test_action_sandbox_runner.py` and they all passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbe68d8a4832aa93665aeae973daf)