### PR TITLE
Handle pathlib UnsupportedOperation in CLI path handling

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -6,6 +6,7 @@ import argparse
 import getpass
 import json
 import os
+import pathlib
 import random
 import re
 import sys
@@ -24,6 +25,28 @@ __all__ = ["main"]
 
 _BIRTH_ALIAS_ENV = "SINGULAR_ENABLE_BIRTH_ALIAS"
 _HOST_PATH_CLS = type(Path())
+
+
+def _path_unsupported_errors() -> tuple[type[Exception], ...]:
+    """Return exception types raised when host-incompatible path classes are built."""
+
+    errors: list[type[Exception]] = [NotImplementedError, RuntimeError]
+    unsupported = getattr(getattr(pathlib, "_abc", None), "UnsupportedOperation", None)
+    if isinstance(unsupported, type) and issubclass(unsupported, Exception):
+        errors.append(unsupported)
+    return tuple(dict.fromkeys(errors))
+
+
+_PATH_UNSUPPORTED_ERRORS = _path_unsupported_errors()
+
+
+def _safe_path(raw: str) -> Path:
+    """Build a path safely across host/path-flavor mismatches."""
+
+    try:
+        return Path(raw)
+    except _PATH_UNSUPPORTED_ERRORS:
+        return _HOST_PATH_CLS(raw)
 
 
 def _birth_alias_enabled() -> bool:
@@ -648,8 +671,8 @@ def _implicit_registry_root_from_env_or_default() -> Path:
 
     def _expanded(raw_path: str) -> Path:
         try:
-            return Path(raw_path).expanduser()
-        except (NotImplementedError, RuntimeError):
+            return _safe_path(raw_path).expanduser()
+        except _PATH_UNSUPPORTED_ERRORS:
             return _HOST_PATH_CLS(raw_path).expanduser()
 
     raw = os.environ.get("SINGULAR_ROOT")

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -181,6 +181,36 @@ def test_implicit_registry_root_windows_uses_path_for_env_value(monkeypatch) -> 
     assert root == Path(r"C:\tmp\singular").expanduser()
 
 
+def test_safe_path_windows_fallback_handles_unsupported_operation(monkeypatch) -> None:
+    class UnsupportedOperation(Exception):
+        pass
+
+    FakeAbc = type("FakeAbc", (), {"UnsupportedOperation": UnsupportedOperation})
+
+    monkeypatch.setattr(cli.pathlib, "_abc", FakeAbc, raising=False)
+    monkeypatch.setattr(cli, "_PATH_UNSUPPORTED_ERRORS", cli._path_unsupported_errors())
+
+    def _raise(raw: str) -> Path:
+        raise UnsupportedOperation(raw)
+
+    monkeypatch.setattr(cli, "Path", _raise)
+
+    root = cli._safe_path(r"C:\tmp\singular")
+
+    assert root == cli._HOST_PATH_CLS(r"C:\tmp\singular")
+
+
+def test_safe_path_windows_fallback_handles_not_implemented(monkeypatch) -> None:
+    def _raise(raw: str) -> Path:
+        raise NotImplementedError(raw)
+
+    monkeypatch.setattr(cli, "Path", _raise)
+
+    root = cli._safe_path(r"C:\tmp\singular")
+
+    assert root == cli._HOST_PATH_CLS(r"C:\tmp\singular")
+
+
 def test_implicit_registry_root_windows_defaults_to_user_home(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(cli.os, "name", "nt")
     monkeypatch.delenv("SINGULAR_ROOT", raising=False)


### PR DESCRIPTION
### Motivation
- Path construction on non-host path flavors can raise different exception types across Python versions (e.g., `pathlib._abc.UnsupportedOperation` on Python 3.13) which caused fallback logic to miss some cases. 
- The CLI needs a robust, simple way to construct paths that falls back to the host `Path` class when the native `Path` instantiation is unsupported. 

### Description
- Added `_path_unsupported_errors()` to detect and return the exception types to treat as path-construction failures, including dynamic detection of `pathlib._abc.UnsupportedOperation`. 
- Introduced `_safe_path(raw: str)` to prefer `Path(raw)` and explicitly catch the supported failure exceptions to return the host path class `_HOST_PATH_CLS(raw)` as a fallback. 
- Replaced direct `Path(...).expanduser()` uses in implicit registry root resolution with the `_safe_path(...).expanduser()` call and retained an explicit fallback when expansion itself raises host/path-flavor incompatibility errors. 
- Added regression tests to `tests/test_cli_config.py` that verify fallback behavior for both modern `UnsupportedOperation` and legacy `NotImplementedError` failure modes. 

### Testing
- Ran `pytest -q tests/test_cli_config.py -k "safe_path_windows_fallback or implicit_registry_root_windows"` and the targeted tests passed. 
- Ran `pytest -q tests/test_cli_config.py` and the whole file passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdbe9b884832abdc936d47d3b6022)