### PR TITLE
Handle stale startup stop signals in orchestrator run loop

### DIFF
--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -141,6 +141,7 @@ class OrchestratorService:
         self._failure_streak_by_task: dict[str, int] = {}
         self._introspection_tick_count = 0
         self._host_thresholds = load_host_sensor_thresholds()
+        self._started_at = datetime.now(timezone.utc)
 
         self._subscribe_external_stimuli()
 
@@ -683,6 +684,8 @@ class OrchestratorService:
         previous_term = signal.signal(signal.SIGTERM, _handle_signal)
 
         try:
+            if self._handle_startup_stop_signal():
+                self._running = False
             while self._running:
                 if self.stop_signal_path.exists():
                     log.info("orchestrator stop requested via %s", self.stop_signal_path)
@@ -722,6 +725,71 @@ class OrchestratorService:
             signal.signal(signal.SIGINT, previous_int)
             signal.signal(signal.SIGTERM, previous_term)
             self._save_state()
+
+    def _handle_startup_stop_signal(self) -> bool:
+        if not self.stop_signal_path.exists():
+            return False
+
+        payload: dict[str, Any] | None = None
+        try:
+            raw = json.loads(self.stop_signal_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                payload = raw
+        except (OSError, json.JSONDecodeError):
+            payload = None
+
+        reason = str(payload.get("reason", "")).strip() if payload else ""
+        requested_at = str(payload.get("requested_at", "")).strip() if payload else ""
+        requested_at_dt = self._parse_utc_timestamp(requested_at)
+        log.info(
+            "startup_stop_signal_detected reason=%s requested_at=%s path=%s",
+            reason or "unknown",
+            requested_at or "unknown",
+            self.stop_signal_path,
+        )
+        if requested_at_dt is not None and requested_at_dt >= self._started_at:
+            log.info(
+                "startup_stop_signal_honored reason=%s requested_at=%s path=%s",
+                reason or "unknown",
+                requested_at,
+                self.stop_signal_path,
+            )
+            return True
+
+        consumed_path = self.stop_signal_path.with_name(
+            f"orchestrator.stop.consumed.{int(time.time())}.json"
+        )
+        try:
+            self.stop_signal_path.replace(consumed_path)
+            log.info(
+                "startup_stop_signal_consumed reason=%s requested_at=%s source=%s archived_to=%s",
+                reason or "unknown",
+                requested_at or "unknown",
+                self.stop_signal_path,
+                consumed_path,
+            )
+        except OSError:
+            self.stop_signal_path.unlink(missing_ok=True)
+            log.info(
+                "startup_stop_signal_consumed reason=%s requested_at=%s source=%s archived_to=deleted",
+                reason or "unknown",
+                requested_at or "unknown",
+                self.stop_signal_path,
+            )
+        return False
+
+    @staticmethod
+    def _parse_utc_timestamp(value: str) -> datetime | None:
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
 
 
 def run_orchestrator_daemon(

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import timedelta
 import json
 import logging
 
@@ -253,21 +254,69 @@ routines:
     assert routine_tasks[0]["priority"] > 90
 
 
-def test_orchestrator_run_forever_stops_on_stop_signal(monkeypatch, tmp_path: Path) -> None:
+def test_orchestrator_run_forever_consumes_stale_startup_stop_signal(
+    monkeypatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)
     (life / "mem").mkdir(parents=True)
     monkeypatch.setenv("SINGULAR_HOME", str(life))
 
     service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
-    service.stop_signal_path.write_text('{"stop": true}', encoding="utf-8")
+    stale_requested_at = (service._started_at - timedelta(minutes=5)).isoformat()
+    service.stop_signal_path.write_text(
+        json.dumps(
+            {
+                "stop": True,
+                "reason": "life_extinction_detected",
+                "requested_at": stale_requested_at,
+            }
+        ),
+        encoding="utf-8",
+    )
 
     called = {"tick": 0}
-    monkeypatch.setattr(service, "tick", lambda: called.__setitem__("tick", called["tick"] + 1))
+    def _fake_tick() -> LifecyclePhase:
+        called["tick"] += 1
+        service._running = False
+        return LifecyclePhase.ACTION
+
+    monkeypatch.setattr(service, "tick", _fake_tick)
+    monkeypatch.setattr(service, "_external_stimulus_detected", lambda: True)
+    caplog.set_level(logging.INFO)
 
     service.run_forever()
 
-    assert called["tick"] == 0
+    assert called["tick"] == 1
+    assert not service.stop_signal_path.exists()
+    archived = sorted((life / "mem").glob("orchestrator.stop.consumed.*.json"))
+    assert archived
+    assert "startup_stop_signal_detected" in caplog.text
+    assert "startup_stop_signal_consumed" in caplog.text
+
+
+def test_orchestrator_run_forever_honors_runtime_stop_signal(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "mem").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+
+    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+    called = {"tick": 0}
+
+    def _fake_tick() -> LifecyclePhase:
+        called["tick"] += 1
+        service.stop_signal_path.write_text('{"stop": true}', encoding="utf-8")
+        return LifecyclePhase.ACTION
+
+    monkeypatch.setattr(service, "tick", _fake_tick)
+    monkeypatch.setattr(service, "_external_stimulus_detected", lambda: True)
+
+    service.run_forever()
+
+    assert called["tick"] == 1
 
 
 def test_orchestrator_run_forever_recovers_from_transient_tick_failure(


### PR DESCRIPTION
### Motivation
- Prevent a leftover `mem/orchestrator.stop.json` from a previous run from immediately stopping a newly started orchestrator. 
- Make it possible to distinguish a stop requested for the current run from a stale stop file created earlier, and provide explicit logs for startup stop handling. 

### Description
- Add a start timestamp `self._started_at` to `OrchestratorService` and call a new private method `_handle_startup_stop_signal()` before entering the main `run_forever` loop. 
- Implement `_handle_startup_stop_signal()` to read and parse `self.stop_signal_path` JSON, extract `reason` and `requested_at`, and log `startup_stop_signal_detected`. 
- Honor a startup stop when `requested_at >= self._started_at` (log `startup_stop_signal_honored`) and otherwise consume the stale stop by moving it to `orchestrator.stop.consumed.<timestamp>.json` or deleting on FS error (log `startup_stop_signal_consumed`). 
- Add `_parse_utc_timestamp()` helper for robust ISO/Z timestamp parsing and update `tests/test_orchestrator_service.py` to cover stale-startup consumption and runtime stop behavior. 

### Testing
- Ran the targeted tests with `pytest -q tests/test_orchestrator_service.py -k "startup_stop_signal or runtime_stop_signal or transient_tick_failure or raises_after_transient"` and observed `4 passed, 9 deselected`. 
- Ran the full file with `pytest -q tests/test_orchestrator_service.py` and observed `13 passed`. 
- New and existing orchestrator tests now validate both consumption of stale startup stop files and honoring runtime stop files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01f0fe16c832a96feca3c30056c7f)