### PR TITLE
Dashboard: lier actions critiques en UI et backend (+ `emergency_stop`)

### DIFF
--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -312,6 +312,8 @@ class DashboardActionService:
                 result = self._memorial(params)
             elif action == "clone":
                 result = self._clone(params)
+            elif action == "emergency_stop":
+                result = self._emergency_stop(params)
             else:
                 payload = ActionResult(
                     ok=False,
@@ -521,6 +523,50 @@ class DashboardActionService:
 
         data, log = self._capture(_run)
         return ActionResult(ok=True, action="archive", data=data, log=log)
+
+    def _emergency_stop(self, params: dict[str, Any]) -> ActionResult:
+        scope = params.get("scope", "active_life")
+        if scope != "active_life":
+            raise ValueError("emergency_stop only supports scope=active_life")
+
+        from singular.lives import load_registry, resolve_life
+
+        life = resolve_life(None)
+        if life is None:
+            raise ValueError("no active life")
+        registry = load_registry()
+        active = registry.get("active")
+        lives = registry.get("lives") if isinstance(registry.get("lives"), dict) else {}
+        metadata = lives.get(active) if isinstance(active, str) else None
+        mem_dir = Path(life) / "mem"
+        stop_path = mem_dir / "orchestrator.stop.json"
+        requested_at = datetime.now(timezone.utc).isoformat()
+
+        def _run() -> dict[str, Any]:
+            mem_dir.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "stop": True,
+                "reason": "dashboard_emergency_stop",
+                "requested_at": requested_at,
+                "requested_by": "dashboard",
+                "scope": scope,
+                "life": active,
+            }
+            stop_path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            return {
+                "life": active,
+                "name": getattr(metadata, "name", active),
+                "path": str(life),
+                "stop_signal_path": str(stop_path),
+                "requested_at": requested_at,
+                "guided_message": "Arrêt d’urgence demandé: le signal d’arrêt sera honoré par l’orchestrateur actif.",
+            }
+
+        data, log = self._capture(_run)
+        return ActionResult(ok=True, action="emergency_stop", data=data, log=log)
 
     def _memorial(self, params: dict[str, Any]) -> ActionResult:
         name = self._require_non_empty_text(params.get("name"), field="name", max_len=80)

--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -1,3 +1,12 @@
+const actionResultTargets=()=>[
+  document.getElementById('action-result'),
+  document.getElementById('critical-action-result'),
+].filter(Boolean);
+
+const writeActionResult=text=>{
+  actionResultTargets().forEach(target=>{target.textContent=text;});
+};
+
 export const runAction=(action,payload,{onAfterAction}={})=>{
   const token=document.getElementById('action-token')?.value||'';
   const q=new URLSearchParams();
@@ -7,10 +16,38 @@ export const runAction=(action,payload,{onAfterAction}={})=>{
     if(!r.ok){throw new Error(`HTTP ${r.status}`);}
     return r.json();
   }).then(async data=>{
-    document.getElementById('action-result').textContent=JSON.stringify(data,null,2);
+    writeActionResult(JSON.stringify(data,null,2));
     if(typeof onAfterAction==='function'){await onAfterAction();}
   }).catch(err=>{
-    document.getElementById('action-result').textContent=`Erreur action ${action}: ${err.message}`;
+    writeActionResult(`Erreur action ${action}: ${err.message}`);
+  });
+};
+
+const actionPayload=(action,lifeName)=>{
+  if(action==='birth'){return {name:lifeName()||'Nouvelle vie'};}
+  if(action==='talk'){return {prompt:document.getElementById('action-prompt')?.value||''};}
+  if(action==='archive'){return {name:lifeName()};}
+  if(action==='emergency_stop'){return {scope:'active_life'};}
+  return {};
+};
+
+const confirmCriticalAction=button=>{
+  const message=button.dataset.confirm;
+  if(message&&!window.confirm(message)){return false;}
+  const secondMessage=button.dataset.confirmAgain;
+  if(secondMessage&&!window.confirm(secondMessage)){return false;}
+  return true;
+};
+
+export const bindCriticalActionHandlers=(handlers)=>{
+  const lifeName=()=>document.getElementById('action-life-name')?.value||'';
+  document.querySelectorAll('.critical-actions-bar [data-dashboard-action]').forEach(button=>{
+    if(button.offsetParent===null){return;}
+    button.onclick=()=>{
+      if(button.disabled||!confirmCriticalAction(button)){return false;}
+      const action=button.dataset.dashboardAction||'';
+      return runAction(action,actionPayload(action,lifeName),handlers);
+    };
   });
 };
 
@@ -25,4 +62,5 @@ export const bindActionHandlers=(handlers)=>{
   document.getElementById('act-archive').onclick=()=>runAction('archive',{name:lifeName()},handlers);
   document.getElementById('act-memorial').onclick=()=>runAction('memorial',{name:lifeName(),message:'Merci pour ce cycle de vie.'},handlers);
   document.getElementById('act-clone').onclick=()=>runAction('clone',{name:lifeName(),new_name:`${lifeName()||'Vie'} clone`},handlers);
+  bindCriticalActionHandlers(handlers);
 };

--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -385,6 +385,18 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
   box-shadow: var(--glow);
 }
 
+.critical-action-result {
+  margin: -4px 0 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: rgba(9, 16, 39, 0.92);
+  color: #dbe6ff;
+  white-space: pre-wrap;
+  max-height: 180px;
+  overflow: auto;
+}
+
 .critical-action-btn {
   font-weight: 700;
   border-color: rgba(127, 166, 255, 0.6);

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -18,17 +18,29 @@
 </nav>
 
 <section class='critical-actions-bar' aria-label='Actions critiques'>
-  <button type='button' class='critical-action-btn'>Créer une vie</button>
-  <button type='button' class='critical-action-btn critical-action-warning' onclick="return confirm('Confirmer la suppression/l’archivage ? Portée : la vie ciblée et ses données associées (historique, artefacts, contexte).');">Supprimer/archiver une vie</button>
-  <button type='button' class='critical-action-btn'>Parler à une vie</button>
+  <button id='critical-birth' type='button' class='critical-action-btn' data-dashboard-action='birth'>Créer une vie</button>
   <button
+    id='critical-archive'
+    type='button'
+    class='critical-action-btn critical-action-warning'
+    data-dashboard-action='archive'
+    data-confirm="Confirmer la suppression/l’archivage ? Portée : la vie ciblée et ses données associées (historique, artefacts, contexte)."
+  >
+    Supprimer/archiver une vie
+  </button>
+  <button id='critical-talk' type='button' class='critical-action-btn' data-dashboard-action='talk'>Parler à une vie</button>
+  <button
+    id='critical-emergency-stop'
     type='button'
     class='critical-action-btn critical-action-danger'
-    onclick="if (!confirm('ARRÊT D’URGENCE : cette action stoppe immédiatement les opérations en cours. Confirmez-vous ?')) return false; return confirm('DOUBLE VALIDATION — Confirmez à nouveau l’arrêt d’urgence global.');"
+    data-dashboard-action='emergency_stop'
+    data-confirm="ARRÊT D’URGENCE : cette action stoppe immédiatement les opérations en cours. Confirmez-vous ?"
+    data-confirm-again="DOUBLE VALIDATION — Confirmez à nouveau l’arrêt d’urgence global."
   >
     Arrêt d’urgence
   </button>
 </section>
+<div id='critical-action-result' class='critical-action-result' role='status' aria-live='polite'>Aucune action critique exécutée.</div>
 
 <div id='stale-data-banner' class='stale-banner panel-hidden' role='status' aria-live='polite'></div>
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi_stub import TestClient
 
 from singular.dashboard import create_app, run
+from singular.lives import create_life
 
 
 def _receive_with_timeout(ws: TestClient._WSConnection, timeout: float = 2.0) -> dict[str, object]:
@@ -1421,6 +1422,15 @@ def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: py
     body = client.get("/").json()
     assert "Actions rapides" in body
     assert "action-result" in body
+    assert "critical-action-result" in body
+    assert "critical-birth" in body
+    assert "data-dashboard-action='birth'" in body
+    assert "critical-talk" in body
+    assert "data-dashboard-action='talk'" in body
+    assert "critical-archive" in body
+    assert "data-dashboard-action='archive'" in body
+    assert "critical-emergency-stop" in body
+    assert "data-dashboard-action='emergency_stop'" in body
     assert "Créer vie" in body
     assert "Discuter" in body
     assert "Archiver" in body
@@ -1437,6 +1447,32 @@ def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: py
     with pytest.raises(Exception):
         app._routes["/api/actions/{action}"]("lives_list", token="wrong", payload="{}")
 
+
+def test_dashboard_emergency_stop_action_writes_active_life_stop_signal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    meta = create_life("Urgence")
+
+    app = create_app(
+        runs_dir=meta.path / "runs", psyche_file=meta.path / "mem" / "psyche.json"
+    )
+    route = app._routes["/api/actions/{action}"]
+
+    result = route("emergency_stop", payload=json.dumps({"scope": "active_life"}))
+
+    assert result["ok"] is True
+    assert result["action"] == "emergency_stop"
+    stop_path = meta.path / "mem" / "orchestrator.stop.json"
+    assert result["data"]["stop_signal_path"] == str(stop_path)
+    payload = json.loads(stop_path.read_text(encoding="utf-8"))
+    assert payload["stop"] is True
+    assert payload["reason"] == "dashboard_emergency_stop"
+    assert payload["requested_by"] == "dashboard"
+    assert payload["life"] == meta.slug
 
 def test_dashboard_actions_validation_robustness(tmp_path: Path) -> None:
     app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")


### PR DESCRIPTION
### Motivation
- Rendre les actions critiques de la barre d’actions utilisables de façon explicite depuis l’UI (identifiants/attributs) et afficher leurs résultats dans une zone visible, pas seulement dans l’onglet technique.
- Fournir une implémentation backend pour un arrêt d’urgence sûr ciblant la vie active afin que le bouton puisse déclencher une action concrète et auditable.

### Description
- Ajout d’identifiants et d’attributs `data-dashboard-action` aux boutons de la barre critique : `critical-birth`, `critical-talk`, `critical-archive`, `critical-emergency-stop`, et insertion d’un conteneur visible `#critical-action-result` dans `src/singular/dashboard/templates/dashboard.html`.
- JS : refactor de `runAction()` pour écrire la sortie à la fois dans `#action-result` et `#critical-action-result`, ajout de `bindCriticalActionHandlers()` qui réutilise `runAction()` pour `birth`, `talk`, `archive` et `emergency_stop`, et confirmation double pour les actions dangereuses dans `src/singular/dashboard/static/actions.js`.
- Backend : ajout d’une action explicite `emergency_stop` dans `DashboardActionService` (implémentation `_emergency_stop`) qui valide le `scope`, résout la vie active et écrit `mem/orchestrator.stop.json` pour signaler l’arrêt à l’orchestrateur, exposée via la route existante `/api/actions/{action}` (`src/singular/dashboard/actions.py`).
- UI/CSS : ajout de la classe `.critical-action-result` pour rendre visible et formatée la sortie des actions critiques (`src/singular/dashboard/static/dashboard.css`).
- Tests : extension des tests du dashboard pour vérifier la présence du markup critique et que l’action `emergency_stop` crée bien le signal d’arrêt dans la vie active (`tests/test_dashboard.py`).

### Testing
- Exécuté : `pytest tests/test_dashboard.py::test_dashboard_actions_endpoint_and_ui_panel` — réussite.
- Exécuté : `pytest tests/test_dashboard.py::test_dashboard_emergency_stop_action_writes_active_life_stop_signal` — réussite.
- Exécuté : `pytest tests/test_dashboard.py::test_dashboard_actions_validation_robustness` — réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022b85e960832a98da9a17b1d7b5c9)