### PR TITLE
Avoid duplicate circuit-breaker open logs

### DIFF
--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -927,8 +927,9 @@ class MutationGovernancePolicy:
     def record_violation(self, *, category: str, severity: str = "high") -> None:
         self._prune_history()
         now = self._now()
+        was_open = self._circuit_open_until is not None and now < self._circuit_open_until
         self._violation_timestamps.append(now)
-        if len(self._violation_timestamps) >= self.circuit_breaker_threshold:
+        if not was_open and len(self._violation_timestamps) >= self.circuit_breaker_threshold:
             self._circuit_open_until = now + timedelta(seconds=self.circuit_breaker_cooldown_seconds)
             log.error(
                 "governance circuit breaker opened: category=%s severity=%s threshold=%s cooldown=%ss",

--- a/tests/test_values_schema.py
+++ b/tests/test_values_schema.py
@@ -1,6 +1,7 @@
-from pathlib import Path
 from datetime import datetime, timedelta, timezone
 import json
+import logging
+from pathlib import Path
 
 import pytest
 
@@ -115,6 +116,30 @@ def test_policy_opens_circuit_breaker_on_repeated_violations(tmp_path: Path) -> 
     assert decision.allowed is False
     assert "circuit-breaker active" in decision.reason
     assert decision.severity == "critical"
+
+
+def test_policy_logs_circuit_breaker_opened_only_once_when_already_open(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    clock = {"now": start}
+    policy = MutationGovernancePolicy(
+        circuit_breaker_threshold=2,
+        circuit_breaker_window_seconds=60.0,
+        circuit_breaker_cooldown_seconds=120.0,
+    )
+    policy._now = lambda: clock["now"]  # type: ignore[method-assign]
+    caplog.set_level(logging.ERROR, logger="singular.governance.policy")
+
+    policy.record_violation(category="quota", severity="high")
+    policy.record_violation(category="quota", severity="high")
+    policy.record_violation(category="quota", severity="high")
+    policy.record_violation(category="quota", severity="high")
+
+    opened_events = [
+        record for record in caplog.records if "governance circuit breaker opened" in record.message
+    ]
+    assert len(opened_events) == 1
 
 
 def test_policy_safe_mode_blocks_writes(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Éviter que des violations supplémentaires pendant la période où le circuit est déjà ouvert réassignent `_circuit_open_until` et génèrent plusieurs logs `governance circuit breaker opened`, ce qui produit du bruit de log et des doublons d'événement.

### Description
- Avant d'ouvrir le circuit la fonction calcule `was_open = self._circuit_open_until is not None and now < self._circuit_open_until` et n'assigne `self._circuit_open_until` ni ne logge l'ouverture que si `not was_open` et le seuil est atteint, et un test `test_policy_logs_circuit_breaker_opened_only_once_when_already_open` a été ajouté pour vérifier qu'un seul événement d'ouverture est enregistré.

### Testing
- Exécution de `pytest -q tests/test_values_schema.py -k circuit_breaker` qui a réussi avec `3 passed, 12 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e011664ff8832abc26aa6b3b4e278b)