### PR TITLE
Ajouter métriques de régulation comportementale et intégration orchestrateur/dashboard

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -15,6 +15,7 @@ from fastapi.staticfiles import StaticFiles
 from singular.lives import get_registry_root, load_registry, set_life_status
 from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
+from singular.metrics.behavioral_regulation import compute_behavioral_regulation_metrics
 from singular.memory import read_causal_timeline, read_skills
 from singular.storage_retention import retention_status_snapshot
 
@@ -573,6 +574,8 @@ def create_app(
             global_status = "stable"
 
         autonomy_metrics = compute_autonomy_metrics(records)
+        major_decisions = [e for e in records if str(e.get("event", "")).startswith("orchestrator") or str(e.get("event", ""))=="mutation"]
+        behavioral_metrics = compute_behavioral_regulation_metrics(records, decision_events=major_decisions)
         ecosystem = _compute_ecosystem(current_life_only=current_life_only)
         summary = ecosystem.get("summary", {}) if isinstance(ecosystem, dict) else {}
         metrics_contract = (
@@ -667,6 +670,7 @@ def create_app(
             "suggested_actions": suggested_actions,
             "global_status": global_status,
             "autonomy_metrics": autonomy_metrics,
+            "behavioral_regulation_metrics": behavioral_metrics,
             "vital_metrics": {
                 "circadian_cycle": {"phase": circadian_phase, "hour_utc": hour_utc},
                 "active_objectives": {

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -208,6 +208,17 @@ export const loadCockpit=()=>Promise.all([
   document.getElementById('kpi-autonomy-decision').textContent=`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`;
   document.getElementById('kpi-autonomy-latency').textContent=fmtNum(autonomy.perception_to_action_latency_ms,' ms');
   document.getElementById('kpi-autonomy-cost').textContent=fmtNum(autonomy.resource_cost_per_gain);
+  const behavior=d.behavioral_regulation_metrics||{};
+  const behaviorAlerts=behavior.alerts||{};
+  const behaviorCorr=behavior.decision_correlation||{};
+  document.getElementById('kpi-behavior-diversity').textContent=fmtPct(behavior.behavioral_diversity);
+  document.getElementById('kpi-behavior-robustness').textContent=fmtPct(behavior.perturbation_robustness);
+  document.getElementById('kpi-behavior-recovery').textContent=fmtNum(behavior.recovery_time_seconds,' s');
+  document.getElementById('kpi-behavior-goals').textContent=fmtPct(behavior.goal_generation_autonomy);
+  document.getElementById('kpi-behavior-homeostasis').textContent=fmtPct(behavior.homeostatic_stability);
+  document.getElementById('kpi-behavior-trend').textContent=String(behavior.temporal_trend||na());
+  document.getElementById('kpi-behavior-correlation').textContent=`${behaviorCorr.major_decisions_count??0} décisions majeures`;
+  if(behaviorAlerts.homeostasis_unstable||behaviorAlerts.robustness_low){setStatusTone(document.getElementById('kpi-behavior-homeostasis'),'bad');}
   const vital=d.vital_timeline||{};
   const skillLifecycle=d.skills_lifecycle||{};
   const vitalMetrics=d.vital_metrics||{};

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -359,6 +359,13 @@
       <div class='card'><div class='card-label'>Causes</div><div id='kpi-vital-causes' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Latence P→A</div><div id='kpi-autonomy-latency' class='card-value'>Pas encore mesuré</div></div>
       <div class='card'><div class='card-label'>Coût par gain</div><div id='kpi-autonomy-cost' class='card-value'>Pas encore mesuré</div></div>
+      <div class='card'><div class='card-label'>Diversité comportementale</div><div id='kpi-behavior-diversity' class='card-value'>Pas encore mesuré</div></div>
+      <div class='card'><div class='card-label'>Robustesse perturbations</div><div id='kpi-behavior-robustness' class='card-value'>Pas encore mesuré</div></div>
+      <div class='card'><div class='card-label'>Temps récupération</div><div id='kpi-behavior-recovery' class='card-value'>Pas encore mesuré</div></div>
+      <div class='card'><div class='card-label'>Autonomie buts</div><div id='kpi-behavior-goals' class='card-value'>Pas encore mesuré</div></div>
+      <div class='card'><div class='card-label'>Stabilité homéostatique</div><div id='kpi-behavior-homeostasis' class='card-value'>Pas encore mesuré</div></div>
+      <div class='card'><div class='card-label'>Tendance temporelle</div><div id='kpi-behavior-trend' class='card-value'>Pas encore mesuré</div></div>
+      <div class='card'><div class='card-label'>Corrélations décisions</div><div id='kpi-behavior-correlation' class='card-value'>Pas encore mesuré</div></div>
       <div class='card'><div class='card-label'>Phase circadienne</div><div id='kpi-circadian-phase' class='card-value'>Non disponible</div></div>
       <div class='card'><div class='card-label'>Objectifs actifs</div><div id='kpi-active-objectives-count' class='card-value'>0</div></div>
       <div class='card'><div class='card-label'>Progression quêtes</div><div id='kpi-quests-progress' class='card-value'>Non disponible</div></div>

--- a/src/singular/metrics/__init__.py
+++ b/src/singular/metrics/__init__.py
@@ -1,5 +1,13 @@
 """Metrics utilities for singular."""
 
 from .autonomy import compute_autonomy_metrics
+from .behavioral_regulation import (
+    compute_behavioral_regulation_metrics,
+    compute_regulation_inputs,
+)
 
-__all__ = ["compute_autonomy_metrics"]
+__all__ = [
+    "compute_autonomy_metrics",
+    "compute_behavioral_regulation_metrics",
+    "compute_regulation_inputs",
+]

--- a/src/singular/metrics/behavioral_regulation.py
+++ b/src/singular/metrics/behavioral_regulation.py
@@ -1,0 +1,126 @@
+"""Behavioral regulation metrics for orchestration and cockpit dashboards."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime
+from statistics import mean
+from typing import Any
+
+
+def _as_float(value: object) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _parse_ts(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def compute_behavioral_regulation_metrics(
+    records: list[dict[str, Any]],
+    *,
+    decision_events: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    actions = [r for r in records if str(r.get("event", "")).strip() in {"mutation", "interaction", "refuse", "delay", "test_coevolution"}]
+    event_counts = Counter(str(r.get("event", "unknown")) for r in actions)
+    total_actions = sum(event_counts.values())
+    diversity = min(1.0, len([k for k,v in event_counts.items() if v>0]) / 5.0) if total_actions else None
+
+    accepted = 0
+    rejected = 0
+    for r in actions:
+        status = r.get("accepted")
+        if not isinstance(status, bool):
+            status = r.get("ok")
+        if status is True:
+            accepted += 1
+        elif status is False:
+            rejected += 1
+    robustness = (accepted / (accepted + rejected)) if (accepted + rejected) else None
+
+    recovery_times: list[float] = []
+    last_failure: datetime | None = None
+    for r in records:
+        ts = _parse_ts(r.get("ts"))
+        if ts is None:
+            continue
+        status = r.get("accepted")
+        if not isinstance(status, bool):
+            status = r.get("ok")
+        if status is False:
+            last_failure = ts
+        elif status is True and last_failure is not None:
+            recovery_times.append(max(0.0, (ts - last_failure).total_seconds()))
+            last_failure = None
+    recovery_seconds = mean(recovery_times) if recovery_times else None
+
+    proactive = sum(1 for r in actions if r.get("proactive") is True)
+    goals_autonomy = (proactive / total_actions) if total_actions else None
+
+    health_scores = [
+        _as_float((r.get("health") or {}).get("score"))
+        for r in records if isinstance(r.get("health"), dict)
+    ]
+    health_scores = [s for s in health_scores if s is not None]
+    homeo = None
+    if len(health_scores) >= 2:
+        volatility = mean(abs(health_scores[i]-health_scores[i-1]) for i in range(1, len(health_scores)))
+        homeo = max(0.0, min(1.0, 1.0 - (volatility / 10.0)))
+
+    trend = "stable"
+    if len(health_scores) >= 4:
+        half = len(health_scores)//2
+        first = mean(health_scores[:half])
+        second = mean(health_scores[half:])
+        if second > first + 0.2:
+            trend = "amélioration"
+        elif second < first - 0.2:
+            trend = "dégradation"
+
+    decisions = decision_events or []
+    decision_correlation = {
+        "major_decisions_count": len(decisions),
+        "recent_decisions": decisions[-5:],
+    }
+
+    return {
+        "behavioral_diversity": diversity,
+        "perturbation_robustness": robustness,
+        "recovery_time_seconds": recovery_seconds,
+        "goal_generation_autonomy": goals_autonomy,
+        "homeostatic_stability": homeo,
+        "temporal_trend": trend,
+        "alerts": {
+            "diversity_low": diversity is not None and diversity < 0.35,
+            "robustness_low": robustness is not None and robustness < 0.55,
+            "recovery_slow": recovery_seconds is not None and recovery_seconds > 120.0,
+            "homeostasis_unstable": homeo is not None and homeo < 0.5,
+        },
+        "decision_correlation": decision_correlation,
+    }
+
+
+def compute_regulation_inputs(metrics: dict[str, Any]) -> dict[str, float]:
+    diversity = _as_float(metrics.get("behavioral_diversity")) or 0.5
+    robustness = _as_float(metrics.get("perturbation_robustness")) or 0.5
+    recovery = _as_float(metrics.get("recovery_time_seconds")) or 60.0
+    homeo = _as_float(metrics.get("homeostatic_stability")) or 0.5
+    autonomy = _as_float(metrics.get("goal_generation_autonomy")) or 0.5
+
+    mutation_rate_scale = max(0.6, min(1.5, 1.2 - homeo * 0.4 + (0.5 - robustness) * 0.6))
+    metabolic_pressure_scale = max(0.7, min(1.6, 1.0 + (recovery / 300.0) + (0.5 - homeo) * 0.5))
+    exploration_intensity_scale = max(0.5, min(1.7, 1.0 + (0.5 - diversity) * 0.8 + (autonomy - 0.5) * 0.6))
+
+    return {
+        "mutation_rate_scale": mutation_rate_scale,
+        "metabolic_pressure_scale": metabolic_pressure_scale,
+        "exploration_intensity_scale": exploration_intensity_scale,
+    }

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -41,6 +41,7 @@ from singular.quests import QuestRuntime
 from singular.sensors import load_host_sensor_thresholds
 from singular.skills.runtime import SkillRuntime
 from singular.routines import RoutinesOrchestrator
+from singular.metrics import compute_behavioral_regulation_metrics, compute_regulation_inputs
 
 log = logging.getLogger(__name__)
 
@@ -142,6 +143,7 @@ class OrchestratorService:
         self._introspection_tick_count = 0
         self._host_thresholds = load_host_sensor_thresholds()
         self._started_at = datetime.now(timezone.utc)
+        self._behavioral_metrics: dict[str, Any] = {}
 
         self._subscribe_external_stimuli()
 
@@ -386,9 +388,13 @@ class OrchestratorService:
             if mood.value == "fatigue":
                 tick_budget *= max(fatigue_slowdown, 1.0)
             adaptation = self._compute_runtime_adaptation()
+            behavior_metrics = self._compute_behavioral_metrics()
+            regulation_inputs = compute_regulation_inputs(behavior_metrics)
             tick_budget *= adaptation["tick_budget_scale"]
+            tick_budget *= regulation_inputs["mutation_rate_scale"]
             tick_budget = max(0.01, min(tick_budget, self.config.mutation_window_seconds))
             cpu_budget_percent *= adaptation["cpu_budget_scale"]
+            cpu_budget_percent *= regulation_inputs["metabolic_pressure_scale"]
             previous_safe_mode = bool(self.governance_policy.safe_mode)
             self.governance_policy.safe_mode = bool(adaptation["enforce_prudent_mode"])
             if (
@@ -407,6 +413,8 @@ class OrchestratorService:
                     "safe_mode": self.governance_policy.safe_mode,
                     "aggressive_exploration": adaptation["allow_aggressive_exploration"],
                     "skip_action_tick": adaptation["skip_action_tick"],
+                    "behavioral_metrics": behavior_metrics,
+                    "regulation_inputs": regulation_inputs,
                 }
                 self.bus.publish("orchestrator.adaptation", audit_payload, payload_version=1)
                 log.info("orchestrator adaptation applied: %s", audit_payload)
@@ -430,9 +438,9 @@ class OrchestratorService:
             if not self.config.dry_run:
                 strategy = self.goals.derive_execution_strategy(self._latest_signals)
                 execution_strategy = dict(strategy)
-                if adaptation["allow_aggressive_exploration"]:
+                if adaptation["allow_aggressive_exploration"] or regulation_inputs["exploration_intensity_scale"] > 1.15:
                     execution_strategy["exploration_intensity"] = "aggressive"
-                    execution_strategy["adaptation_source"] = "stable_resources"
+                    execution_strategy["adaptation_source"] = "stable_resources+behavioral_metrics"
                 routine_specs = [
                     {"id": spec.id, "prompt": spec.prompt, "priority": spec.priority}
                     for spec in self.routines.specs
@@ -627,6 +635,16 @@ class OrchestratorService:
                 "warmth": self.resource_manager.warmth,
             },
         }
+
+    def _compute_behavioral_metrics(self) -> dict[str, Any]:
+        records = self._load_recent_run_events(limit=80)
+        major_decisions = [
+            e for e in self.state.last_events
+            if isinstance(e, dict) and str(e.get("phase", "")) == LifecyclePhase.ACTION.value
+        ]
+        metrics = compute_behavioral_regulation_metrics(records, decision_events=major_decisions)
+        self._behavioral_metrics = metrics
+        return metrics
 
     def _track_action_failure_and_request_help(
         self,


### PR DESCRIPTION
### Motivation
- Fournir des métriques de qualité opérationnelle (diversité comportementale, robustesse aux perturbations, temps de récupération, autonomie de génération de buts, stabilité homéostatique) et tendances temporelles pour mieux piloter l'orchestrateur. 
- Exposer ces métriques dans le cockpit pour suivi, alertes et corrélations avec décisions majeures. 
- Utiliser automatiquement ces métriques comme entrées de régulation pour ajuster la pression de mutation, la pression métabolique et l'intensité d'exploration afin d'améliorer la résilience et l'efficacité runtime.

### Description
- Ajout du module `src/singular/metrics/behavioral_regulation.py` fournissant `compute_behavioral_regulation_metrics` et `compute_regulation_inputs` (diversité, robustesse, temps de récupération, autonomie buts, stabilité homéostatique, tendances, seuils d'alerte et corrélation aux décisions). 
- Intégration dans l'orchestrateur via `src/singular/orchestrator/service.py` avec la nouvelle méthode `_compute_behavioral_metrics`, calcul périodique pendant la phase `ACTION`, enrichissement des payloads d'audit et application des échelles de régulation (`mutation_rate_scale`, `metabolic_pressure_scale`, `exploration_intensity_scale`) aux variables runtime (`tick_budget`, `cpu_budget_percent`, et `execution_strategy`). 
- Exposition API et UI: inclusion de `behavioral_regulation_metrics` dans le payload cockpit (`src/singular/dashboard/__init__.py`), ajout de KPI cards dans le template (`src/singular/dashboard/templates/dashboard.html`) et rendu côté client dans `src/singular/dashboard/static/render-cockpit.js`. 
- Export des nouvelles fonctions depuis `src/singular/metrics/__init__.py` pour usage centralisé par le runtime et le dashboard.

### Testing
- Tests automatisés exécutés: `python -m pytest -q tests/test_scheduler_reevaluation.py tests/test_dashboard_smoke_e2e.py` et les tests invoqués ont réussi (tous verts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74082b6e4832a9556bb6e3d25fa77)