### PR TITLE
Fix dashboard lives table mapping for timestamped run files

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -135,7 +135,18 @@ def create_app(
         if isinstance(run_id, str) and run_id:
             return run_id
         run = record.get("_run_file")
-        return str(run) if isinstance(run, str) else "unknown"
+        if not isinstance(run, str):
+            return "unknown"
+        normalized = run.strip()
+        if not normalized:
+            return "unknown"
+        # Legacy JSONL files often follow <run_id>-<timestamp>.jsonl.
+        # Normalize back to <run_id> so registry run mappings can resolve life names.
+        if "-" in normalized:
+            candidate, suffix = normalized.rsplit("-", 1)
+            if candidate and suffix.isdigit() and len(suffix) >= 8:
+                return candidate
+        return normalized
 
     def _registry_run_to_life_mapping() -> dict[str, str]:
         registry = load_registry()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -819,6 +819,39 @@ def test_lives_comparison_compare_lives_filter(tmp_path: Path) -> None:
     assert payload["filters"]["time_window"] == "all"
 
 
+def test_lives_comparison_maps_timestamped_run_file_to_registry_life(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "loop-20260415120000.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-15T12:00:00",
+                "accepted": True,
+                "score_base": 12.0,
+                "score_new": 9.0,
+                "health": {"score": 88.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    monkeypatch.setattr(
+        "singular.dashboard.load_registry",
+        lambda: {
+            "active": "life-alpha",
+            "lives": {"life-alpha": {"slug": "life-alpha", "run_id": "loop"}},
+        },
+    )
+
+    payload = app._routes["/lives/comparison"]()
+
+    assert "life-alpha" in payload["lives"]
+    assert payload["unattached_runs"]["records_count"] == 0
+
+
 def test_psyche_missing_returns_404(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Legacy run log filenames like `<run_id>-<timestamp>.jsonl` caused `_record_run_id` to return the full stem and prevented registry `run_id` mappings from resolving life names, so lives could appear as `unknown` and not show in the comparison table.

### Description
- Normalize `_run_file` in `create_app` by stripping the value and collapsing names of the form `<run_id>-<timestamp>` back to `<run_id>` in `src/singular/dashboard/__init__.py` by updating the `_record_run_id` helper; non-string or empty values now return `"unknown"`.
- Add a regression test `test_lives_comparison_maps_timestamped_run_file_to_registry_life` in `tests/test_dashboard.py` that writes `loop-20260415120000.jsonl` and asserts the life is resolved via the registry instead of being listed as unattached.

### Testing
- Ran the targeted tests with `pytest -q tests/test_dashboard.py -k "lives_comparison_maps_timestamped_run_file_to_registry_life or lives_comparison_compare_lives_filter"`, but test collection failed due to a missing environment dependency (`ModuleNotFoundError: No module named 'fastapi.staticfiles'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdf9295f4832ab18cee16b9714a9e)