### PR TITLE
Ajouter un résumé opérateur des vies dans l’onglet Décider

### DIFF
--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -47,6 +47,66 @@ const sparkline=(values)=>{
 const toneByRisk=(el,risk)=>{el.classList.remove('status-good','status-warn','status-bad','status-muted');if(risk==='ok'){el.classList.add('status-good');return;}if(risk==='warn'){el.classList.add('status-warn');return;}if(risk==='critical'){el.classList.add('status-bad');return;}el.classList.add('status-muted');};
 const extractHostMetrics=(record)=>{if(record&&typeof record.host_metrics==='object'&&record.host_metrics){return record.host_metrics;}if(record&&typeof record.signals==='object'&&record.signals&&typeof record.signals.host_metrics==='object'){return record.signals.host_metrics;}if(record&&typeof record.payload==='object'&&record.payload&&typeof record.payload.host_metrics==='object'){return record.payload.host_metrics;}return null;};
 
+const operatorSummaryState={context:null,lives:null,eco:null,cockpit:null};
+
+const firstDefined=(...values)=>values.find(value=>value!==null&&value!==undefined&&value!=='');
+const formatOneDecimal=value=>value===null||value===undefined||Number.isNaN(Number(value))?na():Number(value).toFixed(1);
+const riskRows=rows=>(rows||[]).filter(row=>row.extinction_seen_in_runs===true||row.trend==='dégradation'||Number(row.alerts_count||0)>0);
+const extractMood=row=>firstDefined(row?.emotional_state?.mood,row?.mood,row?.latest_mood,row?.psyche?.mood);
+const extractEnergy=(row,eco)=>{
+  const life=row?.life;
+  const organisms=eco?.organisms||{};
+  const organism=life?organisms[life]:null;
+  return firstDefined(row?.emotional_state?.energy,row?.energy,row?.psyche?.energy,organism?.energy);
+};
+
+const renderOperatorSummary=()=>{
+  const root=document.getElementById('operator-lives-summary');
+  if(!root){return;}
+  const ctx=operatorSummaryState.context||{};
+  const lives=operatorSummaryState.lives||{};
+  const eco=operatorSummaryState.eco||{};
+  const cockpit=operatorSummaryState.cockpit||{};
+  const rows=Array.isArray(lives.table)?lives.table:[];
+  const counts=(lives.life_metrics_contract||eco.life_metrics_contract||{}).counts||{};
+  const total=Number(Object.prototype.hasOwnProperty.call(ctx,'registry_lives_count')?ctx.registry_lives_count:firstDefined(counts.total_lives,rows.length,0));
+  const alive=Number(Object.prototype.hasOwnProperty.call(counts,'alive_lives')?counts.alive_lives:rows.filter(row=>row.is_registry_active_life===true).length);
+  const risks=riskRows(rows);
+  const selected=rows.find(row=>row.selected_life===true);
+  const latest=rows.find(row=>row.last_activity)||rows[0];
+  const focus=selected||latest;
+  const activeLife=ctx.registry_state?.active;
+  const selectedLabel=selected?.life||cockpit.selected_life||null;
+  const activeSelectedLabel=activeLife&&selectedLabel&&activeLife!==selectedLabel?`active=${activeLife} · sélectionnée=${selectedLabel}`:(selectedLabel||activeLife||'Aucune');
+  const lastActivity=latest?.last_activity||(total>0?'run en cours non encore indexé':na());
+  const mood=extractMood(focus);
+  const energy=extractEnergy(focus,eco);
+  const moodLabel=mood||'données de mood absentes';
+  const energyLabel=energy===null||energy===undefined?na():formatOneDecimal(energy);
+  const trend=focus?.trend||cockpit.trend||na();
+  const liveness=firstDefined(focus?.life_liveness_index,cockpit.liveness_index);
+
+  document.getElementById('operator-lives-total').textContent=total>0?String(total):'aucune vie dans le registre';
+  document.getElementById('operator-selected-life').textContent=activeSelectedLabel;
+  document.getElementById('operator-alive-lives').textContent=String(alive);
+  document.getElementById('operator-risk-lives').textContent=String(risks.length);
+  document.getElementById('operator-last-activity').textContent=lastActivity;
+  document.getElementById('operator-mood-energy').textContent=`${moodLabel} · énergie=${energyLabel}`;
+  document.getElementById('operator-trend').textContent=String(trend);
+  document.getElementById('operator-liveness').textContent=formatOneDecimal(liveness);
+
+  const states=document.getElementById('operator-lives-empty-states');
+  states.innerHTML='';
+  const messages=[];
+  if(total<=0){messages.push('aucune vie dans le registre');}
+  if(total>0&&!rows.some(row=>row.last_activity)){messages.push('run en cours non encore indexé');}
+  if(!mood){messages.push('données de mood absentes');}
+  if(!messages.length){messages.push('Synthèse opérateur à jour.');}
+  for(const message of messages){const li=document.createElement('li');li.textContent=message;states.appendChild(li);}
+  setStatusTone(document.getElementById('operator-risk-lives'),risks.length?'warn':'good');
+  setStatusTone(document.getElementById('operator-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
+};
+
 const renderHostMetrics=(records)=>{
   const metricDef=[
     {key:'cpu',label:'host-cpu',trend:'host-cpu-trend',raw:'cpu_percent',suffix:'%'},
@@ -94,7 +154,13 @@ const renderHostMetrics=(records)=>{
   return unsupportedCount<metricDef.length;
 };
 
-export const loadContext=()=>fetchJson('/dashboard/context').then(ctx=>{
+export const loadContext=()=>Promise.all([
+  fetchJson('/dashboard/context'),
+  fetchJson('/lives/comparison?sort_by=last_activity&sort_order=desc'),
+]).then(([ctx,lives])=>{
+  operatorSummaryState.context=ctx;
+  operatorSummaryState.lives=lives;
+  renderOperatorSummary();
   document.getElementById('ctx-root').textContent=ctx.singular_root||na();
   document.getElementById('ctx-home').textContent=ctx.singular_home||na();
   document.getElementById('ctx-lives-count').textContent=String(ctx.registry_lives_count||0);
@@ -142,6 +208,9 @@ export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJs
   document.getElementById('eco-total-lives').textContent=String(total);
   document.getElementById('eco-alive-lives').textContent=String(alive);
   document.getElementById('eco-dead-lives').textContent=String(dead);
+  operatorSummaryState.eco=eco;
+  operatorSummaryState.lives=lives;
+  renderOperatorSummary();
   const rows=lives.table||[];
   const selected=rows.find(row=>row.selected_life===true);
   document.getElementById('eco-selected-life').textContent=selected?.life||'Aucune';
@@ -193,6 +262,8 @@ export const loadCockpit=()=>Promise.all([
   const fmtPct=(value)=>value===null||value===undefined?na():`${(Number(value)*100).toFixed(1)}%`;
   const fmtNum=(value,suffix='')=>value===null||value===undefined?na():`${Number(value).toFixed(2)}${suffix}`;
 
+  operatorSummaryState.cockpit={trend,liveness_index:livenessIndex,selected_life:essentialPayload.selected_life};
+  renderOperatorSummary();
   document.getElementById('kpi-health').textContent=healthValue;
   document.getElementById('kpi-trend').textContent=trend;
   document.getElementById('kpi-accepted').textContent=accepted;

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -51,6 +51,24 @@
     <p><strong>Les vies agissent de manière autonome ; aucune action humaine requise hors gouvernance.</strong></p>
   </div>
 
+  <section id='operator-lives-summary' class='panel level-panel' data-essential-level='1' aria-live='polite'>
+    <h2 class='heading-reset-top'>Résumé opérateur des vies</h2>
+    <p class='section-help'>Vue accessible sans mode technique : registre, activité, humeur/énergie, tendance et liveness.</p>
+    <div class='cards-grid'>
+      <div class='card'><div class='card-label'>Nombre de vies</div><div id='operator-lives-total' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Vie active / sélectionnée</div><div id='operator-selected-life' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Vies vivantes</div><div id='operator-alive-lives' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Vies en risque</div><div id='operator-risk-lives' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Dernière activité</div><div id='operator-last-activity' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Humeur / énergie</div><div id='operator-mood-energy' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Tendance</div><div id='operator-trend' class='card-value'>Chargement…</div></div>
+      <div class='card'><div class='card-label'>Liveness</div><div id='operator-liveness' class='card-value'>Chargement…</div></div>
+    </div>
+    <ul id='operator-lives-empty-states' class='list-tight-top'>
+      <li>Chargement du registre des vies…</li>
+    </ul>
+  </section>
+
   <section id='cockpit'>
     <h2>État de l’écosystème</h2>
     <p class='section-help'>Vue synthétique d’observation de l’écosystème (sans prescriptions opérateur).</p>


### PR DESCRIPTION
### Motivation
- Rendre disponible aux opérateurs (hors mode technique) une synthèse claire des vies et de leur état sans ouvrir les panneaux techniques.
- Fournir un résumé rapide combinant le contexte du dashboard et la comparaison des vies pour aider la lecture et la détection rapide d’anomalies.

### Description
- Ajout d’un bloc visible non technique `Résumé opérateur des vies` dans `#tab-decider-maintenant` avec cartes pour nombre de vies, vie active/sélectionnée, vies vivantes, vies en risque, dernière activité, humeur/énergie, tendance et liveness (`src/singular/dashboard/templates/dashboard.html`).
- Implémentation d’un nouvel état `operatorSummaryState` et d’une fonction `renderOperatorSummary()` dans `src/singular/dashboard/static/render-cockpit.js` qui calcule les vies à risque et extrait humeur/énergie quand disponibles.
- Chargement en parallèle de `/dashboard/context` et `/lives/comparison?sort_by=last_activity&sort_order=desc` depuis `loadContext()`, et rafraîchissement du résumé opérateur depuis `loadEco()` et `loadCockpit()` pour utiliser les données au fur et à mesure de leur arrivée (`src/singular/dashboard/static/render-cockpit.js`).
- Ajout d’états explicites habituellement affichés dans le résumé : « aucune vie dans le registre », « run en cours non encore indexé », « données de mood absentes ».

### Testing
- `node --check src/singular/dashboard/static/render-cockpit.js` a été exécuté avec succès (vérification syntaxique JS). ✅
- `python -m pytest tests/test_dashboard_smoke_e2e.py` a été exécuté et a réussi (1 test passé, 1 avertissement). ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022d97e92c832aac150f72dc6d27cf)