### PR TITLE
Prioritize explicit `life` field in lives comparison (avoid grouping by run-like skill prefix)

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -179,11 +179,11 @@ def create_app(
         return mapping
 
     def _record_life(record: dict[str, object]) -> str:
+        if isinstance(record.get("life"), str):
+            return str(record["life"])
         skill = record.get("skill")
         if isinstance(skill, str) and ":" in skill:
             return skill.split(":", 1)[0]
-        if isinstance(record.get("life"), str):
-            return str(record["life"])
         run_id = _record_run_id(record)
         if run_id != "unknown":
             mapped_life = _registry_run_to_life_mapping().get(run_id)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -819,6 +819,31 @@ def test_lives_comparison_compare_lives_filter(tmp_path: Path) -> None:
     assert payload["filters"]["time_window"] == "all"
 
 
+def test_lives_comparison_prefers_record_life_over_skill_prefix(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "compare.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-11T09:00:00",
+                "life": "life-a",
+                "skill": "loop-20260411090000:skills/a.py",
+                "accepted": True,
+                "score_base": 10.0,
+                "score_new": 8.0,
+                "health": {"score": 80.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+
+    payload = app._routes["/lives/comparison"]()
+
+    assert set(payload["lives"]) == {"life-a"}
+
+
 def test_lives_comparison_maps_timestamped_run_file_to_registry_life(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- The lives comparison view sometimes grouped records by a run-like prefix extracted from the `skill` field, causing runs to appear instead of the actual `life` declared on the record. This change ensures the dashboard shows lives, not runs.

### Description
- Update `_record_life` in `src/singular/dashboard/__init__.py` to return the explicit `life` field when present before falling back to parsing the `skill` prefix or mapping run ids.
- Add a regression test `test_lives_comparison_prefers_record_life_over_skill_prefix` in `tests/test_dashboard.py` that verifies a record with `"life": "life-a"` is grouped under `life-a` even if `skill` starts with a timestamped run-like prefix.
- Keep existing fallback behaviour (skill prefix, then registry run-id mapping) for legacy records.

### Testing
- Added unit test `tests/test_dashboard.py::test_lives_comparison_prefers_record_life_over_skill_prefix` which asserts grouping by `life` when present. 
- Attempted `pytest -q tests/test_dashboard.py -k lives_comparison` locally but test collection failed with `ModuleNotFoundError: No module named 'fastapi.staticfiles'` due to missing environment dependency, so tests could not be run in this environment. 
- The new test should pass in CI where `fastapi` and static files support are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe5deae24832ab6913b0cd42c23d4)