### PR TITLE
Clarify DeathMonitor action outcome semantics and add regression tests

### DIFF
--- a/src/singular/life/death.py
+++ b/src/singular/life/death.py
@@ -19,11 +19,11 @@ class DeathMonitor:
         self,
         iteration: int,
         psyche: Psyche,
-        success: bool,
+        action_succeeded: bool,
         resources: float | None = None,
     ) -> Tuple[bool, str | None]:
         """Update state and return ``(dead, reason)`` for current iteration."""
-        if not success:
+        if not action_succeeded:
             self.failures += 1
         else:
             self.failures = 0

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -1505,8 +1505,13 @@ def run(
             resource_manager.apply_world_state(updated_world_state)
             save_checkpoint(checkpoint_path, state)
 
+            # DeathMonitor convention: ``action_succeeded=True`` means the
+            # mutation outcome is accepted (not a failure signal).
             dead, reason = org.monitor.check(
-                state.iteration, psyche, mutated_score <= base_score, org.resources
+                state.iteration,
+                psyche,
+                action_succeeded=accepted,
+                resources=org.resources,
             )
             if dead:
                 death_reason = reason or "unknown"

--- a/tests/test_death.py
+++ b/tests/test_death.py
@@ -10,6 +10,13 @@ from singular.life.death import DeathMonitor
 from singular.events import EventBus
 
 
+class _StablePsyche:
+    energy = 1.0
+    curiosity = 1.0
+    patience = 1.0
+    playfulness = 1.0
+
+
 def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
     for node in ast.walk(tree):
         if isinstance(node, ast.Constant) and isinstance(node.value, int):
@@ -90,6 +97,99 @@ def test_death_by_age(tmp_path: Path, monkeypatch):
     assert any(entry.get("event") == "death" for entry in log)
     episodes = episodic.read_text().splitlines()
     assert any(json.loads(line)["event"] == "death" for line in episodes)
+
+
+def test_death_monitor_triggers_on_five_consecutive_failures():
+    psyche = _StablePsyche()
+    monitor = DeathMonitor(max_failures=5, max_age=999, min_trait=0.0)
+
+    for iteration in range(1, 5):
+        dead, reason = monitor.check(
+            iteration=iteration,
+            psyche=psyche,
+            action_succeeded=False,
+            resources=1.0,
+        )
+        assert dead is False
+        assert reason is None
+
+    dead, reason = monitor.check(
+        iteration=5,
+        psyche=psyche,
+        action_succeeded=False,
+        resources=1.0,
+    )
+    assert dead is True
+    assert reason == "too many failures"
+
+
+def test_death_monitor_success_resets_failure_counter():
+    psyche = _StablePsyche()
+    monitor = DeathMonitor(max_failures=5, max_age=999, min_trait=0.0)
+
+    for iteration in range(1, 5):
+        dead, _ = monitor.check(
+            iteration=iteration,
+            psyche=psyche,
+            action_succeeded=False,
+            resources=1.0,
+        )
+        assert dead is False
+
+    dead, reason = monitor.check(
+        iteration=5,
+        psyche=psyche,
+        action_succeeded=True,
+        resources=1.0,
+    )
+    assert dead is False
+    assert reason is None
+    assert monitor.failures == 0
+
+    dead, reason = monitor.check(
+        iteration=6,
+        psyche=psyche,
+        action_succeeded=False,
+        resources=1.0,
+    )
+    assert dead is False
+    assert reason is None
+    assert monitor.failures == 1
+
+
+def test_death_monitor_edge_conditions_unchanged():
+    psyche = _StablePsyche()
+
+    age_monitor = DeathMonitor(max_age=3, max_failures=99, min_trait=0.0)
+    dead, reason = age_monitor.check(
+        iteration=3,
+        psyche=psyche,
+        action_succeeded=True,
+        resources=1.0,
+    )
+    assert dead is True
+    assert reason == "old age"
+
+    resource_monitor = DeathMonitor(max_age=99, max_failures=99, min_trait=0.0)
+    dead, reason = resource_monitor.check(
+        iteration=1,
+        psyche=psyche,
+        action_succeeded=True,
+        resources=0.0,
+    )
+    assert dead is True
+    assert reason == "resources exhausted"
+
+    psyche.energy = 0.0
+    energy_monitor = DeathMonitor(max_age=99, max_failures=99, min_trait=0.0)
+    dead, reason = energy_monitor.check(
+        iteration=1,
+        psyche=psyche,
+        action_succeeded=True,
+        resources=1.0,
+    )
+    assert dead is True
+    assert reason == "energy depleted"
 
 
 def test_death_by_failures(tmp_path: Path, monkeypatch):

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -16,8 +16,8 @@ def test_energy_persistence(tmp_path):
 def test_energy_death():
     psyche = Psyche(energy=1.0)
     monitor = DeathMonitor(max_age=99, max_failures=99, min_trait=0.0)
-    dead, _ = monitor.check(0, psyche, success=True)
+    dead, _ = monitor.check(0, psyche, action_succeeded=True)
     assert not dead
     psyche.consume(1.0)
-    dead, reason = monitor.check(1, psyche, success=True)
+    dead, reason = monitor.check(1, psyche, action_succeeded=True)
     assert dead and reason == "energy depleted"

--- a/tests/test_targeted_lifecycle_narrative_trajectory.py
+++ b/tests/test_targeted_lifecycle_narrative_trajectory.py
@@ -77,9 +77,19 @@ def test_targeted_lifecycle_birth_introspection_goals_world_action_death(
     # mort (invariant raison terminale)
     monitor = DeathMonitor(max_failures=2)
     psyche = _DummyPsyche()
-    dead, reason = monitor.check(iteration=1, psyche=psyche, success=False, resources=1.0)
+    dead, reason = monitor.check(
+        iteration=1,
+        psyche=psyche,
+        action_succeeded=False,
+        resources=1.0,
+    )
     assert dead is False
-    dead, reason = monitor.check(iteration=2, psyche=psyche, success=False, resources=1.0)
+    dead, reason = monitor.check(
+        iteration=2,
+        psyche=psyche,
+        action_succeeded=False,
+        resources=1.0,
+    )
     assert dead is True
     assert reason == "too many failures"
 


### PR DESCRIPTION
### Motivation
- The `DeathMonitor.check` parameter name `success` was ambiguous relative to business signals and needed an explicit name. 
- Failure accounting should be unambiguous so the `failures` counter only increments on real action failures and resets on success. 
- The evolutionary loop should pass an explicit business signal (accepted/failed) rather than an expression like `mutated_score <= base_score` to clarify intent at the call site.

### Description
- Renamed `DeathMonitor.check` parameter from `success` to `action_succeeded` and updated internal logic to increment `self.failures` only when `action_succeeded` is false and to reset it on true in `src/singular/life/death.py`.
- Replaced the implicit boolean expression call with an explicit keyword argument at the call site in `src/singular/life/loop.py` by passing `action_succeeded=accepted` and added a short comment documenting the convention.
- Updated existing tests to use the new `action_succeeded` keyword where applicable in `tests/test_energy.py` and `tests/test_targeted_lifecycle_narrative_trajectory.py`.
- Added focused unit tests in `tests/test_death.py` to assert that 5 consecutive failures trigger "too many failures", that a success resets the failure counter, and that edge conditions (`old age`, `resources exhausted`, `energy depleted`) remain unchanged.

### Testing
- Ran `pytest -q tests/test_death.py tests/test_energy.py tests/test_targeted_lifecycle_narrative_trajectory.py` and all tests passed (13 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e02080c3e0832a8c51c2ddec9fa640)