### PR TITLE
Normaliser les relations de l'arbre généalogique et ajouter le tableau «Relations actives»

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -194,6 +194,25 @@ def create_app(
                 return mapped_life
         return "unknown"
 
+    def _parse_iso8601(value: object) -> datetime | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        normalized = value.strip()
+        if normalized.endswith("Z"):
+            normalized = normalized[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed
+
+    def _iso_or_none(value: datetime | None) -> str | None:
+        if value is None:
+            return None
+        return value.astimezone(timezone.utc).isoformat()
+
     def _compute_ecosystem(current_life_only: bool = False) -> dict:
         organisms: dict[str, dict[str, object]] = {}
         for directory in _runs_dirs(current_life_only=current_life_only):
@@ -1173,24 +1192,115 @@ def create_app(
         }
 
     @app.get("/lives/genealogy")
-    def read_lives_genealogy() -> dict[str, object]:
+    def read_lives_genealogy(life: str | None = None) -> dict[str, object]:
         registry = load_registry()
         lives = registry.get("lives", {})
         active = registry.get("active")
         nodes: list[dict[str, object]] = []
-        edges: list[dict[str, str]] = []
-        social_edges: list[dict[str, str]] = []
-        conflicts: list[dict[str, str]] = []
+        relationships: list[dict[str, object]] = []
+        active_conflicts: list[dict[str, object]] = []
+        if isinstance(life, str):
+            life = life.strip() or None
+        relation_updates: dict[tuple[str, str, str], datetime] = {}
+
+        relations_journal = get_registry_root() / "mem" / "lives_relations.jsonl"
+        if relations_journal.exists():
+            for line in relations_journal.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                event = record.get("event")
+                actor = record.get("actor")
+                target = record.get("target")
+                timestamp = _parse_iso8601(record.get("ts"))
+                if not (
+                    isinstance(event, str)
+                    and isinstance(actor, str)
+                    and actor
+                    and isinstance(target, str)
+                    and target
+                    and timestamp is not None
+                ):
+                    continue
+                pair = tuple(sorted((actor, target)))
+                if event == "ally":
+                    relation_updates[(pair[0], pair[1], "alliance")] = timestamp
+                elif event in {"rival", "reconcile"}:
+                    relation_updates[(pair[0], pair[1], "rivalry")] = timestamp
+
+        def _relation_timestamp(source: str, target: str, relation_type: str) -> str | None:
+            pair = tuple(sorted((source, target)))
+            return _iso_or_none(relation_updates.get((pair[0], pair[1], relation_type)))
+
+        def _relation_severity(*, relation_type: str, source_status: str, target_status: str, proximity: float) -> int:
+            if relation_type == "rivalry":
+                base = 2
+                if source_status == "active" and target_status == "active":
+                    base += 1
+                if proximity >= 0.65:
+                    base += 1
+                return min(base, 4)
+            if relation_type == "alliance":
+                if source_status == "active" and target_status == "active":
+                    return 1
+                return 2
+            return 1
+
+        def _append_relationship(
+            *,
+            source: str,
+            target: str,
+            relation_type: str,
+            source_status: str,
+            target_status: str,
+            source_proximity: float,
+            active_relation: bool = True,
+        ) -> None:
+            severity = _relation_severity(
+                relation_type=relation_type,
+                source_status=source_status,
+                target_status=target_status,
+                proximity=source_proximity,
+            )
+            item = {
+                "source": source,
+                "target": target,
+                "type": relation_type,
+                "status": "active" if active_relation else "inactive",
+                "updated_at": _relation_timestamp(source, target, relation_type),
+                "severity": severity,
+            }
+            relationships.append(item)
+            if relation_type == "rivalry" and active_relation:
+                active_conflicts.append(
+                    {
+                        "life_a": min(source, target),
+                        "life_b": max(source, target),
+                        "type": relation_type,
+                        "status": "active",
+                        "updated_at": item["updated_at"],
+                        "severity": severity,
+                    }
+                )
+
         if not isinstance(lives, dict):
             return {
                 "active": active,
                 "nodes": nodes,
-                "edges": edges,
-                "social_edges": social_edges,
-                "active_conflicts": conflicts,
+                "edges": [],
+                "social_edges": [],
+                "relationships": relationships,
+                "active_conflicts": active_conflicts,
+                "active_relations": [],
+                "filters": {"life": life},
                 "onboarding": {"required": active is None, "message": "Aucune vie, créez-en une." if active is None else None},
             }
 
+        statuses_by_slug: dict[str, str] = {}
+        proximity_by_slug: dict[str, float] = {}
         for slug, meta in sorted(lives.items()):
             name = getattr(meta, "name", slug)
             status = getattr(meta, "status", "active")
@@ -1208,39 +1318,144 @@ def create_app(
                 allies = ()
             if not isinstance(rivals, (tuple, list)):
                 rivals = ()
+            normalized_status = str(status).strip().lower() if isinstance(status, str) else "unknown"
+            if normalized_status not in {"active", "extinct", "archived"}:
+                normalized_status = "unknown"
+            proximity_value = float(proximity_score) if isinstance(proximity_score, (int, float)) else 0.5
+            proximity_value = max(0.0, min(1.0, proximity_value))
+            statuses_by_slug[slug] = normalized_status
+            proximity_by_slug[slug] = proximity_value
             nodes.append(
                 {
                     "slug": slug,
                     "name": str(name),
-                    "status": str(status),
+                    "status": normalized_status,
                     "active": slug == active,
                     "lineage_depth": int(lineage_depth) if isinstance(lineage_depth, int) else 0,
                     "parents": [str(parent) for parent in parents if isinstance(parent, str)],
                     "children": [str(child) for child in children if isinstance(child, str)],
                     "allies": [str(ally) for ally in allies if isinstance(ally, str)],
                     "rivals": [str(rival) for rival in rivals if isinstance(rival, str)],
-                    "proximity_score": float(proximity_score) if isinstance(proximity_score, (int, float)) else 0.5,
+                    "proximity_score": proximity_value,
                 }
             )
-            for parent in parents:
-                if isinstance(parent, str) and parent:
-                    edges.append({"parent": parent, "child": slug})
-            for ally in allies:
-                if isinstance(ally, str) and ally:
-                    social_edges.append({"source": slug, "target": ally, "kind": "ally"})
-            for rival in rivals:
-                if isinstance(rival, str) and rival:
-                    social_edges.append({"source": slug, "target": rival, "kind": "rival"})
-                    pair = tuple(sorted((slug, rival)))
-                    if pair[0] != pair[1]:
-                        conflicts.append({"life_a": pair[0], "life_b": pair[1]})
-        unique_conflicts = {(item["life_a"], item["life_b"]) for item in conflicts}
+
+        known_lives = set(statuses_by_slug)
+        unique_parent_edges: set[tuple[str, str]] = set()
+        unique_alliance_edges: set[tuple[str, str]] = set()
+        unique_rival_edges: set[tuple[str, str]] = set()
+        for node in nodes:
+            slug = str(node["slug"])
+            source_status = statuses_by_slug.get(slug, "unknown")
+            for parent in node.get("parents", []):
+                if isinstance(parent, str) and parent and parent in known_lives:
+                    edge_key = (parent, slug)
+                    if edge_key in unique_parent_edges:
+                        continue
+                    unique_parent_edges.add(edge_key)
+                    _append_relationship(
+                        source=parent,
+                        target=slug,
+                        relation_type="parentage",
+                        source_status=statuses_by_slug.get(parent, "unknown"),
+                        target_status=source_status,
+                        source_proximity=proximity_by_slug.get(parent, 0.5),
+                    )
+
+            for ally in node.get("allies", []):
+                if not (isinstance(ally, str) and ally and ally in known_lives and ally != slug):
+                    continue
+                edge_key = tuple(sorted((slug, ally)))
+                if edge_key in unique_alliance_edges:
+                    continue
+                unique_alliance_edges.add(edge_key)
+                _append_relationship(
+                    source=edge_key[0],
+                    target=edge_key[1],
+                    relation_type="alliance",
+                    source_status=statuses_by_slug.get(edge_key[0], "unknown"),
+                    target_status=statuses_by_slug.get(edge_key[1], "unknown"),
+                    source_proximity=proximity_by_slug.get(edge_key[0], 0.5),
+                )
+
+            for rival in node.get("rivals", []):
+                if not (isinstance(rival, str) and rival and rival in known_lives and rival != slug):
+                    continue
+                edge_key = tuple(sorted((slug, rival)))
+                if edge_key in unique_rival_edges:
+                    continue
+                unique_rival_edges.add(edge_key)
+                _append_relationship(
+                    source=edge_key[0],
+                    target=edge_key[1],
+                    relation_type="rivalry",
+                    source_status=statuses_by_slug.get(edge_key[0], "unknown"),
+                    target_status=statuses_by_slug.get(edge_key[1], "unknown"),
+                    source_proximity=proximity_by_slug.get(edge_key[0], 0.5),
+                )
+
+        unique_conflicts = {
+            (
+                item["life_a"],
+                item["life_b"],
+                item["type"],
+                item["status"],
+                item["updated_at"],
+                item["severity"],
+            )
+            for item in active_conflicts
+        }
+        filtered_relations = [
+            relation
+            for relation in relationships
+            if relation["status"] == "active"
+            and (
+                life is None
+                or relation["source"] == life
+                or relation["target"] == life
+            )
+        ]
+        filtered_relations.sort(
+            key=lambda item: (
+                int(item.get("severity", 0)),
+                _parse_iso8601(item.get("updated_at")) or datetime.fromtimestamp(0, timezone.utc),
+                str(item.get("type", "")),
+                str(item.get("source", "")),
+                str(item.get("target", "")),
+            ),
+            reverse=True,
+        )
         return {
             "active": active,
             "nodes": nodes,
-            "edges": edges,
-            "social_edges": social_edges,
-            "active_conflicts": [{"life_a": a, "life_b": b} for a, b in sorted(unique_conflicts)],
+            "edges": [
+                {"parent": str(item["source"]), "child": str(item["target"])}
+                for item in relationships
+                if item.get("type") == "parentage"
+            ],
+            "social_edges": [
+                {
+                    "source": str(item["source"]),
+                    "target": str(item["target"]),
+                    "kind": "ally" if item.get("type") == "alliance" else "rival",
+                }
+                for item in relationships
+                if item.get("type") in {"alliance", "rivalry"}
+            ],
+            "relationships": relationships,
+            "active_relations": filtered_relations,
+            "active_conflicts": [
+                {
+                    "life_a": a,
+                    "life_b": b,
+                    "type": relation_type,
+                    "status": status,
+                    "updated_at": updated_at,
+                    "severity": severity,
+                }
+                for a, b, relation_type, status, updated_at, severity in sorted(unique_conflicts)
+            ],
+            "filters": {"life": life},
             "onboarding": {
                 "required": not nodes and active is None,
                 "message": "Aucune vie, créez-en une." if not nodes and active is None else None,

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -294,7 +294,17 @@ export const renderGenealogyTree=(payload)=>{
   const treeEl=document.getElementById('genealogy-tree');
   const socialEl=document.getElementById('social-network-tree');
   const conflictsEl=document.getElementById('active-conflicts');
-  if(!nodes.length){treeEl.textContent='Aucune lignée enregistrée.';socialEl.textContent='Aucun réseau social.';conflictsEl.textContent='Aucun conflit.';return;}
+  const relationsBody=document.getElementById('active-relations-table-body');
+  const lifeFilterEl=document.getElementById('genealogy-relations-life-filter');
+  const relationships=payload?.relationships||[];
+  const relationRows=payload?.active_relations||[];
+  if(!nodes.length){
+    treeEl.textContent='Aucune lignée enregistrée.';
+    socialEl.textContent='Aucun réseau social.';
+    conflictsEl.textContent='Aucun conflit.';
+    if(relationsBody){relationsBody.innerHTML=\"<tr><td colspan='6'>Aucune relation active.</td></tr>\";}
+    return;
+  }
   const bySlug=new Map(nodes.map(node=>[node.slug,node]));
   const children=new Map();
   for(const node of nodes){children.set(node.slug,[]);} 
@@ -307,10 +317,31 @@ export const renderGenealogyTree=(payload)=>{
   for(const node of detached){lines.push(`• ${node.name} (${node.slug}) [orphan]`);} 
   treeEl.textContent=lines.join('\n');
   const socialLines=[];
-  for(const node of nodes){const allies=(node.allies||[]).join(', ')||'-';const rivals=(node.rivals||[]).join(', ')||'-';socialLines.push(`${node.slug} | proximité=${Number(node.proximity_score||0.5).toFixed(2)} | alliés: ${allies} | rivaux: ${rivals}`);} 
+  for(const node of nodes){
+    const allies=relationships.filter(item=>item.type==='alliance'&&(item.source===node.slug||item.target===node.slug)).map(item=>item.source===node.slug?item.target:item.source).join(', ')||'-';
+    const rivals=relationships.filter(item=>item.type==='rivalry'&&(item.source===node.slug||item.target===node.slug)).map(item=>item.source===node.slug?item.target:item.source).join(', ')||'-';
+    socialLines.push(`${node.slug} | statut=${node.status} | proximité=${Number(node.proximity_score||0.5).toFixed(2)} | alliés: ${allies} | rivaux: ${rivals}`);
+  } 
   socialEl.textContent=socialLines.join('\n');
   const conflicts=payload?.active_conflicts||[];
-  conflictsEl.textContent=conflicts.length?conflicts.map(c=>`${c.life_a} ⚔ ${c.life_b}`).join('\n'):'Aucun conflit actif.';
+  conflictsEl.textContent=conflicts.length?conflicts.map(c=>`${c.life_a} ⚔ ${c.life_b} | sévérité=${c.severity??'-'} | MAJ=${c.updated_at||'n/a'}`).join('\n'):'Aucun conflit actif.';
+  if(relationsBody){
+    if(!relationRows.length){relationsBody.innerHTML=\"<tr><td colspan='6'>Aucune relation active pour ce filtre.</td></tr>\";}
+    else{
+      relationsBody.innerHTML=relationRows.map(row=>`<tr><td>${row.type||'unknown'}</td><td>${row.source||'-'}</td><td>${row.target||'-'}</td><td>${row.status||'unknown'}</td><td>${row.severity??'-'}</td><td>${row.updated_at||'n/a'}</td></tr>`).join('');
+    }
+  }
+  if(lifeFilterEl){
+    const currentValue=(payload?.filters?.life)||'all';
+    const options=['<option value=\"all\">Toutes les vies</option>',...nodes.map(node=>`<option value=\"${node.slug}\">${node.name} (${node.slug})</option>`)];
+    lifeFilterEl.innerHTML=options.join('');
+    lifeFilterEl.value=currentValue;
+    lifeFilterEl.onchange=()=>{
+      const selected=lifeFilterEl.value;
+      const route=selected&&selected!=='all'?`/lives/genealogy?life=${encodeURIComponent(selected)}`:'/lives/genealogy';
+      fetchJson(route).then(renderGenealogyTree).catch(error=>{document.getElementById('genealogy-tree').textContent='Impossible de charger la généalogie.';throw error;});
+    };
+  }
 };
 
 export const loadGenealogy=()=>fetchJson('/lives/genealogy').then(renderGenealogyTree).catch(error=>{document.getElementById('genealogy-tree').textContent='Impossible de charger la généalogie.';throw error;});

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -341,6 +341,28 @@
     <pre id='genealogy-tree'>Chargement…</pre>
     <div class='content-top-gap'><strong>Réseau social</strong><pre id='social-network-tree'>Chargement…</pre></div>
     <div class='content-top-gap'><strong>Conflits actifs</strong><pre id='active-conflicts'>Chargement…</pre></div>
+    <div class='content-top-gap'>
+      <strong>Relations actives</strong>
+      <label for='genealogy-relations-life-filter' class='text-muted-small'>Filtrer par vie</label>
+      <select id='genealogy-relations-life-filter'>
+        <option value='all'>Toutes les vies</option>
+      </select>
+      <table class='table-base table-spacing-top'>
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Source</th>
+            <th>Cible</th>
+            <th>Statut</th>
+            <th>Sévérité</th>
+            <th>Dernière mise à jour</th>
+          </tr>
+        </thead>
+        <tbody id='active-relations-table-body'>
+          <tr><td colspan='6'>Chargement…</td></tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1017,6 +1017,131 @@ def test_dashboard_life_metrics_contract_is_consistent_across_endpoints(
     assert ecosystem_contract == cockpit_contract
 
 
+def test_lives_genealogy_returns_normalized_relationships_and_conflicts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "registry-root"
+    (root / "mem").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    (root / "mem" / "lives_relations.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-04-13T08:00:00+00:00",
+                        "event": "ally",
+                        "actor": "life-a",
+                        "target": "life-b",
+                        "details": {},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-04-14T09:00:00+00:00",
+                        "event": "rival",
+                        "actor": "life-a",
+                        "target": "life-c",
+                        "details": {},
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    monkeypatch.setattr(
+        "singular.dashboard.load_registry",
+        lambda: {
+            "active": "life-a",
+            "lives": {
+                "life-a": {
+                    "slug": "life-a",
+                    "name": "Life A",
+                    "status": "active",
+                    "parents": [],
+                    "children": ["life-b", "life-c"],
+                    "allies": ["life-b"],
+                    "rivals": ["life-c"],
+                    "proximity_score": 0.82,
+                    "lineage_depth": 0,
+                },
+                "life-b": {
+                    "slug": "life-b",
+                    "name": "Life B",
+                    "status": "active",
+                    "parents": ["life-a"],
+                    "children": [],
+                    "allies": ["life-a"],
+                    "rivals": [],
+                    "proximity_score": 0.66,
+                    "lineage_depth": 1,
+                },
+                "life-c": {
+                    "slug": "life-c",
+                    "name": "Life C",
+                    "status": "active",
+                    "parents": ["life-a"],
+                    "children": [],
+                    "allies": [],
+                    "rivals": ["life-a"],
+                    "proximity_score": 0.3,
+                    "lineage_depth": 1,
+                },
+            },
+        },
+    )
+
+    payload = app._routes["/lives/genealogy"]()
+
+    assert payload["filters"] == {"life": None}
+    assert payload["active_relations"]
+    for relation in payload["relationships"]:
+        assert "type" in relation
+        assert "status" in relation
+        assert "updated_at" in relation
+        assert "severity" in relation
+    for conflict in payload["active_conflicts"]:
+        assert "type" in conflict
+        assert "status" in conflict
+        assert "updated_at" in conflict
+        assert "severity" in conflict
+    first = payload["active_relations"][0]
+    assert first["type"] == "rivalry"
+    assert first["severity"] >= payload["active_relations"][-1]["severity"]
+
+
+def test_lives_genealogy_life_filter_limits_active_relations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "registry-root"
+    (root / "mem").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    monkeypatch.setattr(
+        "singular.dashboard.load_registry",
+        lambda: {
+            "active": "life-a",
+            "lives": {
+                "life-a": {"slug": "life-a", "allies": ["life-b"], "rivals": ["life-c"]},
+                "life-b": {"slug": "life-b", "allies": ["life-a"], "rivals": []},
+                "life-c": {"slug": "life-c", "allies": [], "rivals": ["life-a"]},
+            },
+        },
+    )
+
+    payload = app._routes["/lives/genealogy"](life="life-b")
+
+    assert payload["filters"] == {"life": "life-b"}
+    assert payload["active_relations"]
+    assert all(
+        relation["source"] == "life-b" or relation["target"] == "life-b"
+        for relation in payload["active_relations"]
+    )
+
+
 def test_psyche_missing_returns_404(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Passer du rendu texte libre de la généalogie à une API structurée pour permettre un affichage et un tri fiables des relations entre vies.
- Expliciter le type/état/horodatage/sévérité des relations et conflits pour faciliter le diagnostic et le filtrage côté UI.
- Fournir un tableau triable et filtrable «Relations actives» dans l'interface pour lister rapidement les interactions pertinentes.

### Description
- Refactor de l'endpoint `read_lives_genealogy` dans `src/singular/dashboard/__init__.py` pour renvoyer `nodes`, une liste normalisée `relationships` (types `parentage`/`alliance`/`rivalry`) et `active_relations` triées, avec champs `type`, `status`, `updated_at`, `severity` et filtrage via le paramètre `life`; lecture des horodatages depuis `mem/lives_relations.jsonl` et helpers `_parse_iso8601` / `_iso_or_none` ajoutés.
- Enrichissement des `active_conflicts` avec `type`, `status`, `updated_at` et `severity`, et conservation d'une projection rétrocompatible `edges` / `social_edges` dérivée de la structure normalisée.
- Ajout d'une nouvelle section UI dans `src/singular/dashboard/templates/dashboard.html` contenant le sélecteur de vie et le tableau `Relations actives` (`#active-relations-table-body`).
- Mise à jour de `src/singular/dashboard/static/render-lives.js` (`renderGenealogyTree`) pour consommer la nouvelle API, afficher les conflits enrichis et remplir le tableau + gérer le filtre par vie côté client.
- Ajout de tests dans `tests/test_dashboard.py` qui valident la présence des champs `type`, `status`, `updated_at`, `severity` sur `relationships` et `active_conflicts`, et testent le filtrage par vie (`life` query param).

### Testing
- `python -m py_compile src/singular/dashboard/__init__.py tests/test_dashboard.py` a été exécuté et a réussi.
- `pytest -q tests/test_dashboard.py -k genealogy` a été lancé mais la collecte a échoué dans cet environnement en raison d'une dépendance d'exécution manquante (`ModuleNotFoundError: No module named 'fastapi.staticfiles'`), donc les assertions d'intégration n'ont pas pu être exécutées ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff5d21fac832a82c8cdf601fa8a44)