### PR TITLE
Add Windows-specific retry handling for atomic_write_text replace

### DIFF
--- a/src/singular/io_utils.py
+++ b/src/singular/io_utils.py
@@ -8,11 +8,16 @@ from typing import Any, Iterator
 import json
 import os
 import tempfile
+import time
 
 if os.name == "nt":
     import msvcrt
 else:
     import fcntl
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
 
 
 def _ensure_parent(path: Path) -> None:
@@ -26,7 +31,7 @@ def _locked_file(path: Path) -> Iterator[None]:
     lock_path = path.with_suffix(path.suffix + ".lock")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     with lock_path.open("a+b") as lock_file:
-        if os.name == "nt":
+        if _is_windows():
             lock_file.seek(0)
             msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
         else:
@@ -34,7 +39,7 @@ def _locked_file(path: Path) -> Iterator[None]:
         try:
             yield
         finally:
-            if os.name == "nt":
+            if _is_windows():
                 lock_file.seek(0)
                 msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
             else:
@@ -63,8 +68,8 @@ def atomic_write_text(path: Path | str, data: str, fsync: bool = True) -> None:
             tmp.flush()
             if fsync:
                 os.fsync(tmp.fileno())
-        os.replace(tmp.name, destination)
-        if fsync and os.name != "nt":
+        _replace_with_retry(tmp.name, destination)
+        if fsync and not _is_windows():
             dir_fd = os.open(destination.parent, os.O_RDONLY)
             try:
                 os.fsync(dir_fd)
@@ -75,6 +80,41 @@ def atomic_write_text(path: Path | str, data: str, fsync: bool = True) -> None:
             os.unlink(tmp.name)
         except FileNotFoundError:
             pass
+
+
+def _replace_with_retry(source: str, destination: Path) -> None:
+    """Replace ``destination`` with ``source``, retrying transient Windows lock errors."""
+
+    max_attempts = 6
+    delay_seconds = 0.025
+    max_delay_seconds = 0.2
+    first_exception: PermissionError | OSError | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            os.replace(source, destination)
+            return
+        except PermissionError as exc:
+            if not _is_windows():
+                raise
+            if first_exception is None:
+                first_exception = exc
+        except OSError as exc:
+            if not _is_windows() or getattr(exc, "winerror", None) != 5:
+                raise
+            if first_exception is None:
+                first_exception = exc
+
+        if attempt < max_attempts:
+            time.sleep(delay_seconds)
+            delay_seconds = min(delay_seconds * 2, max_delay_seconds)
+
+    assert first_exception is not None
+    first_exception.add_note(
+        "atomic_write_text failed to replace temporary file after "
+        f"{max_attempts} attempts (source={source!r}, destination={str(destination)!r})."
+    )
+    raise first_exception
 
 
 def append_jsonl_line(

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -60,3 +60,60 @@ def test_resource_manager_save_atomic(
         "food": 2,
         "warmth": 3,
     }
+
+
+def test_atomic_write_text_retries_permission_error_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "state.json"
+    destination.write_text('{"old": true}', encoding="utf-8")
+    original_replace = io_utils.os.replace
+    attempts = 0
+    delays: list[float] = []
+
+    def flaky_replace(src, dst):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise PermissionError("Access denied")
+        return original_replace(src, dst)
+
+    monkeypatch.setattr(io_utils, "_is_windows", lambda: True)
+    monkeypatch.setattr(io_utils.os, "replace", flaky_replace)
+    monkeypatch.setattr(io_utils.time, "sleep", delays.append)
+
+    io_utils.atomic_write_text(destination, '{"new": true}')
+
+    assert attempts == 3
+    assert delays == [0.025, 0.05]
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"new": True}
+
+
+def test_atomic_write_text_windows_retry_raises_enriched_initial_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "state.json"
+    destination.write_text('{"old": true}', encoding="utf-8")
+    attempts = 0
+    delays: list[float] = []
+
+    def always_failing_replace(_src, _dst):
+        nonlocal attempts
+        attempts += 1
+        raise PermissionError("Access denied")
+
+    monkeypatch.setattr(io_utils, "_is_windows", lambda: True)
+    monkeypatch.setattr(io_utils.os, "replace", always_failing_replace)
+    monkeypatch.setattr(io_utils.time, "sleep", delays.append)
+
+    with pytest.raises(PermissionError) as exc_info:
+        io_utils.atomic_write_text(destination, '{"new": true}')
+
+    assert attempts == 6
+    assert delays == [0.025, 0.05, 0.1, 0.2, 0.2]
+    notes = getattr(exc_info.value, "__notes__", [])
+    assert any(
+        "after 6 attempts" in note and str(destination) in note and "destination=" in note
+        for note in notes
+    )
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"old": True}


### PR DESCRIPTION
### Motivation
- Les remplacements atomiques de fichier sur Windows peuvent échouer temporairement avec `PermissionError` (ou `OSError` avec `winerror == 5`) à cause de verrous externes, il faut une stratégie de retry ciblée pour améliorer la robustesse de `atomic_write_text`.

### Description
- Ajout de la fonction `_replace_with_retry` utilisée par `atomic_write_text` pour envelopper `os.replace` et retenter jusqu'à 6 fois avec backoff exponentiel court (25ms → 50ms → 100ms, plafonné à 200ms) uniquement quand `_is_windows()` est vrai.
- La logique n’intercepte que `PermissionError` et `OSError` dont `winerror == 5` en contexte Windows, et réémet l’exception initiale enrichie via `add_note` après épuisement des tentatives; le nettoyage du fichier temporaire dans le `finally` est conservé.
- Ajout de l helper `_is_windows()` et usage cohérent dans les chemins de verrouillage et de fsync pour isoler la détection plateforme.
- Fichiers modifiés : `src/singular/io_utils.py` et `tests/test_atomic_writes.py` (tests ajoutés pour retry réussi et échec final enrichi).

### Testing
- Exécution de `pytest -q tests/test_atomic_writes.py` qui a réussi avec `5 passed` et vérifie le comportement de retry et la propagation/enrichissement de l’exception en échec définitif.
- Tests unitaires ajoutés : un test qui simule `os.replace` échouant deux fois puis réussissant, et un test qui simule un échec permanent pour vérifier les notes d’exception.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0100dd0c0832a83f84976108f5601)