### PR TITLE
Include registry lives without records in dashboard comparison

### DIFF
--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -85,6 +85,57 @@ def aggregate_lives(
         by_life.setdefault(life_name, []).append(record)
 
     comparison: dict[str, dict[str, object]] = {}
+    for slug, raw_meta in registry_lives.items():
+        if not isinstance(slug, str):
+            continue
+        registry_status = "active"
+        display_name = slug
+        if isinstance(raw_meta, dict):
+            status_value = raw_meta.get("status")
+            if isinstance(status_value, str) and status_value in {"active", "extinct"}:
+                registry_status = status_value
+            name_value = raw_meta.get("name")
+            if isinstance(name_value, str) and name_value:
+                display_name = name_value
+        else:
+            status_value = getattr(raw_meta, "status", None)
+            if isinstance(status_value, str) and status_value in {"active", "extinct"}:
+                registry_status = status_value
+            name_value = getattr(raw_meta, "name", None)
+            if isinstance(name_value, str) and name_value:
+                display_name = name_value
+        is_selected = isinstance(active_life, str) and active_life in {slug, display_name}
+        is_extinct = registry_status == "extinct"
+        comparison[display_name] = {
+            "health_score": None,
+            "progression_slope": None,
+            "failure_rate": None,
+            "evolution_speed": None,
+            "mutations": 0,
+            "current_health_score": None,
+            "trend": "plateau",
+            "trend_rank": life_trend_rank("plateau"),
+            "stability": None,
+            "last_activity": None,
+            "alerts": [],
+            "alerts_count": 0,
+            "iterations": 0,
+            "selected_life": is_selected,
+            "life_status": registry_status,
+            "is_registry_active_life": registry_status == "active",
+            "has_recent_activity": False,
+            "extinction_seen_in_runs": is_extinct,
+            "run_terminated": False,
+            "vital_timeline": compute_vital_timeline(
+                age=0,
+                current_health=None,
+                failure_rate=None,
+                failure_streak=0,
+                extinction_seen=is_extinct,
+                registry_status=registry_status,
+            ),
+        }
+
     for life_name, all_records in by_life.items():
         all_records = sorted(all_records, key=lambda rec: str(rec.get("ts", "")))
         mutation_records = [rec for rec in all_records if is_mutation_record(rec)]

--- a/tests/test_dashboard_services.py
+++ b/tests/test_dashboard_services.py
@@ -70,3 +70,96 @@ def test_lives_comparison_service_aggregates_metrics() -> None:
     assert comparison["alpha"]["failure_rate"] == 0.5
     assert comparison["alpha"]["mutations"] == 2
     assert comparison["alpha"]["trend"] in {"plateau", "dégradation", "amélioration"}
+
+
+def test_lives_comparison_includes_registry_life_without_records_in_table() -> None:
+    comparison, _ = aggregate_lives(
+        [
+            {
+                "life": "alpha",
+                "ts": "2026-01-01T00:00:00Z",
+                "score_base": 10,
+                "score_new": 9,
+            }
+        ],
+        registry={
+            "active": "alpha",
+            "lives": {
+                "alpha": {"name": "alpha", "status": "active"},
+                "beta": {"name": "beta", "status": "active"},
+            },
+        },
+        compare_lives=None,
+        time_window="all",
+        record_life=lambda rec: str(rec.get("life", "unknown")),
+        record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
+        is_mutation_record=lambda rec: "score_base" in rec,
+        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        alerts_from_records=lambda _: [],
+        compute_vital_timeline=lambda **_: {"ok": True},
+        set_life_status=lambda *_: None,
+        registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
+    )
+
+    table = [{"life": name, **payload} for name, payload in comparison.items()]
+    assert {row["life"] for row in table} == {"alpha", "beta"}
+    beta = next(row for row in table if row["life"] == "beta")
+    assert beta["current_health_score"] is None
+    assert beta["iterations"] == 0
+    assert beta["has_recent_activity"] is False
+
+
+def test_lives_comparison_marks_selected_active_life_without_records() -> None:
+    comparison, _ = aggregate_lives(
+        [],
+        registry={
+            "active": "beta",
+            "lives": {
+                "alpha": {"name": "alpha", "status": "active"},
+                "beta": {"name": "beta", "status": "active"},
+            },
+        },
+        compare_lives=None,
+        time_window="all",
+        record_life=lambda rec: str(rec.get("life", "unknown")),
+        record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
+        is_mutation_record=lambda rec: "score_base" in rec,
+        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        alerts_from_records=lambda _: [],
+        compute_vital_timeline=lambda **_: {"ok": True},
+        set_life_status=lambda *_: None,
+        registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
+    )
+
+    assert comparison["beta"]["selected_life"] is True
+    assert comparison["alpha"]["selected_life"] is False
+
+
+def test_lives_comparison_default_rows_follow_active_and_dead_filters() -> None:
+    comparison, _ = aggregate_lives(
+        [],
+        registry={
+            "active": "alpha",
+            "lives": {
+                "alpha": {"name": "alpha", "status": "active"},
+                "beta": {"name": "beta", "status": "extinct"},
+            },
+        },
+        compare_lives=None,
+        time_window="all",
+        record_life=lambda rec: str(rec.get("life", "unknown")),
+        record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
+        is_mutation_record=lambda rec: "score_base" in rec,
+        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        alerts_from_records=lambda _: [],
+        compute_vital_timeline=lambda **_: {"ok": True},
+        set_life_status=lambda *_: None,
+        registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
+    )
+
+    table = [{"life": name, **payload} for name, payload in comparison.items()]
+    active_only = [row for row in table if row.get("is_registry_active_life") is True]
+    dead_only = [row for row in table if row.get("extinction_seen_in_runs") is True]
+
+    assert [row["life"] for row in active_only] == ["alpha"]
+    assert [row["life"] for row in dead_only] == ["beta"]


### PR DESCRIPTION
### Motivation
- Ensure lives present in the registry are visible in the dashboard comparison even when they have no run records, so UI filters and selection behave consistently. 
- Make the `selected_life` flag accurate for an active life that has no records. 
- Provide explicit default metrics and lifecycle status for registry-only lives so downstream filtering (`active_only`, `dead_only`) works predictably.

### Description
- In `aggregate_lives` initialize the `comparison` map from `registry["lives"]` and add a default row per registry life with explicit fields such as `current_health_score=None`, `iterations=0`, `has_recent_activity=False`, `selected_life` computed from `registry["active"]`, `life_status` and `is_registry_active_life` set from registry metadata, and a default `vital_timeline` via `compute_vital_timeline`.
- Preserve the existing enrichment logic that processes `records` and re-populates/overwrites entries for lives that do have mutation records. 
- Add unit tests in `tests/test_dashboard_services.py` covering registry lives without records appearing in the table, selected active life without records, and that `active_only` / `dead_only` semantics apply to the default rows.

### Testing
- Ran `pytest -q tests/test_dashboard_services.py` which attempted to collect the new tests and failed during collection due to a missing test environment dependency (`ModuleNotFoundError: No module named 'fastapi.staticfiles'`).
- The new unit tests were added and exercise the `aggregate_lives` behavior, but full test execution in this environment is blocked by the missing dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfee00b224832a8e397fc146c406ae)