### PR TITLE
Introduce identity memory package with consolidation pipeline and retention

### DIFF
--- a/src/singular/identity/__init__.py
+++ b/src/singular/identity/__init__.py
@@ -1,13 +1,18 @@
-"""Identity file creation and reading utilities."""
+"""Identity primitives and memory consolidation helpers."""
 
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+from .consolidation import ConsolidationPipeline, ConsolidationPolicy, ConsolidationResult
+from .episodic_store import EpisodicStore
+from .self_model import IdentityInvariantError, SelfModelStore
+from .semantic_memory import SemanticMemoryStore
 
 
 @dataclass
@@ -23,22 +28,7 @@ class Identity:
 def create_identity(
     name: str, soulseed: str, path: Path | str = Path("id.json")
 ) -> Identity:
-    """Create an identity JSON file.
-
-    Parameters
-    ----------
-    name:
-        Name of the identity.
-    soulseed:
-        Seed string representing the soul.
-    path:
-        Path where the ``id.json`` file will be written.
-
-    Returns
-    -------
-    Identity
-        The identity information that was written to the file.
-    """
+    """Create an identity JSON file."""
 
     identity = Identity(
         name=name,
@@ -56,21 +46,24 @@ def create_identity(
 
 
 def read_identity(path: Path | str = Path("id.json")) -> Identity:
-    """Read an identity JSON file.
-
-    Parameters
-    ----------
-    path:
-        Path to the ``id.json`` file.
-
-    Returns
-    -------
-    Identity
-        The identity information loaded from the file.
-    """
+    """Read an identity JSON file."""
 
     path = Path(path)
     with path.open(encoding="utf-8") as file:
         data: dict[str, Any] = json.load(file)
 
     return Identity(**data)
+
+
+__all__ = [
+    "ConsolidationPipeline",
+    "ConsolidationPolicy",
+    "ConsolidationResult",
+    "EpisodicStore",
+    "Identity",
+    "IdentityInvariantError",
+    "SemanticMemoryStore",
+    "SelfModelStore",
+    "create_identity",
+    "read_identity",
+]

--- a/src/singular/identity/consolidation.py
+++ b/src/singular/identity/consolidation.py
@@ -1,0 +1,62 @@
+"""Periodic identity-memory consolidation pipeline (short-term -> long-term)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .episodic_store import EpisodicStore
+from .semantic_memory import SemanticMemoryStore
+from .self_model import SelfModelStore
+
+
+@dataclass(frozen=True)
+class ConsolidationPolicy:
+    """Retention/compaction policy that preserves identity invariants."""
+
+    keep_last_episodes: int = 1_000
+    keep_top_self_model_entries: int = 100
+
+
+@dataclass(frozen=True)
+class ConsolidationResult:
+    """Result metadata for one consolidation cycle."""
+
+    consolidated_at: str
+    episodes_seen: int
+    facts_count: int
+    episodic_compaction: dict[str, Any]
+
+
+class ConsolidationPipeline:
+    """Orchestrates identity memory consolidation into durable structures."""
+
+    def __init__(
+        self,
+        *,
+        mem_dir: Path | str,
+        policy: ConsolidationPolicy | None = None,
+    ) -> None:
+        root = Path(mem_dir)
+        self.policy = policy or ConsolidationPolicy()
+        self.episodic = EpisodicStore(root / "episodic.jsonl")
+        self.semantic = SemanticMemoryStore(root / "semantic_memory.json")
+        self.self_model = SelfModelStore(root / "self_model.json")
+
+    def run(self) -> ConsolidationResult:
+        episodes = self.episodic.read_all()
+        facts = self.semantic.consolidate_from_episodes(episodes)
+        self.self_model.apply_facts(facts)
+        self.self_model.compact(self.policy.keep_top_self_model_entries)
+        compaction = self.episodic.compact(
+            keep_last=self.policy.keep_last_episodes,
+            preserve_identity_events=True,
+        )
+        return ConsolidationResult(
+            consolidated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            episodes_seen=len(episodes),
+            facts_count=len(facts),
+            episodic_compaction=compaction,
+        )

--- a/src/singular/identity/episodic_store.py
+++ b/src/singular/identity/episodic_store.py
@@ -1,0 +1,81 @@
+"""Raw timestamped episodic journal with retention-aware compaction."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from ..io_utils import append_jsonl_line, atomic_write_text
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+class EpisodicStore:
+    """Persistent append-only JSONL store for short-term episodes."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.touch(exist_ok=True)
+
+    def append(self, episode: dict[str, Any]) -> dict[str, Any]:
+        payload = dict(episode)
+        payload.setdefault("ts", _now_iso())
+        append_jsonl_line(self.path, payload, with_lock=True)
+        return payload
+
+    def read_all(self) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    parsed = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict):
+                    rows.append(parsed)
+        return rows
+
+    def truncate_to_rows(self, rows: Iterable[dict[str, Any]]) -> None:
+        serialized = "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in rows)
+        atomic_write_text(self.path, serialized)
+
+    def compact(
+        self,
+        *,
+        keep_last: int,
+        preserve_identity_events: bool = True,
+    ) -> dict[str, Any]:
+        """Retain recent events while preserving identity invariants."""
+
+        events = self.read_all()
+        if keep_last < 0:
+            keep_last = 0
+        if len(events) <= keep_last:
+            return {"compacted": False, "total": len(events), "kept": len(events)}
+
+        retained = events[-keep_last:] if keep_last else []
+        if preserve_identity_events:
+            retained_ids = {id(row) for row in retained}
+            invariants = [
+                row
+                for row in events
+                if row.get("event") in {"identity.created", "identity.invariant"}
+                and id(row) not in retained_ids
+            ]
+            retained = invariants + retained
+
+        self.truncate_to_rows(retained)
+        return {
+            "compacted": True,
+            "total": len(events),
+            "kept": len(retained),
+            "dropped": len(events) - len(retained),
+        }

--- a/src/singular/identity/self_model.py
+++ b/src/singular/identity/self_model.py
@@ -1,0 +1,87 @@
+"""Stable self-model storage preserving identity invariants."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from ..io_utils import atomic_write_text
+
+
+class IdentityInvariantError(ValueError):
+    """Raised when a retention/compaction request violates identity invariants."""
+
+
+class SelfModelStore:
+    """Persistent self-model for traits, preferences, and constraints."""
+
+    _REQUIRED_ROOT_KEYS = {"traits", "preferences", "constraints"}
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self.write(self._default_model())
+
+    def _default_model(self) -> dict[str, Any]:
+        return {
+            "traits": {},
+            "preferences": {},
+            "constraints": {},
+            "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        }
+
+    def read(self) -> dict[str, Any]:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload = self._default_model()
+        if not isinstance(payload, dict):
+            payload = self._default_model()
+        for key in self._REQUIRED_ROOT_KEYS:
+            if not isinstance(payload.get(key), dict):
+                payload[key] = {}
+        payload.setdefault("updated_at", datetime.now(timezone.utc).isoformat(timespec="seconds"))
+        return payload
+
+    def write(self, model: dict[str, Any]) -> None:
+        missing = self._REQUIRED_ROOT_KEYS.difference(model)
+        if missing:
+            raise IdentityInvariantError(f"Missing invariant sections in self model: {sorted(missing)}")
+        atomic_write_text(self.path, json.dumps(model, ensure_ascii=False, indent=2) + "\n")
+
+    def apply_facts(self, facts: list[dict[str, Any]]) -> dict[str, Any]:
+        model = self.read()
+        for fact in facts:
+            kind = str(fact.get("kind", ""))
+            value = str(fact.get("value", "")).strip()
+            confidence = float(fact.get("confidence", 0.5) or 0.5)
+            if not value:
+                continue
+            if kind == "user_fact":
+                model["traits"][value] = confidence
+            elif kind == "preference":
+                model["preferences"][value] = confidence
+            elif kind == "constraint":
+                model["constraints"][value] = confidence
+        model["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        self.write(model)
+        return model
+
+    def compact(self, keep_top_n_per_section: int = 50) -> dict[str, Any]:
+        """Compact model while keeping invariant root sections."""
+
+        model = self.read()
+        keep_n = max(1, keep_top_n_per_section)
+        for section in self._REQUIRED_ROOT_KEYS:
+            values = model.get(section, {})
+            if not isinstance(values, dict):
+                model[section] = {}
+                continue
+            top_items = sorted(values.items(), key=lambda item: float(item[1]), reverse=True)[:keep_n]
+            model[section] = dict(top_items)
+        model["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        self.write(model)
+        return model

--- a/src/singular/identity/semantic_memory.py
+++ b/src/singular/identity/semantic_memory.py
@@ -1,0 +1,81 @@
+"""Semantic memory extraction and consolidation from episodic events."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from ..io_utils import atomic_write_text
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _fact_key(fact: dict[str, Any]) -> str:
+    canonical = json.dumps(fact, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+class SemanticMemoryStore:
+    """Consolidated facts extracted from episodic events."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            atomic_write_text(self.path, "[]")
+
+    def read_facts(self) -> list[dict[str, Any]]:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return []
+        if not isinstance(payload, list):
+            return []
+        return [item for item in payload if isinstance(item, dict)]
+
+    def write_facts(self, facts: list[dict[str, Any]]) -> None:
+        atomic_write_text(self.path, json.dumps(facts, ensure_ascii=False, indent=2) + "\n")
+
+    def extract_facts(self, episodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        extracted: list[dict[str, Any]] = []
+        for episode in episodes:
+            ts = str(episode.get("ts") or _now_iso())
+            for key in ("user_fact", "preference", "constraint"):
+                value = episode.get(key)
+                if isinstance(value, str) and value.strip():
+                    extracted.append(
+                        {
+                            "id": _fact_key({"kind": key, "value": value.strip()}),
+                            "kind": key,
+                            "value": value.strip(),
+                            "first_seen": ts,
+                            "last_seen": ts,
+                            "mentions": 1,
+                            "confidence": 0.6,
+                        }
+                    )
+        return extracted
+
+    def merge_facts(self, new_facts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        current = {fact.get("id"): fact for fact in self.read_facts() if fact.get("id")}
+        for fact in new_facts:
+            fid = fact.get("id")
+            if fid in current:
+                existing = current[fid]
+                mentions = int(existing.get("mentions", 1)) + 1
+                existing["mentions"] = mentions
+                existing["last_seen"] = fact.get("last_seen") or fact.get("first_seen")
+                existing["confidence"] = min(0.99, round(0.5 + mentions * 0.1, 2))
+            else:
+                current[fid] = fact
+        merged = sorted(current.values(), key=lambda item: (str(item.get("kind")), str(item.get("value"))))
+        self.write_facts(merged)
+        return merged
+
+    def consolidate_from_episodes(self, episodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return self.merge_facts(self.extract_facts(episodes))

--- a/tests/test_identity_consolidation_pipeline.py
+++ b/tests/test_identity_consolidation_pipeline.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from singular.identity import ConsolidationPipeline, ConsolidationPolicy, EpisodicStore
+
+
+def test_pipeline_consolidates_facts_and_updates_self_model(tmp_path: Path) -> None:
+    mem = tmp_path / "mem"
+    store = EpisodicStore(mem / "episodic.jsonl")
+    store.append({"event": "identity.created", "summary": "boot"})
+    store.append({"event": "conversation", "user_fact": "user_name:Alice"})
+    store.append({"event": "conversation", "preference": "likes:tea"})
+    store.append({"event": "conversation", "constraint": "prefers:privacy"})
+
+    pipeline = ConsolidationPipeline(
+        mem_dir=mem,
+        policy=ConsolidationPolicy(keep_last_episodes=2, keep_top_self_model_entries=5),
+    )
+    result = pipeline.run()
+
+    assert result.episodes_seen == 4
+    assert result.facts_count == 3
+
+    semantic_payload = (mem / "semantic_memory.json").read_text(encoding="utf-8")
+    assert "likes:tea" in semantic_payload
+
+    self_model_payload = (mem / "self_model.json").read_text(encoding="utf-8")
+    assert "user_name:Alice" in self_model_payload
+    assert "prefers:privacy" in self_model_payload
+
+
+def test_pipeline_compaction_preserves_identity_invariants(tmp_path: Path) -> None:
+    mem = tmp_path / "mem"
+    store = EpisodicStore(mem / "episodic.jsonl")
+    store.append({"event": "identity.created", "summary": "init"})
+    for index in range(6):
+        store.append({"event": "conversation", "summary": f"turn-{index}"})
+
+    pipeline = ConsolidationPipeline(
+        mem_dir=mem,
+        policy=ConsolidationPolicy(keep_last_episodes=2, keep_top_self_model_entries=2),
+    )
+    pipeline.run()
+
+    lines = (mem / "episodic.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    assert "identity.created" in lines[0]


### PR DESCRIPTION
### Motivation
- Centralize identity-related memory management into a dedicated package and enable periodic consolidation from short-term episodic events into durable semantic and self-model stores.
- Provide retention/compaction primitives that avoid accidentally removing identity-critical events or corrupting self-model invariants.

### Description
- Converted `src/singular/identity.py` into a package `src/singular/identity/__init__.py` while preserving the public API functions `create_identity` and `read_identity` and exporting the new components. 
- Added `src/singular/identity/episodic_store.py` implementing a JSONL append-only episodic store with `append`, `read_all`, `truncate_to_rows`, and `compact` that preserves identity events. 
- Added `src/singular/identity/semantic_memory.py` implementing extraction, merging, and persistence of consolidated facts (`semantic_memory.json`) from episodic events. 
- Added `src/singular/identity/self_model.py` implementing a durable self-model for `traits`, `preferences`, and `constraints` with invariant validation and `compact` (top‑N per section). 
- Added `src/singular/identity/consolidation.py` implementing `ConsolidationPipeline` and `ConsolidationPolicy` to run short-term → long-term consolidation (semantic extraction, self-model update+compaction, episodic compaction). 
- Added tests `tests/test_identity_consolidation_pipeline.py` covering fact consolidation and invariant-preserving episodic compaction. 

### Testing
- Ran unit tests with `pytest -q tests/test_identity.py tests/test_identity_consolidation_pipeline.py` and received `4 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e02f9f79f4832aa0ef0e97b9a73bfc)