### PR TITLE
Extraire signaux narratifs pour le planificateur et feedback de blessure identitaire

### DIFF
--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -155,6 +155,7 @@ class IntrinsicGoals:
         host_environmental_pressure = 0.0
         host_environmental_variance = 0.0
         narrative = (perception_signals or {}).get("narrative_indicators")
+        planner_narrative = (perception_signals or {}).get("planner_narrative_signals")
         execution_history = (perception_signals or {}).get("execution_history")
         risk_aversion = 0.0
         accumulated_confidence = 0.5
@@ -163,6 +164,11 @@ class IntrinsicGoals:
         repeated_failure_pressure = 0.0
         delayed_crisis_pressure = 0.0
         delayed_opportunity_pressure = 0.0
+        narrative_coherence = 0.5
+        narrative_regret = 0.0
+        narrative_pride = 0.0
+        identity_drift = 0.0
+        identity_wounds = _clamp(_as_float(getattr(psyche, "identity_wounds", 0.0), default=0.0)) if psyche else 0.0
         if isinstance(narrative, Mapping):
             risk_aversion = _mean_mapping_value(narrative.get("risk_aversion_by_action_family"))
             confidence_map = narrative.get("accumulated_confidence_by_action_family")
@@ -176,6 +182,11 @@ class IntrinsicGoals:
             repeated_failure_pressure = _clamp(
                 _as_float(execution_history.get("repeated_failure_pressure", 0.0), default=0.0)
             )
+        if isinstance(planner_narrative, Mapping):
+            narrative_coherence = _clamp(_as_float(planner_narrative.get("coherence_signal", 0.5), default=0.5))
+            narrative_regret = _clamp(_as_float(planner_narrative.get("regret_pressure", 0.0), default=0.0))
+            narrative_pride = _clamp(_as_float(planner_narrative.get("pride_drive", 0.0), default=0.0))
+            identity_drift = _clamp(_as_float(planner_narrative.get("identity_drift", 0.0), default=0.0))
         world_events = (perception_signals or {}).get("world_events")
         if isinstance(world_events, list):
             total_events = float(len(world_events))
@@ -251,6 +262,7 @@ class IntrinsicGoals:
             + 0.25 * resilience
             + 0.2 * telemetry_quality_pressure
             + 0.15 * (1.0 - repeated_failure_pressure),
+            # narrative-sensitive pressure
             robustesse=0.2
             + 0.35 * (1.0 - health_norm)
             + 0.25 * (1.0 - resource_stability)
@@ -284,6 +296,10 @@ class IntrinsicGoals:
             - 0.25 * risk_aversion
             - 0.18 * repeated_failure_pressure,
         )
+        base_weights.coherence += (0.25 * narrative_coherence) + (0.12 * narrative_pride) - (0.2 * identity_drift)
+        base_weights.robustesse += (0.2 * narrative_regret) + (0.25 * identity_wounds)
+        base_weights.efficacite += (0.12 * narrative_pride) - (0.1 * narrative_regret)
+        base_weights.exploration -= (0.15 * narrative_regret) + (0.2 * identity_wounds)
         modulation = apply_perception_rules(perception_signals)
         deltas = modulation["deltas"]
         weights = GoalWeights(
@@ -311,6 +327,11 @@ class IntrinsicGoals:
                     "host_environmental_variance": host_environmental_variance,
                     "narrative_risk_aversion": risk_aversion,
                     "narrative_accumulated_confidence": accumulated_confidence,
+                    "narrative_coherence": narrative_coherence,
+                    "narrative_regret": narrative_regret,
+                    "narrative_pride": narrative_pride,
+                    "identity_drift": identity_drift,
+                    "identity_wounds": identity_wounds,
                     "injuries_pressure": injuries_pressure,
                     "success_boost": success_boost,
                     "repeated_failure_pressure": repeated_failure_pressure,
@@ -489,6 +510,7 @@ class IntrinsicGoals:
         self,
         operator_stats: Mapping[str, Mapping[str, float]],
         skill_reputation: Mapping[str, Mapping[str, float | int]] | None = None,
+        planner_narrative_signals: Mapping[str, Any] | None = None,
     ) -> dict[str, float]:
         """Return per-operator biases using objective weights and usage telemetry."""
 
@@ -512,6 +534,8 @@ class IntrinsicGoals:
         reputation_failure_penalty = _clamp(reputation_failures / max(reputation_samples, 1.0) / 3.0, 0.0, 1.0)
 
         biases: dict[str, float] = {}
+        coherence_bonus = _clamp(_as_float((planner_narrative_signals or {}).get("coherence_signal", 0.0), default=0.0))
+        dissonance_malus = _clamp(_as_float((planner_narrative_signals or {}).get("dissonance_signal", 0.0), default=0.0))
         for name, stats in operator_stats.items():
             count = float(stats.get("count", 0.0))
             reward = float(stats.get("reward", 0.0))
@@ -527,4 +551,6 @@ class IntrinsicGoals:
                 resource_cost=_clamp((count / max_count) * 0.6 + mean_reputation_cost * 0.4),
                 novelty=exploration_signal,
             ) + self.state.weights.efficacite * efficiency_signal + self.state.weights.coherence * telemetry_alignment
+            biases[name] += (self.state.weights.coherence * 0.2 * coherence_bonus)
+            biases[name] -= (self.state.weights.robustesse * 0.25 * dissonance_malus)
         return biases

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -40,6 +40,7 @@ from singular.environment import sim_world
 from singular.environment.reputation import ReputationSystem
 from singular.environment.world_resources import CompetitorIntent, WorldResourcePool
 from singular.goals import IntrinsicGoals
+from singular import self_narrative
 from singular.resource_manager import ResourceManager
 from singular.resource_manager import CapabilityStatus
 from singular.life.metabolism.rewards import RewardContribution, apply_rewards
@@ -958,6 +959,7 @@ def run(
                 continue
 
             policy = psyche.mutation_policy()
+            planner_narrative_signals = self_narrative.extract_planner_signals()
             last_health = (
                 float(state.health_history[-1].get("score", 50.0))
                 if state.health_history
@@ -974,7 +976,7 @@ def run(
                     "ecological_debt": resource_manager.ecological_debt,
                     "relational_debt": resource_manager.relational_debt,
                 },
-                perception_signals=signals,
+                perception_signals={**signals, "planner_narrative_signals": planner_narrative_signals},
             )
             baseline_failure_risk = (
                 float(state.health_counters.get("sandbox_failures", 0))
@@ -1038,6 +1040,7 @@ def run(
             combined_bias = intrinsic_goals.influence_operator_scores(
                 stats,
                 skill_reputation=logger.skill_reputation(),
+                planner_narrative_signals=planner_narrative_signals,
             )
             psyche_bias = getattr(psyche, "operator_bias", lambda names: {})(list(operators.keys()))
             for operator_name, extra_bias in belief_bias.items():
@@ -1106,6 +1109,29 @@ def run(
             elif mutated_score <= base_score:
                 if hasattr(psyche, "feel"):
                     psyche.feel(Mood.PLEASURE)
+
+            identity_violations: list[str] = []
+            commitments = getattr(psyche, "identity_commitments", {})
+            red_lines = commitments.get("red_lines", []) if isinstance(commitments, Mapping) else []
+            for red_line in red_lines:
+                token = str(red_line).strip().lower()
+                if token and token in f"{op_name} {reflection.decision_reason}".lower():
+                    identity_violations.append(token)
+            if identity_violations:
+                psyche.identity_wounds = min(1.0, float(getattr(psyche, "identity_wounds", 0.0)) + 0.15 * len(identity_violations))
+
+            _write_json(
+                Path("mem") / "decision_signal_audit.json",
+                {
+                    "iteration": state.iteration,
+                    "operator": op_name,
+                    "planner_narrative_signals": planner_narrative_signals,
+                    "weights_after": asdict(goal_weights),
+                    "combined_bias_after": combined_bias,
+                    "identity_violations": identity_violations,
+                    "identity_wounds": float(getattr(psyche, "identity_wounds", 0.0)),
+                },
+            )
 
             diff = "".join(
                 difflib.unified_diff(

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -89,6 +89,13 @@ class Psyche:
     social_states: Dict[str, Dict[str, float]] = field(default_factory=dict)
     schema_version: int = field(default=3, init=False)
     mood_history: list[str] = field(default_factory=list)
+    identity_commitments: dict[str, list[str]] = field(
+        default_factory=lambda: {
+            "values": ["coherence", "safety", "utility"],
+            "red_lines": ["harm_user", "silent_data_loss"],
+        }
+    )
+    identity_wounds: float = 0.0
 
     # ``last_mood`` is updated every time :meth:`feel` is called and can be
     # queried by other subsystems (interaction and mutation policies).
@@ -582,6 +589,8 @@ class Psyche:
                 for target, values in self.social_states.items()
                 if isinstance(values, dict)
             },
+            "identity_commitments": self.identity_commitments,
+            "identity_wounds": float(self.identity_wounds),
         }
         if self.objectives:
             state["objectives"] = {
@@ -661,6 +670,11 @@ class Psyche:
                 if isinstance(values, dict)
             },
             mood_history=[str(entry) for entry in mood_history[-256:]],
+            identity_commitments={
+                "values": [str(v) for v in data.get("identity_commitments", {}).get("values", ["coherence", "safety", "utility"])],
+                "red_lines": [str(v) for v in data.get("identity_commitments", {}).get("red_lines", ["harm_user", "silent_data_loss"])],
+            },
+            identity_wounds=_clamp(float(data.get("identity_wounds", 0.0))),
         )
         mood_val = data.get("last_mood")
         psyche.last_mood = Mood(mood_val) if mood_val else None

--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -69,6 +69,36 @@ class SelfNarrative:
         return payload
 
 
+def extract_planner_signals(narrative: SelfNarrative | None = None) -> dict[str, Any]:
+    """Extract planner-ready narrative signals from the persistent story."""
+
+    current = narrative or load()
+    regrets = current.regrets_and_pride
+    failures = len(regrets.significant_failures)
+    incidents = len(regrets.costly_incidents)
+    successes = len(regrets.significant_successes)
+    abandoned = len(regrets.abandoned_skills)
+    drift = sum(1 for trend in current.trait_trends.values() if trend.trend in {"up", "down"})
+    coherence = max(0.0, min(1.0, 1.0 - ((failures + incidents + abandoned) / max(1.0, successes + failures + 1.0))))
+    regret_pressure = max(0.0, min(1.0, (failures + incidents + abandoned) / 12.0))
+    pride_drive = max(0.0, min(1.0, successes / 12.0))
+    identity_drift = max(0.0, min(1.0, drift / max(1.0, len(current.trait_trends))))
+    dissonance = max(0.0, min(1.0, regret_pressure * 0.6 + identity_drift * 0.4 - pride_drive * 0.3))
+    return {
+        "coherence_signal": coherence,
+        "regret_pressure": regret_pressure,
+        "pride_drive": pride_drive,
+        "identity_drift": identity_drift,
+        "dissonance_signal": dissonance,
+        "counts": {
+            "successes": successes,
+            "failures": failures,
+            "abandoned": abandoned,
+            "incidents": incidents,
+        },
+    }
+
+
 def _default_trait_trends() -> dict[str, TraitTrend]:
     return {key: TraitTrend() for key in _TRAIT_KEYS}
 


### PR DESCRIPTION
### Motivation
- Fournir au planificateur des signaux narratifs structurés (cohérence, regrets, fierté, drift identitaire, dissonance) dérivés de la mémoire `self_narrative` pour modulation des objectifs et du scoring des opérateurs.
- Injecter ces signaux dans la modulation dynamique des pondérations intrinsèques et appliquer des bonus/malus au scoring des opérateurs pour améliorer la cohérence comportementale.
- Introduire des engagements identitaires persistants (valeurs / lignes rouges) et un mécanisme de « blessure identitaire » durable quand ces lignes sont violées, afin d’influencer les priorités futures.

### Description
- Ajout de `extract_planner_signals` dans `src/singular/self_narrative.py` qui calcule et renvoie des signaux quantifiés (`coherence_signal`, `regret_pressure`, `pride_drive`, `identity_drift`, `dissonance_signal`) et des compteurs associés.
- Extension de `IntrinsicGoals.update_tick` et de sa logique interne dans `src/singular/goals/intrinsic.py` pour consommer `planner_narrative_signals`, intégrer `identity_wounds` et ajuster `base_weights` avant application des `perception_rules`.
- Modification de `IntrinsicGoals.influence_operator_scores` pour accepter `planner_narrative_signals` et appliquer un `coherence_bonus` et un `dissonance_malus` lors du calcul des biais par opérateur.
- Ajout dans `src/singular/psyche.py` des champs persistés `identity_commitments` (avec `values` et `red_lines`) et `identity_wounds`, ainsi que de leur sérialisation/désérialisation dans `save_state` / `load_state`.
- Intégration dans la boucle évolutive `src/singular/life/loop.py` pour extraire les signaux via `self_narrative.extract_planner_signals()`, les injecter dans `IntrinsicGoals.update_tick`, appliquer une détection de violation des `red_lines`, incrémenter durablement `psyche.identity_wounds` et journaliser un audit décisionnel JSON (`mem/decision_signal_audit.json`) contenant signaux et pondérations après modulation.

### Testing
- Compilation statique des modules modifiés réalisée avec `python -m compileall src/singular/self_narrative.py src/singular/goals/intrinsic.py src/singular/psyche.py src/singular/life/loop.py` et réussie (pas d'erreur de syntaxe).
- Aucun test unitaire additionnel automatisé n'a été ajouté dans cette PR; changements limités à extraction de signaux, modulation et journalisation pour permettre tests d'intégration ultérieurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7360db328832a85ed23a65b9d7f62)