### PR TITLE
Ensure lives (not runs) are shown in dashboard comparison table

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -135,7 +135,18 @@ def create_app(
         if isinstance(run_id, str) and run_id:
             return run_id
         run = record.get("_run_file")
-        return str(run) if isinstance(run, str) else "unknown"
+        if not isinstance(run, str):
+            return "unknown"
+        normalized = run.strip()
+        if not normalized:
+            return "unknown"
+        # Legacy JSONL files often follow <run_id>-<timestamp>.jsonl.
+        # Normalize back to <run_id> so registry run mappings can resolve life names.
+        if "-" in normalized:
+            candidate, suffix = normalized.rsplit("-", 1)
+            if candidate and suffix.isdigit() and len(suffix) >= 8:
+                return candidate
+        return normalized
 
     def _registry_run_to_life_mapping() -> dict[str, str]:
         registry = load_registry()
@@ -168,11 +179,31 @@ def create_app(
         return mapping
 
     def _record_life(record: dict[str, object]) -> str:
+        registry = load_registry()
+        registry_lives = registry.get("lives")
+        known_lives: set[str] = set()
+        if isinstance(registry_lives, dict):
+            for slug, metadata in registry_lives.items():
+                if isinstance(slug, str) and slug:
+                    known_lives.add(slug)
+                if isinstance(metadata, dict):
+                    name = metadata.get("name")
+                else:
+                    name = getattr(metadata, "name", None)
+                if isinstance(name, str) and name:
+                    known_lives.add(name)
+
         skill = record.get("skill")
         if isinstance(skill, str) and ":" in skill:
             return skill.split(":", 1)[0]
-        if isinstance(record.get("life"), str):
-            return str(record["life"])
+        life_field = record.get("life")
+        if isinstance(life_field, str) and life_field.strip():
+            normalized_life = life_field.strip()
+            if normalized_life in known_lives:
+                return normalized_life
+            mapped_from_life = _registry_run_to_life_mapping().get(normalized_life)
+            if isinstance(mapped_from_life, str) and mapped_from_life:
+                return mapped_from_life
         run_id = _record_run_id(record)
         if run_id != "unknown":
             mapped_life = _registry_run_to_life_mapping().get(run_id)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -819,6 +819,74 @@ def test_lives_comparison_compare_lives_filter(tmp_path: Path) -> None:
     assert payload["filters"]["time_window"] == "all"
 
 
+def test_lives_comparison_maps_timestamped_run_file_to_registry_life(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "loop-20260415120000.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-15T12:00:00",
+                "accepted": True,
+                "score_base": 12.0,
+                "score_new": 9.0,
+                "health": {"score": 88.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    monkeypatch.setattr(
+        "singular.dashboard.load_registry",
+        lambda: {
+            "active": "life-alpha",
+            "lives": {"life-alpha": {"slug": "life-alpha", "run_id": "loop"}},
+        },
+    )
+
+    payload = app._routes["/lives/comparison"]()
+
+    assert "life-alpha" in payload["lives"]
+    assert payload["unattached_runs"]["records_count"] == 0
+
+
+def test_lives_comparison_resolves_life_field_when_it_contains_run_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "loop-20260415120000.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-15T12:00:00",
+                "life": "loop-20260415120000",
+                "accepted": True,
+                "score_base": 13.0,
+                "score_new": 9.0,
+                "health": {"score": 90.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    monkeypatch.setattr(
+        "singular.dashboard.load_registry",
+        lambda: {
+            "active": "life-alpha",
+            "lives": {"life-alpha": {"slug": "life-alpha", "run_id": "loop"}},
+        },
+    )
+
+    payload = app._routes["/lives/comparison"]()
+
+    assert "life-alpha" in payload["lives"]
+    assert "loop-20260415120000" not in payload["lives"]
+    assert payload["unattached_runs"]["records_count"] == 0
+
+
 def test_psyche_missing_returns_404(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()


### PR DESCRIPTION
## Summary
- Hardened life resolution in the dashboard comparison pipeline so run identifiers are not surfaced as life names.
- Updated `_record_life` to:
  - Build a set of known life slugs/names from the registry.
  - Accept `record["life"]` only if it matches a known life.
  - Otherwise treat `record["life"]` as a possible run id and resolve it through registry run-id mapping.
  - Fall back to normalized `_record_run_id` mapping, then `unknown`.
- This ensures the comparison table stays life-centric, even when records carry run-like values in `life`.

## Tests
- Added regression test `test_lives_comparison_resolves_life_field_when_it_contains_run_id`.
- Existing timestamped run-file mapping regression remains in place.
- Could not execute tests in this environment because collection fails with missing `fastapi.staticfiles` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdf9295f4832ab18cee16b9714a9e)