### PR TITLE
Use monotonic timers for OpenAI/local latency metrics

### DIFF
--- a/src/singular/providers/llm_local.py
+++ b/src/singular/providers/llm_local.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+import time
 from typing import Any
 
 from . import ProviderExecutionError, ProviderMetrics, ProviderTimeoutError, ProviderUnavailableError
@@ -49,6 +50,7 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
     """Generate a reply using a small local transformers model."""
 
     pipe = _get_pipe()
+    start = time.perf_counter()
     try:
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(_infer, pipe, prompt)
@@ -59,9 +61,11 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
         raise
     except Exception as exc:
         raise ProviderExecutionError("Error running local model") from exc
+    finally:
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        LAST_METRICS.latency_ms = round(elapsed_ms, 2)
 
     reply = _filter(text[len(prompt) :].strip())
-    LAST_METRICS.latency_ms = min(timeout * 50.0, 400.0)
     LAST_METRICS.input_tokens = len(prompt.split())
     LAST_METRICS.output_tokens = len(reply.split())
     LAST_METRICS.estimated_cost_usd = cost_estimate(prompt, reply)

--- a/src/singular/providers/llm_openai.py
+++ b/src/singular/providers/llm_openai.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from typing import Any
 
 from . import (
@@ -48,6 +49,7 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
     if OpenAI is None:
         raise ProviderUnavailableError("openai dependency is not installed")
 
+    start = time.perf_counter()
     try:  # pragma: no cover - network call
         client = OpenAI(api_key=api_key)
         response: Any = client.chat.completions.create(
@@ -69,6 +71,9 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
         raise ProviderUnavailableError("Unable to connect to OpenAI") from exc
     except Exception as exc:
         raise ProviderExecutionError("Unexpected OpenAI provider failure") from exc
+    finally:
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        LAST_METRICS.latency_ms = round(elapsed_ms, 2)
 
     filtered = _filter(text)
     usage = getattr(response, "usage", None)
@@ -77,7 +82,6 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
     LAST_METRICS.input_tokens = input_tokens or len(prompt.split())
     LAST_METRICS.output_tokens = output_tokens or len(filtered.split())
     LAST_METRICS.estimated_cost_usd = cost_estimate(prompt, filtered, input_tokens=input_tokens, output_tokens=output_tokens)
-    LAST_METRICS.latency_ms = min(timeout * 100.0, 800.0)
     return filtered
 
 

--- a/tests/providers/test_llm_local.py
+++ b/tests/providers/test_llm_local.py
@@ -24,14 +24,31 @@ def test_load_llm_client_local():
 
 def test_local_provider_timeout(monkeypatch):
     monkeypatch.setattr(llm_local, "_get_pipe", lambda: object())
+    timer_values = iter([20.0, 20.4])
 
     def fake_infer(_pipe, _prompt):
         raise ProviderTimeoutError("timed out")
 
     monkeypatch.setattr(llm_local, "_infer", fake_infer)
+    monkeypatch.setattr(llm_local.time, "perf_counter", lambda: next(timer_values))
 
     with pytest.raises(ProviderTimeoutError):
         llm_local.generate_reply("hello")
+    assert llm_local.LAST_METRICS.latency_ms == 400.0
+
+
+def test_local_provider_latency_uses_elapsed_time(monkeypatch):
+    monkeypatch.setattr(llm_local, "_get_pipe", lambda: object())
+    timer_values = iter([30.0, 30.04567])
+
+    def fake_infer(_pipe, _prompt):
+        return "hello world"
+
+    monkeypatch.setattr(llm_local, "_infer", fake_infer)
+    monkeypatch.setattr(llm_local.time, "perf_counter", lambda: next(timer_values))
+
+    assert llm_local.generate_reply("hello") == "world"
+    assert llm_local.LAST_METRICS.latency_ms == 45.67
 
 
 def test_local_retry_bounded(monkeypatch):

--- a/tests/providers/test_llm_openai.py
+++ b/tests/providers/test_llm_openai.py
@@ -46,6 +46,7 @@ def test_generate_reply_success(monkeypatch):
 
 def test_openai_quota_maps_to_typed_error(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    timer_values = iter([1.0, 1.25])
 
     class FakeRateLimitError(Exception):
         pass
@@ -60,9 +61,34 @@ def test_openai_quota_maps_to_typed_error(monkeypatch):
 
     monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
     monkeypatch.setattr(llm_openai, "RateLimitError", FakeRateLimitError)
+    monkeypatch.setattr(llm_openai.time, "perf_counter", lambda: next(timer_values))
 
     with pytest.raises(ProviderQuotaExceededError):
         llm_openai.generate_reply("hi")
+    assert llm_openai.LAST_METRICS.latency_ms == 250.0
+
+
+def test_generate_reply_latency_uses_elapsed_time(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    class FakeCompletions:
+        def create(self, *, model, messages, max_tokens, timeout):
+            del model, messages, max_tokens, timeout
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+            )
+
+    class FakeClient:
+        def __init__(self, api_key):
+            assert api_key == "test-key"
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    timer_values = iter([10.0, 10.1234])
+    monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
+    monkeypatch.setattr(llm_openai.time, "perf_counter", lambda: next(timer_values))
+
+    assert llm_openai.generate_reply("hi", timeout=3.0) == "ok"
+    assert llm_openai.LAST_METRICS.latency_ms == 123.4
 
 
 def test_retry_strategy_is_bounded():


### PR DESCRIPTION
### Motivation
- Replace artificial latency heuristics with real elapsed-time measurements for more accurate diagnostics and observability.
- Ensure latency is recorded even when provider calls raise recoverable errors so metrics reflect real-world behavior.

### Description
- Imported `time` and start a monotonic timer with `start = time.perf_counter()` immediately before making the provider call in `src/singular/providers/llm_openai.py` and `src/singular/providers/llm_local.py`.
- Record elapsed milliseconds in a `finally` block with `elapsed_ms = (time.perf_counter() - start) * 1000` and assign `LAST_METRICS.latency_ms = round(elapsed_ms, 2)` so latency is set on success and error paths.
- Removed the previous synthetic `min(timeout * ...)` latency formulas from both providers.
- Updated tests `tests/providers/test_llm_openai.py` and `tests/providers/test_llm_local.py` to mock `time.perf_counter` and assert that `LAST_METRICS.latency_ms` is derived from the mocked elapsed time on both success and error cases.

### Testing
- Ran `pytest -q tests/providers/test_llm_openai.py tests/providers/test_llm_local.py` and the suite completed with `10 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74f1b8f94832abff44a9ad93435fd)