### PR TITLE
Add benchmark runner, weighted scoring, standardized artifacts, and regression guard

### DIFF
--- a/artifacts/benchmarks/adaptation.json
+++ b/artifacts/benchmarks/adaptation.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-16T00:36:30.305000+00:00",
+  "domain": "adaptation",
+  "score": 1.0,
+  "case_count": 2,
+  "cases": [
+    {
+      "id": "adaptation_contrainte_1",
+      "prompt": "Adapter la réponse quand le réseau est indisponible.",
+      "score": 1.0,
+      "max_score": 1.0
+    },
+    {
+      "id": "adaptation_feedback_1",
+      "prompt": "Intégrer un feedback utilisateur négatif.",
+      "score": 1.0,
+      "max_score": 1.0
+    }
+  ]
+}

--- a/artifacts/benchmarks/code.json
+++ b/artifacts/benchmarks/code.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-16T00:36:30.305317+00:00",
+  "domain": "code",
+  "score": 0.8334,
+  "case_count": 2,
+  "cases": [
+    {
+      "id": "code_complexite_1",
+      "prompt": "Donner la complexité de la recherche binaire.",
+      "score": 1.0,
+      "max_score": 1.0
+    },
+    {
+      "id": "code_qualite_1",
+      "prompt": "Comment sécuriser une écriture de fichier JSON ?",
+      "score": 0.6667,
+      "max_score": 1.0
+    }
+  ]
+}

--- a/artifacts/benchmarks/interaction.json
+++ b/artifacts/benchmarks/interaction.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-16T00:36:30.305636+00:00",
+  "domain": "interaction",
+  "score": 1.0,
+  "case_count": 2,
+  "cases": [
+    {
+      "id": "interaction_clarification_1",
+      "prompt": "Répondre à une demande ambiguë.",
+      "score": 1.0,
+      "max_score": 1.0
+    },
+    {
+      "id": "interaction_ton_1",
+      "prompt": "Adopter un ton professionnel et bienveillant.",
+      "score": 1.0,
+      "max_score": 1.0
+    }
+  ]
+}

--- a/artifacts/benchmarks/memoire.json
+++ b/artifacts/benchmarks/memoire.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-16T00:36:30.305881+00:00",
+  "domain": "memoire",
+  "score": 1.0,
+  "case_count": 2,
+  "cases": [
+    {
+      "id": "memoire_contexte_1",
+      "prompt": "Retenir une préférence utilisateur exprimée plus tôt.",
+      "score": 1.0,
+      "max_score": 1.0
+    },
+    {
+      "id": "memoire_restitution_1",
+      "prompt": "Restituer une décision passée avec justification.",
+      "score": 1.0,
+      "max_score": 1.0
+    }
+  ]
+}

--- a/artifacts/benchmarks/planification.json
+++ b/artifacts/benchmarks/planification.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-16T00:36:30.306069+00:00",
+  "domain": "planification",
+  "score": 1.0,
+  "case_count": 2,
+  "cases": [
+    {
+      "id": "planification_release_1",
+      "prompt": "Planifier un déploiement en 3 phases.",
+      "score": 1.0,
+      "max_score": 1.0
+    },
+    {
+      "id": "planification_priorisation_1",
+      "prompt": "Prioriser un backlog critique.",
+      "score": 1.0,
+      "max_score": 1.0
+    }
+  ]
+}

--- a/artifacts/benchmarks/raisonnement.json
+++ b/artifacts/benchmarks/raisonnement.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-16T00:36:30.306247+00:00",
+  "domain": "raisonnement",
+  "score": 1.0,
+  "case_count": 2,
+  "cases": [
+    {
+      "id": "raisonnement_deduction_1",
+      "prompt": "Si tous les A sont B et tous les B sont C, que peut-on dire des A ?",
+      "score": 1.0,
+      "max_score": 1.0
+    },
+    {
+      "id": "raisonnement_causal_1",
+      "prompt": "Identifier une cause probable d'une baisse de conversion après changement d'interface.",
+      "score": 1.0,
+      "max_score": 1.0
+    }
+  ]
+}

--- a/benchmarks/adaptation.json
+++ b/benchmarks/adaptation.json
@@ -1,0 +1,17 @@
+{
+  "domain": "adaptation",
+  "cases": [
+    {
+      "id": "adaptation_contrainte_1",
+      "prompt": "Adapter la réponse quand le réseau est indisponible.",
+      "reference_keywords": ["fallback", "hors ligne", "continuité"],
+      "candidate_answer": "Prévoir un fallback hors ligne pour assurer la continuité."
+    },
+    {
+      "id": "adaptation_feedback_1",
+      "prompt": "Intégrer un feedback utilisateur négatif.",
+      "reference_keywords": ["feedback", "itération", "ajustement"],
+      "candidate_answer": "Le feedback déclenche une itération avec ajustement de la solution."
+    }
+  ]
+}

--- a/benchmarks/code.json
+++ b/benchmarks/code.json
@@ -1,0 +1,17 @@
+{
+  "domain": "code",
+  "cases": [
+    {
+      "id": "code_complexite_1",
+      "prompt": "Donner la complexité de la recherche binaire.",
+      "reference_keywords": ["O(log n)", "complexité", "recherche binaire"],
+      "candidate_answer": "La complexité de la recherche binaire est O(log n)."
+    },
+    {
+      "id": "code_qualite_1",
+      "prompt": "Comment sécuriser une écriture de fichier JSON ?",
+      "reference_keywords": ["temporaire", "atomique", "validation"],
+      "candidate_answer": "On écrit dans un fichier temporaire, on valide puis on remplace de façon atomique."
+    }
+  ]
+}

--- a/benchmarks/interaction.json
+++ b/benchmarks/interaction.json
@@ -1,0 +1,17 @@
+{
+  "domain": "interaction",
+  "cases": [
+    {
+      "id": "interaction_clarification_1",
+      "prompt": "Répondre à une demande ambiguë.",
+      "reference_keywords": ["clarifier", "question", "objectif"],
+      "candidate_answer": "Il faut clarifier l'objectif avec une question ciblée."
+    },
+    {
+      "id": "interaction_ton_1",
+      "prompt": "Adopter un ton professionnel et bienveillant.",
+      "reference_keywords": ["professionnel", "bienveillant", "concis"],
+      "candidate_answer": "Utiliser un ton professionnel, bienveillant et concis."
+    }
+  ]
+}

--- a/benchmarks/memoire.json
+++ b/benchmarks/memoire.json
@@ -1,0 +1,17 @@
+{
+  "domain": "memoire",
+  "cases": [
+    {
+      "id": "memoire_contexte_1",
+      "prompt": "Retenir une préférence utilisateur exprimée plus tôt.",
+      "reference_keywords": ["préférence", "persistée", "contexte"],
+      "candidate_answer": "La préférence doit être persistée et réinjectée dans le contexte."
+    },
+    {
+      "id": "memoire_restitution_1",
+      "prompt": "Restituer une décision passée avec justification.",
+      "reference_keywords": ["décision", "historique", "justification"],
+      "candidate_answer": "La décision est relue depuis l'historique avec sa justification."
+    }
+  ]
+}

--- a/benchmarks/planification.json
+++ b/benchmarks/planification.json
@@ -1,0 +1,17 @@
+{
+  "domain": "planification",
+  "cases": [
+    {
+      "id": "planification_release_1",
+      "prompt": "Planifier un déploiement en 3 phases.",
+      "reference_keywords": ["canary", "monitoring", "rollback"],
+      "candidate_answer": "Commencer par canary, surveiller avec monitoring, puis rollback si besoin."
+    },
+    {
+      "id": "planification_priorisation_1",
+      "prompt": "Prioriser un backlog critique.",
+      "reference_keywords": ["impact", "urgence", "dépendances"],
+      "candidate_answer": "Classer par impact et urgence en tenant compte des dépendances."
+    }
+  ]
+}

--- a/benchmarks/raisonnement.json
+++ b/benchmarks/raisonnement.json
@@ -1,0 +1,17 @@
+{
+  "domain": "raisonnement",
+  "cases": [
+    {
+      "id": "raisonnement_deduction_1",
+      "prompt": "Si tous les A sont B et tous les B sont C, que peut-on dire des A ?",
+      "reference_keywords": ["A", "C", "tous"],
+      "candidate_answer": "Tous les A appartiennent aussi à C."
+    },
+    {
+      "id": "raisonnement_causal_1",
+      "prompt": "Identifier une cause probable d'une baisse de conversion après changement d'interface.",
+      "reference_keywords": ["friction", "parcours", "utilisateur"],
+      "candidate_answer": "Une friction introduite dans le parcours utilisateur peut expliquer la baisse."
+    }
+  ]
+}

--- a/benchmarks/weights.json
+++ b/benchmarks/weights.json
@@ -1,0 +1,8 @@
+{
+  "raisonnement": 0.2,
+  "code": 0.2,
+  "planification": 0.15,
+  "memoire": 0.15,
+  "interaction": 0.15,
+  "adaptation": 0.15
+}

--- a/mem/benchmark_summary.json
+++ b/mem/benchmark_summary.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-04-16T00:36:30.306633+00:00",
+  "global_score": 0.9667,
+  "domain_scores": {
+    "adaptation": 1.0,
+    "code": 0.8334,
+    "interaction": 1.0,
+    "memoire": 1.0,
+    "planification": 1.0,
+    "raisonnement": 1.0
+  },
+  "weights": {
+    "adaptation": 0.15,
+    "code": 0.2,
+    "interaction": 0.15,
+    "memoire": 0.15,
+    "planification": 0.15,
+    "raisonnement": 0.2
+  },
+  "non_regression": {
+    "max_allowed_drop": 0.05,
+    "previous_global_score": 0.9667,
+    "drop": 0.0,
+    "status": "passed"
+  }
+}

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from singular.benchmarks import BenchmarkRegressionError, run_benchmarks
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run benchmark suites and emit artifacts.")
+    parser.add_argument("--benchmarks-dir", default="benchmarks", help="Benchmark definitions directory.")
+    parser.add_argument("--artifacts-dir", default="artifacts/benchmarks", help="Benchmark artifacts directory.")
+    parser.add_argument("--summary-path", default="mem/benchmark_summary.json", help="Consolidated summary JSON path.")
+    parser.add_argument("--weights-path", default="benchmarks/weights.json", help="Domain weights JSON path.")
+    parser.add_argument(
+        "--max-regression-drop",
+        type=float,
+        default=0.05,
+        help="Fail when global score drop exceeds this threshold.",
+    )
+    args = parser.parse_args()
+
+    try:
+        result = run_benchmarks(
+            benchmarks_dir=Path(args.benchmarks_dir),
+            artifacts_dir=Path(args.artifacts_dir),
+            summary_path=Path(args.summary_path),
+            weights_path=Path(args.weights_path),
+            max_regression_drop=args.max_regression_drop,
+        )
+    except BenchmarkRegressionError as exc:
+        print(str(exc))
+        return 1
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/singular/benchmarks/__init__.py
+++ b/src/singular/benchmarks/__init__.py
@@ -1,0 +1,5 @@
+"""Benchmark runner utilities."""
+
+from .runner import BenchmarkRegressionError, run_benchmarks
+
+__all__ = ["BenchmarkRegressionError", "run_benchmarks"]

--- a/src/singular/benchmarks/runner.py
+++ b/src/singular/benchmarks/runner.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class BenchmarkRegressionError(RuntimeError):
+    """Raised when benchmark score regression exceeds threshold."""
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _token_score(candidate: str, keywords: list[str]) -> float:
+    if not keywords:
+        return 1.0
+
+    candidate_text = candidate.lower()
+    hits = 0
+    for keyword in keywords:
+        if keyword.lower() in candidate_text:
+            hits += 1
+
+    return hits / len(keywords)
+
+
+def _load_weights(weights_path: Path, domains: list[str]) -> dict[str, float]:
+    if weights_path.exists():
+        loaded = _load_json(weights_path)
+    else:
+        loaded = {}
+
+    if not loaded:
+        return {domain: 1.0 / len(domains) for domain in domains}
+
+    total = sum(float(loaded.get(domain, 0.0)) for domain in domains)
+    if total <= 0:
+        return {domain: 1.0 / len(domains) for domain in domains}
+
+    return {domain: float(loaded.get(domain, 0.0)) / total for domain in domains}
+
+
+def run_benchmarks(
+    benchmarks_dir: Path,
+    artifacts_dir: Path,
+    summary_path: Path,
+    weights_path: Path,
+    max_regression_drop: float,
+) -> dict:
+    benchmark_files = sorted(
+        path
+        for path in benchmarks_dir.glob("*.json")
+        if path.name not in {"weights.json"}
+    )
+
+    if len(benchmark_files) < 6:
+        raise ValueError("At least 6 benchmark domains are required.")
+
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    per_domain_scores: dict[str, float] = {}
+    domain_artifacts: list[dict] = []
+
+    for benchmark_file in benchmark_files:
+        benchmark_def = _load_json(benchmark_file)
+        domain = benchmark_def["domain"]
+        cases = benchmark_def.get("cases", [])
+
+        scored_cases = []
+        for case in cases:
+            score = _token_score(
+                case.get("candidate_answer", ""),
+                case.get("reference_keywords", []),
+            )
+            scored_cases.append(
+                {
+                    "id": case["id"],
+                    "prompt": case.get("prompt", ""),
+                    "score": round(score, 4),
+                    "max_score": 1.0,
+                }
+            )
+
+        domain_score = (
+            sum(case["score"] for case in scored_cases) / len(scored_cases)
+            if scored_cases
+            else 0.0
+        )
+        per_domain_scores[domain] = round(domain_score, 4)
+
+        artifact = {
+            "schema_version": "1.0",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "domain": domain,
+            "score": round(domain_score, 4),
+            "case_count": len(scored_cases),
+            "cases": scored_cases,
+        }
+        domain_artifacts.append(artifact)
+
+        artifact_path = artifacts_dir / f"{domain}.json"
+        with artifact_path.open("w", encoding="utf-8") as handle:
+            json.dump(artifact, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+
+    weights = _load_weights(weights_path=weights_path, domains=sorted(per_domain_scores))
+    global_score = sum(per_domain_scores[d] * weights[d] for d in per_domain_scores)
+    global_score = round(global_score, 4)
+
+    previous_global_score = None
+    if summary_path.exists():
+        try:
+            previous_global_score = float(_load_json(summary_path).get("global_score"))
+        except (ValueError, TypeError, json.JSONDecodeError):
+            previous_global_score = None
+
+    drop = 0.0
+    regression_failed = False
+    if previous_global_score is not None:
+        drop = round(previous_global_score - global_score, 4)
+        regression_failed = drop > max_regression_drop
+
+    summary = {
+        "schema_version": "1.0",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "global_score": global_score,
+        "domain_scores": per_domain_scores,
+        "weights": weights,
+        "non_regression": {
+            "max_allowed_drop": max_regression_drop,
+            "previous_global_score": previous_global_score,
+            "drop": drop,
+            "status": "failed" if regression_failed else "passed",
+        },
+    }
+
+    with summary_path.open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+    if regression_failed:
+        raise BenchmarkRegressionError(
+            f"Global score regression {drop:.4f} exceeds threshold {max_regression_drop:.4f}."
+        )
+
+    return {
+        "global_score": global_score,
+        "domain_scores": per_domain_scores,
+        "artifacts": domain_artifacts,
+    }

--- a/tests/test_benchmarks_runner.py
+++ b/tests/test_benchmarks_runner.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from singular.benchmarks.runner import BenchmarkRegressionError, run_benchmarks
+
+
+def _write_domain(path: Path, domain: str, candidate: str) -> None:
+    payload = {
+        "domain": domain,
+        "cases": [
+            {
+                "id": f"{domain}_1",
+                "prompt": "p",
+                "reference_keywords": ["alpha", "beta"],
+                "candidate_answer": candidate,
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_run_benchmarks_writes_artifacts_and_summary(tmp_path: Path) -> None:
+    benchmarks_dir = tmp_path / "benchmarks"
+    artifacts_dir = tmp_path / "artifacts"
+    summary_path = tmp_path / "mem" / "benchmark_summary.json"
+    weights_path = benchmarks_dir / "weights.json"
+
+    benchmarks_dir.mkdir()
+    for domain in ["raisonnement", "code", "planification", "memoire", "interaction", "adaptation"]:
+        _write_domain(benchmarks_dir / f"{domain}.json", domain, "alpha beta")
+
+    weights_path.write_text(
+        json.dumps(
+            {
+                "raisonnement": 2,
+                "code": 2,
+                "planification": 1,
+                "memoire": 1,
+                "interaction": 1,
+                "adaptation": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_benchmarks(
+        benchmarks_dir=benchmarks_dir,
+        artifacts_dir=artifacts_dir,
+        summary_path=summary_path,
+        weights_path=weights_path,
+        max_regression_drop=0.05,
+    )
+
+    assert result["global_score"] == 1.0
+    assert set(result["domain_scores"]) == {
+        "raisonnement",
+        "code",
+        "planification",
+        "memoire",
+        "interaction",
+        "adaptation",
+    }
+
+    for domain in result["domain_scores"]:
+        artifact_path = artifacts_dir / f"{domain}.json"
+        assert artifact_path.exists()
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        assert payload["schema_version"] == "1.0"
+        assert payload["domain"] == domain
+        assert payload["case_count"] == 1
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary["global_score"] == 1.0
+    assert summary["non_regression"]["status"] == "passed"
+
+
+def test_run_benchmarks_fails_on_regression(tmp_path: Path) -> None:
+    benchmarks_dir = tmp_path / "benchmarks"
+    artifacts_dir = tmp_path / "artifacts"
+    summary_path = tmp_path / "mem" / "benchmark_summary.json"
+
+    benchmarks_dir.mkdir()
+    for domain in ["raisonnement", "code", "planification", "memoire", "interaction", "adaptation"]:
+        _write_domain(benchmarks_dir / f"{domain}.json", domain, "alpha beta")
+
+    run_benchmarks(
+        benchmarks_dir=benchmarks_dir,
+        artifacts_dir=artifacts_dir,
+        summary_path=summary_path,
+        weights_path=benchmarks_dir / "weights.json",
+        max_regression_drop=0.01,
+    )
+
+    for domain in ["raisonnement", "code", "planification", "memoire", "interaction", "adaptation"]:
+        _write_domain(benchmarks_dir / f"{domain}.json", domain, "alpha")
+
+    with pytest.raises(BenchmarkRegressionError):
+        run_benchmarks(
+            benchmarks_dir=benchmarks_dir,
+            artifacts_dir=artifacts_dir,
+            summary_path=summary_path,
+            weights_path=benchmarks_dir / "weights.json",
+            max_regression_drop=0.01,
+        )


### PR DESCRIPTION
### Motivation
- Provide a simple, deterministic benchmark suite spanning six domains to track behaviour and regressions. 
- Standardize per-domain artifact output and publish a consolidated summary for CI and observability. 
- Compute a weighted global score with per-domain sub-scores to support prioritized evaluation. 
- Fail CI when the global score drops beyond a configurable threshold to guard against regressions.

### Description
- Added a `benchmarks/` directory with six domain JSON definitions (`raisonnement`, `code`, `planification`, `memoire`, `interaction`, `adaptation`) and `benchmarks/weights.json` for domain weighting. 
- Introduced a single CLI runner `scripts/run_benchmarks.py` that discovers domain files, loads weights, and invokes the runner (it ensures `src/` is on `sys.path` when run from the repo). 
- Implemented core logic in `src/singular/benchmarks/runner.py` which performs token-keyword scoring per case, normalizes weights, writes standardized artifacts to `artifacts/benchmarks/*.json` (schema_version `1.0`), computes a weighted global score and per-domain scores, and writes a consolidated `mem/benchmark_summary.json`. 
- Added `tests/test_benchmarks_runner.py` validating artifact + summary generation and the non-regression gate which raises `BenchmarkRegressionError` when drop > configured threshold.

### Testing
- Executed the runner locally with `python scripts/run_benchmarks.py`, which produced the per-domain artifacts and a summary in `mem/benchmark_summary.json` (success). 
- Ran the automated test suite for the new code with `pytest -q tests/test_benchmarks_runner.py`, which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e02e82114c832a9a271b4d6154976c)