### PR TITLE
Add `websockets` to dashboard optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ yaml = ["pyyaml>=6.0,<7"]
 dashboard = [
     "fastapi>=0.110,<1",
     "uvicorn>=0.29,<1",
+    "websockets>=12,<16",
 ]
 viz = ["matplotlib>=3.8,<4"]
 


### PR DESCRIPTION
### Motivation
- Enable real-time websocket support for dashboard features by declaring the `websockets` dependency in the extras.

### Description
- Added `"websockets>=12,<16"` to the `dashboard` optional dependencies list in `pyproject.toml`.

### Testing
- No automated tests were run for this dependency-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e018147bcc832abc438e7a006ccdae)