### PR TITLE
Implement robust host metric fallback chain with per-metric status metadata

### DIFF
--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -204,6 +204,7 @@ class DashboardActionService:
         recent = records[-120:]
         history_map: dict[str, list[dict[str, Any]]] = {"cpu": [], "ram": [], "temperature": [], "disk": []}
         latest_values: dict[str, float | None] = {"cpu": None, "ram": None, "temperature": None, "disk": None}
+        latest_statuses: dict[str, dict[str, Any] | None] = {"cpu": None, "ram": None, "temperature": None, "disk": None}
         latest_adaptation: dict[str, Any] | None = None
         for record in recent:
             ts = record.get("ts")
@@ -215,18 +216,30 @@ class DashboardActionService:
                     "temperature": host_metrics.get("host_temperature_c"),
                     "disk": host_metrics.get("disk_used_percent"),
                 }
+                metric_status_map = (
+                    host_metrics.get("metric_status") if isinstance(host_metrics.get("metric_status"), dict) else {}
+                )
+                metric_status_aliases = {
+                    "cpu": "cpu_percent",
+                    "ram": "ram_used_percent",
+                    "temperature": "host_temperature_c",
+                    "disk": "disk_used_percent",
+                }
                 for metric_name, raw_value in metric_map.items():
-                    if not isinstance(raw_value, (int, float)):
-                        continue
-                    value = float(raw_value)
-                    latest_values[metric_name] = value
-                    history_map[metric_name].append(
-                        {
-                            "ts": ts if isinstance(ts, str) else None,
-                            "value": value,
-                            "risk": self._host_metric_risk(metric_name, value, thresholds),
-                        }
-                    )
+                    status_payload = metric_status_map.get(metric_status_aliases[metric_name], {})
+                    if isinstance(status_payload, dict):
+                        latest_statuses[metric_name] = status_payload
+                        raw_value = status_payload.get("value", raw_value)
+                    if isinstance(raw_value, (int, float)):
+                        value = float(raw_value)
+                        latest_values[metric_name] = value
+                        history_map[metric_name].append(
+                            {
+                                "ts": ts if isinstance(ts, str) else None,
+                                "value": value,
+                                "risk": self._host_metric_risk(metric_name, value, thresholds),
+                            }
+                        )
             event = record.get("event")
             adaptation_payload: dict[str, Any] | None = None
             if event == "orchestrator.adaptation" and isinstance(record.get("payload"), dict):
@@ -247,18 +260,25 @@ class DashboardActionService:
         global_status = "ok"
         for metric_name in ("cpu", "ram", "temperature", "disk"):
             value = latest_values[metric_name]
-            risk = self._host_metric_risk(metric_name, value, thresholds)
+            status_payload = latest_statuses.get(metric_name) if isinstance(latest_statuses.get(metric_name), dict) else {}
+            status = str((status_payload or {}).get("status") or ("available" if value is not None else "unsupported"))
+            reason = (status_payload or {}).get("reason")
+            last_seen_at = (status_payload or {}).get("last_seen_at")
+            unit = (status_payload or {}).get("unit")
+            risk = self._host_metric_risk(metric_name, value, thresholds) if status != "unsupported" else "unsupported"
             trend_history = history_map[metric_name][-8:]
-            supported = value is not None
             metrics_payload[metric_name] = {
-                "supported": supported,
                 "value": value,
+                "unit": unit,
+                "status": status,
+                "reason": reason,
+                "last_seen_at": last_seen_at,
                 "risk": risk,
                 "history": trend_history,
             }
             if risk_priority.get(risk, -1) > risk_priority.get(global_status, 0):
                 global_status = risk
-        if all(not metrics_payload[name]["supported"] for name in metrics_payload):
+        if all(metrics_payload[name]["status"] == "unsupported" for name in metrics_payload):
             global_status = "unsupported"
 
         return {

--- a/src/singular/sensors/config.py
+++ b/src/singular/sensors/config.py
@@ -11,6 +11,22 @@ from typing import Any, Mapping
 DEFAULT_HOST_SENSORS_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "host_sensors.yaml"
 ENV_HOST_SENSORS_CONFIG_PATH = "SINGULAR_HOST_SENSORS_CONFIG"
 ENV_HOST_SENSORS_OVERRIDES = "SINGULAR_HOST_SENSORS_OVERRIDES"
+HOST_METRIC_STATUS_AVAILABLE = "available"
+HOST_METRIC_STATUS_PARTIAL = "partial"
+HOST_METRIC_STATUS_UNSUPPORTED = "unsupported"
+
+HOST_METRIC_UNITS: dict[str, str] = {
+    "cpu_percent": "percent",
+    "cpu_load_1m": "load",
+    "ram_used_percent": "percent",
+    "ram_available_mb": "MB",
+    "disk_used_percent": "percent",
+    "disk_free_gb": "GB",
+    "host_temperature_c": "C",
+    "process_cpu_percent": "percent",
+    "process_rss_mb": "MB",
+    "host_uptime_s": "s",
+}
 
 
 class HostSensorsConfigError(ValueError):
@@ -237,6 +253,10 @@ __all__ = [
     "DEFAULT_HOST_SENSORS_CONFIG_PATH",
     "ENV_HOST_SENSORS_CONFIG_PATH",
     "ENV_HOST_SENSORS_OVERRIDES",
+    "HOST_METRIC_STATUS_AVAILABLE",
+    "HOST_METRIC_STATUS_PARTIAL",
+    "HOST_METRIC_STATUS_UNSUPPORTED",
+    "HOST_METRIC_UNITS",
     "HostSensorThresholds",
     "HostSensorsConfigError",
     "load_host_sensor_thresholds",

--- a/src/singular/sensors/host.py
+++ b/src/singular/sensors/host.py
@@ -11,9 +11,11 @@ system-metric collection failures.
 from __future__ import annotations
 
 import os
+import platform
 import shutil
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +27,9 @@ except Exception:  # pragma: no cover - optional dependency
 _MB = 1024 * 1024
 _GB = 1024 * 1024 * 1024
 _LAST_PROCESS_SAMPLE: "_ProcessSample | None" = None
+_STATUS_AVAILABLE = "available"
+_STATUS_PARTIAL = "partial"
+_STATUS_UNSUPPORTED = "unsupported"
 
 
 @dataclass
@@ -38,6 +43,27 @@ def _safe_float(value: object, default: float = 0.0) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _metric_payload(
+    *,
+    value: float | None,
+    unit: str,
+    status: str,
+    reason: str | None = None,
+    last_seen_at: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "value": value,
+        "unit": unit,
+        "status": status,
+        "reason": reason,
+        "last_seen_at": last_seen_at,
+    }
 
 
 def _collect_memory_stdlib() -> tuple[float, float]:
@@ -135,12 +161,30 @@ def _collect_temperatures_psutil() -> float | None:
     return sum(values) / len(values)
 
 
-def collect_host_metrics() -> dict[str, float | None]:
+def _collect_uptime_seconds() -> tuple[float | None, str | None]:
+    if psutil is not None:
+        try:
+            boot_time = _safe_float(psutil.boot_time())  # type: ignore[attr-defined]
+            now = time.time()
+            return max(now - boot_time, 0.0), None
+        except Exception:
+            pass
+    if platform.system() == "Linux":
+        try:
+            raw = Path("/proc/uptime").read_text(encoding="utf-8").split()[0]
+            return max(_safe_float(raw), 0.0), None
+        except Exception:
+            return None, "linux_uptime_unavailable"
+    return None, "uptime_probe_not_supported_on_platform"
+
+
+def collect_host_metrics() -> dict[str, Any]:
     """Return normalized host metrics.
 
     Keys are stable and always present.
     """
 
+    collected_at = _utc_now_iso()
     cpu_percent = 0.0
     cpu_load_1m: float | None = None
     ram_used_percent = 0.0
@@ -150,57 +194,201 @@ def collect_host_metrics() -> dict[str, float | None]:
     host_temperature_c: float | None = None
     process_cpu_percent = 0.0
     process_rss_mb = 0.0
+    host_uptime_s: float | None = None
+    strategy = "minimal_fallback"
+
+    metric_statuses: dict[str, dict[str, Any]] = {
+        "cpu_percent": _metric_payload(value=None, unit="percent", status=_STATUS_UNSUPPORTED, reason="cpu_probe_unavailable"),
+        "cpu_load_1m": _metric_payload(value=None, unit="load", status=_STATUS_UNSUPPORTED, reason="load_probe_unavailable"),
+        "ram_used_percent": _metric_payload(value=None, unit="percent", status=_STATUS_UNSUPPORTED, reason="memory_probe_unavailable"),
+        "ram_available_mb": _metric_payload(value=None, unit="MB", status=_STATUS_UNSUPPORTED, reason="memory_probe_unavailable"),
+        "disk_used_percent": _metric_payload(value=None, unit="percent", status=_STATUS_UNSUPPORTED, reason="disk_probe_unavailable"),
+        "disk_free_gb": _metric_payload(value=None, unit="GB", status=_STATUS_UNSUPPORTED, reason="disk_probe_unavailable"),
+        "host_temperature_c": _metric_payload(
+            value=None,
+            unit="C",
+            status=_STATUS_UNSUPPORTED,
+            reason="temperature_sensor_unavailable",
+        ),
+        "process_cpu_percent": _metric_payload(
+            value=None,
+            unit="percent",
+            status=_STATUS_UNSUPPORTED,
+            reason="process_probe_unavailable",
+        ),
+        "process_rss_mb": _metric_payload(value=None, unit="MB", status=_STATUS_UNSUPPORTED, reason="process_probe_unavailable"),
+        "host_uptime_s": _metric_payload(value=None, unit="s", status=_STATUS_UNSUPPORTED, reason="uptime_probe_unavailable"),
+    }
 
     if psutil is not None:
+        strategy = "primary"
         try:
             cpu_percent = max(0.0, min(_safe_float(psutil.cpu_percent(interval=None)), 100.0))
+            metric_statuses["cpu_percent"] = _metric_payload(
+                value=cpu_percent, unit="percent", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
         except Exception:
             cpu_percent = 0.0
 
         try:
             load = os.getloadavg()[0]
             cpu_load_1m = max(_safe_float(load), 0.0)
+            metric_statuses["cpu_load_1m"] = _metric_payload(
+                value=cpu_load_1m, unit="load", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
         except Exception:
             cpu_load_1m = None
+            metric_statuses["cpu_load_1m"] = _metric_payload(
+                value=None,
+                unit="load",
+                status=_STATUS_PARTIAL,
+                reason="loadavg_not_supported_on_platform",
+            )
 
         try:
             vm = psutil.virtual_memory()
             ram_used_percent = max(0.0, min(_safe_float(getattr(vm, "percent", 0.0)), 100.0))
             ram_available_mb = max(_safe_float(getattr(vm, "available", 0.0)) / _MB, 0.0)
+            metric_statuses["ram_used_percent"] = _metric_payload(
+                value=ram_used_percent, unit="percent", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
+            metric_statuses["ram_available_mb"] = _metric_payload(
+                value=ram_available_mb, unit="MB", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
         except Exception:
             ram_used_percent, ram_available_mb = _collect_memory_stdlib()
+            metric_statuses["ram_used_percent"] = _metric_payload(
+                value=ram_used_percent, unit="percent", status=_STATUS_PARTIAL, reason="psutil_virtual_memory_failed"
+            )
+            metric_statuses["ram_available_mb"] = _metric_payload(
+                value=ram_available_mb, unit="MB", status=_STATUS_PARTIAL, reason="psutil_virtual_memory_failed"
+            )
 
         try:
             du = psutil.disk_usage(str(Path.cwd()))
             disk_used_percent = max(0.0, min(_safe_float(getattr(du, "percent", 0.0)), 100.0))
             disk_free_gb = max(_safe_float(getattr(du, "free", 0.0)) / _GB, 0.0)
+            metric_statuses["disk_used_percent"] = _metric_payload(
+                value=disk_used_percent, unit="percent", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
+            metric_statuses["disk_free_gb"] = _metric_payload(
+                value=disk_free_gb, unit="GB", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
         except Exception:
             disk_used_percent, disk_free_gb = _collect_disk_stdlib()
+            metric_statuses["disk_used_percent"] = _metric_payload(
+                value=disk_used_percent, unit="percent", status=_STATUS_PARTIAL, reason="psutil_disk_usage_failed"
+            )
+            metric_statuses["disk_free_gb"] = _metric_payload(
+                value=disk_free_gb, unit="GB", status=_STATUS_PARTIAL, reason="psutil_disk_usage_failed"
+            )
 
         host_temperature_c = _collect_temperatures_psutil()
+        if host_temperature_c is not None:
+            metric_statuses["host_temperature_c"] = _metric_payload(
+                value=host_temperature_c, unit="C", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
+        else:
+            metric_statuses["host_temperature_c"] = _metric_payload(
+                value=None,
+                unit="C",
+                status=_STATUS_PARTIAL,
+                reason="temperature_sensor_not_exposed_by_os",
+            )
 
         try:
             process = psutil.Process(os.getpid())
             process_cpu_percent = max(0.0, min(_safe_float(process.cpu_percent(interval=None)), 100.0))
             process_rss_mb = max(_safe_float(process.memory_info().rss) / _MB, 0.0)
+            metric_statuses["process_cpu_percent"] = _metric_payload(
+                value=process_cpu_percent, unit="percent", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
+            metric_statuses["process_rss_mb"] = _metric_payload(
+                value=process_rss_mb, unit="MB", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            )
         except Exception:
             process_cpu_percent, process_rss_mb = _collect_process_stdlib()
+            metric_statuses["process_cpu_percent"] = _metric_payload(
+                value=process_cpu_percent, unit="percent", status=_STATUS_PARTIAL, reason="psutil_process_probe_failed"
+            )
+            metric_statuses["process_rss_mb"] = _metric_payload(
+                value=process_rss_mb, unit="MB", status=_STATUS_PARTIAL, reason="psutil_process_probe_failed"
+            )
     else:
+        strategy = "partial_fallback"
         try:
             cpu_percent = max(0.0, min(_safe_float(os.getloadavg()[0]), 100.0))
+            metric_statuses["cpu_percent"] = _metric_payload(
+                value=cpu_percent,
+                unit="percent",
+                status=_STATUS_PARTIAL,
+                reason="loadavg_used_as_cpu_proxy",
+                last_seen_at=collected_at,
+            )
         except Exception:
             cpu_percent = 0.0
+            metric_statuses["cpu_percent"] = _metric_payload(
+                value=None,
+                unit="percent",
+                status=_STATUS_UNSUPPORTED,
+                reason="cpu_probe_unavailable_without_psutil",
+            )
 
         try:
             cpu_load_1m = max(_safe_float(os.getloadavg()[0]), 0.0)
+            metric_statuses["cpu_load_1m"] = _metric_payload(
+                value=cpu_load_1m, unit="load", status=_STATUS_PARTIAL, reason="loadavg_stdlib_fallback", last_seen_at=collected_at
+            )
         except Exception:
             cpu_load_1m = None
+            metric_statuses["cpu_load_1m"] = _metric_payload(
+                value=None, unit="load", status=_STATUS_UNSUPPORTED, reason="loadavg_not_supported_on_platform"
+            )
 
         ram_used_percent, ram_available_mb = _collect_memory_stdlib()
+        if ram_available_mb > 0.0:
+            metric_statuses["ram_used_percent"] = _metric_payload(
+                value=ram_used_percent, unit="percent", status=_STATUS_PARTIAL, reason="memory_stdlib_fallback", last_seen_at=collected_at
+            )
+            metric_statuses["ram_available_mb"] = _metric_payload(
+                value=ram_available_mb, unit="MB", status=_STATUS_PARTIAL, reason="memory_stdlib_fallback", last_seen_at=collected_at
+            )
         disk_used_percent, disk_free_gb = _collect_disk_stdlib()
+        if disk_free_gb > 0.0 or disk_used_percent > 0.0:
+            metric_statuses["disk_used_percent"] = _metric_payload(
+                value=disk_used_percent, unit="percent", status=_STATUS_PARTIAL, reason="disk_stdlib_fallback", last_seen_at=collected_at
+            )
+            metric_statuses["disk_free_gb"] = _metric_payload(
+                value=disk_free_gb, unit="GB", status=_STATUS_PARTIAL, reason="disk_stdlib_fallback", last_seen_at=collected_at
+            )
         process_cpu_percent, process_rss_mb = _collect_process_stdlib()
+        metric_statuses["process_cpu_percent"] = _metric_payload(
+            value=process_cpu_percent, unit="percent", status=_STATUS_PARTIAL, reason="process_stdlib_fallback", last_seen_at=collected_at
+        )
+        metric_statuses["process_rss_mb"] = _metric_payload(
+            value=process_rss_mb, unit="MB", status=_STATUS_PARTIAL, reason="process_stdlib_fallback", last_seen_at=collected_at
+        )
 
-    payload: dict[str, float | None] = {
+    host_uptime_s, uptime_reason = _collect_uptime_seconds()
+    if host_uptime_s is not None:
+        metric_statuses["host_uptime_s"] = _metric_payload(
+            value=host_uptime_s, unit="s", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+        )
+    else:
+        metric_statuses["host_uptime_s"] = _metric_payload(
+            value=None, unit="s", status=_STATUS_UNSUPPORTED, reason=uptime_reason or "uptime_probe_unavailable"
+        )
+
+    if strategy != "primary":
+        has_minimal_signal = any(metric_statuses[name]["value"] is not None for name in ("host_uptime_s", "cpu_load_1m", "ram_available_mb"))
+        cpu_or_disk_unavailable = (
+            metric_statuses["cpu_percent"]["status"] == _STATUS_UNSUPPORTED
+            and metric_statuses["disk_used_percent"]["status"] == _STATUS_UNSUPPORTED
+        )
+        if has_minimal_signal and cpu_or_disk_unavailable:
+            strategy = "minimal_fallback"
+
+    payload: dict[str, Any] = {
         "cpu_percent": cpu_percent,
         "cpu_load_1m": cpu_load_1m,
         "ram_used_percent": ram_used_percent,
@@ -210,5 +398,8 @@ def collect_host_metrics() -> dict[str, float | None]:
         "host_temperature_c": host_temperature_c,
         "process_cpu_percent": process_cpu_percent,
         "process_rss_mb": process_rss_mb,
+        "host_uptime_s": host_uptime_s,
+        "collection_strategy": strategy,
+        "metric_status": metric_statuses,
     }
     return payload

--- a/src/singular/sensors/host_metrics_store.py
+++ b/src/singular/sensors/host_metrics_store.py
@@ -19,6 +19,10 @@ _METRICS_KEYS = (
     "host_temperature_c",
     "process_cpu_percent",
     "process_rss_mb",
+    "cpu_load_1m",
+    "ram_available_mb",
+    "disk_free_gb",
+    "host_uptime_s",
 )
 
 
@@ -64,13 +68,48 @@ def _safe_float(value: Any) -> float | None:
         return None
 
 
+def _extract_metric_value(metrics: dict[str, Any], key: str) -> float | None:
+    raw = metrics.get(key)
+    if isinstance(raw, dict):
+        return _safe_float(raw.get("value"))
+    return _safe_float(raw)
+
+
+def _extract_metric_snapshot(metrics: dict[str, Any], key: str) -> dict[str, Any] | None:
+    candidate = metrics.get(key)
+    if not isinstance(candidate, dict):
+        return None
+    value = _safe_float(candidate.get("value"))
+    return {
+        "value": value,
+        "unit": candidate.get("unit"),
+        "status": candidate.get("status"),
+        "reason": candidate.get("reason"),
+        "last_seen_at": candidate.get("last_seen_at"),
+    }
+
+
+def _coerce_metric_status_block(metrics: dict[str, Any]) -> dict[str, Any]:
+    explicit = metrics.get("metric_status")
+    if isinstance(explicit, dict):
+        return explicit
+    snapshots: dict[str, Any] = {}
+    for key in _METRICS_KEYS:
+        snapshot = _extract_metric_snapshot(metrics, key)
+        if snapshot is not None:
+            snapshots[key] = snapshot
+    return snapshots
+
+
 def append_host_metrics_sample(metrics: dict[str, Any]) -> None:
     """Append one host sample and enforce retention."""
 
     path = host_metrics_file()
     payload = {
         "ts": _utc_now_iso(),
-        "metrics": {key: _safe_float(metrics.get(key)) for key in _METRICS_KEYS},
+        "metrics": {key: _extract_metric_value(metrics, key) for key in _METRICS_KEYS},
+        "metric_status": _coerce_metric_status_block(metrics),
+        "collection_strategy": metrics.get("collection_strategy"),
     }
     append_jsonl_line_safe(path, payload)
     _trim_retention(path=path, retention=_retention_samples())
@@ -138,7 +177,7 @@ def compute_host_metrics_aggregates(
         if not isinstance(metrics, dict):
             continue
         for key in _METRICS_KEYS:
-            value = _safe_float(metrics.get(key))
+            value = _extract_metric_value(metrics, key)
             if value is not None:
                 metrics_by_key[key].append(value)
 

--- a/tests/test_host_metrics_store.py
+++ b/tests/test_host_metrics_store.py
@@ -27,6 +27,7 @@ def test_host_metrics_store_writes_jsonl_with_retention(tmp_path, monkeypatch) -
     assert len(lines) == 3
     latest = json.loads(lines[-1])
     assert latest["metrics"]["cpu_percent"] == 14.0
+    assert "metric_status" in latest
 
 
 def test_host_metrics_aggregates_and_impact(tmp_path, monkeypatch) -> None:
@@ -49,3 +50,34 @@ def test_host_metrics_aggregates_and_impact(tmp_path, monkeypatch) -> None:
     assert impact["impact_level"] in {"moderate", "high", "critical"}
     assert impact["decision_bias"] == "robustesse"
 
+
+def test_host_metrics_store_accepts_metric_status_payload(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    append_host_metrics_sample(
+        {
+            "cpu_percent": {
+                "value": 42.0,
+                "unit": "percent",
+                "status": "available",
+                "reason": None,
+                "last_seen_at": "2026-01-01T00:00:00+00:00",
+            },
+            "ram_used_percent": 55.0,
+            "metric_status": {
+                "cpu_percent": {
+                    "value": 42.0,
+                    "unit": "percent",
+                    "status": "available",
+                    "reason": None,
+                    "last_seen_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+            "collection_strategy": "partial_fallback",
+        }
+    )
+
+    lines = host_metrics_file().read_text(encoding="utf-8").splitlines()
+    latest = json.loads(lines[-1])
+    assert latest["metrics"]["cpu_percent"] == 42.0
+    assert latest["metric_status"]["cpu_percent"]["status"] == "available"
+    assert latest["collection_strategy"] == "partial_fallback"

--- a/tests/test_host_sensor.py
+++ b/tests/test_host_sensor.py
@@ -6,7 +6,7 @@ from singular.sensors import host
 def test_collect_host_metrics_returns_normalized_payload() -> None:
     metrics = host.collect_host_metrics()
 
-    assert set(metrics) == {
+    assert {
         "cpu_percent",
         "cpu_load_1m",
         "ram_used_percent",
@@ -16,7 +16,10 @@ def test_collect_host_metrics_returns_normalized_payload() -> None:
         "host_temperature_c",
         "process_cpu_percent",
         "process_rss_mb",
-    }
+        "host_uptime_s",
+        "collection_strategy",
+        "metric_status",
+    }.issubset(set(metrics))
     assert isinstance(metrics["cpu_percent"], float)
     assert isinstance(metrics["ram_used_percent"], float)
     assert isinstance(metrics["ram_available_mb"], float)
@@ -24,6 +27,8 @@ def test_collect_host_metrics_returns_normalized_payload() -> None:
     assert isinstance(metrics["disk_free_gb"], float)
     assert isinstance(metrics["process_cpu_percent"], float)
     assert isinstance(metrics["process_rss_mb"], float)
+    assert metrics["host_uptime_s"] is None or isinstance(metrics["host_uptime_s"], float)
+    assert isinstance(metrics["metric_status"], dict)
     assert metrics["cpu_load_1m"] is None or isinstance(metrics["cpu_load_1m"], float)
     assert metrics["host_temperature_c"] is None or isinstance(metrics["host_temperature_c"], float)
 
@@ -35,3 +40,4 @@ def test_collect_host_metrics_without_psutil(monkeypatch) -> None:
     assert metrics["host_temperature_c"] is None
     assert metrics["cpu_load_1m"] is None or metrics["cpu_load_1m"] >= 0.0
     assert 0.0 <= metrics["cpu_percent"] <= 100.0
+    assert metrics["collection_strategy"] in {"partial_fallback", "minimal_fallback"}

--- a/tests/test_host_sensors.py
+++ b/tests/test_host_sensors.py
@@ -51,6 +51,9 @@ class _FakePsutil:
     def Process(self, _pid: int):
         return self._process
 
+    def boot_time(self):
+        return 1000.0
+
 
 def test_collect_host_metrics_nominal_with_psutil(monkeypatch) -> None:
     fake_psutil = _FakePsutil(
@@ -82,6 +85,9 @@ def test_collect_host_metrics_nominal_with_psutil(monkeypatch) -> None:
     assert metrics["host_temperature_c"] == 65.0
     assert metrics["process_cpu_percent"] == 12.0
     assert metrics["process_rss_mb"] == 256.0
+    assert metrics["collection_strategy"] == "primary"
+    assert metrics["metric_status"]["cpu_percent"]["status"] == "available"
+    assert metrics["metric_status"]["host_temperature_c"]["status"] == "available"
 
 
 def test_collect_host_metrics_handles_unavailable_sensors(monkeypatch) -> None:
@@ -102,6 +108,9 @@ def test_collect_host_metrics_handles_unavailable_sensors(monkeypatch) -> None:
     assert metrics["host_temperature_c"] is None
     assert metrics["process_cpu_percent"] == 0.0
     assert metrics["process_rss_mb"] == 0.0
+    assert metrics["metric_status"]["cpu_percent"]["status"] == "unsupported"
+    assert metrics["metric_status"]["ram_available_mb"]["status"] == "unsupported"
+    assert metrics["metric_status"]["host_temperature_c"]["status"] == "unsupported"
 
 
 def test_collect_host_metrics_clamps_outlier_values(monkeypatch) -> None:
@@ -134,6 +143,7 @@ def test_collect_host_metrics_clamps_outlier_values(monkeypatch) -> None:
     assert metrics["host_temperature_c"] is None
     assert metrics["process_cpu_percent"] == 100.0
     assert metrics["process_rss_mb"] == 0.0
+    assert metrics["metric_status"]["host_temperature_c"]["status"] == "partial"
 
 
 def test_collect_host_metrics_unit_conversions(monkeypatch) -> None:
@@ -159,3 +169,54 @@ def test_collect_host_metrics_unit_conversions(monkeypatch) -> None:
     assert metrics["ram_available_mb"] == 1536.0
     assert metrics["disk_free_gb"] == 250.0
     assert metrics["process_rss_mb"] == 512.0
+
+
+def test_collect_host_metrics_windows_minimal_fallback_not_all_unsupported(monkeypatch) -> None:
+    monkeypatch.setattr(host, "psutil", None)
+    monkeypatch.setattr(host.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(host.os, "getloadavg", lambda: (_ for _ in ()).throw(OSError("unsupported")))
+    monkeypatch.setattr(host, "_collect_memory_stdlib", lambda: (0.0, 2048.0))
+    monkeypatch.setattr(host, "_collect_disk_stdlib", lambda: (0.0, 0.0))
+    monkeypatch.setattr(host, "_collect_uptime_seconds", lambda: (3600.0, None))
+    monkeypatch.setattr(host, "_collect_process_stdlib", lambda: (0.0, 0.0))
+
+    metrics = host.collect_host_metrics()
+
+    assert metrics["collection_strategy"] == "minimal_fallback"
+    statuses = metrics["metric_status"]
+    assert statuses["host_uptime_s"]["status"] == "available"
+    assert statuses["ram_available_mb"]["status"] == "partial"
+    assert any(entry["status"] != "unsupported" for entry in statuses.values())
+
+
+def test_collect_host_metrics_linux_and_macos_temperature_status(monkeypatch) -> None:
+    linux_psutil = _FakePsutil(
+        cpu_percent=20.0,
+        ram_percent=50.0,
+        ram_available_bytes=2 * 1024 * 1024 * 1024,
+        disk_percent=40.0,
+        disk_free_bytes=100 * 1024 * 1024 * 1024,
+        process_cpu_percent=3.0,
+        process_rss_bytes=128 * 1024 * 1024,
+        temperatures=None,
+    )
+    monkeypatch.setattr(host, "psutil", linux_psutil)
+    monkeypatch.setattr(host.os, "getloadavg", lambda: (0.8, 0.5, 0.2))
+    monkeypatch.setattr(host.platform, "system", lambda: "Linux")
+    linux_metrics = host.collect_host_metrics()
+    assert linux_metrics["metric_status"]["host_temperature_c"]["status"] == "partial"
+
+    mac_psutil = _FakePsutil(
+        cpu_percent=21.0,
+        ram_percent=55.0,
+        ram_available_bytes=3 * 1024 * 1024 * 1024,
+        disk_percent=45.0,
+        disk_free_bytes=120 * 1024 * 1024 * 1024,
+        process_cpu_percent=4.0,
+        process_rss_bytes=200 * 1024 * 1024,
+        temperatures={"chip": [types.SimpleNamespace(current=46.0)]},
+    )
+    monkeypatch.setattr(host, "psutil", mac_psutil)
+    monkeypatch.setattr(host.platform, "system", lambda: "Darwin")
+    mac_metrics = host.collect_host_metrics()
+    assert mac_metrics["metric_status"]["host_temperature_c"]["status"] == "available"


### PR DESCRIPTION
### Motivation

- Rendre la collecte des métriques hôte plus résiliente face à l'absence de `psutil` ou à des capteurs OS partiels en introduisant une chaîne de fallback explicite (primaire / partiel / minimal). 
- Fournir une signalisation par-métrique claire pour le dashboard afin d’éviter que tout soit considéré comme « unsupported » lorsque quelques mesures de base sont disponibles.

### Description

- Ajout d’une chaîne de collecte dans `src/singular/sensors/host.py` avec trois stratégies (`primary`, `partial_fallback`, `minimal_fallback`), et ajout de `host_uptime_s` et `collection_strategy` au payload; chaque métrique expose maintenant une structure `metric_status` contenant `value`, `unit`, `status`, `reason`, `last_seen_at`.
- Extension de la config dans `src/singular/sensors/config.py` pour exposer constantes de statuts et un mapping d’unités (`HOST_METRIC_UNITS`) afin d’uniformiser les métadonnées par métrique.
- Mise à jour du store `src/singular/sensors/host_metrics_store.py` pour accepter et persister à la fois le format scalar legacy et le nouveau bloc structuré `metric_status`, et pour agréger correctement les valeurs (ajout des clés `cpu_load_1m`, `ram_available_mb`, `disk_free_gb`, `host_uptime_s`).
- Adaptation de la consolidation utilisée par le dashboard dans `src/singular/dashboard/actions.py` pour lire `metric_status` lorsque présent et renvoyer, pour chaque métrique (cpu/ram/temperature/disk), `value`, `unit`, `status`, `reason`, `last_seen_at` tout en conservant `risk` et `history`.
- Ajout / mise à jour de tests dans `tests/test_host_sensor.py`, `tests/test_host_sensors.py`, `tests/test_host_metrics_store.py` pour couvrir scénarios psutil présent/absent, Linux/macOS/Windows simulés, persistance et compatibilité avec l’ancien format.

### Testing

- Tests unitaires ciblés exécutés: `pytest -q tests/test_host_sensor.py tests/test_host_sensors.py tests/test_host_metrics_store.py`.
- Résultat: tous les tests ciblés ont réussi (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0059c6a18832aae178469ef892cc9)