### PR TITLE
Add life liveness index with proof signals in comparison and cockpit

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -31,6 +31,7 @@ from singular.dashboard.services.trajectory import (
 )
 from singular.dashboard.services.lives_comparison import (
     aggregate_lives as aggregate_lives_service,
+    compute_liveness_index as compute_liveness_index_service,
     parse_ts as parse_ts_service,
     resolve_time_window_cutoff as resolve_time_window_cutoff_service,
     life_trend_label as life_trend_label_service,
@@ -463,6 +464,10 @@ def create_app(
                 "daily_skills": build_daily_skills_snapshot([]),
                 "life_metrics_contract": _build_metrics_contract({}),
                 "trajectory": _build_trajectory([]),
+                "life_liveness_index": 0.0,
+                "life_liveness_components": {},
+                "life_liveness_proofs": [],
+                "life_liveness_life": None,
             }
             return empty
 
@@ -601,6 +606,34 @@ def create_app(
             failure_streak=max_failure_streak,
             extinction_seen=any(rec.get("event") == "death" for rec in records),
         )
+        comparison, _ = _aggregate_lives(current_life_only=current_life_only)
+        comparison_rows = [
+            {"life": life_name, **payload}
+            for life_name, payload in comparison.items()
+            if isinstance(payload, dict)
+        ]
+        selected_row = next(
+            (
+                row
+                for row in comparison_rows
+                if row.get("selected_life") is True and isinstance(row.get("life"), str)
+            ),
+            None,
+        )
+        if selected_row is None and comparison_rows:
+            selected_row = max(
+                comparison_rows,
+                key=lambda row: float(row.get("life_liveness_index") or 0.0),
+            )
+        selected_life = selected_row.get("life") if isinstance(selected_row, dict) else None
+        filtered_records = [
+            record for record in records if selected_life and _record_life(record) == selected_life
+        ]
+        liveness_payload = (
+            compute_liveness_index_service(filtered_records or records)
+            if records
+            else {"index": 0.0, "components": {}, "proofs": []}
+        )
 
         return {
             "run": latest.stem,
@@ -645,6 +678,10 @@ def create_app(
             "daily_skills": build_daily_skills_snapshot(records),
             "life_metrics_contract": metrics_contract,
             "trajectory": trajectory,
+            "life_liveness_index": liveness_payload.get("index", 0.0),
+            "life_liveness_components": liveness_payload.get("components", {}),
+            "life_liveness_proofs": liveness_payload.get("proofs", []),
+            "life_liveness_life": selected_life,
         }
 
     def _summarize_cockpit_essential(current_life_only: bool = False) -> dict[str, object]:
@@ -1288,6 +1325,7 @@ def create_app(
             "stability": "stability",
             "last_activity": "last_activity",
             "iterations": "iterations",
+            "liveness": "life_liveness_index",
         }
         key_name = sort_key_map.get(sort_by, "current_health_score")
         reverse = sort_order != "asc"

--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -4,13 +4,35 @@ from datetime import datetime, timedelta, timezone
 from typing import Callable
 
 
+_RECENT_ACTIVITY_EVENTS = {
+    "mutation",
+    "interaction",
+    "consciousness",
+    "quest",
+    "quest_triggered",
+    "quest_resolved",
+    "decision",
+    "action",
+    "perception",
+}
+_PERCEPTION_EVENTS = {"perception", "signal", "sense", "observe"}
+_DECISION_EVENTS = {"decision", "consciousness", "plan", "evaluate"}
+_ACTION_EVENTS = {"action", "mutation", "interaction", "act", "execute"}
+_INTERACTION_EVENTS = {"interaction", "conversation", "talk", "message"}
+_OBJECTIVE_EVENTS = {"quest", "quest_triggered", "objective", "goal"}
+_PROGRESS_EVENTS = {"quest_resolved", "objective_progress", "objective_completed", "goal_progress"}
+
+
 def parse_ts(value: object) -> datetime | None:
     if not isinstance(value, str):
         return None
     try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def resolve_time_window_cutoff(time_window: str) -> datetime | None:
@@ -46,6 +68,240 @@ def life_trend_rank(trend: str) -> int:
     if trend == "amélioration":
         return 2
     return -1
+
+
+def _normalized_event(record: dict[str, object]) -> str:
+    event = record.get("event")
+    if isinstance(event, str):
+        return event.strip().lower()
+    return ""
+
+
+def compute_liveness_index(
+    records: list[dict[str, object]],
+    *,
+    now: datetime | None = None,
+) -> dict[str, object]:
+    reference = now or datetime.now(timezone.utc)
+    sorted_records = sorted(records, key=lambda rec: str(rec.get("ts", "")))
+    recent_cutoff = reference - timedelta(hours=24)
+    loop_cutoff = reference - timedelta(hours=48)
+    interaction_cutoff = reference - timedelta(days=7)
+
+    component_details: dict[str, dict[str, object]] = {
+        "recent_activity": {"score": 0.0, "count": 0, "cutoff": recent_cutoff.isoformat()},
+        "perception_decision_action_loop": {"score": 0.0, "completed": False, "window_hours": 48},
+        "active_objectives_progress": {"score": 0.0, "active_objectives": 0, "progress_events": 0},
+        "interactions": {"score": 0.0, "count": 0, "window_days": 7},
+        "validated_internal_modifications": {"score": 0.0, "accepted_useful_changes": 0},
+    }
+    proofs: list[dict[str, object]] = []
+
+    # 1) Recent concrete activity
+    recent_activity_count = 0
+    for record in sorted_records:
+        ts = parse_ts(record.get("ts"))
+        if ts is None or ts < recent_cutoff:
+            continue
+        event_name = _normalized_event(record)
+        has_concrete_mutation = any(
+            key in record for key in ("score_base", "score_new", "accepted", "ok", "operator", "op")
+        )
+        if event_name in _RECENT_ACTIVITY_EVENTS or has_concrete_mutation:
+            recent_activity_count += 1
+            proofs.append(
+                {
+                    "ts": record.get("ts"),
+                    "component": "recent_activity",
+                    "evidence": "activité concrète récente",
+                    "event": event_name or "mutation",
+                }
+            )
+    if recent_activity_count >= 2:
+        component_details["recent_activity"]["score"] = 1.0
+    elif recent_activity_count == 1:
+        component_details["recent_activity"]["score"] = 0.5
+    component_details["recent_activity"]["count"] = recent_activity_count
+
+    # 2) Perception → decision → action loop
+    perception_ts: datetime | None = None
+    decision_ts: datetime | None = None
+    action_ts: datetime | None = None
+    for record in sorted_records:
+        ts = parse_ts(record.get("ts"))
+        if ts is None or ts < loop_cutoff:
+            continue
+        event_name = _normalized_event(record)
+        if perception_ts is None and (
+            event_name in _PERCEPTION_EVENTS or isinstance(record.get("perception_summary"), str)
+        ):
+            perception_ts = ts
+            proofs.append(
+                {
+                    "ts": record.get("ts"),
+                    "component": "perception_decision_action_loop",
+                    "evidence": "perception observée",
+                    "event": event_name or "perception",
+                }
+            )
+            continue
+        if perception_ts is not None and decision_ts is None and ts >= perception_ts and (
+            event_name in _DECISION_EVENTS
+            or isinstance(record.get("decision_reason"), str)
+            or isinstance(record.get("justification"), str)
+        ):
+            decision_ts = ts
+            proofs.append(
+                {
+                    "ts": record.get("ts"),
+                    "component": "perception_decision_action_loop",
+                    "evidence": "décision observée",
+                    "event": event_name or "decision",
+                }
+            )
+            continue
+        if perception_ts is not None and decision_ts is not None and ts >= decision_ts:
+            accepted = record.get("accepted")
+            if not isinstance(accepted, bool):
+                accepted = record.get("ok")
+            if event_name in _ACTION_EVENTS or isinstance(accepted, bool):
+                action_ts = ts
+                proofs.append(
+                    {
+                        "ts": record.get("ts"),
+                        "component": "perception_decision_action_loop",
+                        "evidence": "action observée",
+                        "event": event_name or "action",
+                    }
+                )
+                break
+    loop_completed = perception_ts is not None and decision_ts is not None and action_ts is not None
+    component_details["perception_decision_action_loop"]["completed"] = loop_completed
+    component_details["perception_decision_action_loop"]["score"] = 1.0 if loop_completed else 0.0
+
+    # 3) Active objectives with progress
+    active_objectives_count = 0
+    objective_progress_count = 0
+    for record in sorted_records:
+        event_name = _normalized_event(record)
+        objective_value = record.get("objective")
+        has_objective_payload = (
+            event_name in _OBJECTIVE_EVENTS
+            or isinstance(objective_value, str)
+            or isinstance(record.get("objective_priorities"), dict)
+        )
+        if has_objective_payload:
+            active_objectives_count += 1
+        explicit_progress = event_name in _PROGRESS_EVENTS
+        status = record.get("status")
+        if not explicit_progress and isinstance(status, str):
+            explicit_progress = status.strip().lower() in {"in_progress", "progress", "done", "completed", "success"}
+        progress_value = record.get("progress")
+        if not explicit_progress and isinstance(progress_value, (int, float)):
+            explicit_progress = float(progress_value) > 0
+        if explicit_progress and has_objective_payload:
+            objective_progress_count += 1
+            proofs.append(
+                {
+                    "ts": record.get("ts"),
+                    "component": "active_objectives_progress",
+                    "evidence": "objectif actif avec progression",
+                    "event": event_name or "objective_progress",
+                }
+            )
+    if active_objectives_count > 0 and objective_progress_count > 0:
+        component_details["active_objectives_progress"]["score"] = 1.0
+    component_details["active_objectives_progress"]["active_objectives"] = active_objectives_count
+    component_details["active_objectives_progress"]["progress_events"] = objective_progress_count
+
+    # 4) Interactions
+    interaction_count = 0
+    for record in sorted_records:
+        ts = parse_ts(record.get("ts"))
+        if ts is None or ts < interaction_cutoff:
+            continue
+        event_name = _normalized_event(record)
+        interaction_payload = record.get("interaction")
+        has_interaction = (
+            event_name in _INTERACTION_EVENTS
+            or isinstance(interaction_payload, dict)
+            or isinstance(record.get("speaker"), str)
+            or isinstance(record.get("user_message"), str)
+            or isinstance(record.get("world_event"), str)
+        )
+        if has_interaction:
+            interaction_count += 1
+            proofs.append(
+                {
+                    "ts": record.get("ts"),
+                    "component": "interactions",
+                    "evidence": "interaction détectée",
+                    "event": event_name or "interaction",
+                }
+            )
+    if interaction_count >= 2:
+        component_details["interactions"]["score"] = 1.0
+    elif interaction_count == 1:
+        component_details["interactions"]["score"] = 0.5
+    component_details["interactions"]["count"] = interaction_count
+
+    # 5) Useful validated internal modifications
+    accepted_useful_modifications = 0
+    for record in sorted_records:
+        accepted = record.get("accepted")
+        if not isinstance(accepted, bool):
+            accepted = record.get("ok")
+        if accepted is not True:
+            continue
+        score_base = record.get("score_base")
+        score_new = record.get("score_new")
+        score_improved = (
+            isinstance(score_base, (int, float))
+            and isinstance(score_new, (int, float))
+            and float(score_new) < float(score_base)
+        )
+        health = record.get("health")
+        health_score = health.get("score") if isinstance(health, dict) else None
+        has_quality_signal = score_improved or isinstance(health_score, (int, float))
+        if not has_quality_signal:
+            continue
+        accepted_useful_modifications += 1
+        proofs.append(
+            {
+                "ts": record.get("ts"),
+                "component": "validated_internal_modifications",
+                "evidence": "modification interne validée utile",
+                "event": _normalized_event(record) or "mutation",
+            }
+        )
+    component_details["validated_internal_modifications"]["accepted_useful_changes"] = (
+        accepted_useful_modifications
+    )
+    if accepted_useful_modifications >= 1:
+        component_details["validated_internal_modifications"]["score"] = 1.0
+
+    component_scores = [
+        float(component_details[name]["score"])
+        for name in (
+            "recent_activity",
+            "perception_decision_action_loop",
+            "active_objectives_progress",
+            "interactions",
+            "validated_internal_modifications",
+        )
+    ]
+    index = round((sum(component_scores) / 5.0) * 100.0, 1)
+
+    sorted_proofs = sorted(
+        proofs,
+        key=lambda item: parse_ts(item.get("ts")) or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    return {
+        "index": index,
+        "components": component_details,
+        "proofs": sorted_proofs[:5],
+    }
 
 
 def aggregate_lives(
@@ -134,6 +390,22 @@ def aggregate_lives(
                 extinction_seen=is_extinct,
                 registry_status=registry_status,
             ),
+            "life_liveness_index": 0.0,
+            "life_liveness_components": {
+                "recent_activity": {"score": 0.0, "count": 0},
+                "perception_decision_action_loop": {"score": 0.0, "completed": False},
+                "active_objectives_progress": {
+                    "score": 0.0,
+                    "active_objectives": 0,
+                    "progress_events": 0,
+                },
+                "interactions": {"score": 0.0, "count": 0},
+                "validated_internal_modifications": {
+                    "score": 0.0,
+                    "accepted_useful_changes": 0,
+                },
+            },
+            "life_liveness_proofs": [],
         }
 
     for life_name, all_records in by_life.items():
@@ -225,6 +497,7 @@ def aggregate_lives(
             if sandbox_stability_points
             else None
         )
+        liveness = compute_liveness_index(all_records)
 
         comparison[life_name] = {
             "health_score": (
@@ -256,6 +529,9 @@ def aggregate_lives(
                 extinction_seen=extinction_seen,
                 registry_status=registry_status,
             ),
+            "life_liveness_index": liveness["index"],
+            "life_liveness_components": liveness["components"],
+            "life_liveness_proofs": liveness["proofs"],
         }
     unattached_summary = {
         "records_count": sum(unattached_runs.values()),

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -186,6 +186,8 @@ export const loadCockpit=()=>Promise.all([
   const trend=d.trend||na();
   const accepted=d.accepted_mutation_rate===null?na():`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
   const alertsCount=Number(essentialPayload.critical_alerts_count??(d.critical_alerts||[]).length||0);
+  const livenessIndex=d.life_liveness_index===null||d.life_liveness_index===undefined?na():Number(d.life_liveness_index).toFixed(1);
+  const livenessProofs=Array.isArray(d.life_liveness_proofs)?d.life_liveness_proofs:[];
   const autonomy=d.autonomy_metrics||{};
   const decisionQuality=autonomy.decision_quality||{};
   const fmtPct=(value)=>value===null||value===undefined?na():`${(Number(value)*100).toFixed(1)}%`;
@@ -195,6 +197,7 @@ export const loadCockpit=()=>Promise.all([
   document.getElementById('kpi-trend').textContent=trend;
   document.getElementById('kpi-accepted').textContent=accepted;
   document.getElementById('kpi-alerts').textContent=String(alertsCount);
+  document.getElementById('kpi-liveness-index').textContent=livenessIndex;
   document.getElementById('kpi-next-action').textContent=essentialPayload.next_action||d.next_action||na();
   const selectedLifeEl=document.getElementById('essential-selected-life');
   if(selectedLifeEl){selectedLifeEl.textContent=String(essentialPayload.selected_life||'Aucune');}
@@ -249,6 +252,18 @@ export const loadCockpit=()=>Promise.all([
   linksList.innerHTML='';
   for(const link of objectiveLinks.slice(-5).reverse()){const li=document.createElement('li');li.textContent=`${link.objective||'objectif'} ↔ ${link.event||'événement'} (${link.at||na()})`;linksList.appendChild(li);} 
   if(!objectiveLinks.length){const li=document.createElement('li');li.textContent='Aucun lien narratif détecté';linksList.appendChild(li);} 
+  const livenessProofsEl=document.getElementById('kpi-liveness-proofs');
+  livenessProofsEl.innerHTML='';
+  for(const proof of livenessProofs.slice(0,5)){
+    const li=document.createElement('li');
+    li.textContent=`${proof.ts||na()} · ${proof.evidence||'preuve'} (${proof.component||'signal'})`;
+    livenessProofsEl.appendChild(li);
+  }
+  if(!livenessProofs.length){
+    const li=document.createElement('li');
+    li.textContent='Aucune preuve récente.';
+    livenessProofsEl.appendChild(li);
+  }
   setStatusTone(document.getElementById('kpi-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
   const notable=d.last_notable_mutation;
   if(notable){const acceptedBadge=notable.accepted===true?'acceptée':(notable.accepted===false?'refusée':na());document.getElementById('kpi-notable-summary').textContent=`${notable.timestamp||na()} · ${notable.life||na()} · ${notable.operator||na()} · ${acceptedBadge} · Δ=${notable.impact_delta??na()}`;}

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -155,13 +155,14 @@ const renderLivesTable=(rows)=>{
     tr.dataset.life=row.life||'';
     if(row.life&&row.life===livesUiState.selectedLife){tr.classList.add('selected');}
     const score=row.current_health_score===null||row.current_health_score===undefined?na():Number(row.current_health_score).toFixed(1);
+    const liveness=row.life_liveness_index===null||row.life_liveness_index===undefined?na():Number(row.life_liveness_index).toFixed(1);
     const stability=row.stability===null||row.stability===undefined?na():`${(Number(row.stability)*100).toFixed(1)}%`;
     const lastActivity=row.last_activity||na();
     const state=rowStateSummary(row);
     const risk=rowRiskSummary(row);
     const activity=rowActivitySummary(row);
     const codeEvolutionEndpoint=row.code_evolution_endpoint||`/api/lives/${encodeURIComponent(row.life||'')}/code-evolution`;
-    tr.innerHTML=`<td>${escapeHtml(row.life||na())}<br/><a href='${escapeHtml(codeEvolutionEndpoint)}' target='_blank' rel='noopener noreferrer'>audit code</a></td><td>${score}</td><td>${escapeHtml(row.trend||na())}</td><td>${stability}</td><td>${escapeHtml(lastActivity)}</td><td>${row.iterations??0}</td><td><span class='summary-pill ${state.tone}'>${state.label}</span></td><td><span class='summary-pill ${risk.tone}'>${risk.label}</span></td><td><span class='summary-pill ${activity.tone}'>${activity.label}</span></td>`;
+    tr.innerHTML=`<td>${escapeHtml(row.life||na())}<br/><a href='${escapeHtml(codeEvolutionEndpoint)}' target='_blank' rel='noopener noreferrer'>audit code</a></td><td>${score}</td><td>${escapeHtml(row.trend||na())}</td><td>${stability}</td><td>${escapeHtml(lastActivity)}</td><td>${row.iterations??0}</td><td>${liveness}</td><td><span class='summary-pill ${state.tone}'>${state.label}</span></td><td><span class='summary-pill ${risk.tone}'>${risk.label}</span></td><td><span class='summary-pill ${activity.tone}'>${activity.label}</span></td>`;
     tr.onclick=()=>showLifeDetails(row.life||'');
     tr.onkeydown=event=>{
       if(event.key==='Enter'||event.key===' '){
@@ -171,7 +172,7 @@ const renderLivesTable=(rows)=>{
     };
     body.appendChild(tr);
   }
-  if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='9'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}
+  if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='10'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}
 };
 
 const renderEssentialLivesSummary=rows=>{
@@ -186,11 +187,13 @@ const renderEssentialLivesSummary=rows=>{
 const showLifeDetails=lifeName=>{
   const panel=document.getElementById('life-detail-panel');
   const content=document.getElementById('life-detail-content');
+  const proofs=document.getElementById('life-detail-liveness-proofs');
   if(!panel||!content){return;}
   const row=lifeName?livesUiState.rowsByLife.get(lifeName):null;
   if(!row){
     panel.classList.add('panel-hidden');
     content.textContent='Aucune vie sélectionnée.';
+    if(proofs){proofs.innerHTML='<li>Aucune vie sélectionnée.</li>';}
     livesUiState.selectedLife=null;
     return;
   }
@@ -204,6 +207,7 @@ const showLifeDetails=lifeName=>{
     ['Tendance',row.trend],
     ['Dernière activité',row.last_activity],
     ['Itérations',row.iterations??0],
+    ['Life liveness index',row.life_liveness_index===null||row.life_liveness_index===undefined?na():Number(row.life_liveness_index).toFixed(1)],
     ['Alertes',row.alerts_count??0],
     ['Run terminé',row.run_terminated?'oui':'non'],
     ['Extinction runs',row.extinction_seen_in_runs?'oui':'non'],
@@ -211,6 +215,20 @@ const showLifeDetails=lifeName=>{
   ];
   const metadataRows=metadata.map(([key,value])=>`<tr><th>${escapeHtml(key)}</th><td>${escapeHtml(value)}</td></tr>`).join('');
   content.innerHTML=`<div class='detail-badges'>${summarizeBadges(row)||badge('Aucun badge',BADGE_TONE.info)}</div><table class='table-base life-meta-table'><tbody>${metadataRows}</tbody></table><h4>Timeline vitale</h4><pre>${escapeHtml(JSON.stringify(row.vital_timeline||{},null,2))}</pre>`;
+  if(proofs){
+    proofs.innerHTML='';
+    const recentProofs=Array.isArray(row.life_liveness_proofs)?row.life_liveness_proofs:[];
+    for(const item of recentProofs.slice(0,5)){
+      const li=document.createElement('li');
+      li.textContent=`${item.ts||na()} · ${item.evidence||'preuve'} (${item.component||'signal'})`;
+      proofs.appendChild(li);
+    }
+    if(!recentProofs.length){
+      const li=document.createElement('li');
+      li.textContent='Aucune preuve récente.';
+      proofs.appendChild(li);
+    }
+  }
   document.querySelectorAll('#lives-table-body tr.lives-row').forEach(node=>{
     node.classList.toggle('selected',node.dataset.life===lifeName);
   });

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -51,10 +51,15 @@
       <div class='cards-grid content-top-gap'>
         <div class='card'><div class='card-label kpi-label' title='Évolution récente du système'>Tendance</div><div id='kpi-trend' class='card-value actionable-signal'>Non disponible</div></div>
         <div class='card'><div class='card-label kpi-label' title='Part des mutations validées'>Mutations acceptées</div><div id='kpi-accepted' class='card-value'>Pas encore mesuré</div></div>
+        <div class='card'><div class='card-label kpi-label' title='Indice de vivacité basé sur des preuves concrètes'>Life liveness index</div><div id='kpi-liveness-index' class='card-value actionable-signal'>0.0</div></div>
         <div class='card'><div class='card-label'>Stabilité long terme</div><div id='kpi-autonomy-stability' class='card-value actionable-signal'>Pas encore mesuré</div></div>
         <div class='card'><div class='card-label'>Qualité décision</div><div id='kpi-autonomy-decision' class='card-value'>Pas encore mesuré</div></div>
         <div class='card'><div class='card-label'>Initiatives</div><div id='kpi-autonomy-proactive' class='card-value'>Pas encore mesuré</div></div>
         <div class='card'><div class='card-label'>Âge</div><div id='kpi-vital-age' class='card-value'>0</div></div>
+      </div>
+      <div class='panel panel-compact panel-top-gap'>
+        <h4 class='heading-reset-top'>Preuves de vie</h4>
+        <ul id='kpi-liveness-proofs' class='list-tight-top'><li>Aucune preuve récente.</li></ul>
       </div>
     </details>
 
@@ -169,6 +174,7 @@
           <th><button data-sort='stability'>Stabilité</button></th>
           <th><button data-sort='last_activity'>Dernière activité</button></th>
           <th><button data-sort='iterations'>Itérations</button></th>
+          <th><button data-sort='liveness'>Liveness</button></th>
           <th>État</th>
           <th>Risque</th>
           <th>Activité</th>
@@ -177,6 +183,8 @@
       <aside id='life-detail-panel' class='panel panel-hidden life-detail-panel' aria-live='polite'>
         <h3 class='heading-reset-top'>Détails de vie</h3>
         <p class='text-muted-small'>Cliquez sur une ligne pour afficher les badges complets et métadonnées.</p>
+        <h4>Preuves de vie</h4>
+        <ul id='life-detail-liveness-proofs' class='list-tight-top'><li>Aucune vie sélectionnée.</li></ul>
         <div id='life-detail-content'>Aucune vie sélectionnée.</div>
       </aside>
     </div>

--- a/tests/test_liveness_index.py
+++ b/tests/test_liveness_index.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from singular.dashboard.services.lives_comparison import aggregate_lives, compute_liveness_index
+
+
+NOW = datetime(2026, 4, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_liveness_index_reaches_high_score_when_all_signals_present() -> None:
+    records = [
+        {"ts": "2026-04-15T10:00:00+00:00", "event": "perception", "perception_summary": "host stable"},
+        {
+            "ts": "2026-04-15T10:02:00+00:00",
+            "event": "consciousness",
+            "decision_reason": "best weighted score",
+            "objective": "stabiliser",
+            "status": "in_progress",
+            "progress": 0.3,
+        },
+        {"ts": "2026-04-15T10:03:00+00:00", "event": "interaction", "interaction": {"with": "human"}},
+        {
+            "ts": "2026-04-15T10:05:00+00:00",
+            "event": "mutation",
+            "accepted": True,
+            "score_base": 12.0,
+            "score_new": 10.0,
+            "health": {"score": 82.0},
+        },
+        {"ts": "2026-04-15T10:06:00+00:00", "event": "interaction", "speaker": "world"},
+    ]
+
+    payload = compute_liveness_index(records, now=NOW)
+
+    assert payload["index"] == 100.0
+    assert payload["components"]["recent_activity"]["score"] == 1.0
+    assert payload["components"]["perception_decision_action_loop"]["completed"] is True
+    assert payload["components"]["active_objectives_progress"]["score"] == 1.0
+    assert payload["components"]["interactions"]["score"] == 1.0
+    assert payload["components"]["validated_internal_modifications"]["score"] == 1.0
+    assert len(payload["proofs"]) == 5
+
+
+def test_liveness_index_avoids_false_positive_on_sparse_noise() -> None:
+    records = [
+        {"ts": "2026-04-10T10:00:00+00:00", "event": "heartbeat"},
+        {"ts": "2026-04-15T11:00:00+00:00", "event": "heartbeat"},
+        {"ts": "2026-04-15T11:10:00+00:00", "accepted": True},
+    ]
+
+    payload = compute_liveness_index(records, now=NOW)
+
+    # Only one weak recent signal (accepted without validated usefulness).
+    assert payload["index"] <= 20.0
+    assert payload["components"]["active_objectives_progress"]["score"] == 0.0
+    assert payload["components"]["interactions"]["score"] == 0.0
+    assert payload["components"]["validated_internal_modifications"]["score"] == 0.0
+
+
+def test_liveness_index_partial_interaction_threshold() -> None:
+    records = [
+        {"ts": "2026-04-15T10:00:00+00:00", "event": "interaction", "interaction": {"with": "human"}},
+        {"ts": "2026-04-15T10:02:00+00:00", "event": "mutation", "accepted": False, "score_base": 5, "score_new": 7},
+    ]
+
+    payload = compute_liveness_index(records, now=NOW)
+
+    assert payload["components"]["interactions"]["score"] == 0.5
+    assert payload["components"]["interactions"]["count"] == 1
+
+
+def test_lives_comparison_exposes_liveness_fields() -> None:
+    records = [
+        {
+            "life": "alpha",
+            "ts": "2026-04-15T10:00:00+00:00",
+            "event": "perception",
+            "score_base": 10.0,
+            "score_new": 9.0,
+            "accepted": True,
+            "health": {"score": 75.0, "sandbox_stability": 0.8},
+        },
+        {
+            "life": "alpha",
+            "ts": "2026-04-15T10:01:00+00:00",
+            "event": "consciousness",
+            "decision_reason": "keep safe",
+            "objective": "maintain",
+            "status": "in_progress",
+            "progress": 0.2,
+        },
+        {
+            "life": "alpha",
+            "ts": "2026-04-15T10:02:00+00:00",
+            "event": "interaction",
+            "interaction": {"with": "world"},
+        },
+    ]
+
+    comparison, _ = aggregate_lives(
+        records,
+        registry={"active": "alpha", "lives": {"alpha": {"status": "active"}}},
+        compare_lives=None,
+        time_window="all",
+        record_life=lambda rec: str(rec.get("life", "unknown")),
+        record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
+        is_mutation_record=lambda rec: "score_base" in rec,
+        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        alerts_from_records=lambda _: [],
+        compute_vital_timeline=lambda **_: {"ok": True},
+        set_life_status=lambda *_: None,
+        registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
+    )
+
+    alpha = comparison["alpha"]
+    assert isinstance(alpha["life_liveness_index"], float)
+    assert "recent_activity" in alpha["life_liveness_components"]
+    assert isinstance(alpha["life_liveness_proofs"], list)
+    assert len(alpha["life_liveness_proofs"]) <= 5


### PR DESCRIPTION
### Motivation
- Fournir un score concret de « vivacité » par vie à partir de preuves objectives (activité, boucle perception→décision→action, progression d’objectifs, interactions, modifications internes validées) pour éviter les faux positifs et améliorer le pilotage.
- Exposer ce score et ses composantes côté API et UI pour faciliter le diagnostic rapide et la priorisation des vies.

### Description
- Implémente `compute_liveness_index` dans `src/singular/dashboard/services/lives_comparison.py` qui calcule un `life_liveness_index` (0–100) à partir de 5 composantes et collecte jusqu’à 5 preuves horodatées; normalise aussi les timestamps naïfs en UTC dans `parse_ts` pour éviter les erreurs de comparaison.
- Ajoute les champs `life_liveness_index`, `life_liveness_components` et `life_liveness_proofs` dans l’agrégation renvoyée par `aggregate_lives` et renseigne ces champs pour les vies sans enregistrements.
- Intègre le calcul/sélection de la vie cible et l’inclusion du payload liveness dans le résumé cockpit (`/api/cockpit`) via `compute_liveness_index` (backend: `src/singular/dashboard/__init__.py`).
- Met à jour l’UI et les templates pour afficher la KPI et preuves de vivacité: `src/singular/dashboard/templates/dashboard.html`, `src/singular/dashboard/static/render-cockpit.js`, `src/singular/dashboard/static/render-lives.js` (nouvelle colonne « Liveness », panneau « Preuves de vie » dans cockpit et détail vie).
- Ajoute des tests dédiés `tests/test_liveness_index.py` couvrant cas posifs, bruit sparse, seuil d’interaction partielle et exposition des champs via `aggregate_lives`.

### Testing
- Exécution ciblée avec `pytest -q tests/test_liveness_index.py tests/test_dashboard_services.py tests/test_dashboard.py::test_dashboard_starts_with_empty_registry_and_exposes_onboarding tests/test_dashboard.py::test_dashboard_cockpit_endpoint_schema tests/test_dashboard.py::test_dashboard_endpoints` a été lancée.
- Tous les tests exécutés ont réussi: `13 passed` (les scénarios liveness, l’agrégation et les endpoints cockpit/lives ont passé les assertions).
- Les changements de parsing ISO ont permis d’éliminer une erreur de comparaison naive/aware lors des tests (fix intégré dans `parse_ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0097d4094832a9b64c32a0405bc87)