### PR TITLE
Dashboard: adopter un langage observationnel et résumé quotidien autonome

### DIFF
--- a/src/singular/dashboard/static/dashboard.js
+++ b/src/singular/dashboard/static/dashboard.js
@@ -11,60 +11,68 @@ const setActionableTone=(el,tone)=>{
   if(!el){return;}
   el.classList.remove('actionable-warn','actionable-critical');
   el.dataset.actionable='off';
-  if(tone==='warn'){
-    el.classList.add('actionable-warn');
-    el.dataset.actionable='on';
-  }
   if(tone==='critical'){
     el.classList.add('actionable-critical');
     el.dataset.actionable='on';
   }
 };
 
+const isUrgencyText=text=>{
+  const content=String(text||'').toLowerCase();
+  return content.includes('critique')||content.includes('critical')||content.includes('urgence')||content.includes('emergency');
+};
+
+const updateDailyNarrativeSummary=()=>{
+  const summaryList=document.getElementById('daily-autonomous-summary');
+  if(!summaryList){return;}
+
+  const healthText=document.getElementById('kpi-health')?.textContent?.trim()||'non disponible';
+  const activeLivesText=document.getElementById('kpi-active-lives')?.textContent?.trim()||'0';
+  const alertsText=document.getElementById('kpi-alerts')?.textContent?.trim()||'0';
+  const trendText=document.getElementById('kpi-trend')?.textContent?.trim()||'non disponible';
+  const riskText=document.getElementById('kpi-vital-risk')?.textContent?.trim()||'';
+
+  const alertsValue=parseFloatSafe(alertsText)||0;
+  const items=[
+    `Autonomie observée: ${healthText}.`,
+    `Stabilité collective: ${activeLivesText} vies actives suivies aujourd’hui.`,
+    `La tendance récente est ${trendText}.`,
+    alertsValue>0
+      ? `${alertsText} incidents critiques ont été enregistrés sans intervention humaine.`
+      : 'Aucun incident critique détecté sur la période observée.'
+  ];
+
+  if(isUrgencyText(riskText) || alertsValue>=3){
+    items.push(`🚨 Urgence humaine requise: ${riskText||'un signal critique demande une validation humaine immédiate.'}`);
+  }
+
+  summaryList.innerHTML='';
+  items.forEach(line=>{
+    const li=document.createElement('li');
+    const urgent=line.startsWith('🚨');
+    li.textContent=line;
+    if(urgent){
+      li.classList.add('actionable-critical');
+      li.dataset.humanRequired='true';
+      li.setAttribute('aria-label','Urgence humaine requise');
+    }
+    summaryList.appendChild(li);
+  });
+};
+
 const evaluateActionableSignals=()=>{
-  const expertMode=document.body?.dataset?.dashboardMode==='expert';
   const alertsEl=document.getElementById('kpi-alerts');
   const riskEl=document.getElementById('kpi-vital-risk');
 
-  // Mode standard : uniquement alertes d’observation + état d’urgence.
   const alerts=parseFloatSafe(alertsEl?.textContent);
-  if(alerts===null||alerts<=0){setActionableTone(alertsEl,null);}
-  else if(alerts>=3){setActionableTone(alertsEl,'critical');}
-  else{setActionableTone(alertsEl,'warn');}
+  if(alerts!==null&&alerts>=3){setActionableTone(alertsEl,'critical');}
+  else{setActionableTone(alertsEl,null);}
 
-  const riskText=String(riskEl?.textContent||'').toLowerCase();
-  if(riskText.includes('critique')||riskText.includes('critical')||riskText.includes('urgence')||riskText.includes('emergency')){
-    setActionableTone(riskEl,'critical');
-  }else if(riskText.includes('élevé')||riskText.includes('high')||riskText.includes('warn')){
-    setActionableTone(riskEl,'warn');
-  }else{
-    setActionableTone(riskEl,null);
-  }
+  if(isUrgencyText(riskEl?.textContent)){ setActionableTone(riskEl,'critical'); }
+  else{ setActionableTone(riskEl,null); }
 
-  if(!expertMode){
-    ['kpi-health','kpi-next-action','kpi-trend','kpi-autonomy-stability'].forEach(id=>setActionableTone(document.getElementById(id),null));
-    return;
-  }
-
-  // Mode expert : conservation des signaux avancés existants.
-  const healthEl=document.getElementById('kpi-health');
-  const trendEl=document.getElementById('kpi-trend');
-  const autonomyStabilityEl=document.getElementById('kpi-autonomy-stability');
-  const health=parseFloatSafe(healthEl?.textContent);
-  if(health===null){setActionableTone(healthEl,null);}
-  else if(health<40){setActionableTone(healthEl,'critical');}
-  else if(health<65){setActionableTone(healthEl,'warn');}
-  else{setActionableTone(healthEl,null);}
-
-  const trendText=String(trendEl?.textContent||'').toLowerCase();
-  if(trendText.includes('dégradation')||trendText.includes('degradation')){setActionableTone(trendEl,'warn');}
-  else{setActionableTone(trendEl,null);}
-
-  const stability=parseFloatSafe(autonomyStabilityEl?.textContent);
-  if(stability===null){setActionableTone(autonomyStabilityEl,null);}
-  else if(stability<50){setActionableTone(autonomyStabilityEl,'critical');}
-  else if(stability<70){setActionableTone(autonomyStabilityEl,'warn');}
-  else{setActionableTone(autonomyStabilityEl,null);}
+  ['kpi-health','kpi-next-action','kpi-trend','kpi-autonomy-stability'].forEach(id=>setActionableTone(document.getElementById(id),null));
+  updateDailyNarrativeSummary();
 };
 
 const bindSeeMoreToggles=()=>{

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -51,11 +51,20 @@
       <h3 class='heading-reset-top'>Indicateurs clés</h3>
       <div id='cockpit-status' class='card card-value'>Statut global: Non disponible</div>
       <div class='cards-grid'>
-        <div class='card'><div class='card-label kpi-label' title='Niveau global de santé de l’organisme'>Santé globale</div><div id='kpi-health' class='card-value'>Pas encore mesuré</div></div>
-        <div class='card'><div class='card-label kpi-label' title='Nombre de vies actives'>Vies actives</div><div id='kpi-active-lives' class='card-value'>0</div></div>
-        <div class='card'><div class='card-label kpi-label' title='Nombre d’événements critiques en cours'>Événements critiques</div><div id='kpi-alerts' class='card-value'>0</div></div>
+        <div class='card'><div class='card-label kpi-label' title='Capacité observée du système à fonctionner sans assistance'>Niveau d’autonomie</div><div id='kpi-health' class='card-value'>Pas encore mesuré</div></div>
+        <div class='card'><div class='card-label kpi-label' title='Cohérence observée entre les vies actives'>Stabilité collective</div><div id='kpi-active-lives' class='card-value'>0</div></div>
+        <div class='card'><div class='card-label kpi-label' title='Nombre d’incidents critiques en cours'>Incidents critiques</div><div id='kpi-alerts' class='card-value'>0</div></div>
         <div class='card'><div class='card-label kpi-label' title='Évolution récente du système'>Tendance</div><div id='kpi-trend' class='card-value'>Non disponible</div></div>
       </div>
+    </div>
+
+
+    <div class='panel level-panel' data-essential-level='1'>
+      <h3 class='heading-reset-top'>Résumé quotidien automatique</h3>
+      <p class='section-help'>Ce qui s’est passé sans intervention humaine.</p>
+      <ul id='daily-autonomous-summary' class='list-tight-top'>
+        <li>Collecte des signaux en cours…</li>
+      </ul>
     </div>
 
     <details id='cockpit-followup' class='panel level-panel' data-essential-level='2' open>


### PR DESCRIPTION
### Motivation
- Remplacer le vocabulaire prescriptif dans le cockpit par un langage d’observation pour clarifier que les vies fonctionnent de manière autonome. 
- Éviter les formulations actionnables non urgentes dans le mode opérateur afin de ne signaler explicitement qu’un besoin humain réel. 
- Fournir un résumé quotidien automatique qui restitue « ce qui s’est passé sans intervention humaine » à partir des signaux déjà collectés.

### Description
- Dans `src/singular/dashboard/templates/dashboard.html` les trois KPI du cockpit ont été renommés en `Niveau d’autonomie`, `Stabilité collective` et `Incidents critiques`, et une section `#daily-autonomous-summary` a été ajoutée pour le résumé quotidien. 
- Dans `src/singular/dashboard/static/dashboard.js` la logique a été simplifiée pour ne conserver qu’un marquage critique/urgence (suppression des tonalités « warn » non urgentes). 
- Ajout de la fonction `isUrgencyText` pour détecter les libellés d’urgence et de `updateDailyNarrativeSummary` qui construit de brefs narratifs à partir de `kpi-health`, `kpi-active-lives`, `kpi-alerts`, `kpi-trend` et `kpi-vital-risk`. 
- Les lignes nécessitant une intervention humaine sont explicitement marquées `🚨 Urgence humaine requise` et reçoivent `data-human-required='true'` et une classe `actionable-critical`.

### Testing
- Contrôle de cohérence du diff exécuté avec `git diff --check` et sans avertissement. 
- Vérification de l’état du workspace avec `git status --short` et validation des fichiers modifiés listés. 
- Aucun test automatique supplémentaire (unitaires/CI) n’a été déclenché dans cette opération locale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f757385d38832a97b61b54b1507c91)