### PR TITLE
Ajout du diagnostic de filtrage des vies et bouton de réinitialisation

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -1046,18 +1046,51 @@ def create_app(
             time_window=time_window,
         )
         metrics_contract = _build_metrics_contract(comparison)
-        lives_rows = [{"life": name, **payload} for name, payload in comparison.items()]
+        base_rows = [{"life": name, **payload} for name, payload in comparison.items()]
+        lives_rows = list(base_rows)
+        filter_steps: list[dict[str, object]] = [
+            {
+                "step": "before_filters",
+                "label": "Vies avant filtres endpoint",
+                "applied": True,
+                "count": len(lives_rows),
+            }
+        ]
 
         if active_only:
             lives_rows = [
                 row for row in lives_rows if row.get("is_registry_active_life") is True
             ]
+        filter_steps.append(
+            {
+                "step": "active_only",
+                "label": "Après filtre active_only",
+                "applied": active_only,
+                "count": len(lives_rows),
+            }
+        )
         if degrading_only:
             lives_rows = [row for row in lives_rows if row.get("trend") == "dégradation"]
+        filter_steps.append(
+            {
+                "step": "degrading_only",
+                "label": "Après filtre degrading_only",
+                "applied": degrading_only,
+                "count": len(lives_rows),
+            }
+        )
         if dead_only:
             lives_rows = [
                 row for row in lives_rows if row.get("extinction_seen_in_runs") is True
             ]
+        filter_steps.append(
+            {
+                "step": "dead_only",
+                "label": "Après filtre dead_only",
+                "applied": dead_only,
+                "count": len(lives_rows),
+            }
+        )
 
         sort_key_map: dict[str, str] = {
             "life": "life",
@@ -1076,6 +1109,14 @@ def create_app(
                 str(row.get("life", "")),
             ),
             reverse=reverse,
+        )
+        filter_steps.append(
+            {
+                "step": "sorted",
+                "label": "Après tri",
+                "applied": True,
+                "count": len(lives_rows),
+            }
         )
 
         registry_state = _registry_overview()
@@ -1096,6 +1137,10 @@ def create_app(
                 "dead_only": dead_only,
                 "time_window": time_window,
                 "compare_lives": sorted(compare_set) if compare_set else [],
+            },
+            "filter_diagnostics": {
+                "before_filter_count": len(base_rows),
+                "steps": filter_steps,
             },
         }
 

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -46,6 +46,54 @@ const livesUiState={
   rowsByLife:new Map(),
 };
 
+const formatFilterLabel=(key,value)=>{
+  if(key==='quickFilter'){return `quickFilter=${value}`;}
+  if(key==='focus'){return `focus=${value}`;}
+  if(key==='time_window'){return `time_window=${value}`;}
+  if(key==='current_life_only'){return `current_life_only=${value?'true':'false'}`;}
+  return `${key}=${value}`;
+};
+
+const updateResetFiltersChipStates=()=>{
+  document.querySelectorAll('#lives-quick-filters .filter-chip').forEach(node=>{
+    const active=(node.dataset.filterKey||'all')===livesUiState.quickFilter;
+    node.classList.toggle('active',active);
+    node.setAttribute('aria-pressed',active?'true':'false');
+  });
+  document.querySelectorAll('#lives-focus-chips .filter-chip').forEach(node=>{
+    const active=(node.dataset.focusKey||'all')===livesUiState.focus;
+    node.classList.toggle('active',active);
+    node.setAttribute('aria-pressed',active?'true':'false');
+  });
+};
+
+const resetLivesFilters=(reload=loadLivesBoard)=>{
+  livesUiState.quickFilter='all';
+  livesUiState.focus='all';
+  const timeWindowSelect=document.getElementById('filter-time-window');
+  if(timeWindowSelect){timeWindowSelect.value='all';}
+  scopeState.currentLifeOnly=false;
+  const scopeToggle=document.getElementById('scope-current-life');
+  if(scopeToggle){scopeToggle.checked=false;}
+  updateResetFiltersChipStates();
+  reload();
+};
+
+const renderFilterDiagnostics=(payload)=>{
+  const container=document.getElementById('lives-filter-diagnostics');
+  if(!container){return;}
+  const steps=(payload?.steps)||[];
+  if(!steps.length){
+    container.textContent='Aucun breakdown de filtrage disponible.';
+    return;
+  }
+  const lines=steps.map(step=>{
+    const applied=step.applied===true?'appliqué':'ignoré';
+    return `${step.label||step.step} : ${step.count??0} (${applied})`;
+  });
+  container.textContent=lines.join('\n');
+};
+
 const rowStateSummary=row=>{
   if(row.extinction_seen_in_runs){return {label:'Extinction',tone:'summary-critical'};}
   if(row.is_registry_active_life){return {label:'Active',tone:'summary-ok'};}
@@ -188,9 +236,14 @@ export const loadLivesBoard=()=>{
       const risk=rowRiskSummary(row);
       return {...row,__riskLevel:risk.level,__stateSummary:rowStateSummary(row),__riskSummary:risk,__activitySummary:rowActivitySummary(row)};
     });
+    const clientSteps=[
+      {step:'client_before_focus',label:'Avant focus client',applied:true,count:mappedRows.length},
+    ];
     let tableRows=preset.apply(mappedRows);
+    clientSteps.push({step:'client_after_preset',label:`Après preset ${presetKey}`,applied:true,count:tableRows.length});
     if(livesUiState.focus==='selected'){tableRows=tableRows.filter(row=>row.selected_life);}
     if(livesUiState.focus==='at_risk'){tableRows=tableRows.filter(row=>(row.__riskLevel||0)>=1);}
+    clientSteps.push({step:'client_focus',label:`Après focus ${livesUiState.focus}`,applied:livesUiState.focus!=='all',count:tableRows.length});
     livesUiState.rowsByLife=new Map(mappedRows.map(row=>[row.life,row]));
     renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})),d.life_metrics_contract);
     renderLivesTable(tableRows);
@@ -198,7 +251,19 @@ export const loadLivesBoard=()=>{
     else if(tableRows.length){showLifeDetails(tableRows[0].life||'');}
     else{showLifeDetails('');}
     renderUnattachedRuns(d.unattached_runs);
-    if(!tableRows.length){setPanelState('vies','empty','Aucune vie pour ces filtres. Ajustez la fenêtre ou retirez des filtres.');}
+    renderFilterDiagnostics({...d.filter_diagnostics,steps:[...((d.filter_diagnostics?.steps)||[]),...clientSteps]});
+    if(!tableRows.length){
+      const activeFilters=[
+        ['quickFilter',livesUiState.quickFilter],
+        ['focus',livesUiState.focus],
+        ['time_window',timeWindow],
+        ['current_life_only',scopeState.currentLifeOnly],
+      ];
+      const activeLabels=activeFilters.map(([key,value])=>formatFilterLabel(key,value));
+      const message=`Aucune vie pour ces filtres.<br><strong>Filtres actifs :</strong> ${activeLabels.join(' · ')}<br><button type='button' id='reset-lives-filters-btn' class='filter-chip active'>Réinitialiser les filtres</button>`;
+      setPanelState('vies','empty',message);
+      document.getElementById('reset-lives-filters-btn')?.addEventListener('click',()=>resetLivesFilters(),{once:true});
+    }
   });
 };
 
@@ -275,6 +340,7 @@ export const bindLivesHandlers=(reload=loadLivesBoard)=>{
   });
   document.getElementById('filter-sort-preset').onchange=()=>reload();
   document.getElementById('filter-time-window').onchange=()=>reload();
+  document.getElementById('lives-reset-filters')?.addEventListener('click',()=>resetLivesFilters(reload));
 };
 
 export const bindLiveStreamHandlers=()=>{

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -143,6 +143,13 @@
         <ul id='dead-lives' class='list-compact'></ul>
       </div>
     </div>
+    <div class='panel panel-compact panel-bordered panel-top-gap'>
+      <div class='toolbar-wrap'>
+        <strong>Diagnostic filtrage vies</strong>
+        <button type='button' id='lives-reset-filters' class='filter-chip'>Réinitialiser les filtres</button>
+      </div>
+      <pre id='lives-filter-diagnostics'>Chargement du breakdown…</pre>
+    </div>
     <div class='lives-grid'>
       <table id='lives-table' class='table-base table-spacing-top'>
         <thead><tr>


### PR DESCRIPTION
### Motivation
- Faciliter le débogage opérateur en exposant le nombre de vies avant et après chaque étape de filtrage pour éviter d'inspecter le code.
- Rendre l'état « vide » du panneau `vies` plus utile en affichant les filtres actifs (`quickFilter`, `focus`, `time_window`, `current_life_only`) et proposer un moyen rapide de tout réinitialiser.

### Description
- Enrichit la réponse `GET /lives/comparison` en ajoutant la clé `filter_diagnostics` contenant `before_filter_count` et une liste `steps` avec le nombre d'éléments après chaque étape backend (ex. `active_only`, `degrading_only`, `dead_only`, `sorted`). (fichier modifié: `src/singular/dashboard/__init__.py`)
- Ajoute un panneau de diagnostic dans l'UI `vies` avec un `<pre id='lives-filter-diagnostics'>` et un bouton `#lives-reset-filters` pour réinitialiser les filtres côté client. (fichier modifié: `src/singular/dashboard/templates/dashboard.html`)
- Côté client, implémente `renderFilterDiagnostics`, collecte et concatène les étapes de diagnostic serveur + étapes client (preset, focus) et les affiche; améliore l'état vide pour lister les filtres actifs et insérer un bouton `Réinitialiser les filtres` qui appelle `resetLivesFilters`. (fichier modifié: `src/singular/dashboard/static/render-lives.js`)
- Le flux de reset remet `quickFilter`, `focus`, la `time_window` et le flag `currentLifeOnly` à leurs valeurs par défaut et relance le chargement du tableau.

### Testing
- Compilation syntaxique Python exécutée avec `python -m compileall src/singular/dashboard/__init__.py` et réussie.
- Les modifications JS/HTML ont été ajoutées et les fonctions de rendu et de liaison d'événements ont été vérifiées par inspection statique (aucune erreur de syntaxe détectée lors des opérations automatisées de build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff328f92c832a9edb2ab68e8ad57b)