### PR TITLE
Add causal trace pipeline, API and dashboard view

### DIFF
--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -78,6 +78,19 @@ class RuntimeEvent:
 
 
 @dataclass(frozen=True)
+class CausalTrace:
+    """Correlation record linking input, decision, action and measured result."""
+
+    trace_id: str
+    input: dict[str, Any]
+    decision: dict[str, Any]
+    action: dict[str, Any]
+    result: dict[str, Any]
+    schema_version: str = DEFAULT_SCHEMA_VERSION
+    recorded_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+@dataclass(frozen=True)
 class RuntimeSafetyConfig:
     """Safety controls applied to runtime action execution."""
 
@@ -166,6 +179,7 @@ class AgentRuntime:
         self._critical_error_count = 0
         self._action_timestamps: deque[float] = deque()
         self._recent_actions: deque[str] = deque(maxlen=max(self.safety.watchdog_window_size, 1))
+        self._causal_traces: deque[CausalTrace] = deque(maxlen=200)
 
     @property
     def disabled(self) -> bool:
@@ -286,6 +300,13 @@ class AgentRuntime:
                     },
                 )
                 self.event_bus.publish("action.blocked", result)
+                self._record_causal_trace(
+                    percept=percept,
+                    intent=intent,
+                    request=request,
+                    result=result,
+                    decision=decision,
+                )
                 results.append(result)
                 continue
 
@@ -307,6 +328,13 @@ class AgentRuntime:
                     },
                 )
                 self.event_bus.publish("action.simulated", result)
+                self._record_causal_trace(
+                    percept=percept,
+                    intent=intent,
+                    request=request,
+                    result=result,
+                    decision=decision,
+                )
                 results.append(result)
                 continue
 
@@ -332,6 +360,13 @@ class AgentRuntime:
                     },
                 )
                 self.event_bus.publish("action.failed", result)
+                self._record_causal_trace(
+                    percept=percept,
+                    intent=intent,
+                    request=request,
+                    result=result,
+                    decision=decision,
+                )
                 results.append(result)
                 if self._disabled:
                     break
@@ -360,6 +395,13 @@ class AgentRuntime:
             if self._is_critical_result(result):
                 self._record_critical_error("critical_action_result")
             self.event_bus.publish("action.completed", result)
+            self._record_causal_trace(
+                percept=percept,
+                intent=intent,
+                request=request,
+                result=result,
+                decision=decision,
+            )
             results.append(result)
             if self._disabled:
                 break
@@ -441,3 +483,53 @@ class AgentRuntime:
                     "max_critical_errors": self.safety.max_critical_errors,
                 },
             )
+
+    def _record_causal_trace(
+        self,
+        *,
+        percept: PerceptEvent,
+        intent: Intent,
+        request: ActionRequest,
+        result: ActionResult,
+        decision: Any,
+    ) -> None:
+        policy_details = {
+            "allowed": getattr(decision, "allowed", None),
+            "blocked": getattr(decision, "blocked", None),
+            "reason": getattr(decision, "reason", None),
+            "rule_id": getattr(decision, "rule_id", None),
+            "risk_level": getattr(decision, "risk_level", None),
+            "dry_run": getattr(decision, "dry_run", None),
+        }
+        gain_loss = 1.0 if result.success else -1.0
+        trace = CausalTrace(
+            trace_id=uuid4().hex,
+            input={
+                "kind": "percept_event",
+                "event_type": percept.event_type,
+                "source": percept.source,
+                "payload": percept.payload,
+            },
+            decision={
+                "intent_goal": intent.goal,
+                "intent_rationale": intent.rationale,
+                "policy": policy_details,
+            },
+            action={
+                "action_type": request.action_type,
+                "parameters": request.parameters,
+            },
+            result={
+                "success": result.success,
+                "message": result.message,
+                "error": result.error,
+                "gain_loss": gain_loss,
+                "objective_impact": {
+                    "objective": intent.goal,
+                    "impact": gain_loss,
+                },
+            },
+            schema_version=self.schema_version,
+        )
+        self._causal_traces.append(trace)
+        self.event_bus.publish("causal.trace", trace)

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -15,7 +15,7 @@ from fastapi.staticfiles import StaticFiles
 from singular.lives import get_registry_root, load_registry, set_life_status
 from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
-from singular.memory import read_skills
+from singular.memory import read_causal_timeline, read_skills
 from singular.storage_retention import retention_status_snapshot
 
 from singular.dashboard.actions import DashboardActionService
@@ -92,6 +92,27 @@ def create_app(
             if isinstance(path, Path):
                 lives_paths.append(path)
         return lives_paths
+
+    def _resolve_life_dir(life: str) -> Path | None:
+        registry = load_registry()
+        raw_lives = registry.get("lives")
+        if not isinstance(raw_lives, dict):
+            return None
+        for slug, meta in raw_lives.items():
+            if not isinstance(slug, str):
+                continue
+            path_value = getattr(meta, "path", None)
+            display_name = getattr(meta, "name", None)
+            if isinstance(meta, dict):
+                path_value = meta.get("path", path_value)
+                display_name = meta.get("name", display_name)
+            if isinstance(path_value, str):
+                path_value = Path(path_value)
+            if not isinstance(path_value, Path):
+                continue
+            if life in {slug, str(display_name)}:
+                return path_value
+        return None
 
     def _registry_overview() -> dict[str, object]:
         registry = load_registry()
@@ -909,6 +930,26 @@ def create_app(
                 "total": total,
                 "total_pages": (total + page_size - 1) // page_size if total else 0,
             },
+            "items": items,
+        }
+
+    @app.get("/api/lives/{life}/causal-timeline")
+    def read_life_causal_timeline(
+        life: str,
+        limit: int = 100,
+    ) -> dict[str, object]:
+        life_dir = _resolve_life_dir(life)
+        if life_dir is None:
+            raise HTTPException(status_code=404, detail=f"life '{life}' not found")
+
+        entries = read_causal_timeline(life_dir / "mem" / "causal_timeline.jsonl")
+        entries = [entry for entry in entries if isinstance(entry, dict)]
+        entries.sort(key=lambda item: str(item.get("ts", item.get("recorded_at", ""))))
+        safe_limit = min(max(limit, 1), 500)
+        items = entries[-safe_limit:]
+        return {
+            "life": life,
+            "count": len(items),
             "items": items,
         }
 

--- a/src/singular/dashboard/static/render-timeline.js
+++ b/src/singular/dashboard/static/render-timeline.js
@@ -52,4 +52,38 @@ export const loadTimeline=()=>fetchJson(withScope('/runs/latest')).then(meta=>{
     diff.textContent='';
     setPanelState('timeline-section','empty','Aucun événement pour le run courant.');
   }
+  return fetchJson(withScope('/api/cockpit/essential')).catch(()=>({}));
+}).then(essential=>{
+  const life=essential?.selected_life;
+  const list=document.getElementById('causal-timeline-list');
+  if(!list){return;}
+  list.innerHTML='';
+  if(!life||life==='Aucune'){
+    const li=document.createElement('li');
+    li.textContent='Aucune vie sélectionnée pour la timeline causale.';
+    list.appendChild(li);
+    return;
+  }
+  return fetchJson(`/api/lives/${encodeURIComponent(life)}/causal-timeline?limit=12`).then(payload=>{
+    const items=Array.isArray(payload?.items)?payload.items:[];
+    if(!items.length){
+      const li=document.createElement('li');
+      li.textContent='Aucune trace causale disponible.';
+      list.appendChild(li);
+      return;
+    }
+    for(const item of items.slice().reverse()){
+      const input=item?.input?.kind||'entrée';
+      const action=item?.action?.kind||item?.action?.action_type||'action';
+      const objective=item?.result?.objective_impact?.objective||'objectif';
+      const impact=item?.result?.objective_impact?.impact??item?.result?.gain_loss??na();
+      const li=document.createElement('li');
+      li.textContent=`${item?.ts||item?.recorded_at||na()} · ${input} → ${action} → ${objective} (${impact})`;
+      list.appendChild(li);
+    }
+  }).catch(()=>{
+    const li=document.createElement('li');
+    li.textContent='Timeline causale indisponible.';
+    list.appendChild(li);
+  });
 });

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -99,6 +99,10 @@
     <h2>Timeline des événements</h2>
     <p class='section-help'>Timeline + détail mutation pour expliquer rapidement un changement.</p>
     <div id='timeline' class='timeline-strip'></div>
+    <h3>Ce qui a changé grâce à quoi</h3>
+    <ul id='causal-timeline-list' class='list-tight-top'>
+      <li>Aucune trace causale disponible.</li>
+    </ul>
     <h3>Détail mutation</h3>
     <p id='timeline-summary'>Cliquez sur un événement de mutation.</p>
     <pre id='timeline-impact'></pre>

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -25,7 +25,7 @@ from singular.beliefs.meta_learning import (
     register_run_result,
 )
 from singular.events import EventBus, get_global_event_bus
-from singular.memory import add_episode, register_memory_event_handlers, update_score
+from singular.memory import add_causal_trace, add_episode, register_memory_event_handlers, update_score
 from singular.psyche import Psyche, Mood
 from singular.runs.logger import RunLogger
 from singular.runs.explain import summarize_mutation
@@ -1410,6 +1410,42 @@ def run(
                 "timing_ms": {"base": ms_base, "new": ms_new},
                 "skill_reputation": logger.skill_reputation().get(key, {}),
             }
+            gain_loss = round(base_score - mutated_score, 6)
+            add_causal_trace(
+                {
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                    "trace_id": hashlib.sha1(
+                        f"{logger.run_id}:{state.iteration}:{key}:{op_name}".encode("utf-8")
+                    ).hexdigest(),
+                    "life": org_name,
+                    "run_id": logger.run_id,
+                    "iteration": state.iteration,
+                    "pipeline": "life.loop",
+                    "input": {
+                        "kind": "world_event",
+                        "temperature_c": temp,
+                        "perception_signals": signals,
+                    },
+                    "decision": {
+                        "reason": reflection.decision_reason,
+                        "operator": op_name,
+                        "accepted": accepted,
+                        "objective": dominant_objective,
+                    },
+                    "action": {
+                        "kind": "mutation",
+                        "skill": key,
+                        "impacted_file": skill_path.name,
+                    },
+                    "result": {
+                        "gain_loss": gain_loss,
+                        "objective_impact": {
+                            "objective": dominant_objective,
+                            "impact": gain_loss,
+                        },
+                    },
+                }
+            )
             event_bus.publish(
                 "mutation.applied" if accepted else "mutation.rejected",
                 mutation_payload,

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -51,6 +51,12 @@ def get_episodic_file() -> Path:
     return get_mem_dir() / "episodic.jsonl"
 
 
+def get_causal_timeline_file() -> Path:
+    """Return the path to the causal timeline JSONL file."""
+
+    return get_mem_dir() / "causal_timeline.jsonl"
+
+
 def get_skills_file() -> Path:
     """Return the path to the skills JSON file."""
     return get_mem_dir() / "skills.json"
@@ -102,6 +108,7 @@ def ensure_memory_structure(mem_dir: Path | str | None = None) -> None:
     (mem_dir / "profile.json").touch(exist_ok=True)
     (mem_dir / "values.yaml").touch(exist_ok=True)
     (mem_dir / "episodic.jsonl").touch(exist_ok=True)
+    (mem_dir / "causal_timeline.jsonl").touch(exist_ok=True)
     (mem_dir / "generations.jsonl").touch(exist_ok=True)
     (mem_dir / "skills.json").touch(exist_ok=True)
     (mem_dir / "psyche.json").touch(exist_ok=True)
@@ -249,6 +256,40 @@ def add_episode(
     except Exception:
         # Layered memory is best effort to preserve compatibility.
         pass
+
+
+def read_causal_timeline(path: Path | str | None = None) -> list[dict[str, Any]]:
+    """Read all causal trace entries from the causal timeline JSONL file."""
+
+    if path is None:
+        path = get_causal_timeline_file()
+    path = Path(path)
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                records.append(payload)
+    return records
+
+
+def add_causal_trace(
+    trace: dict[str, Any],
+    path: Path | str | None = None,
+) -> None:
+    """Append one causal trace entry to the causal timeline JSONL file."""
+
+    if path is None:
+        path = get_causal_timeline_file()
+    append_jsonl_line(Path(path), trace)
 
 
 def add_procedural_memory(result: dict[str, Any]) -> None:

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -6,8 +6,10 @@ import os
 import random
 import time
 import re
+from datetime import datetime, timezone
+from uuid import uuid4
 
-from ..memory import add_episode, ensure_memory_structure, read_episodes
+from ..memory import add_causal_trace, add_episode, ensure_memory_structure, read_episodes
 from ..perception import capture_signals
 from ..psyche import Mood, Psyche
 from ..self_narrative import load as load_self_narrative, summarize_short
@@ -307,6 +309,41 @@ def talk(
                     "self_narrative_summary": _trim_for_budget(
                         self_narrative_summary, 180
                     ),
+                },
+            }
+        )
+        gain_estimate = round(
+            float(user_signals.get("satisfaction", 0.0))
+            - float(user_signals.get("frustration", 0.0)),
+            3,
+        )
+        add_causal_trace(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "trace_id": uuid4().hex,
+                "pipeline": "interaction.talk",
+                "input": {
+                    "kind": "human_message",
+                    "message": user_input,
+                    "structured_signals": user_signals,
+                },
+                "decision": {
+                    "provider": provider_name,
+                    "fallback_used": fallback_used,
+                    "error_category": error_category,
+                    "mood": mood_report,
+                },
+                "action": {
+                    "kind": "assistant_reply",
+                    "raw_reply": reply,
+                    "response": response,
+                },
+                "result": {
+                    "gain_loss": gain_estimate,
+                    "objective_impact": {
+                        "objective": f"user_dialogue:{user_signals.get('theme', 'general')}",
+                        "impact": gain_estimate,
+                    },
                 },
             }
         )

--- a/src/singular/resource_manager.py
+++ b/src/singular/resource_manager.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import argparse
 import json
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List
+from uuid import uuid4
 
+from .memory import add_causal_trace
 from .memory import _atomic_write_text
 
 
@@ -141,11 +144,31 @@ class ResourceManager:
         """
 
         neutral = 20.0
+        before = self.warmth
         diff = temp - neutral
+        decision = "hold"
         if diff > 0:
+            decision = "warm_up"
             self.add_warmth(diff * 0.1)
         elif diff < 0:
+            decision = "cool_down"
             self.cool_down(-diff * 0.1)
+        after = self.warmth
+        delta = round(after - before, 3)
+        add_causal_trace(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "trace_id": uuid4().hex,
+                "pipeline": "environment.resource_manager",
+                "input": {"kind": "world_event", "temperature_c": temp},
+                "decision": {"temperature_delta_from_neutral": round(diff, 3), "selected": decision},
+                "action": {"kind": decision, "warmth_before": round(before, 3), "warmth_after": round(after, 3)},
+                "result": {
+                    "gain_loss": delta,
+                    "objective_impact": {"objective": "homeostasis.warmth", "impact": delta},
+                },
+            }
+        )
 
     def simulate_human_interaction(self, amount: float = 5.0) -> None:
         """API used by tests/CLI to increase warmth."""

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -2,14 +2,21 @@ import time
 
 from singular.resource_manager import ResourceManager
 from singular.environment.notifications import auto_post, notify
+from singular.memory import read_causal_timeline
 from singular.perception import PerceptionNoiseFilter
 
 
-def test_update_from_environment_increases_warmth(tmp_path):
+def test_update_from_environment_increases_warmth(tmp_path, monkeypatch):
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     path = tmp_path / "resources.json"
     rm = ResourceManager(warmth=50.0, path=path)
     rm.update_from_environment(30.0)
     assert rm.warmth > 50.0
+    traces = read_causal_timeline(tmp_path / "mem" / "causal_timeline.jsonl")
+    assert traces
+    trace = traces[-1]
+    assert trace["pipeline"] == "environment.resource_manager"
+    assert set(("input", "decision", "action", "result")).issubset(trace)
 
 
 def test_update_from_environment_decreases_warmth(tmp_path):

--- a/tests/test_loop_perception_goals.py
+++ b/tests/test_loop_perception_goals.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import singular.life.loop as life_loop
 from singular.goals.intrinsic import GoalWeights
+from singular.memory import read_causal_timeline
 
 
 class _CaptureGoals:
@@ -67,6 +68,11 @@ def test_run_passes_capture_signals_to_intrinsic_goals(tmp_path: Path, monkeypat
     assert "artifact_events" in _CaptureGoals.last_perception_signals
     assert _CaptureGoals.last_perception_signals["artifact_events"][0]["type"] == "artifact.tech_debt.simple"
     assert isinstance(_CaptureGoals.last_skill_reputation, dict)
+    traces = read_causal_timeline()
+    assert traces
+    last = traces[-1]
+    assert last["pipeline"] == "life.loop"
+    assert set(("input", "decision", "action", "result")).issubset(last)
 
 
 def test_choose_skill_prioritizes_frequent_low_quality_skills(tmp_path: Path) -> None:

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -5,7 +5,7 @@ import pytest
 
 from singular.cli import main
 from singular.lives import load_registry
-from singular.memory import read_episodes
+from singular.memory import read_causal_timeline, read_episodes
 from singular.organisms.talk import _default_reply, talk
 from singular.providers import (
     LLMProviderClient,
@@ -214,6 +214,27 @@ def test_talk_logs_provider_events(monkeypatch, tmp_path):
     assert events[0]["provider"] == "openai"
     assert events[0]["fallback"] is False
     assert events[0]["error_category"] is None
+
+
+def test_talk_creates_complete_causal_trace(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    inputs = iter(["hello", "quit"])
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    monkeypatch.setattr("builtins.print", lambda _msg: None)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
+
+    talk(seed=5)
+
+    traces = read_causal_timeline()
+    assert traces
+    trace = traces[-1]
+    for key in ("input", "decision", "action", "result"):
+        assert key in trace
+    assert trace["input"]["kind"] == "human_message"
+    assert trace["action"]["kind"] == "assistant_reply"
+    assert "gain_loss" in trace["result"]
+    assert "objective_impact" in trace["result"]
 
 
 def test_talk_injects_self_narrative_in_provider_prompt(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Provide end-to-end correlation traces for interaction and loop pipelines to make it possible to link an input → decision → action → measured result. 
- Make causal traces persistent and queryable so the dashboard and operators can inspect what changed and why. 
- Ensure critical interaction paths (talk, resource updates, life loop, agent runtime) produce a consistent 4-part causal trace for observability and metrics.

### Description
- Persist causal traces with new memory helpers `get_causal_timeline_file`, `read_causal_timeline` and `add_causal_trace` and create `mem/causal_timeline.jsonl` during `ensure_memory_structure` (`src/singular/memory.py`).
- Emit causal traces from the talk interaction pipeline including `input`, `decision`, `action` and `result` (gain/impact) (`src/singular/organisms/talk.py`).
- Emit causal traces from the evolutionary loop mutations and the `ResourceManager.update_from_environment` flow with structured `input`/`decision`/`action`/`result` payloads (`src/singular/life/loop.py`, `src/singular/resource_manager.py`).
- Add `CausalTrace` support and automatic causal trace emission on blocked/simulated/failed/completed actions in the central runtime (`src/singular/core/agent_runtime.py`).
- Expose a new API `GET /api/lives/{life}/causal-timeline` to read a life-specific causal timeline and add a simple UI section "Ce qui a changé grâce à quoi" wired to that endpoint (`src/singular/dashboard/__init__.py`, `src/singular/dashboard/static/render-timeline.js`, `src/singular/dashboard/templates/dashboard.html`).
- Add unit tests to assert that an interaction produces a full causal trace (`tests/test_talk.py`), that the loop produces traces (`tests/test_loop_perception_goals.py`), and that environment updates emit traces (`tests/test_environment.py`).

### Testing
- Ran targeted unit tests: `tests/test_talk.py::test_talk_creates_complete_causal_trace`, `tests/test_loop_perception_goals.py::test_run_passes_capture_signals_to_intrinsic_goals`, and `tests/test_environment.py::test_update_from_environment_increases_warmth`, and all three passed. 
- A broader run that included unrelated CLI behavior surfaced an existing `birth` alias/CLI parsing difference causing `SystemExit` in that environment, which is unrelated to the causal-timeline additions. 
- Files changed and exercised by tests include `src/singular/memory.py`, `src/singular/organisms/talk.py`, `src/singular/life/loop.py`, `src/singular/resource_manager.py`, `src/singular/core/agent_runtime.py`, and dashboard files listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00e1300ac832ab52e37bbc9bc418d)