### PR TITLE
Add identity coherence guard with invariant checks and audit logging

### DIFF
--- a/src/singular/identity/__init__.py
+++ b/src/singular/identity/__init__.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .coherence import CoherenceDecision, IdentityCoherenceGuard, IdentityInvariants, detect_contradictions
 from .consolidation import ConsolidationPipeline, ConsolidationPolicy, ConsolidationResult
 from .episodic_store import EpisodicStore
 from .self_model import IdentityInvariantError, SelfModelStore
@@ -56,8 +57,11 @@ def read_identity(path: Path | str = Path("id.json")) -> Identity:
 
 
 __all__ = [
+    "CoherenceDecision",
     "ConsolidationPipeline",
     "ConsolidationPolicy",
+    "IdentityCoherenceGuard",
+    "IdentityInvariants",
     "ConsolidationResult",
     "EpisodicStore",
     "Identity",
@@ -65,5 +69,6 @@ __all__ = [
     "SemanticMemoryStore",
     "SelfModelStore",
     "create_identity",
+    "detect_contradictions",
     "read_identity",
 ]

--- a/src/singular/identity/coherence.py
+++ b/src/singular/identity/coherence.py
@@ -1,0 +1,226 @@
+"""Identity coherence checks between beliefs, goals, history, and decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from singular.io_utils import append_jsonl_line
+
+_AUDIT_RELATIVE_PATH = Path("mem") / "identity_coherence_audit.jsonl"
+_NEGATION_PREFIXES = (
+    "not ",
+    "no ",
+    "never ",
+    "avoid ",
+    "reject ",
+    "against ",
+)
+
+
+@dataclass(frozen=True)
+class IdentityInvariants:
+    """Non-negotiable long-term identity constraints."""
+
+    life_name: str
+    cardinal_values: tuple[str, ...]
+    long_term_commitments: tuple[str, ...]
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "IdentityInvariants":
+        return cls(
+            life_name=str(payload.get("life_name", "")).strip(),
+            cardinal_values=tuple(_normalize_token(value) for value in payload.get("cardinal_values", []) if str(value).strip()),
+            long_term_commitments=tuple(
+                _normalize_token(value)
+                for value in payload.get("long_term_commitments", [])
+                if str(value).strip()
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class CoherenceDecision:
+    """Decision gate output."""
+
+    status: str
+    accepted: bool
+    reasons: tuple[str, ...]
+    contradictions: tuple[dict[str, str], ...]
+    invariant_violations: tuple[str, ...]
+
+
+class IdentityCoherenceGuard:
+    """Detects drift and guards invariant-breaking decisions."""
+
+    def __init__(
+        self,
+        *,
+        invariants: IdentityInvariants,
+        root: Path | str = Path("."),
+    ) -> None:
+        self.invariants = invariants
+        self.root = Path(root)
+        self.audit_path = self.root / _AUDIT_RELATIVE_PATH
+
+    def evaluate_decision(
+        self,
+        *,
+        decision: dict[str, Any],
+        beliefs: list[dict[str, Any]] | None = None,
+        goals: list[dict[str, Any]] | None = None,
+        history: list[dict[str, Any]] | None = None,
+    ) -> CoherenceDecision:
+        contradictions = detect_contradictions(
+            beliefs=beliefs or [], goals=goals or [], history=history or []
+        )
+        violations = self._check_invariants(decision)
+
+        reasons: list[str] = []
+        status = "allowed"
+        accepted = True
+        if contradictions:
+            status = "degraded"
+            reasons.append("decision degraded: contextual contradictions detected")
+        if violations:
+            status = "blocked"
+            accepted = False
+            reasons.append("decision blocked: identity invariants violated")
+
+        record = CoherenceDecision(
+            status=status,
+            accepted=accepted,
+            reasons=tuple(reasons),
+            contradictions=tuple(contradictions),
+            invariant_violations=tuple(violations),
+        )
+        self._audit_if_needed(decision=decision, record=record)
+        return record
+
+    def _check_invariants(self, decision: dict[str, Any]) -> list[str]:
+        violations: list[str] = []
+        proposed_name = str(decision.get("life_name", "")).strip()
+        if proposed_name and self.invariants.life_name and proposed_name != self.invariants.life_name:
+            violations.append("life_name_mismatch")
+
+        decision_values = {
+            _normalize_token(v)
+            for v in decision.get("values", [])
+            if str(v).strip()
+        }
+        missing_values = [
+            value for value in self.invariants.cardinal_values if value not in decision_values
+        ]
+        if missing_values:
+            violations.append("cardinal_values_missing:" + ",".join(missing_values))
+
+        summary = _normalize_text(
+            " ".join(
+                str(part)
+                for part in (
+                    decision.get("action", ""),
+                    decision.get("summary", ""),
+                    decision.get("rationale", ""),
+                )
+                if str(part).strip()
+            )
+        )
+        for commitment in self.invariants.long_term_commitments:
+            if commitment and _is_negated(summary, commitment):
+                violations.append(f"long_term_commitment_negated:{commitment}")
+        return violations
+
+    def _audit_if_needed(self, *, decision: dict[str, Any], record: CoherenceDecision) -> None:
+        if record.status == "allowed":
+            return
+        append_jsonl_line(
+            self.audit_path,
+            {
+                "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "status": record.status,
+                "accepted": record.accepted,
+                "reasons": list(record.reasons),
+                "contradictions": list(record.contradictions),
+                "invariant_violations": list(record.invariant_violations),
+                "decision": decision,
+            },
+        )
+
+
+def detect_contradictions(
+    *,
+    beliefs: list[dict[str, Any]],
+    goals: list[dict[str, Any]],
+    history: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Detect proposition-level contradictions across beliefs, goals, and history."""
+
+    statements: list[tuple[str, str, bool, str]] = []
+    statements.extend(_extract_statements("belief", beliefs, ("hypothesis", "statement", "name")))
+    statements.extend(_extract_statements("goal", goals, ("name", "objective", "summary")))
+    statements.extend(_extract_statements("history", history, ("summary", "event", "note")))
+
+    by_canonical: dict[str, list[tuple[str, str, bool]]] = {}
+    for source, text, positive, canonical in statements:
+        if not canonical:
+            continue
+        by_canonical.setdefault(canonical, []).append((source, text, positive))
+
+    contradictions: list[dict[str, str]] = []
+    for canonical, variants in by_canonical.items():
+        positives = [item for item in variants if item[2]]
+        negatives = [item for item in variants if not item[2]]
+        if positives and negatives:
+            contradictions.append(
+                {
+                    "canonical": canonical,
+                    "positive": f"{positives[0][0]}:{positives[0][1]}",
+                    "negative": f"{negatives[0][0]}:{negatives[0][1]}",
+                }
+            )
+    return contradictions
+
+
+def _extract_statements(
+    source: str,
+    payloads: list[dict[str, Any]],
+    keys: tuple[str, ...],
+) -> list[tuple[str, str, bool, str]]:
+    rows: list[tuple[str, str, bool, str]] = []
+    for item in payloads:
+        for key in keys:
+            raw = str(item.get(key, "")).strip()
+            if not raw:
+                continue
+            positive, canonical = _canonicalize_statement(raw)
+            rows.append((source, raw, positive, canonical))
+            break
+    return rows
+
+
+def _canonicalize_statement(value: str) -> tuple[bool, str]:
+    lowered = _normalize_text(value)
+    for prefix in _NEGATION_PREFIXES:
+        if lowered.startswith(prefix):
+            return False, lowered[len(prefix) :].strip()
+    return True, lowered
+
+
+def _is_negated(summary: str, commitment: str) -> bool:
+    for prefix in _NEGATION_PREFIXES:
+        if f"{prefix}{commitment}" in summary:
+            return True
+    return False
+
+
+def _normalize_text(value: str) -> str:
+    cleaned = " ".join(str(value).strip().lower().split())
+    for punctuation in ",.;:!?()[]{}\"'":
+        cleaned = cleaned.replace(punctuation, "")
+    return cleaned
+
+
+def _normalize_token(value: Any) -> str:
+    return _normalize_text(str(value))

--- a/tests/test_identity_coherence.py
+++ b/tests/test_identity_coherence.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+
+from singular.identity import IdentityCoherenceGuard, IdentityInvariants, detect_contradictions
+
+
+def test_detect_contradictions_between_beliefs_goals_and_history() -> None:
+    contradictions = detect_contradictions(
+        beliefs=[{"hypothesis": "prefer safe mode"}],
+        goals=[{"name": "not prefer safe mode"}],
+        history=[{"summary": "prefer safe mode"}],
+    )
+
+    assert len(contradictions) == 1
+    assert contradictions[0]["canonical"] == "prefer safe mode"
+
+
+def test_guard_blocks_invariant_violation_and_audits_gap(tmp_path: Path) -> None:
+    guard = IdentityCoherenceGuard(
+        invariants=IdentityInvariants(
+            life_name="Singular",
+            cardinal_values=("integrity", "care"),
+            long_term_commitments=("protect memory",),
+        ),
+        root=tmp_path,
+    )
+
+    decision = guard.evaluate_decision(
+        decision={
+            "life_name": "OtherName",
+            "values": ["integrity"],
+            "action": "not protect memory",
+            "summary": "rename and purge long-term traces",
+        },
+        beliefs=[{"hypothesis": "protect memory"}],
+        goals=[{"name": "not protect memory"}],
+        history=[{"summary": "protect memory"}],
+    )
+
+    assert decision.accepted is False
+    assert decision.status == "blocked"
+    assert "life_name_mismatch" in decision.invariant_violations
+    assert any("cardinal_values_missing" in item for item in decision.invariant_violations)
+    assert any("long_term_commitment_negated" in item for item in decision.invariant_violations)
+
+    audit_path = tmp_path / "mem" / "identity_coherence_audit.jsonl"
+    entries = [json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()]
+    assert len(entries) == 1
+    assert entries[0]["status"] == "blocked"
+    assert entries[0]["accepted"] is False
+
+
+def test_guard_recovers_after_drift_with_compliant_decision(tmp_path: Path) -> None:
+    guard = IdentityCoherenceGuard(
+        invariants=IdentityInvariants.from_payload(
+            {
+                "life_name": "Singular",
+                "cardinal_values": ["integrity", "care"],
+                "long_term_commitments": ["protect memory"],
+            }
+        ),
+        root=tmp_path,
+    )
+
+    drifted = guard.evaluate_decision(
+        decision={
+            "life_name": "Singular",
+            "values": ["integrity", "care"],
+            "summary": "not protect memory",
+        },
+        beliefs=[{"hypothesis": "protect memory"}],
+        goals=[{"objective": "not protect memory"}],
+        history=[{"summary": "protect memory"}],
+    )
+    assert drifted.accepted is False
+    assert drifted.status == "blocked"
+
+    recovered = guard.evaluate_decision(
+        decision={
+            "life_name": "Singular",
+            "values": ["integrity", "care"],
+            "summary": "protect memory with redundant backups",
+        },
+        beliefs=[{"hypothesis": "protect memory"}],
+        goals=[{"objective": "protect memory"}],
+        history=[{"summary": "protect memory"}],
+    )
+    assert recovered.accepted is True
+    assert recovered.status == "allowed"
+
+    audit_path = tmp_path / "mem" / "identity_coherence_audit.jsonl"
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1


### PR DESCRIPTION
### Motivation
- Introduce automated coherence checks to detect drift between beliefs, goals, history and decisions and prevent identity-corrupting actions.
- Provide a small, auditable gate that enforces long-term identity invariants such as life name, cardinal values and long-term commitments.

### Description
- Add `src/singular/identity/coherence.py` implementing `IdentityInvariants`, `CoherenceDecision`, `IdentityCoherenceGuard`, and `detect_contradictions` to detect contradictions and validate decisions against invariants.
- Decisions are classified as `allowed`, `degraded` (contextual contradictions) or `blocked` (invariant violations) and blocked decisions return reasons and invariant violation codes.
- Audit records for degraded/blocked decisions are appended to `mem/identity_coherence_audit.jsonl` using `append_jsonl_line` (path is relative to the provided `root`).
- Export the new coherence primitives from the package via `src/singular/identity/__init__.py` and add tests in `tests/test_identity_coherence.py` covering contradiction detection, blocking+audit on invariant violation, and recovery after drift.

### Testing
- Ran `pytest -q tests/test_identity_coherence.py tests/test_identity.py tests/test_identity_consolidation_pipeline.py` and all tests passed.
- Test run summary: `7 passed in 0.24s` which includes the new coherence tests verifying audit file creation and decision outcomes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0309fe598832a8a366c889d4d9c80)