### PR TITLE
Add internal signal-driven quests and hierarchical objectives manager

### DIFF
--- a/src/singular/goals/quest_generation.py
+++ b/src/singular/goals/quest_generation.py
@@ -46,6 +46,7 @@ def generate_quests(
     value_performance_tension: Mapping[str, Any] | float | None,
     world_state: Mapping[str, Any] | None,
     resources: Mapping[str, Any] | None,
+    surprise_signals: Mapping[str, Any] | None = None,
 ) -> list[GeneratedQuest]:
     """Generate candidate quests from psyche, history, tensions, and world/resources."""
 
@@ -74,6 +75,11 @@ def generate_quests(
     opportunity = _clamp(_as_float(world.get("opportunity_pressure", 0.0), default=0.0))
 
     generated: list[GeneratedQuest] = []
+    surprise = surprise_signals or {}
+    surprise_level = _clamp(_as_float(surprise.get("surprise", 0.0), default=0.0))
+    frustration_level = _clamp(_as_float(surprise.get("frustration", 0.0), default=0.0))
+    curiosity_spike = _clamp(_as_float(surprise.get("curiosity", curiosity), default=curiosity))
+    repeated_operator_failures = _clamp(_as_float(surprise.get("operator_family_failure_pressure", 0.0), default=0.0))
 
     if tension >= 0.45:
         generated.append(
@@ -95,6 +101,23 @@ def generate_quests(
                 rationale="Historique récent orienté vers l'échec.",
                 origin="intrinsic",
                 priority=_clamp(0.4 + failure_pressure * 0.5 + (1.0 - resilience) * 0.2),
+            )
+        )
+
+    internal_quest_pressure = _clamp(
+        (surprise_level * 0.3)
+        + (frustration_level * 0.35)
+        + (curiosity_spike * 0.15)
+        + (repeated_operator_failures * 0.4)
+    )
+    if internal_quest_pressure >= 0.3:
+        generated.append(
+            GeneratedQuest(
+                name="probe_operator_failure_cluster",
+                objective="Diagnostiquer les échecs récurrents d'une famille d'opérateurs.",
+                rationale="Signaux internes surprise/frustration/curiosité indiquent un blocage durable.",
+                origin="intrinsic",
+                priority=_clamp(0.4 + internal_quest_pressure * 0.55),
             )
         )
 

--- a/src/singular/life/metabolism/rewards.py
+++ b/src/singular/life/metabolism/rewards.py
@@ -10,6 +10,7 @@ class RewardContribution:
     resolved_quests: int = 0
     tech_debt_delta: float = 0.0
     user_satisfaction: float = 0.0
+    meta_objective_penalty: float = 0.0
 
 
 def apply_rewards(resource_manager: ResourceManager, contribution: RewardContribution) -> None:
@@ -23,5 +24,10 @@ def apply_rewards(resource_manager: ResourceManager, contribution: RewardContrib
         resource_manager.relational_debt = max(0.0, resource_manager.relational_debt - reduction * 0.5)
     if contribution.user_satisfaction > 0:
         resource_manager.add_warmth(min(10.0, contribution.user_satisfaction * 8.0))
+    if contribution.meta_objective_penalty > 0:
+        penalty = min(12.0, contribution.meta_objective_penalty)
+        resource_manager.consume_energy(penalty)
+        resource_manager.consume_food(penalty * 0.35)
+        resource_manager.cool_down(penalty * 0.25)
     resource_manager._clamp()
     resource_manager._save()

--- a/src/singular/motivation.py
+++ b/src/singular/motivation.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Any
+
+from singular.memory import _atomic_write_text
 
 
 @dataclass
@@ -52,3 +57,81 @@ class GoalPolicy:
 
 def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
     return max(low, min(high, value))
+
+
+@dataclass
+class HierarchicalObjectivesState:
+    immediate: dict[str, float] = field(default_factory=dict)
+    meta: dict[str, float] = field(
+        default_factory=lambda: {
+            "future_learning_capacity": 0.5,
+            "skills_diversity": 0.5,
+            "technical_debt_control": 0.5,
+        }
+    )
+    meta_failure_streak: int = 0
+
+
+class HierarchicalObjectivesManager:
+    """Persist and revise immediate/meta goals under perturbations and interruptions."""
+
+    def __init__(self, *, path: Path) -> None:
+        self.path = path
+        self.state = self._load()
+
+    def _load(self) -> HierarchicalObjectivesState:
+        if not self.path.exists():
+            return HierarchicalObjectivesState()
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError, TypeError):
+            return HierarchicalObjectivesState()
+        if not isinstance(payload, dict):
+            return HierarchicalObjectivesState()
+        immediate = payload.get("immediate", {})
+        meta = payload.get("meta", {})
+        return HierarchicalObjectivesState(
+            immediate=dict(immediate) if isinstance(immediate, dict) else {},
+            meta={**HierarchicalObjectivesState().meta, **(meta if isinstance(meta, dict) else {})},
+            meta_failure_streak=int(payload.get("meta_failure_streak", 0) or 0),
+        )
+
+    def _save(self) -> None:
+        _atomic_write_text(
+            self.path,
+            json.dumps(
+                {
+                    "immediate": self.state.immediate,
+                    "meta": self.state.meta,
+                    "meta_failure_streak": self.state.meta_failure_streak,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )
+
+    def revise(self, *, perturbation: dict[str, Any] | None = None) -> HierarchicalObjectivesState:
+        perturbation = perturbation or {}
+        interruption_pressure = _clamp(float(perturbation.get("interruption_pressure", 0.0) or 0.0))
+        for key, value in list(self.state.immediate.items()):
+            self.state.immediate[key] = max(0.0, float(value) * (1.0 - (0.15 * interruption_pressure)))
+        for key, value in list(self.state.meta.items()):
+            decay = 0.03 if interruption_pressure < 0.35 else 0.01
+            self.state.meta[key] = _clamp(float(value) * (1.0 - decay))
+        self._save()
+        return self.state
+
+    def register_meta_outcome(self, *, success: bool) -> int:
+        self.state.meta_failure_streak = 0 if success else self.state.meta_failure_streak + 1
+        self._save()
+        return self.state.meta_failure_streak
+
+    def graded_vital_penalty(self) -> float:
+        streak = max(0, int(self.state.meta_failure_streak))
+        if streak < 2:
+            return 0.0
+        if streak < 4:
+            return 1.5
+        if streak < 7:
+            return 3.0
+        return 5.0

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,5 +1,5 @@
 from singular.psyche import Psyche, Mood
-from singular.motivation import GoalPolicy, Objective
+from singular.motivation import GoalPolicy, Objective, HierarchicalObjectivesManager
 from singular.goals.intrinsic import IntrinsicGoals
 
 
@@ -260,3 +260,14 @@ def test_intrinsic_goals_raise_robustesse_under_eco_relational_debt(tmp_path) ->
 
     assert pressured.robustesse > baseline.robustesse
     assert pressured.exploration < baseline.exploration
+
+
+def test_hierarchical_objectives_persist_and_penalize_meta_failure(tmp_path) -> None:
+    manager = HierarchicalObjectivesManager(path=tmp_path / "hierarchical_goals.json")
+    manager.state.immediate = {"ship_fix": 1.0}
+    manager.revise(perturbation={"interruption_pressure": 0.9})
+    assert manager.state.immediate["ship_fix"] < 1.0
+
+    manager.register_meta_outcome(success=False)
+    manager.register_meta_outcome(success=False)
+    assert manager.graded_vital_penalty() > 0.0

--- a/tests/test_quest_generation.py
+++ b/tests/test_quest_generation.py
@@ -27,3 +27,21 @@ def test_generate_quests_returns_empty_for_stable_state() -> None:
     )
 
     assert quests == []
+
+
+def test_generate_quests_adds_internal_probe_from_surprise_frustration() -> None:
+    quests = generate_quests(
+        psyche_traits={"resilience": 0.5, "optimism": 0.5, "curiosity": 0.5},
+        outcomes_history={"recent_successes": 2, "recent_failures": 2},
+        value_performance_tension=0.0,
+        world_state={"delayed_crisis_pressure": 0.1, "opportunity_pressure": 0.1},
+        resources={"energy": 70, "food": 70, "warmth": 70},
+        surprise_signals={
+            "surprise": 0.7,
+            "frustration": 0.8,
+            "curiosity": 0.9,
+            "operator_family_failure_pressure": 0.8,
+        },
+    )
+
+    assert any(item.name == "probe_operator_failure_cluster" for item in quests)


### PR DESCRIPTION
### Motivation
- Detect and react to internal surprise/frustration/curiosity signals and recurring operator-family failures so the agent can generate targeted investigative quests when execution stalls.  
- Provide a simple, persisted hierarchy of immediate vs meta-objectives to allow revision under interruptions and to track prolonged meta-objective failures.  
- Make meta-objective neglect materially consequential by mapping prolonged failures to a graded vital penalty, so maintaining meta goals becomes constraining.

### Description
- Extend `generate_quests` to accept `surprise_signals` and compute an `internal_quest_pressure` from `surprise`, `frustration`, `curiosity` and `operator_family_failure_pressure`, adding an intrinsic quest `probe_operator_failure_cluster` when pressure exceeds a threshold (`src/singular/goals/quest_generation.py`).  
- Add `HierarchicalObjectivesManager` and `HierarchicalObjectivesState` to persist immediate/meta objectives, revise them under an `interruption_pressure`, track a `meta_failure_streak`, and compute a `graded_vital_penalty()` (paliers: 0, 1.5, 3.0, 5.0) (`src/singular/motivation.py`).  
- Wire a vitality cost into the life metabolism by adding `meta_objective_penalty` to `RewardContribution` and applying resource drains (`energy`, `food`, `warmth`) when a penalty is present (`src/singular/life/metabolism/rewards.py`).  
- Add tests covering the new behaviors: `test_generate_quests_adds_internal_probe_from_surprise_frustration` and `test_hierarchical_objectives_persist_and_penalize_meta_failure` (`tests/test_quest_generation.py`, `tests/test_objectives.py`).

### Testing
- Ran `pytest -q tests/test_quest_generation.py tests/test_objectives.py`.  
- Result: `16 passed` (all added and existing assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73ce5e720832abced5e6f546c3915)