### PR TITLE
Avoid PosixPath construction in implicit registry root resolution

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -11,7 +11,7 @@ import re
 import sys
 import sysconfig
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path, PosixPath
+from pathlib import Path
 from typing import Any, Callable
 
 from .root_config import (
@@ -23,6 +23,7 @@ from .root_config import (
 __all__ = ["main"]
 
 _BIRTH_ALIAS_ENV = "SINGULAR_ENABLE_BIRTH_ALIAS"
+_HOST_PATH_CLS = type(Path())
 
 
 def _birth_alias_enabled() -> bool:
@@ -645,19 +646,17 @@ def _print_table(headers: list[str], rows: list[list[str]]) -> None:
 def _implicit_registry_root_from_env_or_default() -> Path:
     """Return the implicit registry root used before any ``--root`` override."""
 
-    def _safe_path(raw: str) -> Path:
+    def _expanded(raw_path: str) -> Path:
         try:
-            return Path(raw)
-        except NotImplementedError:
-            return PosixPath(raw.replace("\\", "/"))
+            return Path(raw_path).expanduser()
+        except (NotImplementedError, RuntimeError):
+            return _HOST_PATH_CLS(raw_path).expanduser()
 
     raw = os.environ.get("SINGULAR_ROOT")
     if raw:
-        if os.name == "nt":
-            return PosixPath(raw.replace("\\", "/")).expanduser()
-        return _safe_path(raw).expanduser()
+        return _expanded(raw)
     if os.name == "nt":
-        return PosixPath(os.path.expanduser("~/.singular").replace("\\", "/"))
+        return _expanded("~/.singular")
     configured = load_configured_registry_root()
     if configured is not None:
         return configured

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -169,3 +169,34 @@ def test_config_root_set_project_overrides_global(monkeypatch, tmp_path, capsys)
     out = capsys.readouterr().out
     assert exit_code == 0
     assert str(workspace / ".singular" / "project-root") in out
+
+
+def test_implicit_registry_root_windows_uses_path_for_env_value(monkeypatch) -> None:
+    monkeypatch.setattr(cli.os, "name", "nt")
+    monkeypatch.setenv("SINGULAR_ROOT", r"C:\tmp\singular")
+
+    root = cli._implicit_registry_root_from_env_or_default()
+
+    assert isinstance(root, Path)
+    assert root == Path(r"C:\tmp\singular").expanduser()
+
+
+def test_implicit_registry_root_windows_defaults_to_user_home(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(cli.os, "name", "nt")
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+
+    root = cli._implicit_registry_root_from_env_or_default()
+
+    assert root == cli._HOST_PATH_CLS("~/.singular").expanduser()
+
+
+def test_implicit_registry_root_posix_keeps_configured_behavior(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(cli.os, "name", "posix")
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    configured = tmp_path / "configured-root"
+    monkeypatch.setattr(cli, "load_configured_registry_root", lambda: configured)
+
+    root = cli._implicit_registry_root_from_env_or_default()
+
+    assert root == configured


### PR DESCRIPTION
### Motivation
- Prevent constructing `PosixPath` on Windows or on non-Windows hosts that are monkeypatched to appear as Windows, and ensure path handling uses the native `Path` class.
- Preserve existing callers that expect a `Path` return value and that may call `.resolve()` or `.expanduser()` on the result.

### Description
- Removed direct `PosixPath(...)` usage and the `PosixPath` import from `src/singular/cli.py` and route environment/default resolution through `Path(...).expanduser()` with a small fallback for host path instantiation named `_HOST_PATH_CLS`.
- Added `_expanded()` helper inside `_implicit_registry_root_from_env_or_default()` to centralize `expanduser()` and catch `NotImplementedError`/`RuntimeError` to use `_HOST_PATH_CLS` when needed.
- Kept the function return type as `Path` so downstream code using `.resolve()` remains compatible.
- Added three regression tests in `tests/test_cli_config.py` covering `SINGULAR_ROOT` set on Windows, `SINGULAR_ROOT` unset on Windows (default to user home), and unchanged non-Windows configured-root behavior.

### Testing
- Ran `pytest -q tests/test_cli_config.py -k implicit_registry_root` and the focused tests passed (3 passed).
- Ran `pytest -q tests/test_cli_config.py` and the full test file passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfda86534c832a8b6b27518b389d2d)