### PR TITLE
Improve orchestrator loop resilience on transient tick I/O failures

### DIFF
--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -96,6 +96,8 @@ class OrchestratorConfig:
     dry_run: bool = False
     safe_mode: bool = False
     help_request_failure_threshold: int = 3
+    max_consecutive_tick_failures: int = 10
+    tick_failure_backoff_seconds: float = 0.2
 
 
 class OrchestratorService:
@@ -672,6 +674,7 @@ class OrchestratorService:
 
     def run_forever(self) -> None:
         self._running = True
+        consecutive_tick_failures = 0
 
         def _handle_signal(_signum: int, _frame: Any) -> None:
             self._running = False
@@ -685,7 +688,33 @@ class OrchestratorService:
                     log.info("orchestrator stop requested via %s", self.stop_signal_path)
                     self._running = False
                     break
-                self.tick()
+                try:
+                    self.tick()
+                    consecutive_tick_failures = 0
+                except (
+                    PermissionError,
+                    BlockingIOError,
+                    InterruptedError,
+                    TimeoutError,
+                ) as exc:
+                    consecutive_tick_failures += 1
+                    log.warning(
+                        "orchestrator transient tick failure #%s in phase=%s "
+                        "(state_path=%s, stop_signal_path=%s, checkpoint_path=%s): %s",
+                        consecutive_tick_failures,
+                        self.state.current_phase,
+                        self.state_path,
+                        self.stop_signal_path,
+                        self.checkpoint_path,
+                        exc,
+                        exc_info=True,
+                    )
+                    max_failures = max(1, int(self.config.max_consecutive_tick_failures))
+                    if consecutive_tick_failures >= max_failures:
+                        raise
+                    backoff_seconds = max(self.config.tick_failure_backoff_seconds, 0.05)
+                    time.sleep(backoff_seconds)
+                    continue
                 if self._external_stimulus_detected():
                     continue
                 time.sleep(max(self.config.poll_interval_seconds, 0.05))

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 import json
+import logging
+
+import pytest
 
 from singular.events import EventBus
 from singular.orchestrator.service import (
@@ -265,6 +268,64 @@ def test_orchestrator_run_forever_stops_on_stop_signal(monkeypatch, tmp_path: Pa
     service.run_forever()
 
     assert called["tick"] == 0
+
+
+def test_orchestrator_run_forever_recovers_from_transient_tick_failure(
+    monkeypatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "mem").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+
+    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+    calls = {"tick": 0}
+    sleep_calls: list[float] = []
+
+    def _fake_tick() -> LifecyclePhase:
+        calls["tick"] += 1
+        if calls["tick"] == 1:
+            raise PermissionError("temporary permission glitch")
+        service._running = False
+        return LifecyclePhase.ACTION
+
+    monkeypatch.setattr(service, "tick", _fake_tick)
+    monkeypatch.setattr(service, "_external_stimulus_detected", lambda: True)
+    monkeypatch.setattr("singular.orchestrator.service.time.sleep", lambda seconds: sleep_calls.append(seconds))
+    caplog.set_level(logging.WARNING)
+
+    service.run_forever()
+
+    assert calls["tick"] == 2
+    assert sleep_calls
+    assert "phase=" in caplog.text
+    assert str(service.state_path) in caplog.text
+
+
+def test_orchestrator_run_forever_raises_after_transient_tick_failure_threshold(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "mem").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+
+    service = OrchestratorService(
+        config=OrchestratorConfig(
+            dry_run=True,
+            max_consecutive_tick_failures=2,
+            tick_failure_backoff_seconds=0.01,
+        ),
+        bus=EventBus(),
+    )
+    monkeypatch.setattr(service, "tick", lambda: (_ for _ in ()).throw(PermissionError("still locked")))
+    monkeypatch.setattr("singular.orchestrator.service.time.sleep", lambda seconds: None)
+
+    with pytest.raises(PermissionError):
+        service.run_forever()
 
 
 def test_orchestrator_introspection_refreshes_self_narrative(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent the orchestrator from exiting or spinning silently when `tick()` fails due to transient permission / I/O-like errors by adding targeted recovery behavior. 
- Ensure incidents are observable with contextual logs (phase and key state/checkpoint paths) and avoid tight retry loops by introducing backoff and an escalation threshold.

### Description
- Added two new config knobs on `OrchestratorConfig`: `max_consecutive_tick_failures` and `tick_failure_backoff_seconds` to control failure escalation and backoff. 
- Wrapped the `self.tick()` call inside `run_forever()` with a `try/except` that catches transient errors (`PermissionError`, `BlockingIOError`, `InterruptedError`, `TimeoutError`), increments a `consecutive_tick_failures` counter, logs a warning with context (`phase`, `state_path`, `stop_signal_path`, `checkpoint_path`), sleeps for the configured backoff, and continues the loop. 
- If the consecutive failure count reaches the configured threshold the code re-raises the exception to avoid a silent infinite retry loop. 
- Added unit tests in `tests/test_orchestrator_service.py` to verify recovery from a transient `PermissionError` and to verify escalation (raising) when the failure threshold is exceeded, and added small test support imports (`pytest`, `logging`).

### Testing
- Ran `pytest -q tests/test_orchestrator_service.py` which executed the suite containing the two new tests and existing tests, and all tests passed (`12 passed`).
- The new tests are `test_orchestrator_run_forever_recovers_from_transient_tick_failure` and `test_orchestrator_run_forever_raises_after_transient_tick_failure_threshold`, and they validate recovery, backoff invocation, logging context, and threshold-based escalation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0124881dc832a8312e63968942103)