### PR TITLE
Include temporary JSONL run files in dashboard

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -25,7 +25,11 @@ from singular.skills_daily import build_daily_skills_snapshot
 from fastapi.responses import HTMLResponse
 
 from singular.schedulers.reevaluation import alerts_from_records
-from singular.dashboard.repositories.run_records import RunRecordsRepository
+from singular.dashboard.repositories.run_records import (
+    RunRecordsRepository,
+    is_run_jsonl_file,
+    logical_run_file_stem,
+)
 from singular.dashboard.services.trajectory import (
     build_trajectory as build_trajectory_service,
     extract_objective_priorities as extract_objective_priorities_service,
@@ -169,7 +173,11 @@ def create_app(
         normalized = run.strip()
         if not normalized:
             return "unknown"
-        # Legacy JSONL files often follow <run_id>-<timestamp>.jsonl.
+        if normalized.endswith(".jsonl.tmp"):
+            normalized = normalized[: -len(".jsonl.tmp")]
+        elif normalized.endswith(".jsonl"):
+            normalized = normalized[: -len(".jsonl")]
+        # Legacy JSONL files often follow <run_id>-<timestamp>.jsonl(.tmp).
         # Normalize back to <run_id> so registry run mappings can resolve life names.
         if "-" in normalized:
             candidate, suffix = normalized.rsplit("-", 1)
@@ -245,7 +253,7 @@ def create_app(
             if not directory.exists():
                 continue
             for file in directory.iterdir():
-                if not file.is_file() or file.suffix != ".jsonl":
+                if not file.is_file() or not is_run_jsonl_file(file):
                     continue
                 for line in file.read_text(encoding="utf-8").splitlines():
                     if not line.strip():
@@ -333,6 +341,9 @@ def create_app(
 
     def _read_jsonl_records(file: Path) -> list[dict[str, object]]:
         return run_repository.read_jsonl_records(file)
+
+    def _run_file_id(file: Path) -> str:
+        return logical_run_file_stem(file)
 
     def _latest_run_file(current_life_only: bool = False) -> Path | None:
         return run_repository.latest_run_file(current_life_only=current_life_only)
@@ -660,7 +671,7 @@ def create_app(
         )
 
         return {
-            "run": latest.stem,
+            "run": _run_file_id(latest),
             "health_score": health_score,
             "trend": trend,
             "accepted_mutation_rate": accepted_rate,
@@ -813,7 +824,7 @@ def create_app(
         latest = _latest_run_file(current_life_only=current_life_only)
         if latest is not None:
             consciousness_path = _resolve_consciousness_path(
-                latest.stem, current_life_only=current_life_only
+                _run_file_id(latest), current_life_only=current_life_only
             )
             if consciousness_path is not None:
                 for line in consciousness_path.read_text(encoding="utf-8").splitlines():
@@ -841,7 +852,7 @@ def create_app(
         return {
             "quests": quests,
             "objectives": {"items": objectives_items},
-            "conversations": {"run_id": latest.stem if latest is not None else None, "items": conversations_items},
+            "conversations": {"run_id": _run_file_id(latest) if latest is not None else None, "items": conversations_items},
         }
 
     @app.get("/ecosystem")
@@ -854,14 +865,14 @@ def create_app(
         if latest is None:
             return {"run": None, "alerts": []}
         records = _read_jsonl_records(latest)
-        return {"run": latest.stem, "alerts": alerts_from_records(records)}
+        return {"run": _run_file_id(latest), "alerts": alerts_from_records(records)}
 
     @app.get("/runs/latest")
     def read_latest_run(current_life_only: bool = False) -> dict[str, object]:
         latest = _latest_run_file(current_life_only=current_life_only)
         if latest is None:
             return {"run": None, "records": []}
-        return {"run": latest.stem, "records": _read_jsonl_records(latest)}
+        return {"run": _run_file_id(latest), "records": _read_jsonl_records(latest)}
 
     @app.get("/api/runs/{run_id}/timeline")
     def read_run_timeline(
@@ -1055,7 +1066,7 @@ def create_app(
                 last_timestamp = ts
 
         return {
-            "run": latest.stem,
+            "run": _run_file_id(latest),
             "summary": {
                 "entries": len(records),
                 "mutations": mutation_count,
@@ -1789,7 +1800,7 @@ def create_app(
             ts = payload.get("ts")
             return {
                 "type": "run_event",
-                "run_id": file.stem,
+                "run_id": _run_file_id(file),
                 "event": event,
                 "ts": ts if isinstance(ts, str) else None,
             }
@@ -1818,7 +1829,7 @@ def create_app(
                         if not directory.exists():
                             continue
                         for file in directory.iterdir():
-                            if not file.is_file() or file.suffix != ".jsonl":
+                            if not file.is_file() or not is_run_jsonl_file(file):
                                 continue
                             key = f"{directory.parent.name}/{file.name}"
                             current_files.add(key)

--- a/src/singular/dashboard/repositories/run_records.py
+++ b/src/singular/dashboard/repositories/run_records.py
@@ -6,6 +6,38 @@ from pathlib import Path
 from typing import Callable
 
 
+def is_run_jsonl_file(path: Path) -> bool:
+    """Return whether *path* is a persisted or in-progress run JSONL file."""
+
+    return (
+        not path.name.endswith(".consciousness.jsonl")
+        and not path.name.endswith(".consciousness.jsonl.tmp")
+        and (path.suffix == ".jsonl" or path.suffixes[-2:] == [".jsonl", ".tmp"])
+    )
+
+
+def logical_run_file_stem(path: Path) -> str:
+    """Return the logical run identifier represented by a run JSONL path."""
+
+    stem = path.name
+    if stem.endswith(".jsonl.tmp"):
+        stem = stem[: -len(".jsonl.tmp")]
+    elif stem.endswith(".jsonl"):
+        stem = stem[: -len(".jsonl")]
+    else:
+        stem = path.stem
+
+    normalized = stem.strip()
+    if not normalized:
+        return "unknown"
+
+    if "-" in normalized:
+        candidate, suffix = normalized.rsplit("-", 1)
+        if candidate and suffix.isdigit() and len(suffix) >= 8:
+            return candidate
+    return normalized
+
+
 @dataclass
 class RunRecordsRepository:
     """Read dashboard run records from one or many life run directories."""
@@ -54,7 +86,7 @@ class RunRecordsRepository:
             if not directory.exists():
                 continue
             for file in directory.iterdir():
-                if not file.is_file() or file.suffix != ".jsonl":
+                if not file.is_file() or not is_run_jsonl_file(file):
                     continue
                 for line in file.read_text(encoding="utf-8").splitlines():
                     line = line.strip()
@@ -67,7 +99,7 @@ class RunRecordsRepository:
                     if not isinstance(payload, dict):
                         continue
                     if "_run_file" not in payload:
-                        payload["_run_file"] = file.stem
+                        payload["_run_file"] = logical_run_file_stem(file)
                     records.append(payload)
         return records
 
@@ -77,7 +109,7 @@ class RunRecordsRepository:
             if not directory.exists():
                 continue
             for path in directory.iterdir():
-                if path.is_file() and path.suffix == ".jsonl":
+                if path.is_file() and is_run_jsonl_file(path):
                     files.append(path)
         return sorted(
             files,
@@ -117,21 +149,37 @@ class RunRecordsRepository:
         )
 
     def resolve_run_file(self, run_id: str, current_life_only: bool = False) -> Path | None:
-        return next(
-            (
-                directory / f"{run_id}.jsonl"
-                for directory in self.runs_dirs(current_life_only=current_life_only)
-                if (directory / f"{run_id}.jsonl").exists()
-            ),
-            None,
-        )
+        for directory in self.runs_dirs(current_life_only=current_life_only):
+            for filename in (f"{run_id}.jsonl", f"{run_id}.jsonl.tmp"):
+                candidate = directory / filename
+                if candidate.exists():
+                    return candidate
+            if not directory.exists():
+                continue
+            for candidate in self.iter_run_files(current_life_only=current_life_only):
+                if candidate.parent == directory and logical_run_file_stem(candidate) == run_id:
+                    return candidate
+        return None
 
     def resolve_consciousness_path(
         self, run_id: str, current_life_only: bool = False
     ) -> Path | None:
-        raw_run_id = run_id.rsplit("-", 1)[0]
+        raw_run_id = run_id
+        if "-" in raw_run_id:
+            candidate_id, suffix = raw_run_id.rsplit("-", 1)
+            if candidate_id and suffix.isdigit() and len(suffix) >= 8:
+                raw_run_id = candidate_id
+        candidate_ids = [raw_run_id]
+        if run_id not in candidate_ids:
+            candidate_ids.append(run_id)
         for directory in self.runs_dirs(current_life_only=current_life_only):
-            candidate = directory / raw_run_id / "consciousness.jsonl"
-            if candidate.exists():
-                return candidate
+            for candidate_id in candidate_ids:
+                candidates = (
+                    directory / candidate_id / "consciousness.jsonl",
+                    directory / f"{candidate_id}.consciousness.jsonl",
+                    directory / f"{candidate_id}.consciousness.jsonl.tmp",
+                )
+                for candidate in candidates:
+                    if candidate.exists():
+                        return candidate
         return None

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -242,6 +242,59 @@ def test_dashboard_latest_run_summary_endpoint(tmp_path: Path) -> None:
     assert len(latest_payload["records"]) == 3
 
 
+def test_dashboard_includes_temporary_jsonl_run_files(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    run_file = runs_dir / "run-live-20260511090000.jsonl.tmp"
+    run_file.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T09:00:00+00:00",
+                        "event": "interaction",
+                        "organism": "temp-life",
+                        "interaction": "signal",
+                        "energy": 7,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T09:01:00+00:00",
+                        "skill": "temp-life:skills/adapt.py",
+                        "operator": "swap",
+                        "accepted": True,
+                        "score_base": 10.0,
+                        "score_new": 8.0,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+
+    latest_payload = app._routes["/runs/latest"]()
+    assert latest_payload["run"] == "run-live"
+    assert [record["ts"] for record in latest_payload["records"]] == [
+        "2026-05-11T09:00:00+00:00",
+        "2026-05-11T09:01:00+00:00",
+    ]
+
+    timeline_payload = app._routes["/api/runs/{run_id}/timeline"](run_id="run-live")
+    assert timeline_payload["pagination"]["total"] == 2
+    assert [item["event"] for item in timeline_payload["items"]] == [
+        "interaction",
+        "mutation",
+    ]
+
+    ecosystem_payload = app._routes["/ecosystem"]()
+    assert ecosystem_payload["organisms"]["temp-life"]["last_interaction"] == "signal"
+    assert ecosystem_payload["organisms"]["temp-life"]["energy"] == 7
+
+
 def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
@@ -1271,7 +1324,7 @@ def test_psyche_missing_returns_404(tmp_path: Path) -> None:
 def test_websocket_stream_incremental_events_and_growth_stability(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
-    run_file = runs_dir / "run-live.jsonl"
+    run_file = runs_dir / "run-live-20260511090000.jsonl.tmp"
     run_file.write_text(
         json.dumps({"ts": "2026-04-12T10:00:00", "event": "interaction"}) + "\n",
         encoding="utf-8",


### PR DESCRIPTION
### Motivation

- Ensure the dashboard picks up in-progress run logs (`*.jsonl.tmp`) the same way as persisted `*.jsonl` so live runs are not ignored by the UI and websocket stream. 
- Preserve the logical run identifier when filenames include timestamps (e.g. `<run_id>-<timestamp>.jsonl.tmp`) so registry mappings and UI labels remain stable.

### Description

- Added shared helpers `is_run_jsonl_file()` and `logical_run_file_stem()` in `src/singular/dashboard/repositories/run_records.py` to recognize `*.jsonl` and `*.jsonl.tmp` while excluding `*.consciousness.jsonl` variants, and to normalize logical run stems. 
- Updated `load_run_records()`, `iter_run_files()`, and `resolve_run_file()` in `RunRecordsRepository` to include temporary files and to set `"_run_file"` using the normalized logical stem. 
- Enhanced `resolve_consciousness_path()` to consider both directory-based and file-based consciousness paths for timestamped or temporary run ids. 
- Updated dashboard wiring in `src/singular/dashboard/__init__.py` to import and use the new helpers, to stop filtering out temp files in `_compute_ecosystem()` and the websocket loop, and to expose the normalized run id in routes and websocket events (via a `_run_file_id()` wrapper). 
- Added test coverage in `tests/test_dashboard.py` (`test_dashboard_includes_temporary_jsonl_run_files`) and updated websocket-related test cases to use a `*.jsonl.tmp` run file validating `/runs/latest`, the timeline route, `/ecosystem` aggregation, and websocket incremental streaming.

### Testing

- Ran static checks and byte-compile with `python -m py_compile src/singular/dashboard/repositories/run_records.py src/singular/dashboard/__init__.py` which succeeded. 
- Ran targeted tests: `pytest tests/test_dashboard.py::test_dashboard_includes_temporary_jsonl_run_files tests/test_dashboard.py::test_websocket_stream_incremental_events_and_growth_stability tests/test_dashboard.py::test_dashboard_work_items_schema_contains_required_fields -q`, and they all passed. 
- A full suite run (`pytest tests/test_dashboard.py tests/test_dashboard_services.py`) still reports pre-existing dashboard/template and lives-comparison/genealogy failures unrelated to this change (these failures were observed during iteration and not caused by the temporary-file handling). 

Commit: `fc0998d` — "Include temporary JSONL run records in dashboard"

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0228caa6a8832a93f4bcfcadacdf97)