### PR TITLE
Centraliser le comptage des vies via un contrat de métriques partagé

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -36,6 +36,9 @@ from singular.dashboard.services.lives_comparison import (
     life_trend_label as life_trend_label_service,
     life_trend_rank as life_trend_rank_service,
 )
+from singular.dashboard.services.metrics_contract import (
+    build_metrics_contract as build_metrics_contract_service,
+)
 
 
 @dataclass
@@ -251,14 +254,18 @@ def create_app(
             for state in organisms.values()
             if isinstance(state.get("resources"), (int, float))
         )
+        comparison, _ = _aggregate_lives(current_life_only=current_life_only)
+        life_metrics_contract = build_metrics_contract_service(comparison)
+        life_counts = life_metrics_contract.get("counts", {})
         return {
             "organisms": organisms,
             "summary": {
-                "total_organisms": len(organisms),
-                "alive_organisms": alive,
+                "total_organisms": int(life_counts.get("total_lives", len(organisms))),
+                "alive_organisms": int(life_counts.get("alive_lives", alive)),
                 "total_energy": total_energy,
                 "total_resources": total_resources,
             },
+            "life_metrics_contract": life_metrics_contract,
         }
 
     def _skill_lifecycle_summary() -> dict[str, int]:
@@ -432,6 +439,7 @@ def create_app(
                 ),
                 "skills_lifecycle": _skill_lifecycle_summary(),
                 "daily_skills": build_daily_skills_snapshot([]),
+                "life_metrics_contract": _build_metrics_contract({}),
                 "trajectory": _build_trajectory([]),
             }
             return empty
@@ -519,6 +527,16 @@ def create_app(
         autonomy_metrics = compute_autonomy_metrics(records)
         ecosystem = _compute_ecosystem(current_life_only=current_life_only)
         summary = ecosystem.get("summary", {}) if isinstance(ecosystem, dict) else {}
+        metrics_contract = (
+            ecosystem.get("life_metrics_contract", {})
+            if isinstance(ecosystem.get("life_metrics_contract"), dict)
+            else {}
+        )
+        life_counts = (
+            metrics_contract.get("counts", {})
+            if isinstance(metrics_contract.get("counts"), dict)
+            else {}
+        )
 
         hour_utc = datetime.now(timezone.utc).hour
         if 5 <= hour_utc < 12:
@@ -582,8 +600,14 @@ def create_app(
                 "energy_resources": {
                     "total_energy": float(summary.get("total_energy", 0.0) or 0.0),
                     "total_resources": float(summary.get("total_resources", 0.0) or 0.0),
-                    "alive_organisms": int(summary.get("alive_organisms", 0) or 0),
-                    "total_organisms": int(summary.get("total_organisms", 0) or 0),
+                    "alive_organisms": int(
+                        life_counts.get("alive_lives", summary.get("alive_organisms", 0))
+                        or 0
+                    ),
+                    "total_organisms": int(
+                        life_counts.get("total_lives", summary.get("total_organisms", 0))
+                        or 0
+                    ),
                 },
                 "code_generation": {
                     "progression": trend,
@@ -597,6 +621,7 @@ def create_app(
             "vital_timeline": vital_timeline,
             "skills_lifecycle": _skill_lifecycle_summary(),
             "daily_skills": build_daily_skills_snapshot(records),
+            "life_metrics_contract": metrics_contract,
             "trajectory": trajectory,
         }
 
@@ -992,6 +1017,11 @@ def create_app(
             registry_life_meta=_registry_life_meta,
         )
 
+    def _build_metrics_contract(
+        comparison: dict[str, dict[str, object]]
+    ) -> dict[str, object]:
+        return build_metrics_contract_service(comparison)
+
     @app.get("/lives/comparison")
     def read_lives_comparison(
         sort_by: str = "score",
@@ -1015,6 +1045,7 @@ def create_app(
             compare_lives=compare_set,
             time_window=time_window,
         )
+        metrics_contract = _build_metrics_contract(comparison)
         lives_rows = [{"life": name, **payload} for name, payload in comparison.items()]
 
         if active_only:
@@ -1051,6 +1082,7 @@ def create_app(
         return {
             "lives": comparison,
             "table": lives_rows,
+            "life_metrics_contract": metrics_contract,
             "unattached_runs": unattached,
             "onboarding": {
                 "required": bool(registry_state["is_empty"]),

--- a/src/singular/dashboard/services/metrics_contract.py
+++ b/src/singular/dashboard/services/metrics_contract.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+METRICS_CONTRACT_LABELS = {
+    "total_lives": "Vies totales",
+    "alive_lives": "Vies vivantes",
+    "dead_lives": "Vies mortes",
+    "selected_lives": "Vies sélectionnées",
+    "recent_activity_lives": "Vies avec activité récente",
+}
+
+
+def build_life_counts(lives: dict[str, dict[str, Any]]) -> dict[str, int]:
+    total_lives = len(lives)
+    selected_lives = 0
+    recent_activity_lives = 0
+    dead_lives = 0
+
+    for payload in lives.values():
+        if bool(payload.get("selected_life")):
+            selected_lives += 1
+        if bool(payload.get("has_recent_activity")):
+            recent_activity_lives += 1
+
+        life_status = payload.get("life_status")
+        extinct_in_runs = bool(payload.get("extinction_seen_in_runs"))
+        if life_status == "extinct" or extinct_in_runs:
+            dead_lives += 1
+
+    alive_lives = max(total_lives - dead_lives, 0)
+
+    return {
+        "total_lives": total_lives,
+        "alive_lives": alive_lives,
+        "dead_lives": dead_lives,
+        "selected_lives": selected_lives,
+        "recent_activity_lives": recent_activity_lives,
+    }
+
+
+def build_metrics_contract(lives: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "counts": build_life_counts(lives),
+        "labels": METRICS_CONTRACT_LABELS,
+    }

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -130,10 +130,12 @@ export const loadRetentionStatus=()=>fetchJson('/api/retention/status').then(pay
 });
 
 export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJson(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc'))]).then(([eco,lives])=>{
-  const summary=eco.summary||{};
-  const total=Number(summary.total_organisms||0);
-  const alive=Number(summary.alive_organisms||0);
-  const dead=Math.max(total-alive,0);
+  const contract=eco.life_metrics_contract||lives.life_metrics_contract||{};
+  const counts=contract.counts||{};
+  const labels=contract.labels||{};
+  const total=Number(counts.total_lives||0);
+  const alive=Number(counts.alive_lives||0);
+  const dead=Number(counts.dead_lives||0);
   document.getElementById('eco-total-lives').textContent=String(total);
   document.getElementById('eco-alive-lives').textContent=String(alive);
   document.getElementById('eco-dead-lives').textContent=String(dead);
@@ -142,6 +144,9 @@ export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJs
   document.getElementById('eco-selected-life').textContent=selected?.life||'Aucune';
   const latestRow=rows.find(row=>row.last_activity);
   document.getElementById('eco-last-activity').textContent=latestRow?.last_activity||na();
+  document.getElementById('eco-total-lives').title=labels.total_lives||'Vies totales';
+  document.getElementById('eco-alive-lives').title=labels.alive_lives||'Vies vivantes';
+  document.getElementById('eco-dead-lives').title=labels.dead_lives||'Vies mortes';
   const organisms=eco.organisms||{};
   const list=document.getElementById('organisms-list');
   list.innerHTML='';

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -78,13 +78,17 @@ const summarizeBadges=row=>{
   return badges;
 };
 
-const renderLivesBuckets=(rows)=>{
+const renderLivesBuckets=(rows,contract)=>{
   const activeInRegistry=(rows||[]).filter(row=>row.is_registry_active_life===true);
   const extinctInRuns=(rows||[]).filter(row=>row.extinction_seen_in_runs===true);
+  const counts=contract?.counts||{};
+  const labels=contract?.labels||{};
   const aliveList=document.getElementById('alive-lives');
   const deadList=document.getElementById('dead-lives');
-  document.getElementById('alive-count').textContent=String(activeInRegistry.length);
-  document.getElementById('dead-count').textContent=String(extinctInRuns.length);
+  document.getElementById('alive-count').textContent=String(counts.alive_lives??activeInRegistry.length);
+  document.getElementById('dead-count').textContent=String(counts.dead_lives??extinctInRuns.length);
+  document.getElementById('alive-count').title=labels.alive_lives||'Vies vivantes';
+  document.getElementById('dead-count').title=labels.dead_lives||'Vies mortes';
   aliveList.innerHTML='';
   deadList.innerHTML='';
   for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||na();aliveList.appendChild(li);} 
@@ -188,7 +192,7 @@ export const loadLivesBoard=()=>{
     if(livesUiState.focus==='selected'){tableRows=tableRows.filter(row=>row.selected_life);}
     if(livesUiState.focus==='at_risk'){tableRows=tableRows.filter(row=>(row.__riskLevel||0)>=1);}
     livesUiState.rowsByLife=new Map(mappedRows.map(row=>[row.life,row]));
-    renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})));
+    renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})),d.life_metrics_contract);
     renderLivesTable(tableRows);
     if(livesUiState.selectedLife&&livesUiState.rowsByLife.has(livesUiState.selectedLife)){showLifeDetails(livesUiState.selectedLife);}
     else if(tableRows.length){showLifeDetails(tableRows[0].life||'');}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -877,6 +877,74 @@ def test_lives_comparison_maps_timestamped_run_file_to_registry_life(
     assert payload["unattached_runs"]["records_count"] == 0
 
 
+def test_dashboard_life_metrics_contract_is_consistent_across_endpoints(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "contract.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-04-10T09:00:00",
+                        "skill": "life-a:skills/a.py",
+                        "accepted": True,
+                        "score_base": 9.0,
+                        "score_new": 8.0,
+                        "health": {"score": 80.0},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-04-10T09:30:00",
+                        "skill": "life-b:skills/b.py",
+                        "event": "death",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-04-10T10:00:00",
+                        "skill": "life-c:skills/c.py",
+                        "accepted": False,
+                        "score_base": 10.0,
+                        "score_new": 11.0,
+                        "health": {"score": 70.0},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    monkeypatch.setattr(
+        "singular.dashboard.load_registry",
+        lambda: {
+            "active": "life-c",
+            "lives": {
+                "life-a": {"slug": "life-a", "status": "active"},
+                "life-b": {"slug": "life-b", "status": "extinct"},
+                "life-c": {"slug": "life-c", "status": "active"},
+            },
+        },
+    )
+
+    cockpit_contract = app._routes["/api/cockpit"]()["life_metrics_contract"]
+    comparison_contract = app._routes["/lives/comparison"]()["life_metrics_contract"]
+    ecosystem_contract = app._routes["/ecosystem"]()["life_metrics_contract"]
+
+    assert cockpit_contract["counts"] == {
+        "total_lives": 3,
+        "alive_lives": 2,
+        "dead_lives": 1,
+        "selected_lives": 1,
+        "recent_activity_lives": 3,
+    }
+    assert comparison_contract == cockpit_contract
+    assert ecosystem_contract == cockpit_contract
+
+
 def test_psyche_missing_returns_404(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Harmoniser les règles de comptage (total/vivantes/mortes/sélectionnée/activité récente) afin que plusieurs endpoints et l’UI consomment la même source de vérité. 
- Réduire la duplication de logique entre `/api/cockpit`, `/lives/comparison` et `/ecosystem` et faciliter l’évolution des libellés côté frontend.

### Description
- Ajout du service `metrics_contract` (`src/singular/dashboard/services/metrics_contract.py`) qui expose `build_metrics_contract` et centralise les compteurs et libellés partagés. 
- Intégration du contrat dans le backend pour qu’il soit produit/consommé par `/lives/comparison` (ajout de `life_metrics_contract` dans la réponse), par `_compute_ecosystem` (injection des comptes dans le résumé tout en conservant la compatibilité), et par `/api/cockpit` (exposition du `life_metrics_contract`).
- Adaptation du frontend pour lire les compteurs et libellés depuis le contrat en priorité, dans `src/singular/dashboard/static/render-cockpit.js` et `src/singular/dashboard/static/render-lives.js`.
- Ajout d’un test d’intégration `test_dashboard.py::test_dashboard_life_metrics_contract_is_consistent_across_endpoints` vérifiant que des mêmes enregistrements bruts produisent des comptes identiques depuis les trois endpoints.

### Testing
- Compilation rapide de modules avec `python -m py_compile src/singular/dashboard/services/metrics_contract.py src/singular/dashboard/__init__.py` a réussi.
- Exécution ciblée de tests via `pytest -q tests/test_dashboard.py -k "life_metrics_contract_is_consistent_across_endpoints or lives_comparison_table_aggregation_filters_and_sorting or dashboard_cockpit_endpoint_schema"` a échoué pour des raisons d’environnement avec l’erreur `ModuleNotFoundError: No module named 'fastapi.staticfiles'` lors de la collection des tests, donc le test d’intégration n’a pas pu être confirmé dans cet environnement.
- Les modifications ont été formellement validées par inspection statique et compilation partielle des modules concernés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff1db9d10832aa2276577d434317d)