### PR TITLE
Add Operator/Expert UI modes with persistent technical-details toggle

### DIFF
--- a/src/singular/dashboard/static/bootstrap.js
+++ b/src/singular/dashboard/static/bootstrap.js
@@ -247,6 +247,26 @@ const toggleEssentialMode=()=>{
 };
 
 const DASHBOARD_TAB_KEY='singular.dashboard.lastTab';
+const DASHBOARD_TECHNICAL_DETAILS_KEY='singular.dashboard.technicalDetails';
+
+const applyTechnicalDetailsVisibility=isEnabled=>{
+  document.body.dataset.dashboardMode=isEnabled?'expert':'operator';
+  document.body.classList.toggle('technical-details-enabled',isEnabled);
+  document.querySelectorAll('.technical-only').forEach(node=>{
+    node.classList.toggle('panel-hidden',!isEnabled);
+    node.setAttribute('aria-hidden',isEnabled?'false':'true');
+  });
+};
+
+const toggleTechnicalDetails=()=>{
+  const isEnabled=document.body?.dataset?.dashboardMode!=='expert';
+  applyTechnicalDetailsVisibility(isEnabled);
+  localStorage.setItem(DASHBOARD_TECHNICAL_DETAILS_KEY,isEnabled?'1':'0');
+  const btn=document.getElementById('toggle-technical-details');
+  if(!btn){return;}
+  btn.textContent=`Afficher les détails techniques : ${isEnabled?'ON':'OFF'}`;
+  btn.setAttribute('aria-pressed',isEnabled?'true':'false');
+};
 
 const activateDashboardTab=tabId=>{
   const panes=document.querySelectorAll('.tab-pane');
@@ -283,6 +303,15 @@ const bindTabNavigation=()=>{
 
 const bindCommonHandlers=()=>{
   bindTabNavigation();
+  const technicalDetailsBtn=document.getElementById('toggle-technical-details');
+  const technicalDetailsDefault=localStorage.getItem(DASHBOARD_TECHNICAL_DETAILS_KEY)==='1';
+  applyTechnicalDetailsVisibility(technicalDetailsDefault);
+  if(technicalDetailsBtn){
+    technicalDetailsBtn.textContent=`Afficher les détails techniques : ${technicalDetailsDefault?'ON':'OFF'}`;
+    technicalDetailsBtn.setAttribute('aria-pressed',technicalDetailsDefault?'true':'false');
+    technicalDetailsBtn.onclick=toggleTechnicalDetails;
+  }
+
   const essentialBtn=document.getElementById('toggle-essential');
   const defaultEssential=localStorage.getItem(ESSENTIAL_MODE_KEY)==='1';
   applyEssentialVisibility(defaultEssential);

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -14,6 +14,7 @@
     <button type='button' class='tab-trigger' role='tab' id='tab-btn-technique' data-tab='technique' aria-controls='tab-technique'>Technique</button>
   </div>
   <button id='toggle-essential' class='nav-mode-toggle' type='button' aria-pressed='false'>Mode Essentiel : OFF</button>
+  <button id='toggle-technical-details' class='nav-mode-toggle' type='button' aria-pressed='false'>Afficher les détails techniques : OFF</button>
 </nav>
 
 <section class='critical-actions-bar' aria-label='Actions critiques'>
@@ -101,14 +102,14 @@
     <h2>Timeline des événements</h2>
     <p class='section-help'>Timeline + détail mutation pour expliquer rapidement un changement.</p>
     <div id='timeline' class='timeline-strip'></div>
-    <h3>Ce qui a changé grâce à quoi</h3>
-    <ul id='causal-timeline-list' class='list-tight-top'>
+    <h3 class='technical-only'>Ce qui a changé grâce à quoi</h3>
+    <ul id='causal-timeline-list' class='list-tight-top technical-only'>
       <li>Aucune trace causale disponible.</li>
     </ul>
-    <h3>Détail mutation</h3>
-    <p id='timeline-summary'>Cliquez sur un événement de mutation.</p>
-    <pre id='timeline-impact'></pre>
-    <pre id='timeline-diff' class='diff-preview'></pre>
+    <h3 class='technical-only'>Détail mutation</h3>
+    <p id='timeline-summary' class='technical-only'>Cliquez sur un événement de mutation.</p>
+    <pre id='timeline-impact' class='technical-only'></pre>
+    <pre id='timeline-diff' class='diff-preview technical-only'></pre>
   </section>
 </section>
 
@@ -164,7 +165,7 @@
         <ul id='dead-lives' class='list-compact'></ul>
       </div>
     </div>
-    <div class='panel panel-compact panel-bordered panel-top-gap' data-essential-level='2'>
+    <div class='panel panel-compact panel-bordered panel-top-gap technical-only' data-essential-level='2'>
       <div class='toolbar-wrap'>
         <strong>Diagnostic filtrage vies</strong>
         <button type='button' id='lives-reset-filters' class='filter-chip'>Réinitialiser les filtres</button>


### PR DESCRIPTION
### Motivation
- Provide a clear default "Opérateur" observation mode and an "Expert" mode that exposes detailed timeline, payload JSON, diagnostics and internal metrics. 
- Give users a single, discoverable control to show/hide technical details without changing autonomous life behavior. 
- Persist the user preference locally so the chosen display mode survives page reloads.

### Description
- Adds a nav toggle button `#toggle-technical-details` and marks technical sections with the `technical-only` class in `src/singular/dashboard/templates/dashboard.html` so they can be hidden by default. 
- Implements `applyTechnicalDetailsVisibility(isEnabled)` and `toggleTechnicalDetails()` plus the storage key `singular.dashboard.technicalDetails` in `src/singular/dashboard/static/bootstrap.js` and sets `document.body.dataset.dashboardMode` to `operator` or `expert` for compatibility with existing signal logic. 
- Initializes and binds the toggle in `bindCommonHandlers()` so the preference is read from `localStorage` at bootstrap and reapplied on load. 
- Visibility changes only affect UI elements (`.technical-only` and related ARIA attributes) and do not change autonomous life logic or runtime behavior.

### Testing
- Ran `node --check src/singular/dashboard/static/bootstrap.js` which succeeded. 
- Ran `node --check src/singular/dashboard/static/dashboard.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7553bc0cc832abd2dd0933f5ad9c5)