### PR TITLE
Add code evolution audit service and /api/lives/{life}/code-evolution endpoint

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -39,6 +39,9 @@ from singular.dashboard.services.lives_comparison import (
 from singular.dashboard.services.metrics_contract import (
     build_metrics_contract as build_metrics_contract_service,
 )
+from singular.dashboard.services.code_evolution import (
+    aggregate_code_evolution as aggregate_code_evolution_service,
+)
 
 
 @dataclass
@@ -1145,6 +1148,62 @@ def create_app(
     ) -> dict[str, object]:
         return build_metrics_contract_service(comparison)
 
+    def _aggregate_code_evolution(life: str) -> dict[str, object]:
+        return aggregate_code_evolution_service(
+            _load_run_records(current_life_only=False),
+            life=life,
+            record_life=_record_life,
+            record_run_id=_record_run_id,
+            as_float=_as_float,
+        )
+
+    @app.get("/api/lives/{life}/code-evolution")
+    def read_life_code_evolution(
+        life: str,
+        status: str | None = None,
+        change_type: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, object]:
+        payload = _aggregate_code_evolution(life)
+        items = payload.get("items")
+        if not isinstance(items, list):
+            items = []
+
+        normalized_status = status.strip().lower() if isinstance(status, str) else None
+        normalized_change_type = (
+            change_type.strip().lower() if isinstance(change_type, str) else None
+        )
+        filtered_items = [
+            item
+            for item in items
+            if (
+                normalized_status is None
+                or str(item.get("status", "")).lower() == normalized_status
+            )
+            and (
+                normalized_change_type is None
+                or str(item.get("change_type", "")).lower() == normalized_change_type
+            )
+        ]
+        if isinstance(limit, int) and limit >= 0:
+            filtered_items = filtered_items[:limit]
+
+        summary = payload.get("summary")
+        if not isinstance(summary, dict):
+            summary = {"by_status": {}, "by_change_type": {}, "by_target": {}}
+
+        return {
+            "life": life,
+            "count": len(filtered_items),
+            "items": filtered_items,
+            "summary": summary,
+            "filters": {
+                "status": normalized_status,
+                "change_type": normalized_change_type,
+                "limit": limit,
+            },
+        }
+
     @app.get("/lives/comparison")
     def read_lives_comparison(
         sort_by: str = "score",
@@ -1169,7 +1228,14 @@ def create_app(
             time_window=time_window,
         )
         metrics_contract = _build_metrics_contract(comparison)
-        base_rows = [{"life": name, **payload} for name, payload in comparison.items()]
+        base_rows = [
+            {
+                "life": name,
+                "code_evolution_endpoint": f"/api/lives/{name}/code-evolution",
+                **payload,
+            }
+            for name, payload in comparison.items()
+        ]
         lives_rows = list(base_rows)
         filter_steps: list[dict[str, object]] = [
             {

--- a/src/singular/dashboard/services/code_evolution.py
+++ b/src/singular/dashboard/services/code_evolution.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Callable
+
+
+def _as_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _normalize_target(record: dict[str, object]) -> str:
+    file_value = record.get("file")
+    if isinstance(file_value, str) and file_value.strip():
+        return file_value.strip()
+    module_value = record.get("module")
+    if isinstance(module_value, str) and module_value.strip():
+        return module_value.strip()
+    skill_value = record.get("skill")
+    if isinstance(skill_value, str) and skill_value.strip():
+        if ":" in skill_value:
+            _, path = skill_value.split(":", 1)
+            if path.strip():
+                return path.strip()
+        return skill_value.strip()
+    return "unknown"
+
+
+def _normalize_change_type(record: dict[str, object]) -> str:
+    for key in ("change_type", "change_category", "type"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    operator = record.get("operator")
+    if not isinstance(operator, str) or not operator.strip():
+        operator = record.get("op")
+    if isinstance(operator, str) and operator.strip():
+        return operator.strip().lower()
+    return "unknown"
+
+
+def _normalize_status(record: dict[str, object]) -> str:
+    event = record.get("event")
+    if isinstance(event, str):
+        lowered = event.strip().lower()
+        if lowered == "rollback":
+            return "rollback"
+        if lowered == "rejected":
+            return "rejeté"
+        if lowered == "accepted":
+            return "accepté"
+
+    accepted = _as_bool(record.get("accepted"))
+    if accepted is None:
+        accepted = _as_bool(record.get("ok"))
+    if accepted is True:
+        return "accepté"
+    if accepted is False:
+        return "rejeté"
+    return "unknown"
+
+
+def aggregate_code_evolution(
+    records: list[dict[str, object]],
+    *,
+    life: str,
+    record_life: Callable[[dict[str, object]], str],
+    record_run_id: Callable[[dict[str, object]], str],
+    as_float: Callable[[object], float | None],
+) -> dict[str, object]:
+    items: list[dict[str, object]] = []
+    by_status: Counter[str] = Counter()
+    by_change_type: Counter[str] = Counter()
+    by_target: Counter[str] = Counter()
+
+    for record in records:
+        if record_life(record) != life:
+            continue
+
+        score_before = as_float(record.get("score_base"))
+        score_after = as_float(record.get("score_new"))
+        latency_before = as_float(record.get("ms_base"))
+        latency_after = as_float(record.get("ms_new"))
+
+        health = record.get("health")
+        stability_after = None
+        if isinstance(health, dict):
+            stability_after = as_float(health.get("sandbox_stability"))
+        stability_before = as_float(record.get("stability_base"))
+        if stability_after is None:
+            stability_after = as_float(record.get("stability_new"))
+
+        change_type = _normalize_change_type(record)
+        target = _normalize_target(record)
+        status = _normalize_status(record)
+
+        by_status[status] += 1
+        by_change_type[change_type] += 1
+        by_target[target] += 1
+
+        items.append(
+            {
+                "target": target,
+                "change_type": change_type,
+                "metrics": {
+                    "score": {"before": score_before, "after": score_after},
+                    "latency_ms": {"before": latency_before, "after": latency_after},
+                    "stability": {"before": stability_before, "after": stability_after},
+                },
+                "status": status,
+                "timestamp": record.get("ts") if isinstance(record.get("ts"), str) else None,
+                "run_id": record_run_id(record),
+                "trace_id": (
+                    record.get("trace_id") if isinstance(record.get("trace_id"), str) else None
+                ),
+            }
+        )
+
+    items.sort(key=lambda item: str(item.get("timestamp") or ""), reverse=True)
+
+    return {
+        "life": life,
+        "count": len(items),
+        "items": items,
+        "summary": {
+            "by_status": dict(by_status),
+            "by_change_type": dict(by_change_type),
+            "by_target": dict(by_target),
+        },
+    }

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -160,7 +160,8 @@ const renderLivesTable=(rows)=>{
     const state=rowStateSummary(row);
     const risk=rowRiskSummary(row);
     const activity=rowActivitySummary(row);
-    tr.innerHTML=`<td>${escapeHtml(row.life||na())}</td><td>${score}</td><td>${escapeHtml(row.trend||na())}</td><td>${stability}</td><td>${escapeHtml(lastActivity)}</td><td>${row.iterations??0}</td><td><span class='summary-pill ${state.tone}'>${state.label}</span></td><td><span class='summary-pill ${risk.tone}'>${risk.label}</span></td><td><span class='summary-pill ${activity.tone}'>${activity.label}</span></td>`;
+    const codeEvolutionEndpoint=row.code_evolution_endpoint||`/api/lives/${encodeURIComponent(row.life||'')}/code-evolution`;
+    tr.innerHTML=`<td>${escapeHtml(row.life||na())}<br/><a href='${escapeHtml(codeEvolutionEndpoint)}' target='_blank' rel='noopener noreferrer'>audit code</a></td><td>${score}</td><td>${escapeHtml(row.trend||na())}</td><td>${stability}</td><td>${escapeHtml(lastActivity)}</td><td>${row.iterations??0}</td><td><span class='summary-pill ${state.tone}'>${state.label}</span></td><td><span class='summary-pill ${risk.tone}'>${risk.label}</span></td><td><span class='summary-pill ${activity.tone}'>${activity.label}</span></td>`;
     tr.onclick=()=>showLifeDetails(row.life||'');
     tr.onkeydown=event=>{
       if(event.key==='Enter'||event.key===' '){
@@ -206,6 +207,7 @@ const showLifeDetails=lifeName=>{
     ['Alertes',row.alerts_count??0],
     ['Run terminé',row.run_terminated?'oui':'non'],
     ['Extinction runs',row.extinction_seen_in_runs?'oui':'non'],
+    ['Audit code evolution',row.code_evolution_endpoint||`/api/lives/${encodeURIComponent(row.life||'')}/code-evolution`],
   ];
   const metadataRows=metadata.map(([key,value])=>`<tr><th>${escapeHtml(key)}</th><td>${escapeHtml(value)}</td></tr>`).join('');
   content.innerHTML=`<div class='detail-badges'>${summarizeBadges(row)||badge('Aucun badge',BADGE_TONE.info)}</div><table class='table-base life-meta-table'><tbody>${metadataRows}</tbody></table><h4>Timeline vitale</h4><pre>${escapeHtml(JSON.stringify(row.vital_timeline||{},null,2))}</pre>`;

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -630,6 +630,66 @@ def test_dashboard_lives_comparison_excludes_runs_without_explicit_life(tmp_path
     }
 
 
+def test_dashboard_code_evolution_endpoint_and_comparison_link(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "run-2001.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-04-12T12:10:00Z",
+                        "life": "life-explicit",
+                        "file": "skills/perf.py",
+                        "change_type": "perf_fix",
+                        "score_base": 12.0,
+                        "score_new": 9.0,
+                        "ms_base": 110.0,
+                        "ms_new": 88.0,
+                        "accepted": True,
+                        "trace_id": "trace-ok",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-04-12T12:11:00Z",
+                        "life": "life-explicit",
+                        "module": "singular.life.loop",
+                        "operator": "cleanup",
+                        "score_base": 9.0,
+                        "score_new": 10.0,
+                        "ok": False,
+                        "trace_id": "trace-ko",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+
+    comparison_payload = client.get("/lives/comparison").json()
+    life_row = next(row for row in comparison_payload["table"] if row["life"] == "life-explicit")
+    assert life_row["code_evolution_endpoint"] == "/api/lives/life-explicit/code-evolution"
+
+    endpoint_payload = app._routes["/api/lives/{life}/code-evolution"](life="life-explicit")
+    assert endpoint_payload["life"] == "life-explicit"
+    assert endpoint_payload["count"] == 2
+    assert endpoint_payload["summary"]["by_status"] == {"accepté": 1, "rejeté": 1}
+    assert endpoint_payload["items"][0]["run_id"] == "run-2001"
+
+    filtered_payload = app._routes["/api/lives/{life}/code-evolution"](
+        life="life-explicit",
+        status="accepté",
+        limit=1,
+    )
+    assert filtered_payload["count"] == 1
+    assert filtered_payload["items"][0]["status"] == "accepté"
+
+
 def test_run_timeline_endpoint_filters_pagination_and_event_coherence(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()

--- a/tests/test_dashboard_services.py
+++ b/tests/test_dashboard_services.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from singular.dashboard.services.lives_comparison import aggregate_lives
+from singular.dashboard.services.code_evolution import aggregate_code_evolution
 from singular.dashboard.services.trajectory import build_trajectory
 
 
@@ -163,3 +164,59 @@ def test_lives_comparison_default_rows_follow_active_and_dead_filters() -> None:
 
     assert [row["life"] for row in active_only] == ["alpha"]
     assert [row["life"] for row in dead_only] == ["beta"]
+
+
+def test_code_evolution_service_aggregates_by_life_and_metrics() -> None:
+    payload = aggregate_code_evolution(
+        [
+            {
+                "life": "alpha",
+                "file": "skills/a.py",
+                "change_type": "perf_fix",
+                "score_base": 10.0,
+                "score_new": 8.0,
+                "ms_base": 100.0,
+                "ms_new": 75.0,
+                "stability_base": 0.7,
+                "stability_new": 0.9,
+                "accepted": True,
+                "ts": "2026-03-01T00:00:00Z",
+                "run_id": "run-a",
+                "trace_id": "trace-1",
+            },
+            {
+                "life": "alpha",
+                "module": "singular.life.loop",
+                "operator": "cleanup",
+                "score_base": 8.0,
+                "score_new": 9.0,
+                "ok": False,
+                "ts": "2026-03-02T00:00:00Z",
+                "run_id": "run-b",
+                "trace_id": "trace-2",
+            },
+            {
+                "life": "beta",
+                "file": "skills/b.py",
+                "change_type": "robustesse",
+                "score_base": 9.0,
+                "score_new": 7.0,
+                "accepted": True,
+                "ts": "2026-03-03T00:00:00Z",
+                "run_id": "run-c",
+            },
+        ],
+        life="alpha",
+        record_life=lambda rec: str(rec.get("life", "unknown")),
+        record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
+        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+    )
+
+    assert payload["life"] == "alpha"
+    assert payload["count"] == 2
+    assert payload["items"][0]["timestamp"] == "2026-03-02T00:00:00Z"
+    assert payload["items"][1]["metrics"]["latency_ms"] == {"before": 100.0, "after": 75.0}
+    assert payload["items"][1]["metrics"]["stability"] == {"before": 0.7, "after": 0.9}
+    assert payload["summary"]["by_status"] == {"accepté": 1, "rejeté": 1}
+    assert payload["summary"]["by_change_type"] == {"perf_fix": 1, "cleanup": 1}
+    assert payload["summary"]["by_target"] == {"skills/a.py": 1, "singular.life.loop": 1}


### PR DESCRIPTION
### Motivation

- Provide an audit view of code evolution per life to trace what files/modules were touched, the kind of change, before/after metrics and decision outcome. 
- Make it easy to navigate from the lives comparison UI to a dedicated audit endpoint so operators can inspect recent code changes for a life.

### Description

- Add a new aggregation service `aggregate_code_evolution` in `src/singular/dashboard/services/code_evolution.py` that normalizes target (file/module/skill), change type, status (`accepté`, `rejeté`, `rollback`, `unknown`), and collects metrics (score, latency `ms`, stability) plus `timestamp`, `run_id`, and `trace_id`.
- Expose a new endpoint `GET /api/lives/{life}/code-evolution` in `src/singular/dashboard/__init__.py` with optional query filters `status`, `change_type`, and `limit`, and return `life`, `count`, `items`, `summary`, and applied `filters`.
- Enrich the lives comparison rows with a `code_evolution_endpoint` field and add a UI link `audit code` in `src/singular/dashboard/static/render-lives.js` that points to the audit endpoint and includes the endpoint in the life detail metadata.
- Add unit tests: `tests/test_dashboard_services.py` contains `test_code_evolution_service_aggregates_by_life_and_metrics` for the service, and `tests/test_dashboard.py` contains `test_dashboard_code_evolution_endpoint_and_comparison_link` for the endpoint and comparison-link contract.

### Testing

- Ran `pytest -q tests/test_dashboard_services.py tests/test_dashboard.py -k 'code_evolution or lives_comparison_excludes_runs_without_explicit_life or dashboard_endpoints'` which passed with `4 passed, 32 deselected` and one test warning. 
- The new service tests and endpoint tests executed successfully in CI-like local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e007bbd684832a9d71519d286ccd18)