### PR TITLE
Add persistent world state and simple effectors, integrate into life loop

### DIFF
--- a/src/singular/life/effectors/__init__.py
+++ b/src/singular/life/effectors/__init__.py
@@ -1,0 +1,3 @@
+from .core import EffectResult, perform_action
+
+__all__ = ["EffectResult", "perform_action"]

--- a/src/singular/life/effectors/core.py
+++ b/src/singular/life/effectors/core.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Mapping
+
+@dataclass(slots=True)
+class EffectResult:
+    action: str
+    success: bool
+    energy_delta: float = 0.0
+    health_delta: float = 0.0
+    mortality_delta: float = 0.0
+    world_delta: dict[str, float] = field(default_factory=dict)
+    delayed_penalties: list[dict[str, float | int]] = field(default_factory=list)
+    metadata: dict[str, object] = field(default_factory=dict)
+
+def perform_action(action: str, context: Mapping[str, object] | None = None) -> EffectResult:
+    payload = dict(context or {})
+    risk = float(payload.get('risk', 0.0))
+    rarity_pressure = float(payload.get('rarity_pressure', 0.0))
+    success_bias = float(payload.get('success_bias', 0.0))
+    if action == 'resource_management':
+        eff = max(0.0, min(1.0, 0.6 + success_bias - rarity_pressure * 0.1))
+        return EffectResult(action, eff >= 0.5, energy_delta=0.2*eff, health_delta=0.1*eff, world_delta={'rarity': -0.05*eff, 'opportunities': 0.03*eff}, delayed_penalties=[{'ticks': 3, 'energy_delta': -0.1*(1.0-eff)}], metadata={'efficiency': eff})
+    if action == 'structured_user_interaction':
+        q = max(0.0, min(1.0, 0.5 + success_bias - risk * 0.2))
+        return EffectResult(action, q >= 0.45, energy_delta=0.05, health_delta=0.08*q, world_delta={'reputation': 0.06*q, 'opportunities': 0.02*q}, delayed_penalties=[{'ticks': 2, 'mortality_delta': 0.01*max(0.0, risk-q)}], metadata={'interaction_quality': q})
+    impact = max(0.0, min(1.0, 0.55 + success_bias - risk * 0.15))
+    return EffectResult(action, impact >= 0.5, energy_delta=0.1*impact, health_delta=0.05*impact, mortality_delta=-0.01*impact, world_delta={'risks': -0.04*impact, 'opportunities': 0.04*impact}, delayed_penalties=[{'ticks': 4, 'health_delta': -0.08*(1.0-impact)}], metadata={'world_impact': impact})

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -42,6 +42,8 @@ from singular.environment.world_resources import CompetitorIntent, WorldResource
 from singular.goals import IntrinsicGoals
 from singular.resource_manager import ResourceManager
 from singular.lives import load_registry, set_life_status
+from singular.life.effectors import perform_action
+from singular.life.world_state import PersistentWorldState
 
 from . import sandbox
 from .death import DeathMonitor
@@ -814,6 +816,8 @@ def run(
         health_tracker = HealthTracker.from_state(state.health_counters)
         delayed: list[tuple[float, str, Path]] = []
         tick_count = 0
+        persistent_world_state_path = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_state.lifecycle.json"
+        persistent_world_state = PersistentWorldState.load(persistent_world_state_path)
         while time.time() - start < budget_seconds:
             if max_iterations is not None and tick_count >= max_iterations:
                 break
@@ -859,6 +863,11 @@ def run(
                 if hasattr(psyche, "irrational_decision"):
                     decision = psyche.irrational_decision(rng)
             selected_org = world.organisms[org_name]
+            for penalty in persistent_world_state.consume_due_penalties(state.iteration):
+                selected_org.energy += penalty.energy_delta
+                persistent_world_state.mortality_pressure = max(
+                    0.0, persistent_world_state.mortality_pressure + penalty.mortality_delta
+                )
             if selected_org.degraded_mode and state.iteration % DEGRADED_MUTATION_INTERVAL != 0:
                 logger.log_interaction(
                     "degraded_mode_throttle",
@@ -1369,6 +1378,27 @@ def run(
                     )
                 )
 
+            action_name = "simulated_world_task" if accepted else "structured_user_interaction"
+            if action_resolution.granted:
+                action_name = "resource_management"
+            effect_result = perform_action(
+                action_name,
+                {
+                    "risk": persistent_world_state.risks,
+                    "rarity_pressure": persistent_world_state.rarity,
+                    "success_bias": 0.2 if accepted else -0.2,
+                },
+            )
+            selected_org.energy += effect_result.energy_delta
+            persistent_world_state.mortality_pressure = max(
+                0.0,
+                persistent_world_state.mortality_pressure + effect_result.mortality_delta,
+            )
+            persistent_world_state.apply_world_delta(effect_result.world_delta)
+            persistent_world_state.schedule_penalties(
+                state.iteration, effect_result.delayed_penalties
+            )
+
             for other in world.organisms.values():
                 other.energy = max(0.1, other.energy - ecosystem_rules.passive_energy_decay)
                 other.resources = max(
@@ -1570,8 +1600,11 @@ def run(
                 state.iteration,
                 psyche,
                 action_succeeded=accepted,
-                resources=org.resources,
+                resources=max(0.0, org.resources - persistent_world_state.rarity),
             )
+            if persistent_world_state.mortality_pressure > 0.35:
+                dead = True
+                reason = reason or "world_mortality_pressure"
             if dead and reason == "too many failures":
                 can_extinguish = (
                     org.sandbox_violation_streak >= SANDBOX_EXTINCTION_THRESHOLD
@@ -1758,6 +1791,7 @@ def run(
                     world.reproduction_cooldowns.pop(name, None)
                 else:
                     world.reproduction_cooldowns[name] = remaining
+            persistent_world_state.save(persistent_world_state_path)
             tick_count += 1
 
     for org in world.organisms.values():

--- a/src/singular/life/world_state.py
+++ b/src/singular/life/world_state.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+@dataclass
+class DeferredPenalty:
+    due_tick: int
+    energy_delta: float = 0.0
+    health_delta: float = 0.0
+    mortality_delta: float = 0.0
+
+@dataclass
+class PersistentWorldState:
+    rarity: float = 0.5
+    reputation: float = 0.5
+    risks: float = 0.5
+    opportunities: float = 0.5
+    mortality_pressure: float = 0.0
+    deferred_penalties: list[DeferredPenalty] = field(default_factory=list)
+    @classmethod
+    def load(cls, path: Path) -> 'PersistentWorldState':
+        if not path.exists():
+            return cls()
+        payload = json.loads(path.read_text(encoding='utf-8'))
+        return cls(
+            rarity=float(payload.get('rarity', 0.5)),
+            reputation=float(payload.get('reputation', 0.5)),
+            risks=float(payload.get('risks', 0.5)),
+            opportunities=float(payload.get('opportunities', 0.5)),
+            mortality_pressure=float(payload.get('mortality_pressure', 0.0)),
+            deferred_penalties=[DeferredPenalty(**item) for item in payload.get('deferred_penalties', [])],
+        )
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), ensure_ascii=False, indent=2), encoding='utf-8')
+    def to_dict(self) -> dict[str, object]:
+        return {'rarity': self.rarity, 'reputation': self.reputation, 'risks': self.risks, 'opportunities': self.opportunities, 'mortality_pressure': self.mortality_pressure, 'deferred_penalties': [p.__dict__ for p in self.deferred_penalties]}
+    def apply_world_delta(self, world_delta: dict[str, float]) -> None:
+        self.rarity = max(0.0, min(1.0, self.rarity + world_delta.get('rarity', 0.0)))
+        self.reputation = max(0.0, min(1.0, self.reputation + world_delta.get('reputation', 0.0)))
+        self.risks = max(0.0, min(1.0, self.risks + world_delta.get('risks', 0.0)))
+        self.opportunities = max(0.0, min(1.0, self.opportunities + world_delta.get('opportunities', 0.0)))
+    def schedule_penalties(self, current_tick: int, delayed_penalties: list[dict[str, float | int]]) -> None:
+        for penalty in delayed_penalties:
+            self.deferred_penalties.append(DeferredPenalty(due_tick=current_tick + max(1, int(penalty.get('ticks', 0))), energy_delta=float(penalty.get('energy_delta', 0.0)), health_delta=float(penalty.get('health_delta', 0.0)), mortality_delta=float(penalty.get('mortality_delta', 0.0))))
+    def consume_due_penalties(self, current_tick: int) -> list[DeferredPenalty]:
+        due = [p for p in self.deferred_penalties if p.due_tick <= current_tick]
+        self.deferred_penalties = [p for p in self.deferred_penalties if p.due_tick > current_tick]
+        return due


### PR DESCRIPTION
### Motivation

- Model persistent world-level state (rarity, risks, mortality pressure) and deferred penalties across ticks to influence organism outcomes.
- Provide a small effectors API to resolve high-level actions into energy/health/mortality/world deltas and delayed penalties. 
- Integrate world effects and deferred penalties into the main life `run` loop so actions change both organisms and the global world state.

### Description

- Add `singular.life.effectors.core` with `EffectResult` dataclass and `perform_action` function that computes effect deltas for named actions. 
- Add `singular.life.world_state` with `PersistentWorldState` and `DeferredPenalty` types and methods `load`, `save`, `to_dict`, `apply_world_delta`, `schedule_penalties`, and `consume_due_penalties`. 
- Update `singular.life.loop.run` to load and save the persistent world state, consume due penalties before action selection, call `perform_action` to resolve action effects, apply resulting deltas to `selected_org.energy` and the persistent world state, schedule delayed penalties, and incorporate `rarity`/`mortality_pressure` into death checks and resource calculations. 
- Export `EffectResult` and `perform_action` from `singular.life.effectors.__init__`.

### Testing

- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4bb30bfec832ab5529ff777ad12d2)