### PR TITLE
Add fixed critical actions bar with strong confirmations in dashboard

### DIFF
--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -368,3 +368,39 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
   background: rgba(255, 107, 141, 0.22);
   color: var(--bad);
 }
+
+
+.critical-actions-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0 0 14px;
+  padding: 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  background: linear-gradient(120deg, rgba(17, 30, 70, 0.94), rgba(11, 22, 55, 0.96));
+  box-shadow: var(--glow);
+}
+
+.critical-action-btn {
+  font-weight: 700;
+  border-color: rgba(127, 166, 255, 0.6);
+}
+
+.critical-action-warning {
+  border-color: rgba(255, 191, 83, 0.75);
+}
+
+.critical-action-danger {
+  border-color: rgba(255, 107, 141, 0.9);
+  color: #ffd7e2;
+  background: linear-gradient(135deg, rgba(110, 24, 44, 0.95), rgba(82, 18, 33, 0.92));
+}
+
+.critical-action-danger:hover {
+  border-color: #ff7a9a;
+  box-shadow: 0 0 0 2px rgba(255, 107, 141, 0.28);
+}

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -15,6 +15,20 @@
   </div>
   <button id='toggle-essential' class='nav-mode-toggle' type='button' aria-pressed='false'>Mode Essentiel : OFF</button>
 </nav>
+
+<section class='critical-actions-bar' aria-label='Actions critiques'>
+  <button type='button' class='critical-action-btn'>Créer une vie</button>
+  <button type='button' class='critical-action-btn critical-action-warning' onclick="return confirm('Confirmer la suppression/l’archivage ? Portée : la vie ciblée et ses données associées (historique, artefacts, contexte).');">Supprimer/archiver une vie</button>
+  <button type='button' class='critical-action-btn'>Parler à une vie</button>
+  <button
+    type='button'
+    class='critical-action-btn critical-action-danger'
+    onclick="if (!confirm('ARRÊT D’URGENCE : cette action stoppe immédiatement les opérations en cours. Confirmez-vous ?')) return false; return confirm('DOUBLE VALIDATION — Confirmez à nouveau l’arrêt d’urgence global.');"
+  >
+    Arrêt d’urgence
+  </button>
+</section>
+
 <div id='stale-data-banner' class='stale-banner panel-hidden' role='status' aria-live='polite'></div>
 
 <section id='tab-decider-maintenant' class='tab-pane' role='tabpanel' aria-labelledby='tab-btn-decider'>


### PR DESCRIPTION
### Motivation
- Introduire une barre d’actions critiques visible et fixe sous la navigation pour regrouper uniquement les opérations opérateur essentielles (création, suppression/archivage, conversation, arrêt d’urgence). 
- Renforcer la sécurité UX pour les opérations à risque via des confirmations explicites et une double validation sur l’arrêt d’urgence. 

### Description
- Ajout d’une section HTML `critical-actions-bar` dans `src/singular/dashboard/templates/dashboard.html` contenant les boutons `Créer une vie`, `Supprimer/archiver une vie`, `Parler à une vie` et `Arrêt d’urgence` avec confirmations en ligne. 
- Mise en place d’une confirmation explicite pour `Supprimer/archiver une vie` qui indique la portée (vie ciblée + données associées). 
- Mise en place d’une double confirmation JavaScript pour `Arrêt d’urgence` (deux dialogues `confirm`) pour assurer une validation forte. 
- Ajout de règles CSS dans `src/singular/dashboard/static/dashboard.css` pour rendre la barre sticky, styliser les boutons et donner un traitement visuel danger à l’action d’urgence. 

### Testing
- Examen du diff avec `git diff -- src/singular/dashboard/templates/dashboard.html src/singular/dashboard/static/dashboard.css` a produit les modifications attendues et a réussi. 
- Le commit a été créé avec `git commit -m "Add fixed critical actions bar to dashboard"` et s’est effectué avec succès. 
- La PR a été préparée via l’outil `make_pr` et le contenu a été généré avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7549bf0f0832a966915ff5478134e)