### PR TITLE
Harden OpenAI response schema parsing in LLM provider

### DIFF
--- a/src/singular/providers/llm_openai.py
+++ b/src/singular/providers/llm_openai.py
@@ -60,7 +60,23 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
             max_tokens=100,
             timeout=timeout,
         )
-        text: str = response.choices[0].message.content
+        choices = getattr(response, "choices", None)
+        if not isinstance(choices, list):
+            raise ProviderExecutionError("OpenAI response schema error: choices is not a list")
+        if not choices:
+            raise ProviderExecutionError("OpenAI response schema error: empty choices")
+
+        message = getattr(choices[0], "message", None)
+        if message is None:
+            raise ProviderExecutionError("OpenAI response schema error: missing message")
+
+        content = getattr(message, "content", None)
+        if content is None:
+            raise ProviderExecutionError("OpenAI response schema error: missing message content")
+        if not isinstance(content, str):
+            raise ProviderExecutionError("OpenAI response schema error: message content is not a string")
+
+        text: str = content
     except APITimeoutError as exc:
         raise ProviderTimeoutError("OpenAI request timed out") from exc
     except TimeoutError as exc:
@@ -71,6 +87,8 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
         raise ProviderMisconfiguredError("OpenAI credentials are invalid") from exc
     except APIConnectionError as exc:
         raise ProviderUnavailableError("Unable to connect to OpenAI") from exc
+    except ProviderExecutionError:
+        raise
     except Exception as exc:
         raise ProviderExecutionError("Unexpected OpenAI provider failure") from exc
     finally:

--- a/tests/providers/test_llm_openai.py
+++ b/tests/providers/test_llm_openai.py
@@ -4,6 +4,7 @@ import pytest
 
 from singular.providers import (
     LLMProviderClient,
+    ProviderExecutionError,
     ProviderMisconfiguredError,
     ProviderQuotaExceededError,
     ProviderRetryExhaustedError,
@@ -157,3 +158,59 @@ def test_healthcheck_exposes_active_model_from_env(monkeypatch):
 
     result = llm_openai.healthcheck()
     assert result["model"] == "gpt-4.1"
+
+
+def test_generate_reply_schema_error_empty_choices(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    class FakeCompletions:
+        def create(self, **_kwargs):
+            return SimpleNamespace(choices=[])
+
+    class FakeClient:
+        def __init__(self, api_key):
+            assert api_key == "test-key"
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
+
+    with pytest.raises(ProviderExecutionError, match="empty choices"):
+        llm_openai.generate_reply("hi")
+
+
+def test_generate_reply_schema_error_missing_message_content(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    class FakeCompletions:
+        def create(self, **_kwargs):
+            return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace())])
+
+    class FakeClient:
+        def __init__(self, api_key):
+            assert api_key == "test-key"
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
+
+    with pytest.raises(ProviderExecutionError, match="missing message content"):
+        llm_openai.generate_reply("hi")
+
+
+def test_generate_reply_schema_error_non_string_content(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    class FakeCompletions:
+        def create(self, **_kwargs):
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=["not", "text"]))]
+            )
+
+    class FakeClient:
+        def __init__(self, api_key):
+            assert api_key == "test-key"
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setattr(llm_openai, "OpenAI", FakeClient)
+
+    with pytest.raises(ProviderExecutionError, match="not a string"):
+        llm_openai.generate_reply("hi")


### PR DESCRIPTION
### Motivation
- Avoid opaque failures when parsing OpenAI chat completion responses by making structural issues explicit and actionable.
- Differentiate response schema problems from network/auth/timeout errors so callers can handle them distinctly.

### Description
- In `generate()` explicitly extract `choices = getattr(response, "choices", None)` and validate it is a non-empty list, raising `ProviderExecutionError` with an explicit message if not.
- Defensively extract `message` and `content` from the first choice, validate `content` is a `str`, and assign it to the existing `text` variable, raising `ProviderExecutionError` for missing or wrong-typed fields.
- Preserve the existing mapping of `APITimeoutError`/`TimeoutError`/`RateLimitError`/`AuthenticationError`/`APIConnectionError` to typed provider errors and add an `except ProviderExecutionError: raise` to avoid converting schema errors to the generic fallback.
- Add unit tests in `tests/providers/test_llm_openai.py` to cover schema failure cases (`empty choices`, `missing message content`, and `non-string message content`) and import `ProviderExecutionError` for assertions.

### Testing
- Ran `pytest -q tests/providers/test_llm_openai.py` which resulted in `11 passed, 1 skipped`.
- Existing tests for success, env model selection, latency, quota mapping, healthcheck, and retry behavior still pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f750921f0c832a82b4d379de281e55)