### PR TITLE
Add configurable ecosystem archetypes and global event resilience metrics

### DIFF
--- a/configs/ecosystem/lab.json
+++ b/configs/ecosystem/lab.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "mode": "lab",
+  "resource_competition_unit": 0.8,
+  "passive_energy_decay": 0.04,
+  "passive_resource_decay": 0.015,
+  "crossover_interval": 30,
+  "cooperation_probability": 0.35,
+  "competition_bid_ceiling": 6.0,
+  "reputation_action_weights": {"share": 0.35, "steal": -0.3}
+}

--- a/configs/ecosystem/production.json
+++ b/configs/ecosystem/production.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "mode": "production",
+  "resource_competition_unit": 1.0,
+  "passive_energy_decay": 0.05,
+  "passive_resource_decay": 0.02,
+  "crossover_interval": 50,
+  "cooperation_probability": 0.2,
+  "competition_bid_ceiling": 5.0,
+  "reputation_action_weights": {"share": 0.2, "steal": -0.2}
+}

--- a/src/singular/life/ecosystem.py
+++ b/src/singular/life/ecosystem.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class ArchetypeProfile:
+    name: str
+    capabilities: tuple[str, ...]
+    strategy: str
+    energy_bias: float = 0.0
+    resource_bias: float = 0.0
+    cooperation_bias: float = 0.0
+    competition_bias: float = 0.0
+
+
+ARCHETYPES: dict[str, ArchetypeProfile] = {
+    "explorer": ArchetypeProfile(
+        name="explorer",
+        capabilities=("mutation_speed", "discovery"),
+        strategy="high-variance exploration and rapid adaptation",
+        energy_bias=-0.05,
+        resource_bias=0.03,
+        cooperation_bias=0.1,
+        competition_bias=0.0,
+    ),
+    "stabilizer": ArchetypeProfile(
+        name="stabilizer",
+        capabilities=("efficiency", "risk_control"),
+        strategy="conservative mutation and consistency",
+        energy_bias=0.03,
+        resource_bias=0.02,
+        cooperation_bias=0.15,
+        competition_bias=-0.05,
+    ),
+    "parasite": ArchetypeProfile(
+        name="parasite",
+        capabilities=("opportunism", "resource_capture"),
+        strategy="extract resources from ecosystem asymmetries",
+        energy_bias=0.02,
+        resource_bias=0.08,
+        cooperation_bias=-0.2,
+        competition_bias=0.2,
+    ),
+    "guardian": ArchetypeProfile(
+        name="guardian",
+        capabilities=("defense", "collective_recovery"),
+        strategy="protect commons and absorb shocks",
+        energy_bias=0.04,
+        resource_bias=-0.01,
+        cooperation_bias=0.25,
+        competition_bias=-0.1,
+    ),
+}
+
+
+@dataclass
+class EcosystemRulesConfig:
+    schema_version: int = 1
+    mode: str = "production"
+    resource_competition_unit: float = 1.0
+    passive_energy_decay: float = 0.05
+    passive_resource_decay: float = 0.02
+    crossover_interval: int = 50
+    cooperation_probability: float = 0.2
+    competition_bid_ceiling: float = 5.0
+    reputation_action_weights: dict[str, float] = field(
+        default_factory=lambda: {"share": 0.2, "steal": -0.2}
+    )
+
+    @classmethod
+    def from_file(cls, path: Path) -> "EcosystemRulesConfig":
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return cls(
+            schema_version=int(payload.get("schema_version", 1)),
+            mode=str(payload.get("mode", "production")),
+            resource_competition_unit=float(payload.get("resource_competition_unit", 1.0)),
+            passive_energy_decay=float(payload.get("passive_energy_decay", 0.05)),
+            passive_resource_decay=float(payload.get("passive_resource_decay", 0.02)),
+            crossover_interval=int(payload.get("crossover_interval", 50)),
+            cooperation_probability=float(payload.get("cooperation_probability", 0.2)),
+            competition_bid_ceiling=float(payload.get("competition_bid_ceiling", 5.0)),
+            reputation_action_weights=dict(payload.get("reputation_action_weights", {"share": 0.2, "steal": -0.2})),
+        )
+
+
+@dataclass(frozen=True)
+class GlobalEvent:
+    event_type: str
+    intensity: float
+    duration_ticks: int
+    description: str
+
+
+def draw_global_event(rng: random.Random) -> GlobalEvent:
+    templates = [
+        ("resource_crisis", "global resource scarcity"),
+        ("governance_shift", "governance priorities shifted"),
+        ("simulated_catastrophe", "systemic catastrophe simulation"),
+    ]
+    event_type, desc = rng.choice(templates)
+    return GlobalEvent(event_type=event_type, intensity=rng.uniform(0.2, 0.9), duration_ticks=rng.randint(2, 6), description=desc)
+
+
+def compute_population_metrics(before: Mapping[str, tuple[float, float]], after: Mapping[str, tuple[float, float]], ticks_elapsed: int) -> dict[str, float]:
+    if not before or not after:
+        return {"resilience": 0.0, "diversity": 0.0, "recovery_time": float(max(ticks_elapsed, 0))}
+    before_total = sum(max(0.0, e + r) for e, r in before.values())
+    after_total = sum(max(0.0, e + r) for e, r in after.values())
+    resilience = 0.0 if before_total <= 0 else min(after_total / before_total, 2.0)
+    alive = sum(1 for e, r in after.values() if (e + r) > 0.2)
+    diversity = alive / max(len(after), 1)
+    return {
+        "resilience": round(resilience, 4),
+        "diversity": round(diversity, 4),
+        "recovery_time": float(max(ticks_elapsed, 0)),
+    }

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -47,6 +47,7 @@ from singular.life.metabolism.rewards import RewardContribution, apply_rewards
 from singular.lives import load_registry, set_life_status
 from singular.life.effectors import perform_action
 from singular.life.world_state import PersistentWorldState
+from singular.life.ecosystem import ARCHETYPES, EcosystemRulesConfig, compute_population_metrics, draw_global_event
 
 from . import sandbox
 from .death import DeathMonitor
@@ -104,6 +105,7 @@ class Organism:
     sandbox_violation_streak: int = 0
     degraded_mode: bool = False
     monitor: DeathMonitor = field(default_factory=DeathMonitor)
+    archetype: str = "explorer"
 
 
 @dataclass
@@ -755,6 +757,7 @@ def run(
     governance_policy: MutationGovernancePolicy | None = None,
     max_iterations: int | None = None,
     ecosystem_rules: EcosystemRules | None = None,
+    ecosystem_mode: str = "production",
 ) -> Checkpoint:
     """Run the evolutionary loop for at most ``budget_seconds`` seconds.
 
@@ -778,12 +781,29 @@ def run(
     organisms_input = _normalize_organism_inputs(skills_dirs)
 
     world = world or WorldState()
-    ecosystem_rules = ecosystem_rules or EcosystemRules()
+    if ecosystem_rules is None:
+        config_path = (
+            Path(__file__).resolve().parents[3] / "configs" / "ecosystem" / f"{ecosystem_mode}.json"
+        )
+        if config_path.exists():
+            config = EcosystemRulesConfig.from_file(config_path)
+            ecosystem_rules = EcosystemRules(
+                resource_competition_unit=config.resource_competition_unit,
+                passive_energy_decay=config.passive_energy_decay,
+                passive_resource_decay=config.passive_resource_decay,
+                crossover_interval=config.crossover_interval,
+                cooperation_probability=config.cooperation_probability,
+                competition_bid_ceiling=config.competition_bid_ceiling,
+                reputation_action_weights=config.reputation_action_weights,
+            )
+        else:
+            ecosystem_rules = EcosystemRules()
     for org_name, skills_dir in organisms_input.items():
         skills_dir.mkdir(parents=True, exist_ok=True)
         if org_name not in world.organisms:
             prototype = mortality or DeathMonitor()
-            world.organisms[org_name] = Organism(skills_dir, monitor=prototype)
+            archetype = list(ARCHETYPES)[len(world.organisms) % len(ARCHETYPES)]
+            world.organisms[org_name] = Organism(skills_dir, monitor=prototype, archetype=archetype)
 
     operators = operators or _load_default_operators()
     stats: Dict[str, Dict[str, float]] = state.stats
@@ -1453,6 +1473,32 @@ def run(
                 other.resources = max(
                     0.1,
                     other.resources - ecosystem_rules.passive_resource_decay,
+                )
+                profile = ARCHETYPES.get(other.archetype)
+                if profile is not None:
+                    other.energy = max(0.1, other.energy + profile.energy_bias)
+                    other.resources = max(0.1, other.resources + profile.resource_bias)
+
+            if state.iteration > 0 and state.iteration % 40 == 0:
+                shock_rng = random.Random(state.iteration)
+                global_event = draw_global_event(shock_rng)
+                pre_event = {name: (o.energy, o.resources) for name, o in world.organisms.items()}
+                for entity in world.organisms.values():
+                    entity.energy = max(0.1, entity.energy - (global_event.intensity * 0.4))
+                    entity.resources = max(0.1, entity.resources - (global_event.intensity * 0.5))
+                post_event = {name: (o.energy, o.resources) for name, o in world.organisms.items()}
+                reorg = compute_population_metrics(pre_event, post_event, global_event.duration_ticks)
+                event_bus.publish(
+                    "ecosystem.global_event",
+                    {
+                        "iteration": state.iteration,
+                        "event_type": global_event.event_type,
+                        "description": global_event.description,
+                        "intensity": global_event.intensity,
+                        "duration_ticks": global_event.duration_ticks,
+                        "population_reorganization": reorg,
+                    },
+                    payload_version=1,
                 )
 
             sandbox_failure = (

--- a/src/singular/life/test_ecosystem.py
+++ b/src/singular/life/test_ecosystem.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import random
+
+from singular.life.ecosystem import ARCHETYPES, compute_population_metrics, draw_global_event
+
+
+def test_archetypes_are_available() -> None:
+    assert set(ARCHETYPES) == {"explorer", "stabilizer", "parasite", "guardian"}
+
+
+def test_global_event_draw_is_supported() -> None:
+    event = draw_global_event(random.Random(7))
+    assert event.event_type in {"resource_crisis", "governance_shift", "simulated_catastrophe"}
+    assert 0.2 <= event.intensity <= 0.9
+
+
+def test_population_reorganization_metrics() -> None:
+    before = {"a": (1.0, 1.0), "b": (1.0, 0.5)}
+    after = {"a": (0.8, 0.9), "b": (0.4, 0.2)}
+    metrics = compute_population_metrics(before, after, ticks_elapsed=3)
+    assert metrics["resilience"] > 0
+    assert 0 <= metrics["diversity"] <= 1
+    assert metrics["recovery_time"] == 3.0


### PR DESCRIPTION
### Motivation
- Introduce distinct organism archetypes to model different ecological roles and behaviors within the evolutionary loop.
- Externalize `EcosystemRules` so experiments can run in controlled `lab` vs `production` modes with versioned configurations.
- Add a global-event engine to simulate shocks (resource crises, governance shifts, simulated catastrophes) and observe population reorganization.

### Description
- Added `src/singular/life/ecosystem.py` which defines `ArchetypeProfile`, `ARCHETYPES` (`explorer`, `stabilizer`, `parasite`, `guardian`), `EcosystemRulesConfig`, `draw_global_event`, and `compute_population_metrics`.
- Added versioned configuration files `configs/ecosystem/lab.json` and `configs/ecosystem/production.json` and a loader `EcosystemRulesConfig.from_file` to externalize ecosystem parameters.
- Integrated the ecosystem primitives into `src/singular/life/loop.py` by adding an `archetype` field to `Organism`, an optional `ecosystem_mode` parameter, archetype assignment for new organisms, archetype-informed energy/resource biases, and a periodic global-event trigger that publishes `ecosystem.global_event` with `population_reorganization` metrics.
- Added focused unit tests in `src/singular/life/test_ecosystem.py` covering archetype availability, global-event generation, and the population reorganization metrics.

### Testing
- Ran the new unit tests with `pytest -q src/singular/life/test_ecosystem.py`.
- All tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73dbce140832a8a2db80d86269955)