### PR TITLE
Implement essential-mode UI levels and dedicated /api/cockpit/essential projection

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -625,6 +625,30 @@ def create_app(
             "trajectory": trajectory,
         }
 
+    def _summarize_cockpit_essential(current_life_only: bool = False) -> dict[str, object]:
+        cockpit = _summarize_cockpit(current_life_only=current_life_only)
+        comparison, _ = _aggregate_lives(current_life_only=current_life_only)
+        rows = comparison.get("table", []) if isinstance(comparison.get("table"), list) else []
+        selected_life = "Aucune"
+        for row in rows:
+            if isinstance(row, dict) and row.get("selected_life") is True:
+                candidate = row.get("life")
+                if isinstance(candidate, str) and candidate:
+                    selected_life = candidate
+                    break
+        incidents_count = 0
+        critical_alerts = cockpit.get("critical_alerts")
+        if isinstance(critical_alerts, list):
+            incidents_count = len(critical_alerts)
+        return {
+            "schema_version": "2026-04-15",
+            "global_status": cockpit.get("global_status", "unknown"),
+            "critical_alerts_count": incidents_count,
+            "next_action": cockpit.get("next_action") or "Aucune action immédiate",
+            "selected_life": selected_life,
+            "active_incidents_count": incidents_count,
+        }
+
 
     @app.get("/logs")
     def read_logs(current_life_only: bool = False) -> dict[str, str]:
@@ -865,6 +889,10 @@ def create_app(
     @app.get("/api/cockpit")
     def read_cockpit(current_life_only: bool = False) -> dict[str, object]:
         return _summarize_cockpit(current_life_only=current_life_only)
+
+    @app.get("/api/cockpit/essential")
+    def read_cockpit_essential(current_life_only: bool = False) -> dict[str, object]:
+        return _summarize_cockpit_essential(current_life_only=current_life_only)
 
     @app.get("/dashboard/context")
     def read_dashboard_context() -> dict[str, object]:

--- a/src/singular/dashboard/static/bootstrap.js
+++ b/src/singular/dashboard/static/bootstrap.js
@@ -20,6 +20,7 @@ import {
 
 const ws=new WebSocket(`ws://${location.host}/ws`);
 const blockFreshness=new Map();
+const ESSENTIAL_MODE_KEY='singular.dashboard.essentialMode';
 
 const taskDefinitions={
   context:{loader:loadContext,intervalMs:schedulerConfig.frequencies.context,viewKey:'technique',blockId:'parametres',stream:'cold'},
@@ -220,11 +221,27 @@ const bootstrapViewPauseControls=()=>{
   });
 };
 
+const applyEssentialVisibility=isEssential=>{
+  document.body.classList.toggle('essential-mode',isEssential);
+  document.querySelectorAll('[data-essential-level]').forEach(node=>{
+    const level=Number(node.getAttribute('data-essential-level')||'1');
+    const shouldHide=isEssential&&level>=3;
+    if(node.tagName==='DETAILS'&&level===2){
+      node.open=!isEssential;
+    }
+    if(level>=3){
+      node.classList.toggle('panel-hidden',shouldHide);
+    }
+    node.setAttribute('aria-hidden',shouldHide?'true':'false');
+  });
+};
+
 const toggleEssentialMode=()=>{
-  document.body.classList.toggle('essential-mode');
+  const isEssential=!document.body.classList.contains('essential-mode');
+  applyEssentialVisibility(isEssential);
+  localStorage.setItem(ESSENTIAL_MODE_KEY,isEssential?'1':'0');
   const btn=document.getElementById('toggle-essential');
   if(!btn){return;}
-  const isEssential=document.body.classList.contains('essential-mode');
   btn.textContent=`Mode Essentiel : ${isEssential?'ON':'OFF'}`;
   btn.setAttribute('aria-pressed',isEssential?'true':'false');
 };
@@ -267,7 +284,13 @@ const bindTabNavigation=()=>{
 const bindCommonHandlers=()=>{
   bindTabNavigation();
   const essentialBtn=document.getElementById('toggle-essential');
-  if(essentialBtn){essentialBtn.onclick=toggleEssentialMode;}
+  const defaultEssential=localStorage.getItem(ESSENTIAL_MODE_KEY)==='1';
+  applyEssentialVisibility(defaultEssential);
+  if(essentialBtn){
+    essentialBtn.textContent=`Mode Essentiel : ${defaultEssential?'ON':'OFF'}`;
+    essentialBtn.setAttribute('aria-pressed',defaultEssential?'true':'false');
+    essentialBtn.onclick=toggleEssentialMode;
+  }
   const scopeToggle=document.getElementById('scope-current-life');
   if(scopeToggle){
     scopeToggle.onchange=e=>{

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -162,18 +162,23 @@ export const loadHostVitals=()=>fetchJson(withScope('/runs/latest')).then(data=>
   if(!hasData){setPanelState('host-vitals-panel','empty','Capteurs hôte non supportés ou données absentes.');}
 }).catch(error=>{renderHostMetrics([]);throw error;});
 
-export const loadCockpit=()=>fetchJson(withScope('/api/cockpit')).then(d=>{
+export const loadCockpit=()=>Promise.all([
+  fetchJson(withScope('/api/cockpit/essential')),
+  fetchJson(withScope('/api/cockpit')),
+]).then(([essential,d])=>{
   if(!d||typeof d!=='object'){setPanelState('cockpit','empty','Aucune donnée cockpit disponible.');return;}
+  const essentialPayload=(essential&&typeof essential==='object')?essential:{};
   const statusBox=document.getElementById('cockpit-status');
-  statusBox.textContent=`Statut global: ${d.global_status||na()}`;
-  if(d.global_status==='stable'){setStatusTone(statusBox,'good');applyStatusIndicator(statusBox,'good');}
-  else if(d.global_status==='warning'){setStatusTone(statusBox,'warn');applyStatusIndicator(statusBox,'warn');}
-  else if(d.global_status==='critical'){setStatusTone(statusBox,'bad');applyStatusIndicator(statusBox,'bad');}
+  const globalStatus=essentialPayload.global_status||d.global_status;
+  statusBox.textContent=`Statut global: ${globalStatus||na()}`;
+  if(globalStatus==='stable'){setStatusTone(statusBox,'good');applyStatusIndicator(statusBox,'good');}
+  else if(globalStatus==='warning'){setStatusTone(statusBox,'warn');applyStatusIndicator(statusBox,'warn');}
+  else if(globalStatus==='critical'){setStatusTone(statusBox,'bad');applyStatusIndicator(statusBox,'bad');}
 
   const healthValue=d.health_score===null?na():Number(d.health_score).toFixed(1);
   const trend=d.trend||na();
   const accepted=d.accepted_mutation_rate===null?na():`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
-  const alertsCount=(d.critical_alerts||[]).length;
+  const alertsCount=Number(essentialPayload.critical_alerts_count??(d.critical_alerts||[]).length||0);
   const autonomy=d.autonomy_metrics||{};
   const decisionQuality=autonomy.decision_quality||{};
   const fmtPct=(value)=>value===null||value===undefined?na():`${(Number(value)*100).toFixed(1)}%`;
@@ -183,7 +188,11 @@ export const loadCockpit=()=>fetchJson(withScope('/api/cockpit')).then(d=>{
   document.getElementById('kpi-trend').textContent=trend;
   document.getElementById('kpi-accepted').textContent=accepted;
   document.getElementById('kpi-alerts').textContent=String(alertsCount);
-  document.getElementById('kpi-next-action').textContent=d.next_action||na();
+  document.getElementById('kpi-next-action').textContent=essentialPayload.next_action||d.next_action||na();
+  const selectedLifeEl=document.getElementById('essential-selected-life');
+  if(selectedLifeEl){selectedLifeEl.textContent=String(essentialPayload.selected_life||'Aucune');}
+  const incidentsEl=document.getElementById('essential-active-incidents');
+  if(incidentsEl){incidentsEl.textContent=String(essentialPayload.active_incidents_count??alertsCount);}
   document.getElementById('kpi-autonomy-proactive').textContent=fmtPct(autonomy.proactive_initiative_rate);
   document.getElementById('kpi-autonomy-stability').textContent=fmtPct(autonomy.long_term_stability);
   document.getElementById('kpi-autonomy-decision').textContent=`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`;

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -173,6 +173,15 @@ const renderLivesTable=(rows)=>{
   if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='9'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}
 };
 
+const renderEssentialLivesSummary=rows=>{
+  const selected=(rows||[]).find(row=>row.selected_life===true);
+  const selectedLifeEl=document.getElementById('essential-selected-life');
+  if(selectedLifeEl){selectedLifeEl.textContent=selected?.life||'Aucune';}
+  const activeIncidents=(rows||[]).reduce((total,row)=>total+Number(row.alerts_count||0),0);
+  const incidentsEl=document.getElementById('essential-active-incidents');
+  if(incidentsEl){incidentsEl.textContent=String(activeIncidents);}
+};
+
 const showLifeDetails=lifeName=>{
   const panel=document.getElementById('life-detail-panel');
   const content=document.getElementById('life-detail-content');
@@ -250,6 +259,7 @@ export const loadLivesBoard=()=>{
     if(livesUiState.selectedLife&&livesUiState.rowsByLife.has(livesUiState.selectedLife)){showLifeDetails(livesUiState.selectedLife);}
     else if(tableRows.length){showLifeDetails(tableRows[0].life||'');}
     else{showLifeDetails('');}
+    renderEssentialLivesSummary(mappedRows);
     renderUnattachedRuns(d.unattached_runs);
     renderFilterDiagnostics({...d.filter_diagnostics,steps:[...((d.filter_diagnostics?.steps)||[]),...clientSteps]});
     if(!tableRows.length){

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -35,7 +35,7 @@
       <span class='status-pill status-warn'>▲ Alerte</span>
       <span class='status-pill status-bad'>■ Critique</span>
     </div>
-    <div class='panel level-panel'>
+    <div class='panel level-panel' data-essential-level='1'>
       <h3 class='heading-reset-top'>Niveau Critique · action immédiate</h3>
       <div id='cockpit-status' class='card card-value'>Statut global: Non disponible</div>
       <div class='cards-grid'>
@@ -46,7 +46,7 @@
       </div>
     </div>
 
-    <details id='cockpit-followup' class='panel level-panel' open>
+    <details id='cockpit-followup' class='panel level-panel' data-essential-level='2' open>
       <summary>Niveau Suivi · tendances santé/autonomie/vital</summary>
       <div class='cards-grid content-top-gap'>
         <div class='card'><div class='card-label kpi-label' title='Évolution récente du système'>Tendance</div><div id='kpi-trend' class='card-value actionable-signal'>Non disponible</div></div>
@@ -58,7 +58,7 @@
       </div>
     </details>
 
-    <details id='cockpit-detail' class='panel level-panel'>
+    <details id='cockpit-detail' class='panel level-panel technical-only' data-essential-level='3'>
       <summary>Niveau Détail · skills lifecycle, rétention, payload JSON</summary>
       <div class='cards-grid content-top-gap'>
         <div class='card'><div class='card-label'>Skills actives</div><div id='kpi-skills-active' class='card-value'>0</div></div>
@@ -77,7 +77,7 @@
       </div>
     </details>
 
-    <div class='panel'>
+    <div class='panel technical-only' data-essential-level='3'>
       <button type='button' class='toggle-more-btn' data-expand-target='cockpit-context-more' aria-expanded='false'>Voir plus</button>
       <div id='cockpit-context-more' class='panel-hidden'>
         <h3 class='heading-reset-top'>Dernière mutation notable</h3>
@@ -133,7 +133,17 @@
         </select>
       </label>
     </div>
-    <div class='stats-grid'>
+    <div class='stats-grid' data-essential-level='1'>
+      <div class='panel panel-compact panel-bordered'>
+        <strong>Vie sélectionnée</strong>
+        <div id='essential-selected-life' class='card-value'>Aucune</div>
+      </div>
+      <div class='panel panel-compact panel-bordered'>
+        <strong>Incidents actifs</strong>
+        <div id='essential-active-incidents' class='card-value'>0</div>
+      </div>
+    </div>
+    <div class='stats-grid' data-essential-level='2'>
       <div class='panel panel-compact panel-bordered'>
         <strong>Vies actives dans le registre (<span id='alive-count'>0</span>)</strong>
         <ul id='alive-lives' class='list-compact'></ul>
@@ -143,14 +153,14 @@
         <ul id='dead-lives' class='list-compact'></ul>
       </div>
     </div>
-    <div class='panel panel-compact panel-bordered panel-top-gap'>
+    <div class='panel panel-compact panel-bordered panel-top-gap' data-essential-level='2'>
       <div class='toolbar-wrap'>
         <strong>Diagnostic filtrage vies</strong>
         <button type='button' id='lives-reset-filters' class='filter-chip'>Réinitialiser les filtres</button>
       </div>
       <pre id='lives-filter-diagnostics'>Chargement du breakdown…</pre>
     </div>
-    <div class='lives-grid'>
+    <div class='lives-grid technical-only' data-essential-level='3'>
       <table id='lives-table' class='table-base table-spacing-top'>
         <thead><tr>
           <th><button data-sort='life'>Vie</button></th>
@@ -174,7 +184,7 @@
 </section>
 
 <section id='tab-technique' class='tab-pane panel-hidden' role='tabpanel' aria-labelledby='tab-btn-technique'>
-  <div class='panel'>
+  <div class='panel technical-only' data-essential-level='3'>
     <h2 class='heading-reset-top'>Glossaire commun</h2>
     <dl class='glossary'>
       <dt>Vie</dt><dd>Instance suivie dans le registre, avec historique, statut et métriques.</dd>
@@ -265,7 +275,7 @@
     <pre id='raw-eco-json'></pre>
   </div>
 
-  <div id='host-vitals-panel' class='panel'>
+  <div id='host-vitals-panel' class='panel technical-only' data-essential-level='3'>
     <h3 class='heading-reset-top'>Santé hôte consolidée</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label kpi-label'>CPU</div><div id='host-cpu' class='card-value'>Pas encore mesuré</div><div id='host-cpu-trend' class='sparkline'>·</div></div>
@@ -278,7 +288,7 @@
     <div id='host-fallback' class='status-muted panel-hidden fallback-box'>Capteurs hôte indisponibles ou sans données récentes.</div>
   </div>
 
-  <div class='panel'><h3 class='heading-reset-top'>KPIs étendus</h3>
+  <div class='panel technical-only' data-essential-level='3'><h3 class='heading-reset-top'>KPIs étendus</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Terminal</div><div id='kpi-vital-terminal' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Causes</div><div id='kpi-vital-causes' class='card-value'>Non disponible</div></div>
@@ -307,7 +317,7 @@
     <ul id='kpi-objective-links-list' class='list-tight-top'></ul>
   </div>
 
-  <div class='panel'>
+  <div class='panel technical-only' data-essential-level='3'>
     <h3 class='heading-reset-top'>Compétences du quotidien</h3>
     <div class='cards-grid'>
       <div class='card'><div class='card-label'>Fréquence (24h)</div><div id='daily-skill-uses-24h' class='card-value'>0</div></div>
@@ -321,12 +331,12 @@
     </table>
   </div>
 
-  <div id='unattached-runs-panel' class='panel panel-hidden panel-top-gap panel-bordered panel-compact'>
+  <div id='unattached-runs-panel' class='panel panel-hidden panel-top-gap panel-bordered panel-compact technical-only' data-essential-level='3'>
     <strong>Runs non rattachés (<span id='unattached-runs-count'>0</span>)</strong>
     <div class='text-muted-small'>Enregistrements sans vie explicite: <span id='unattached-records-count'>0</span></div>
     <ul id='unattached-runs-list' class='list-compact'></ul>
   </div>
-  <div class='panel panel-top-gap'>
+  <div class='panel panel-top-gap technical-only' data-essential-level='3'>
     <h3 class='heading-reset-top'>Arbre généalogique (simplifié)</h3>
     <pre id='genealogy-tree'>Chargement…</pre>
     <div class='content-top-gap'><strong>Réseau social</strong><pre id='social-network-tree'>Chargement…</pre></div>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -255,6 +255,56 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert "objective_narrative_links" in payload["trajectory"]
 
 
+def test_dashboard_cockpit_essential_projection_schema(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "essential.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-04-12T10:00:00",
+                        "accepted": False,
+                        "op": "flip",
+                        "score_base": 10.0,
+                        "score_new": 12.0,
+                        "health": {"score": 70.0, "sandbox_stability": 0.6},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-04-12T10:05:00",
+                        "event": "alert",
+                        "kind": "health_decline",
+                        "severity": "critical",
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+    response = client.get("/api/cockpit/essential")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload == {
+        "schema_version": "2026-04-15",
+        "global_status": payload["global_status"],
+        "critical_alerts_count": payload["critical_alerts_count"],
+        "next_action": payload["next_action"],
+        "selected_life": payload["selected_life"],
+        "active_incidents_count": payload["active_incidents_count"],
+    }
+    assert payload["global_status"] in {"critical", "warning", "stable", "unknown"}
+    assert isinstance(payload["critical_alerts_count"], int)
+    assert isinstance(payload["next_action"], str)
+    assert isinstance(payload["selected_life"], str)
+    assert isinstance(payload["active_incidents_count"], int)
+
+
 def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
     client = TestClient(app)
@@ -308,6 +358,28 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Nouvelles" in body
     assert "filter-time-window" in body
     assert "life-detail-panel" in body
+    assert "essential-selected-life" in body
+    assert "essential-active-incidents" in body
+    assert "data-essential-level='1'" in body
+    assert "data-essential-level='2'" in body
+    assert "data-essential-level='3'" in body
+
+
+def test_dashboard_essential_mode_critical_blocks_and_visibility_markers(tmp_path: Path) -> None:
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    body = TestClient(app).get("/").json()
+
+    for marker in [
+        "id='cockpit-status'",
+        "id='kpi-alerts'",
+        "id='kpi-next-action'",
+        "id='essential-selected-life'",
+        "id='essential-active-incidents'",
+    ]:
+        assert marker in body
+
+    assert "id='cockpit-detail' class='panel level-panel technical-only' data-essential-level='3'" in body
+    assert "class='lives-grid technical-only' data-essential-level='3'" in body
 
 
 def test_dashboard_index_renders_main_sections(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Provide a compact, stable “essential” cockpit view so critical operators always see five key signals (global status, critical alerts count, next action, selected life, active incidents) while hiding non‑critical/debug info in constrained displays. 
- Expose a reduced backend projection to make the essential UI surface stable and easy to consume by external systems.

### Description
- Add a new backend projection `GET /api/cockpit/essential` returning a small, stable schema (`schema_version`, `global_status`, `critical_alerts_count`, `next_action`, `selected_life`, `active_incidents_count`). (see `src/singular/dashboard/__init__.py`).
- Update the cockpit renderer to fetch both `/api/cockpit/essential` and `/api/cockpit`, using the essential projection to drive level‑1 critical signals and fall back to the full payload for details (`src/singular/dashboard/static/render-cockpit.js`).
- Implement true essential‑mode UI handling in `bootstrap.js` with `data-essential-level` markers, persisted toggle state in `localStorage`, auto-collapse of level‑2 details and hiding of level‑3 technical/debug blocks (`src/singular/dashboard/static/bootstrap.js`).
- Annotate the dashboard template with explicit essential levels and add two essential summary cards (selected life + active incidents), plus mark technical/detail sections as level‑3 (`src/singular/dashboard/templates/dashboard.html`).
- Feed the essential lives summary from the lives comparison data and update lives rendering to keep the essential cards current (`src/singular/dashboard/static/render-lives.js`).
- Add tests that assert the essential projection schema and presence of essential markers/controls in the index HTML (`tests/test_dashboard.py`).

### Testing
- Added tests: `test_dashboard_cockpit_essential_projection_schema`, `test_dashboard_essential_mode_critical_blocks_and_visibility_markers`, and small HTML marker checks appended to existing cockpit/index tests in `tests/test_dashboard.py`.
- Ran the focused test command `pytest -q tests/test_dashboard.py -k "cockpit_endpoint_schema or cockpit_essential_projection_schema or index_contains_cockpit_cards or essential_mode_critical_blocks_and_visibility_markers"` which could not complete in this environment due to missing dashboard extras (`ModuleNotFoundError: No module named 'fastapi.staticfiles'`).
- Other unit tests in the repository were not re-run here because the test environment lacks the optional `dashboard` extras specified in `pyproject.toml` (install `fastapi`/`uvicorn` to run the dashboard tests end‑to‑end).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff4bb0c0c832a9616f0b969fd1772)