### PR TITLE
Amélioration des retries de `os.replace` sur Windows avec fallback verrouillé

### DIFF
--- a/src/singular/io_utils.py
+++ b/src/singular/io_utils.py
@@ -15,6 +15,12 @@ if os.name == "nt":
 else:
     import fcntl
 
+_DEFAULT_REPLACE_MAX_ATTEMPTS = 6
+_DEFAULT_REPLACE_INITIAL_DELAY_SECONDS = 0.025
+_DEFAULT_REPLACE_MAX_DELAY_SECONDS = 0.2
+_WINDOWS_REPLACE_MAX_ATTEMPTS = 8
+_WINDOWS_REPLACE_MAX_DELAY_SECONDS = 0.4
+
 
 def _is_windows() -> bool:
     return os.name == "nt"
@@ -85,10 +91,17 @@ def atomic_write_text(path: Path | str, data: str, fsync: bool = True) -> None:
 def _replace_with_retry(source: str, destination: Path) -> None:
     """Replace ``destination`` with ``source``, retrying transient Windows lock errors."""
 
-    max_attempts = 6
-    delay_seconds = 0.025
-    max_delay_seconds = 0.2
+    max_attempts = (
+        _WINDOWS_REPLACE_MAX_ATTEMPTS if _is_windows() else _DEFAULT_REPLACE_MAX_ATTEMPTS
+    )
+    delay_seconds = _DEFAULT_REPLACE_INITIAL_DELAY_SECONDS
+    max_delay_seconds = (
+        _WINDOWS_REPLACE_MAX_DELAY_SECONDS
+        if _is_windows()
+        else _DEFAULT_REPLACE_MAX_DELAY_SECONDS
+    )
     first_exception: PermissionError | OSError | None = None
+    observed_delays: list[float] = []
 
     for attempt in range(1, max_attempts + 1):
         try:
@@ -106,15 +119,31 @@ def _replace_with_retry(source: str, destination: Path) -> None:
                 first_exception = exc
 
         if attempt < max_attempts:
+            observed_delays.append(delay_seconds)
             time.sleep(delay_seconds)
             delay_seconds = min(delay_seconds * 2, max_delay_seconds)
 
-    assert first_exception is not None
-    first_exception.add_note(
-        "atomic_write_text failed to replace temporary file after "
-        f"{max_attempts} attempts (source={source!r}, destination={str(destination)!r})."
+    assert first_exception is not None  # pragma: no cover - defensive
+
+    with _locked_file(destination):
+        try:
+            os.replace(source, destination)
+            return
+        except PermissionError as exc:
+            if not _is_windows():
+                raise
+            fallback_exception: PermissionError | OSError = exc
+        except OSError as exc:
+            if not _is_windows() or getattr(exc, "winerror", None) != 5:
+                raise
+            fallback_exception = exc
+
+    fallback_exception.add_note(
+        "atomic_write_text failed after retry loop and sidecar-lock fallback "
+        f"(source={source!r}, destination={str(destination)!r}, attempts={max_attempts}, "
+        f"delays={observed_delays!r})."
     )
-    raise first_exception
+    raise fallback_exception
 
 
 def append_jsonl_line(

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -89,6 +90,35 @@ def test_atomic_write_text_retries_permission_error_on_windows(
     assert json.loads(destination.read_text(encoding="utf-8")) == {"new": True}
 
 
+def test_atomic_write_text_retries_winerror_5_oserror_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "state.json"
+    destination.write_text('{"old": true}', encoding="utf-8")
+    original_replace = io_utils.os.replace
+    attempts = 0
+    delays: list[float] = []
+
+    def flaky_replace(src, dst):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 5:
+            error = OSError("Access denied")
+            error.winerror = 5
+            raise error
+        return original_replace(src, dst)
+
+    monkeypatch.setattr(io_utils, "_is_windows", lambda: True)
+    monkeypatch.setattr(io_utils.os, "replace", flaky_replace)
+    monkeypatch.setattr(io_utils.time, "sleep", delays.append)
+
+    io_utils.atomic_write_text(destination, '{"new": true}')
+
+    assert attempts == 5
+    assert delays == [0.025, 0.05, 0.1, 0.2]
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"new": True}
+
+
 def test_atomic_write_text_windows_retry_raises_enriched_initial_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -102,18 +132,51 @@ def test_atomic_write_text_windows_retry_raises_enriched_initial_error(
         attempts += 1
         raise PermissionError("Access denied")
 
+    @contextmanager
+    def fake_lock(_path: Path):
+        yield
+
     monkeypatch.setattr(io_utils, "_is_windows", lambda: True)
+    monkeypatch.setattr(io_utils, "_locked_file", fake_lock)
     monkeypatch.setattr(io_utils.os, "replace", always_failing_replace)
     monkeypatch.setattr(io_utils.time, "sleep", delays.append)
 
     with pytest.raises(PermissionError) as exc_info:
         io_utils.atomic_write_text(destination, '{"new": true}')
 
-    assert attempts == 6
-    assert delays == [0.025, 0.05, 0.1, 0.2, 0.2]
+    assert attempts == 9
+    assert delays == [0.025, 0.05, 0.1, 0.2, 0.4, 0.4, 0.4]
     notes = getattr(exc_info.value, "__notes__", [])
     assert any(
-        "after 6 attempts" in note and str(destination) in note and "destination=" in note
+        "sidecar-lock fallback" in note
+        and "attempts=8" in note
+        and str(destination) in note
+        and "delays=" in note
         for note in notes
     )
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"old": True}
+
+
+def test_atomic_write_text_non_windows_permission_error_not_retried(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    destination = tmp_path / "state.json"
+    destination.write_text('{"old": true}', encoding="utf-8")
+    attempts = 0
+    delays: list[float] = []
+
+    def failing_replace(_src, _dst):
+        nonlocal attempts
+        attempts += 1
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(io_utils, "_is_windows", lambda: False)
+    monkeypatch.setattr(io_utils.os, "replace", failing_replace)
+    monkeypatch.setattr(io_utils.time, "sleep", delays.append)
+
+    with pytest.raises(PermissionError):
+        io_utils.atomic_write_text(destination, '{"new": true}')
+
+    assert attempts == 1
+    assert delays == []
     assert json.loads(destination.read_text(encoding="utf-8")) == {"old": True}


### PR DESCRIPTION
### Motivation

- Rendre les écritures atomiques plus robustes face aux verrous de fichier transitoires rencontrés sur Windows. 
- Centraliser la stratégie de retry pour pouvoir ajuster les paramètres (tentatives et backoff) sans dupliquer la logique. 
- Fournir un fallback contrôlé et une meilleure observabilité en cas d'échec persistant de la substitution atomique.

### Description

- Extraction de la configuration de retry en constantes module (`_DEFAULT_*` et `_WINDOWS_*`) et utilisation de ces constantes dans `_replace_with_retry`.
- Augmentation du nombre de tentatives et du `max_delay` côté Windows (`8` tentatives, backoff max `0.4s`) et maintien du comportement inchangé hors Windows.
- Ajout d'un fallback après l'épuisement des retries qui acquiert le lock sidecar via `_locked_file` et tente `os.replace` une dernière fois, puis enrichit et relance l'exception si cela échoue encore (note contenant `source`, `destination`, `attempts` et `delays`).
- Ajustement et ajout de tests unitaires ciblés appelant `atomic_write_text` pour couvrir `PermissionError`, `OSError(winerror=5)`, le chemin de fallback et le comportement non-Windows sans retry.

### Testing

- Exécution de `pytest -q tests/test_atomic_writes.py` qui a réussi avec `7 passed`.
- Les tests ajoutés/ajustés vérifient les retries sur `PermissionError` et `OSError(winerror=5)`, le comportement de fallback (message enrichi) et l'absence de retry sur non-Windows, et ont tous passé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e01fc46898832ab4919a546ca3df84)