### PR TITLE
Add adaptive immune response framework for dangerous incidents

### DIFF
--- a/security/__init__.py
+++ b/security/__init__.py
@@ -1,9 +1,25 @@
 """Security primitives for action authorization."""
 
+from .immune_response import (
+    AdaptiveImmunityEngine,
+    DangerousIncidentTaxonomy,
+    ImmuneMetrics,
+    ImmuneResponsePlan,
+    IncidentRecord,
+)
 from .policy_engine import (
     ActionPolicyEngine,
     PolicyDecision,
     PolicyRule,
 )
 
-__all__ = ["ActionPolicyEngine", "PolicyDecision", "PolicyRule"]
+__all__ = [
+    "ActionPolicyEngine",
+    "PolicyDecision",
+    "PolicyRule",
+    "AdaptiveImmunityEngine",
+    "DangerousIncidentTaxonomy",
+    "ImmuneMetrics",
+    "ImmuneResponsePlan",
+    "IncidentRecord",
+]

--- a/security/immune_response.py
+++ b/security/immune_response.py
@@ -1,0 +1,163 @@
+"""Incident taxonomy and adaptive immune response primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from math import exp
+
+
+@dataclass(frozen=True)
+class DangerousIncidentTaxonomy:
+    """Taxonomy for dangerous incident classes."""
+
+    toxic_mutational_patterns: tuple[str, ...] = (
+        "semantic_drift",
+        "constraint_bypass",
+        "unsafe_capability_escalation",
+    )
+    critical_regressions: tuple[str, ...] = (
+        "safety_guard_removed",
+        "core_metric_collapse",
+        "test_suite_breakage",
+    )
+    internal_quasi_sabotage: tuple[str, ...] = (
+        "self_disable_protection",
+        "policy_circumvention_attempt",
+        "latent_backdoor_introduction",
+    )
+
+    def classify(self, pattern: str) -> str:
+        if pattern in self.toxic_mutational_patterns:
+            return "toxic_mutation_pattern"
+        if pattern in self.critical_regressions:
+            return "critical_regression"
+        if pattern in self.internal_quasi_sabotage:
+            return "internal_quasi_sabotage"
+        return "unknown"
+
+
+@dataclass(frozen=True)
+class IncidentRecord:
+    """One observed dangerous incident."""
+
+    pattern: str
+    happened_at: datetime
+    recurred: bool = False
+
+
+@dataclass(frozen=True)
+class ImmuneResponsePlan:
+    """Auto-generated immune response after an incident."""
+
+    targeted_tests: tuple[str, ...]
+    hardened_rules: tuple[str, ...]
+    temporary_blacklist: tuple[str, ...]
+    blacklist_ttl_seconds: float
+
+
+@dataclass
+class ImmuneMemoryEntry:
+    pattern: str
+    weight: float = 1.0
+    updated_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(frozen=True)
+class ImmuneMetrics:
+    recurrence_rate: float
+    defense_cost: float
+    learning_speed_impact: float
+
+
+class AdaptiveImmunityEngine:
+    """Maintain incident memory with decay and response automation."""
+
+    def __init__(self, *, half_life_seconds: float = 3600.0) -> None:
+        self.taxonomy = DangerousIncidentTaxonomy()
+        self.half_life_seconds = max(float(half_life_seconds), 1.0)
+        self._memory: dict[str, ImmuneMemoryEntry] = {}
+        self._blacklist_until: dict[str, datetime] = {}
+
+    def trigger_response(self, incident: IncidentRecord) -> ImmuneResponsePlan:
+        category = self.taxonomy.classify(incident.pattern)
+        self._reinforce(incident.pattern, when=incident.happened_at)
+
+        tests = (f"test_guard_{incident.pattern}", f"test_non_regression_{category}")
+        rules = (
+            f"deny_pattern:{incident.pattern}",
+            f"elevate_review:{category}",
+        )
+
+        ttl = 600.0 if incident.recurred else 300.0
+        self._blacklist_until[incident.pattern] = incident.happened_at + timedelta(seconds=ttl)
+
+        return ImmuneResponsePlan(
+            targeted_tests=tests,
+            hardened_rules=rules,
+            temporary_blacklist=(incident.pattern,),
+            blacklist_ttl_seconds=ttl,
+        )
+
+    def decay_memory(self, now: datetime | None = None) -> None:
+        current = now or datetime.now(timezone.utc)
+        for pattern, entry in list(self._memory.items()):
+            elapsed = max((current - entry.updated_at).total_seconds(), 0.0)
+            decayed_weight = entry.weight * exp(-elapsed / self.half_life_seconds)
+            if decayed_weight < 0.05:
+                del self._memory[pattern]
+                continue
+            self._memory[pattern] = ImmuneMemoryEntry(
+                pattern=pattern,
+                weight=decayed_weight,
+                updated_at=current,
+            )
+
+    def is_temporarily_blacklisted(self, pattern: str, now: datetime | None = None) -> bool:
+        current = now or datetime.now(timezone.utc)
+        expires_at = self._blacklist_until.get(pattern)
+        if expires_at is None:
+            return False
+        if current >= expires_at:
+            del self._blacklist_until[pattern]
+            return False
+        return True
+
+    def evaluate_effectiveness(
+        self,
+        *,
+        incidents: list[IncidentRecord],
+        defense_actions_count: int,
+        baseline_learning_velocity: float,
+        current_learning_velocity: float,
+    ) -> ImmuneMetrics:
+        if not incidents:
+            return ImmuneMetrics(0.0, float(defense_actions_count), 0.0)
+
+        recurrences = sum(1 for item in incidents if item.recurred)
+        recurrence_rate = recurrences / len(incidents)
+        defense_cost = float(defense_actions_count) / len(incidents)
+        if baseline_learning_velocity <= 0:
+            learning_impact = 0.0
+        else:
+            learning_impact = (baseline_learning_velocity - current_learning_velocity) / baseline_learning_velocity
+
+        return ImmuneMetrics(
+            recurrence_rate=max(0.0, recurrence_rate),
+            defense_cost=max(0.0, defense_cost),
+            learning_speed_impact=max(-1.0, min(1.0, learning_impact)),
+        )
+
+    def memory_snapshot(self) -> dict[str, float]:
+        return {pattern: entry.weight for pattern, entry in self._memory.items()}
+
+    def _reinforce(self, pattern: str, *, when: datetime) -> None:
+        existing = self._memory.get(pattern)
+        if existing is None:
+            self._memory[pattern] = ImmuneMemoryEntry(pattern=pattern, weight=1.0, updated_at=when)
+            return
+        self._memory[pattern] = ImmuneMemoryEntry(
+            pattern=pattern,
+            weight=existing.weight + 1.0,
+            updated_at=when,
+        )

--- a/tests/test_immune_response.py
+++ b/tests/test_immune_response.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from security.immune_response import AdaptiveImmunityEngine, IncidentRecord
+
+
+def test_trigger_response_builds_targeted_actions_and_blacklist() -> None:
+    engine = AdaptiveImmunityEngine()
+    now = datetime(2026, 5, 3, tzinfo=timezone.utc)
+
+    plan = engine.trigger_response(
+        IncidentRecord(pattern="semantic_drift", happened_at=now, recurred=True)
+    )
+
+    assert "test_guard_semantic_drift" in plan.targeted_tests
+    assert "deny_pattern:semantic_drift" in plan.hardened_rules
+    assert plan.blacklist_ttl_seconds == 600.0
+    assert engine.is_temporarily_blacklisted("semantic_drift", now + timedelta(seconds=1))
+
+
+def test_memory_decay_forgets_weak_entries() -> None:
+    engine = AdaptiveImmunityEngine(half_life_seconds=10.0)
+    start = datetime(2026, 5, 3, tzinfo=timezone.utc)
+    engine.trigger_response(IncidentRecord(pattern="constraint_bypass", happened_at=start))
+
+    engine.decay_memory(start + timedelta(seconds=50))
+
+    assert "constraint_bypass" not in engine.memory_snapshot()
+
+
+def test_effectiveness_metrics_cover_recurrence_cost_and_learning_impact() -> None:
+    engine = AdaptiveImmunityEngine()
+    now = datetime(2026, 5, 3, tzinfo=timezone.utc)
+    incidents = [
+        IncidentRecord(pattern="semantic_drift", happened_at=now, recurred=True),
+        IncidentRecord(pattern="core_metric_collapse", happened_at=now, recurred=False),
+    ]
+
+    metrics = engine.evaluate_effectiveness(
+        incidents=incidents,
+        defense_actions_count=6,
+        baseline_learning_velocity=10.0,
+        current_learning_velocity=8.0,
+    )
+
+    assert metrics.recurrence_rate == 0.5
+    assert metrics.defense_cost == 3.0
+    assert metrics.learning_speed_impact == 0.2


### PR DESCRIPTION
### Motivation
- Formaliser une taxonomie d’incidents dangereux (patterns mutationnels toxiques, régressions critiques, quasi-sabotage interne) pour permettre des réponses automatiques et traçables.
- Après incident, déclencher une réponse immunitaire automatisée (tests ciblés, durcissement de règles, blacklist temporelle) pour limiter la récidive et accélérer la correction.
- Éviter la sur-rigidification en conservant une mémoire immunitaire avec oubli contrôlé et mesurer l’impact défensif sur l’apprentissage.

### Description
- Ajout du module `security/immune_response.py` définissant `DangerousIncidentTaxonomy`, `IncidentRecord`, `ImmuneResponsePlan`, `ImmuneMemoryEntry`, `ImmuneMetrics` et `AdaptiveImmunityEngine` pour orchestrer la mémoire et les réponses automatiques.
- `AdaptiveImmunityEngine.trigger_response()` génère des noms de tests ciblés, durcit des règles locales (`deny_pattern:*`, `elevate_review:*`) et applique une blacklist temporaire dont le TTL augmente en cas de récidive.
- Mémoire immunitaire implémentée avec renforcement des patterns observés et décroissance exponentielle paramétrable (`half_life_seconds`) et purge des traces trop faibles, plus méthodes utilitaires `memory_snapshot()` et `is_temporarily_blacklisted()`.
- Export des primitives depuis `security.__init__.py` et ajout des tests unitaires `tests/test_immune_response.py` couvrant réponse, blacklist, oubli et métriques d’efficacité.

### Testing
- Tests unitaires exécutés avec `pytest -q tests/test_immune_response.py tests/test_core_agent_runtime.py` et ont réussi.
- Total exécuté: `12 passed` (all tests in these modules passed).
- Nouveau fichier de tests `tests/test_immune_response.py` couvre les cas de réponse automatisée, la décroissance de la mémoire et le calcul des métriques d’efficacité.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73ef3691c832aaf54399341987e56)