### PR TITLE
Dashboard: add Critical/Follow-up/Detail tiers, actionable thresholds and "Voir plus" toggles

### DIFF
--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -301,3 +301,42 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
 .tab-pane.panel-hidden {
   display: none;
 }
+
+.level-panel { margin-top: 10px; }
+.level-panel > summary {
+  cursor: pointer;
+  font-weight: 700;
+  color: #dce8ff;
+}
+
+.signal-threshold {
+  margin-top: 6px;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.toggle-more-btn {
+  min-width: 110px;
+  font-weight: 600;
+}
+
+.actionable-signal {
+  border-radius: 8px;
+  padding: 3px 6px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.actionable-signal[data-actionable='off'] {
+  background: transparent;
+  color: #f2f6ff;
+}
+
+.actionable-signal.actionable-warn {
+  background: rgba(255, 191, 83, 0.2);
+  color: var(--warn);
+}
+
+.actionable-signal.actionable-critical {
+  background: rgba(255, 107, 141, 0.22);
+  color: var(--bad);
+}

--- a/src/singular/dashboard/static/dashboard.js
+++ b/src/singular/dashboard/static/dashboard.js
@@ -1,3 +1,100 @@
 import {bootstrapDashboard} from './bootstrap.js';
 
 bootstrapDashboard();
+
+const NON_ACTIONABLE_TEXTS=new Set([
+  'non disponible',
+  'pas encore mesuré',
+  'aucune action suggérée',
+  'aucune action immédiate',
+]);
+
+const parseFloatSafe=value=>{
+  const match=String(value||'').replace(',', '.').match(/-?\d+(\.\d+)?/);
+  return match?Number(match[0]):null;
+};
+
+const setActionableTone=(el,tone)=>{
+  if(!el){return;}
+  el.classList.remove('actionable-warn','actionable-critical');
+  el.dataset.actionable='off';
+  if(tone==='warn'){
+    el.classList.add('actionable-warn');
+    el.dataset.actionable='on';
+  }
+  if(tone==='critical'){
+    el.classList.add('actionable-critical');
+    el.dataset.actionable='on';
+  }
+};
+
+const evaluateActionableSignals=()=>{
+  const healthEl=document.getElementById('kpi-health');
+  const alertsEl=document.getElementById('kpi-alerts');
+  const riskEl=document.getElementById('kpi-vital-risk');
+  const actionEl=document.getElementById('kpi-next-action');
+  const trendEl=document.getElementById('kpi-trend');
+  const autonomyStabilityEl=document.getElementById('kpi-autonomy-stability');
+
+  const health=parseFloatSafe(healthEl?.textContent);
+  if(health===null){setActionableTone(healthEl,null);}
+  else if(health<40){setActionableTone(healthEl,'critical');}
+  else if(health<65){setActionableTone(healthEl,'warn');}
+  else{setActionableTone(healthEl,null);}
+
+  const alerts=parseFloatSafe(alertsEl?.textContent);
+  if(alerts===null||alerts<=0){setActionableTone(alertsEl,null);}
+  else if(alerts>=3){setActionableTone(alertsEl,'critical');}
+  else{setActionableTone(alertsEl,'warn');}
+
+  const riskText=String(riskEl?.textContent||'').toLowerCase();
+  if(riskText.includes('critique')||riskText.includes('critical')){setActionableTone(riskEl,'critical');}
+  else if(riskText.includes('élevé')||riskText.includes('high')||riskText.includes('warn')){setActionableTone(riskEl,'warn');}
+  else{setActionableTone(riskEl,null);}
+
+  const actionText=String(actionEl?.textContent||'').trim().toLowerCase();
+  setActionableTone(actionEl,actionText&&!NON_ACTIONABLE_TEXTS.has(actionText)?'warn':null);
+
+  const trendText=String(trendEl?.textContent||'').toLowerCase();
+  if(trendText.includes('dégradation')||trendText.includes('degradation')){setActionableTone(trendEl,'warn');}
+  else{setActionableTone(trendEl,null);}
+
+  const stability=parseFloatSafe(autonomyStabilityEl?.textContent);
+  if(stability===null){setActionableTone(autonomyStabilityEl,null);}
+  else if(stability<50){setActionableTone(autonomyStabilityEl,'critical');}
+  else if(stability<70){setActionableTone(autonomyStabilityEl,'warn');}
+  else{setActionableTone(autonomyStabilityEl,null);}
+};
+
+const bindSeeMoreToggles=()=>{
+  document.querySelectorAll('[data-expand-target]').forEach(button=>{
+    button.addEventListener('click',()=>{
+      const targetId=button.getAttribute('data-expand-target');
+      const target=targetId?document.getElementById(targetId):null;
+      if(!target){return;}
+      const willOpen=target.classList.contains('panel-hidden');
+      target.classList.toggle('panel-hidden',!willOpen);
+      button.textContent=willOpen?'Voir moins':'Voir plus';
+      button.setAttribute('aria-expanded',willOpen?'true':'false');
+    });
+  });
+};
+
+const bindSignalObserver=()=>{
+  const cockpit=document.getElementById('cockpit');
+  if(!cockpit){return;}
+  evaluateActionableSignals();
+  const observer=new MutationObserver(()=>evaluateActionableSignals());
+  observer.observe(cockpit,{subtree:true,childList:true,characterData:true});
+};
+
+const initDashboardEnhancements=()=>{
+  bindSeeMoreToggles();
+  bindSignalObserver();
+};
+
+if(document.readyState==='loading'){
+  document.addEventListener('DOMContentLoaded',initDashboardEnhancements,{once:true});
+}else{
+  initDashboardEnhancements();
+}

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -29,27 +29,62 @@
 
   <section id='cockpit'>
     <h2>Cockpit décisionnel</h2>
-    <p class='section-help'>Vue réduite aux KPI de décision immédiate (6 KPI).</p>
+    <p class='section-help'>Vue structurée par niveaux: critique (toujours visible), suivi (repliable), détail (drawer).</p>
     <div class='status-legend'>
       <span class='status-pill status-good'>● OK</span>
       <span class='status-pill status-warn'>▲ Alerte</span>
       <span class='status-pill status-bad'>■ Critique</span>
     </div>
-    <div id='cockpit-status' class='card card-value'>Statut global: Non disponible</div>
-    <div class='cards-grid'>
-      <div class='card'><div class='card-label kpi-label' title='Niveau global de santé de l’organisme'>Santé</div><div id='kpi-health' class='card-value'>Pas encore mesuré</div></div>
-      <div class='card'><div class='card-label kpi-label' title='Évolution récente du système'>Tendance</div><div id='kpi-trend' class='card-value'>Non disponible</div></div>
-      <div class='card'><div class='card-label kpi-label' title='Part des mutations validées'>Mutations acceptées</div><div id='kpi-accepted' class='card-value'>Pas encore mesuré</div></div>
-      <div class='card'><div class='card-label kpi-label' title='Nombre d’alertes de niveau critique'>Alertes critiques</div><div id='kpi-alerts' class='card-value'>0</div></div>
-      <div class='card'><div class='card-label kpi-label' title='Risque vital courant'>Risque vital</div><div id='kpi-vital-risk' class='card-value'>Non disponible</div></div>
-      <div class='card'><div class='card-label kpi-label' title='Action prioritaire recommandée'>Prochaine action</div><div id='kpi-next-action' class='card-value'>Non disponible</div></div>
+    <div class='panel level-panel'>
+      <h3 class='heading-reset-top'>Niveau Critique · action immédiate</h3>
+      <div id='cockpit-status' class='card card-value'>Statut global: Non disponible</div>
+      <div class='cards-grid'>
+        <div class='card'><div class='card-label kpi-label' title='Niveau global de santé de l’organisme'>Santé</div><div id='kpi-health' class='card-value actionable-signal'>Pas encore mesuré</div><div class='signal-threshold'>Action si &lt; 65 (critique si &lt; 40)</div></div>
+        <div class='card'><div class='card-label kpi-label' title='Nombre d’alertes de niveau critique'>Alertes critiques</div><div id='kpi-alerts' class='card-value actionable-signal'>0</div><div class='signal-threshold'>Action si ≥ 1 (critique si ≥ 3)</div></div>
+        <div class='card'><div class='card-label kpi-label' title='Risque vital courant'>Risque vital</div><div id='kpi-vital-risk' class='card-value actionable-signal'>Non disponible</div><div class='signal-threshold'>Action si risque élevé / critique</div></div>
+        <div class='card'><div class='card-label kpi-label' title='Action prioritaire recommandée'>Prochaine action</div><div id='kpi-next-action' class='card-value actionable-signal'>Non disponible</div><div class='signal-threshold'>Action si recommandation explicite</div></div>
+      </div>
     </div>
 
+    <details id='cockpit-followup' class='panel level-panel' open>
+      <summary>Niveau Suivi · tendances santé/autonomie/vital</summary>
+      <div class='cards-grid content-top-gap'>
+        <div class='card'><div class='card-label kpi-label' title='Évolution récente du système'>Tendance</div><div id='kpi-trend' class='card-value actionable-signal'>Non disponible</div></div>
+        <div class='card'><div class='card-label kpi-label' title='Part des mutations validées'>Mutations acceptées</div><div id='kpi-accepted' class='card-value'>Pas encore mesuré</div></div>
+        <div class='card'><div class='card-label'>Stabilité long terme</div><div id='kpi-autonomy-stability' class='card-value actionable-signal'>Pas encore mesuré</div></div>
+        <div class='card'><div class='card-label'>Qualité décision</div><div id='kpi-autonomy-decision' class='card-value'>Pas encore mesuré</div></div>
+        <div class='card'><div class='card-label'>Initiatives</div><div id='kpi-autonomy-proactive' class='card-value'>Pas encore mesuré</div></div>
+        <div class='card'><div class='card-label'>Âge</div><div id='kpi-vital-age' class='card-value'>0</div></div>
+      </div>
+    </details>
+
+    <details id='cockpit-detail' class='panel level-panel'>
+      <summary>Niveau Détail · skills lifecycle, rétention, payload JSON</summary>
+      <div class='cards-grid content-top-gap'>
+        <div class='card'><div class='card-label'>Skills actives</div><div id='kpi-skills-active' class='card-value'>0</div></div>
+        <div class='card'><div class='card-label'>Skills dormantes</div><div id='kpi-skills-dormant' class='card-value'>0</div></div>
+        <div class='card'><div class='card-label'>Skills archivées</div><div id='kpi-skills-archived' class='card-value'>0</div></div>
+        <div class='card'><div class='card-label'>Rétention Runs/Mem/Lives</div><div id='kpi-retention-usage' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Dernière purge</div><div id='kpi-retention-last-purge' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Volume libéré</div><div id='kpi-retention-freed' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Éléments supprimés/archivés</div><div id='kpi-retention-items' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Seuils actifs</div><div id='kpi-retention-thresholds' class='card-value'>Chargement…</div></div>
+      </div>
+      <button type='button' class='toggle-more-btn content-top-gap' data-expand-target='cockpit-detail-json' aria-expanded='false'>Voir plus</button>
+      <div id='cockpit-detail-json' class='panel-hidden'>
+        <h4>Payload cockpit</h4>
+        <pre id='raw-cockpit-json'></pre>
+      </div>
+    </details>
+
     <div class='panel'>
-      <h3 class='heading-reset-top'>Dernière mutation notable</h3>
-      <div id='kpi-notable-summary'>Aucune mutation notable</div>
-      <h4>Actions suggérées</h4>
-      <ul id='kpi-actions' class='list-tight-top'></ul>
+      <button type='button' class='toggle-more-btn' data-expand-target='cockpit-context-more' aria-expanded='false'>Voir plus</button>
+      <div id='cockpit-context-more' class='panel-hidden'>
+        <h3 class='heading-reset-top'>Dernière mutation notable</h3>
+        <div id='kpi-notable-summary'>Aucune mutation notable</div>
+        <h4>Actions suggérées</h4>
+        <ul id='kpi-actions' class='list-tight-top'></ul>
+      </div>
     </div>
   </section>
 </section>
@@ -195,10 +230,7 @@
   </section>
 
   <div class='panel'>
-    <h3 class='heading-reset-top'>Payloads bruts</h3>
-    <h4>Payload cockpit</h4>
-    <pre id='raw-cockpit-json'></pre>
-    <h4>Payload écosystème</h4>
+    <h3 class='heading-reset-top'>Payload écosystème</h3>
     <pre id='raw-eco-json'></pre>
   </div>
 
@@ -217,14 +249,10 @@
 
   <div class='panel'><h3 class='heading-reset-top'>KPIs étendus</h3>
     <div class='cards-grid'>
-      <div class='card'><div class='card-label'>Initiatives</div><div id='kpi-autonomy-proactive' class='card-value'>Pas encore mesuré</div></div>
-      <div class='card'><div class='card-label'>Stabilité long terme</div><div id='kpi-autonomy-stability' class='card-value'>Pas encore mesuré</div></div>
-      <div class='card'><div class='card-label'>Qualité décision</div><div id='kpi-autonomy-decision' class='card-value'>Pas encore mesuré</div></div>
-      <div class='card'><div class='card-label'>Latence P→A</div><div id='kpi-autonomy-latency' class='card-value'>Pas encore mesuré</div></div>
-      <div class='card'><div class='card-label'>Coût par gain</div><div id='kpi-autonomy-cost' class='card-value'>Pas encore mesuré</div></div>
-      <div class='card'><div class='card-label'>Âge</div><div id='kpi-vital-age' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Terminal</div><div id='kpi-vital-terminal' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Causes</div><div id='kpi-vital-causes' class='card-value'>Non disponible</div></div>
+      <div class='card'><div class='card-label'>Latence P→A</div><div id='kpi-autonomy-latency' class='card-value'>Pas encore mesuré</div></div>
+      <div class='card'><div class='card-label'>Coût par gain</div><div id='kpi-autonomy-cost' class='card-value'>Pas encore mesuré</div></div>
       <div class='card'><div class='card-label'>Phase circadienne</div><div id='kpi-circadian-phase' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Objectifs actifs</div><div id='kpi-active-objectives-count' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Progression quêtes</div><div id='kpi-quests-progress' class='card-value'>Non disponible</div></div>
@@ -232,9 +260,6 @@
       <div class='card'><div class='card-label'>Ressources totales</div><div id='kpi-resources-total' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Progression génération code</div><div id='kpi-code-progression' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Risques code</div><div id='kpi-code-risks' class='card-value'>Non disponible</div></div>
-      <div class='card'><div class='card-label'>Skills actives</div><div id='kpi-skills-active' class='card-value'>0</div></div>
-      <div class='card'><div class='card-label'>Skills dormantes</div><div id='kpi-skills-dormant' class='card-value'>0</div></div>
-      <div class='card'><div class='card-label'>Skills archivées</div><div id='kpi-skills-archived' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Trajectory en cours</div><div id='kpi-trajectory-in-progress' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Trajectory abandonnés</div><div id='kpi-trajectory-abandoned' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Trajectory complétés</div><div id='kpi-trajectory-completed' class='card-value'>0</div></div>
@@ -245,11 +270,6 @@
       <div class='card'><div class='card-label'>Vies mortes</div><div id='eco-dead-lives' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Vie sélectionnée</div><div id='eco-selected-life' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Dernière activité</div><div id='eco-last-activity' class='card-value'>Non disponible</div></div>
-      <div class='card'><div class='card-label'>Rétention Runs/Mem/Lives</div><div id='kpi-retention-usage' class='card-value'>Chargement…</div></div>
-      <div class='card'><div class='card-label'>Dernière purge</div><div id='kpi-retention-last-purge' class='card-value'>Chargement…</div></div>
-      <div class='card'><div class='card-label'>Volume libéré</div><div id='kpi-retention-freed' class='card-value'>Chargement…</div></div>
-      <div class='card'><div class='card-label'>Éléments supprimés/archivés</div><div id='kpi-retention-items' class='card-value'>Chargement…</div></div>
-      <div class='card'><div class='card-label'>Seuils actifs</div><div id='kpi-retention-thresholds' class='card-value'>Chargement…</div></div>
     </div>
     <ul id='kpi-active-objectives-list' class='list-tight-top'></ul>
     <ul id='kpi-priority-changes-list' class='list-tight-top'></ul>


### PR DESCRIPTION
### Motivation
- Rendre le cockpit décisionnel immédiatement utile en montrant toujours les signaux critiques, en repliant les informations de suivi et en plaçant le détail (skills/retention/payload) dans un tiroir caché par défaut.
- Mettre en évidence uniquement les signaux actionnables via des seuils visuels pour réduire le bruit et accélérer la prise de décision.

### Description
- Restructuration de la section cockpit dans `src/singular/dashboard/templates/dashboard.html` en trois niveaux : **Niveau Critique** (toujours visible), **Niveau Suivi** (collapsible `<details>`), **Niveau Détail** (drawer avec `Voir plus`).
- Déplacement du `raw-cockpit-json` dans le niveau Détail et ajout de boutons `data-expand-target`/`Voir plus` pour masquer par défaut le contenu à faible valeur immédiate.
- Ajout de logique client dans `src/singular/dashboard/static/dashboard.js` pour évaluer les signaux actionnables (fonctions `parseFloatSafe`, `setActionableTone`, `evaluateActionableSignals`) et pour lier les contrôles "Voir plus"; l'évaluation est relancée automatiquement via un `MutationObserver` sur le cockpit.
- Ajout de règles CSS dans `src/singular/dashboard/static/dashboard.css` pour les panneaux par niveau, le texte d'aide de seuils et les états visuels `actionable-warn` / `actionable-critical` applicables aux signaux ciblés.

### Testing
- Exécution de `node --check src/singular/dashboard/static/dashboard.js` et `node --check src/singular/dashboard/static/render-cockpit.js`, les vérifications ont réussi.
- Vérification statique `git diff --check` a été exécutée et n’a pas retourné d’erreurs.
- Contrôle pour identifiants dupliqués dans le template (`python` script qui recherche les `id='...'`) a été exécuté et n’a pas trouvé de doublons.
- Aucune capture d’écran automatisée n’a été fournie car l’environnement d’exécution UI n’est pas accessible ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcc3b1f90832ab15442aba55a8b9e)