### PR TITLE
Support dict and object live path metadata in RunRecordsRepository

### DIFF
--- a/src/singular/dashboard/repositories/run_records.py
+++ b/src/singular/dashboard/repositories/run_records.py
@@ -21,9 +21,13 @@ class RunRecordsRepository:
             return []
         lives_paths: list[Path] = []
         for meta in raw_lives.values():
-            path = getattr(meta, "path", None)
-            if isinstance(path, Path):
-                lives_paths.append(path)
+            path_value = getattr(meta, "path", None)
+            if isinstance(meta, dict):
+                path_value = meta.get("path", path_value)
+            if isinstance(path_value, str):
+                path_value = Path(path_value)
+            if isinstance(path_value, Path):
+                lives_paths.append(path_value)
         return lives_paths
 
     def runs_dirs(self, current_life_only: bool = False) -> list[Path]:

--- a/tests/test_dashboard_run_records_repository.py
+++ b/tests/test_dashboard_run_records_repository.py
@@ -31,3 +31,16 @@ def test_run_records_repository_latest_file_uses_timestamp(tmp_path: Path) -> No
 
     assert latest is not None
     assert latest.stem == "b"
+
+
+def test_run_records_repository_runs_dirs_supports_dict_registry_metadata(tmp_path: Path) -> None:
+    alpha_dir = tmp_path / "alpha"
+    repo = RunRecordsRepository(
+        base_dir=tmp_path,
+        runs_path=None,
+        registry_loader=lambda: {"lives": {"alpha": {"path": str(alpha_dir)}}},
+    )
+
+    runs_dirs = repo.runs_dirs()
+
+    assert alpha_dir / "runs" in runs_dirs


### PR DESCRIPTION
### Motivation
- Registry `lives` entries can be represented either as objects exposing a `.path` attribute or as plain dicts with a `"path"` key, and the repository needs to handle both formats.
- Path values should be normalized to `Path` objects and non-path / invalid values should be ignored cleanly.

### Description
- Update `_registry_lives_paths()` in `src/singular/dashboard/repositories/run_records.py` to read `path` from either an object attribute or a dict key, convert `str` values to `Path`, and collect only valid `Path` instances.
- Add a test `test_run_records_repository_runs_dirs_supports_dict_registry_metadata` in `tests/test_dashboard_run_records_repository.py` that supplies `{"lives": {"alpha": {"path": "<tmp>/alpha"}}}` and asserts that `runs_dirs()` includes `<tmp>/alpha/runs`.

### Testing
- Ran `pytest -q tests/test_dashboard_run_records_repository.py`, which failed during test collection due to a missing dependency `fastapi.staticfiles` in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfef1aae90832a96d2bed026fd377b)