### PR TITLE
Make OpenAI model configurable via env and surface active model in healthcheck

### DIFF
--- a/src/singular/providers/llm_openai.py
+++ b/src/singular/providers/llm_openai.py
@@ -16,6 +16,7 @@ from . import (
 )
 
 MAX_RETRIES = 2
+DEFAULT_OPENAI_MODEL = "gpt-3.5-turbo"
 
 LAST_METRICS = ProviderMetrics(provider="openai")
 
@@ -44,6 +45,7 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
     """Generate a reply via OpenAI using typed errors for failures."""
 
     api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+    model = (os.getenv("OPENAI_MODEL") or "").strip() or DEFAULT_OPENAI_MODEL
     if not api_key:
         raise ProviderMisconfiguredError("OPENAI_API_KEY not configured")
     if OpenAI is None:
@@ -53,7 +55,7 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
     try:  # pragma: no cover - network call
         client = OpenAI(api_key=api_key)
         response: Any = client.chat.completions.create(
-            model="gpt-3.5-turbo",
+            model=model,
             messages=[{"role": "user", "content": prompt}],
             max_tokens=100,
             timeout=timeout,
@@ -114,9 +116,15 @@ def embed(text: str, *, timeout: float = 8.0) -> list[float]:
 
 def healthcheck() -> dict[str, object]:
     api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+    model = (os.getenv("OPENAI_MODEL") or "").strip() or DEFAULT_OPENAI_MODEL
     if not api_key:
-        return {"ok": False, "provider": "openai", "error": "missing OPENAI_API_KEY"}
-    return {"ok": OpenAI is not None, "provider": "openai"}
+        return {
+            "ok": False,
+            "provider": "openai",
+            "model": model,
+            "error": "missing OPENAI_API_KEY",
+        }
+    return {"ok": OpenAI is not None, "provider": "openai", "model": model}
 
 
 def cost_estimate(

--- a/tests/providers/test_llm_openai.py
+++ b/tests/providers/test_llm_openai.py
@@ -27,7 +27,7 @@ def test_generate_reply_success(monkeypatch):
 
     class FakeCompletions:
         def create(self, *, model, messages, max_tokens, timeout):
-            assert model == "gpt-3.5-turbo"
+            assert model == llm_openai.DEFAULT_OPENAI_MODEL
             assert messages == [{"role": "user", "content": "hi"}]
             assert max_tokens == 100
             assert timeout == 3.0
@@ -42,6 +42,29 @@ def test_generate_reply_success(monkeypatch):
 
     monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
     assert llm_openai.generate_reply("hi", timeout=3.0) == "hello"
+
+
+def test_generate_reply_uses_openai_model_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_MODEL", " gpt-4.1-mini ")
+
+    class FakeCompletions:
+        def create(self, *, model, messages, max_tokens, timeout):
+            assert model == "gpt-4.1-mini"
+            assert messages == [{"role": "user", "content": "hi"}]
+            assert max_tokens == 100
+            assert timeout == 2.0
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="hello"))]
+            )
+
+    class FakeClient:
+        def __init__(self, api_key):
+            assert api_key == "test-key"
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
+    assert llm_openai.generate_reply("hi", timeout=2.0) == "hello"
 
 
 def test_openai_quota_maps_to_typed_error(monkeypatch):
@@ -116,3 +139,21 @@ def test_openai_version():
     from packaging import version
 
     assert version.parse(openai.__version__) >= version.parse("1.0.0")
+
+
+def test_healthcheck_exposes_active_model_default(monkeypatch):
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(llm_openai, "OpenAI", object())
+
+    result = llm_openai.healthcheck()
+    assert result["model"] == llm_openai.DEFAULT_OPENAI_MODEL
+
+
+def test_healthcheck_exposes_active_model_from_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_MODEL", " gpt-4.1 ")
+    monkeypatch.setattr(llm_openai, "OpenAI", object())
+
+    result = llm_openai.healthcheck()
+    assert result["model"] == "gpt-4.1"


### PR DESCRIPTION
### Motivation
- Provide a controlled, local fallback for the OpenAI chat model and allow operators to override it via environment to change models without code edits.
- Ensure the provider exposes the effective model in healthcheck output to aid runtime diagnostics and troubleshooting.
- Add tests to validate environment precedence, trimming behavior, and healthcheck reporting.

### Description
- Introduce `DEFAULT_OPENAI_MODEL = "gpt-3.5-turbo"` and resolve the active model with `model = (os.getenv("OPENAI_MODEL") or "").strip() or DEFAULT_OPENAI_MODEL` in `generate()`.
- Use the resolved `model` value in `client.chat.completions.create(...)` instead of a hardcoded model string.
- Enrich `healthcheck()` to include the active `model` field in the returned dict, including when the API key is missing.
- Update/add tests in `tests/providers/test_llm_openai.py` to assert default fallback, trimming/priority of `OPENAI_MODEL`, and that `healthcheck()` reports the active model.

### Testing
- Ran `pytest -q tests/providers/test_llm_openai.py` and the test suite for that file passed with `8 passed, 1 skipped`.
- The new/updated provider tests validate both default and `OPENAI_MODEL`-driven behavior and succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74fd098e4832aaef0a2c491ef22d2)