### PR TITLE
Guard dashboard static DOM access and add smoke tests

### DIFF
--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -52,15 +52,21 @@ export const bindCriticalActionHandlers=(handlers)=>{
 };
 
 export const bindActionHandlers=(handlers)=>{
-  const lifeName=()=>document.getElementById('action-life-name').value||'';
-  document.getElementById('act-birth').onclick=()=>runAction('birth',{name:lifeName()||'Nouvelle vie'},handlers);
-  document.getElementById('act-talk').onclick=()=>runAction('talk',{prompt:document.getElementById('action-prompt').value||''},handlers);
-  document.getElementById('act-loop').onclick=()=>runAction('loop',{budget_seconds:Number(document.getElementById('action-budget').value||0)},handlers);
-  document.getElementById('act-report').onclick=()=>runAction('report',{},handlers);
-  document.getElementById('act-lives-list').onclick=()=>runAction('lives_list',{},handlers);
-  document.getElementById('act-lives-use').onclick=()=>runAction('lives_use',{name:lifeName()},handlers);
-  document.getElementById('act-archive').onclick=()=>runAction('archive',{name:lifeName()},handlers);
-  document.getElementById('act-memorial').onclick=()=>runAction('memorial',{name:lifeName(),message:'Merci pour ce cycle de vie.'},handlers);
-  document.getElementById('act-clone').onclick=()=>runAction('clone',{name:lifeName(),new_name:`${lifeName()||'Vie'} clone`},handlers);
+  const lifeName=()=>document.getElementById('action-life-name')?.value||'';
+  const prompt=()=>document.getElementById('action-prompt')?.value||'';
+  const budget=()=>Number(document.getElementById('action-budget')?.value||0);
+  const bind=(id,handler)=>{
+    const button=document.getElementById(id);
+    if(button){button.onclick=handler;}
+  };
+  bind('act-birth',()=>runAction('birth',{name:lifeName()||'Nouvelle vie'},handlers));
+  bind('act-talk',()=>runAction('talk',{prompt:prompt()},handlers));
+  bind('act-loop',()=>runAction('loop',{budget_seconds:budget()},handlers));
+  bind('act-report',()=>runAction('report',{},handlers));
+  bind('act-lives-list',()=>runAction('lives_list',{},handlers));
+  bind('act-lives-use',()=>runAction('lives_use',{name:lifeName()},handlers));
+  bind('act-archive',()=>runAction('archive',{name:lifeName()},handlers));
+  bind('act-memorial',()=>runAction('memorial',{name:lifeName(),message:'Merci pour ce cycle de vie.'},handlers));
+  bind('act-clone',()=>runAction('clone',{name:lifeName(),new_name:`${lifeName()||'Vie'} clone`},handlers));
   bindCriticalActionHandlers(handlers);
 };

--- a/src/singular/dashboard/static/bootstrap.js
+++ b/src/singular/dashboard/static/bootstrap.js
@@ -195,7 +195,8 @@ const bootstrapPauseControls=()=>{
   wrap.className='panel';
   wrap.innerHTML="<h3 class='heading-reset-top'>Contrôle des mises à jour</h3><div id='updates-status'>Mises à jour globales: actives</div><button id='updates-toggle' type='button'>Pause updates</button>";
   section.prepend(wrap);
-  document.getElementById('updates-toggle').onclick=toggleSchedulerPause;
+  const toggle=document.getElementById('updates-toggle');
+  if(toggle){toggle.onclick=toggleSchedulerPause;}
 };
 
 const toggleViewPause=viewKey=>{
@@ -348,8 +349,13 @@ export const bootstrapDashboard=()=>{
 
   ws.onmessage=e=>{
     const m=JSON.parse(e.data);
-    if(m.type==='psyche'){document.getElementById('psyche').textContent=JSON.stringify(m.data,null,2);return;}
-    if(m.type==='quests'){document.getElementById('quests').textContent=JSON.stringify(m.data,null,2);return;}
+    if(m.type==='psyche'){const psyche=document.getElementById('psyche');if(psyche){psyche.textContent=JSON.stringify(m.data,null,2);}return;}
+    if(m.type==='quests'){
+      const raw=document.getElementById('quests-json-raw');
+      if(raw){raw.textContent=JSON.stringify(m.data,null,2);}
+      else{loadQuests();}
+      return;
+    }
     if(['timeline','run_event','alert','alerts'].includes(m.type)){
       const task=schedulerTasks.get('timeline');
       if(task){task.nextRunAt=0;}

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -4,16 +4,22 @@ import {renderQuestsSection} from './render-quests.js';
 import {renderObjectivesSection} from './render-objectives.js';
 import {renderConversationsSection} from './render-conversations.js';
 
+const byId=id=>document.getElementById(id);
+const setText=(id,text)=>{const el=byId(id);if(el){el.textContent=text;}return el;};
+const setTitle=(id,text)=>{const el=byId(id);if(el){el.title=text;}return el;};
+const clearElement=id=>{const el=byId(id);if(el){el.innerHTML='';}return el;};
+const setTone=(id,tone)=>{const el=byId(id);if(el){setStatusTone(el,tone);}return el;};
+
 const renderDailySkills=(dailySkills)=>{
   const frequency=dailySkills?.frequency_totals||{};
   const progression=dailySkills?.progression_pipeline||{};
   const topSkills=dailySkills?.top_skills||[];
-  document.getElementById('daily-skill-uses-24h').textContent=String(frequency.uses_24h||0);
-  document.getElementById('daily-skill-uses-7d').textContent=String(frequency.uses_7d||0);
-  document.getElementById('daily-skill-top').textContent=String(topSkills[0]?.skill||na());
-  document.getElementById('daily-skill-progression').textContent=`${progression.learned||0}→${progression.used||0}→${progression.improved||0}`;
-  const body=document.getElementById('daily-skills-table-body');
-  body.innerHTML='';
+  setText('daily-skill-uses-24h',String(frequency.uses_24h||0));
+  setText('daily-skill-uses-7d',String(frequency.uses_7d||0));
+  setText('daily-skill-top',String(topSkills[0]?.skill||na()));
+  setText('daily-skill-progression',`${progression.learned||0}→${progression.used||0}→${progression.improved||0}`);
+  const body=clearElement('daily-skills-table-body');
+  if(!body){return;}
   for(const item of topSkills){
     const tr=document.createElement('tr');
     const successRate=item.success_rate===null||item.success_rate===undefined?na():`${(Number(item.success_rate)*100).toFixed(1)}%`;
@@ -44,7 +50,7 @@ const sparkline=(values)=>{
   return values.map(v=>ticks[Math.min(ticks.length-1,Math.max(0,Math.round(((v-min)/(max-min))*(ticks.length-1))))]).join('');
 };
 
-const toneByRisk=(el,risk)=>{el.classList.remove('status-good','status-warn','status-bad','status-muted');if(risk==='ok'){el.classList.add('status-good');return;}if(risk==='warn'){el.classList.add('status-warn');return;}if(risk==='critical'){el.classList.add('status-bad');return;}el.classList.add('status-muted');};
+const toneByRisk=(el,risk)=>{if(!el){return;}el.classList.remove('status-good','status-warn','status-bad','status-muted');if(risk==='ok'){el.classList.add('status-good');return;}if(risk==='warn'){el.classList.add('status-warn');return;}if(risk==='critical'){el.classList.add('status-bad');return;}el.classList.add('status-muted');};
 const extractHostMetrics=(record)=>{if(record&&typeof record.host_metrics==='object'&&record.host_metrics){return record.host_metrics;}if(record&&typeof record.signals==='object'&&record.signals&&typeof record.signals.host_metrics==='object'){return record.signals.host_metrics;}if(record&&typeof record.payload==='object'&&record.payload&&typeof record.payload.host_metrics==='object'){return record.payload.host_metrics;}return null;};
 
 const operatorSummaryState={context:null,lives:null,eco:null,cockpit:null};
@@ -86,25 +92,25 @@ const renderOperatorSummary=()=>{
   const trend=focus?.trend||cockpit.trend||na();
   const liveness=firstDefined(focus?.life_liveness_index,cockpit.liveness_index);
 
-  document.getElementById('operator-lives-total').textContent=total>0?String(total):'aucune vie dans le registre';
-  document.getElementById('operator-selected-life').textContent=activeSelectedLabel;
-  document.getElementById('operator-alive-lives').textContent=String(alive);
-  document.getElementById('operator-risk-lives').textContent=String(risks.length);
-  document.getElementById('operator-last-activity').textContent=lastActivity;
-  document.getElementById('operator-mood-energy').textContent=`${moodLabel} · énergie=${energyLabel}`;
-  document.getElementById('operator-trend').textContent=String(trend);
-  document.getElementById('operator-liveness').textContent=formatOneDecimal(liveness);
+  setText('operator-lives-total',total>0?String(total):'aucune vie dans le registre');
+  setText('operator-selected-life',activeSelectedLabel);
+  setText('operator-alive-lives',String(alive));
+  setText('operator-risk-lives',String(risks.length));
+  setText('operator-last-activity',lastActivity);
+  setText('operator-mood-energy',`${moodLabel} · énergie=${energyLabel}`);
+  setText('operator-trend',String(trend));
+  setText('operator-liveness',formatOneDecimal(liveness));
 
-  const states=document.getElementById('operator-lives-empty-states');
-  states.innerHTML='';
+  const states=clearElement('operator-lives-empty-states');
+  if(!states){return;}
   const messages=[];
   if(total<=0){messages.push('aucune vie dans le registre');}
   if(total>0&&!rows.some(row=>row.last_activity)){messages.push('run en cours non encore indexé');}
   if(!mood){messages.push('données de mood absentes');}
   if(!messages.length){messages.push('Synthèse opérateur à jour.');}
   for(const message of messages){const li=document.createElement('li');li.textContent=message;states.appendChild(li);}
-  setStatusTone(document.getElementById('operator-risk-lives'),risks.length?'warn':'good');
-  setStatusTone(document.getElementById('operator-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
+  setTone('operator-risk-lives',risks.length?'warn':'good');
+  setTone('operator-trend',trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
 };
 
 const renderHostMetrics=(records)=>{
@@ -134,23 +140,24 @@ const renderHostMetrics=(records)=>{
     const risk=hostRisk(def.key,latest);
     if(riskWeight[risk]>riskWeight[global]){global=risk;}
     if(risk==='unsupported'){unsupportedCount+=1;}
-    const el=document.getElementById(def.label);
-    const trendEl=document.getElementById(def.trend);
-    el.textContent=latest===null?na():`${latest.toFixed(1)}${def.suffix} · ${risk}`;
-    trendEl.textContent=sparkline(values.slice(-12));
-    toneByRisk(el,risk);
+    const el=byId(def.label);
+    const trendEl=byId(def.trend);
+    if(el){el.textContent=latest===null?na():`${latest.toFixed(1)}${def.suffix} · ${risk}`;toneByRisk(el,risk);}
+    if(trendEl){trendEl.textContent=sparkline(values.slice(-12));}
   }
   if(unsupportedCount===metricDef.length){global='unsupported';}
-  const globalEl=document.getElementById('host-global');
-  globalEl.textContent=global;
-  toneByRisk(globalEl,global);
-  applyStatusIndicator(globalEl,global==='ok'?'good':(global==='warn'?'warn':(global==='critical'?'bad':null)));
-  document.getElementById('host-fallback').classList.toggle('panel-hidden',unsupportedCount===0);
-  const adaptationEl=document.getElementById('host-adaptation');
-  if(latestAdaptation){
+  const globalEl=byId('host-global');
+  if(globalEl){
+    globalEl.textContent=global;
+    toneByRisk(globalEl,global);
+    applyStatusIndicator(globalEl,global==='ok'?'good':(global==='warn'?'warn':(global==='critical'?'bad':null)));
+  }
+  byId('host-fallback')?.classList.toggle('panel-hidden',unsupportedCount===0);
+  const adaptationEl=byId('host-adaptation');
+  if(adaptationEl&&latestAdaptation){
     const rules=Array.isArray(latestAdaptation.payload?.triggered_rules)?latestAdaptation.payload.triggered_rules:[];
     adaptationEl.textContent=`Dernière adaptation capteur: ${latestAdaptation.ts||na()} · règles=${rules.join(', ')||na()} · prudent=${latestAdaptation.payload?.safe_mode===true?'oui':'non'}`;
-  }else{adaptationEl.textContent='Dernière adaptation capteur: aucune adaptation trouvée';}
+  }else if(adaptationEl){adaptationEl.textContent='Dernière adaptation capteur: aucune adaptation trouvée';}
   return unsupportedCount<metricDef.length;
 };
 
@@ -161,23 +168,22 @@ export const loadContext=()=>Promise.all([
   operatorSummaryState.context=ctx;
   operatorSummaryState.lives=lives;
   renderOperatorSummary();
-  document.getElementById('ctx-root').textContent=ctx.singular_root||na();
-  document.getElementById('ctx-home').textContent=ctx.singular_home||na();
-  document.getElementById('ctx-lives-count').textContent=String(ctx.registry_lives_count||0);
+  setText('ctx-root',ctx.singular_root||na());
+  setText('ctx-home',ctx.singular_home||na());
+  setText('ctx-lives-count',String(ctx.registry_lives_count||0));
   const policy=ctx.policy||{};
   const autonomy=policy.autonomy||{};
   const permissions=policy.permissions||{};
-  document.getElementById('ctx-policy-version').textContent=String(policy.version??na());
-  document.getElementById('ctx-policy-autonomy').textContent=`safe_mode=${autonomy.safe_mode?'on':'off'} · quota=${autonomy.mutation_quota_per_window??na()}/${autonomy.mutation_quota_window_seconds??na()}s`;
-  document.getElementById('ctx-policy-permissions').textContent=`auto=${(permissions.modifiable_paths||[]).length} · review=${(permissions.review_required_paths||[]).length} · forbidden=${(permissions.forbidden_paths||[]).length}`;
-  const impactList=document.getElementById('ctx-policy-impact');
-  impactList.innerHTML='';
-  for(const item of (ctx.policy_impact||[])){const li=document.createElement('li');li.textContent=String(item);impactList.appendChild(li);} 
-  if(!(ctx.policy_impact||[]).length){const li=document.createElement('li');li.textContent='Aucun impact disponible.';impactList.appendChild(li);} 
+  setText('ctx-policy-version',String(policy.version??na()));
+  setText('ctx-policy-autonomy',`safe_mode=${autonomy.safe_mode?'on':'off'} · quota=${autonomy.mutation_quota_per_window??na()}/${autonomy.mutation_quota_window_seconds??na()}s`);
+  setText('ctx-policy-permissions',`auto=${(permissions.modifiable_paths||[]).length} · review=${(permissions.review_required_paths||[]).length} · forbidden=${(permissions.forbidden_paths||[]).length}`);
+  const impactList=clearElement('ctx-policy-impact');
+  if(impactList){for(const item of (ctx.policy_impact||[])){const li=document.createElement('li');li.textContent=String(item);impactList.appendChild(li);} 
+  if(!(ctx.policy_impact||[]).length){const li=document.createElement('li');li.textContent='Aucun impact disponible.';impactList.appendChild(li);} } 
   const lifecycle=ctx.skills_lifecycle||{};
-  document.getElementById('kpi-skills-active').textContent=String(lifecycle.active||0);
-  document.getElementById('kpi-skills-dormant').textContent=String(lifecycle.dormant||0);
-  document.getElementById('kpi-skills-archived').textContent=String(lifecycle.archived||0);
+  setText('kpi-skills-active',String(lifecycle.active||0));
+  setText('kpi-skills-dormant',String(lifecycle.dormant||0));
+  setText('kpi-skills-archived',String(lifecycle.archived||0));
 });
 
 export const loadRetentionStatus=()=>fetchJson('/api/retention/status').then(payload=>{
@@ -190,12 +196,12 @@ export const loadRetentionStatus=()=>fetchJson('/api/retention/status').then(pay
   const thresholds=payload?.thresholds||{};
   const activeThresholds=payload?.active_thresholds||{};
   const exceeded=Object.entries(activeThresholds).filter(([,active])=>Boolean(active)).map(([key])=>key);
-  document.getElementById('kpi-retention-usage').textContent=`${Number(runs.size_mb||0).toFixed(2)}MB / ${Number(mem.size_mb||0).toFixed(2)}MB / ${Number(lives.size_mb||0).toFixed(2)}MB`;
-  document.getElementById('kpi-retention-last-purge').textContent=String(lastPurge?.at||'jamais');
-  document.getElementById('kpi-retention-freed').textContent=`${Number(summary.freed_mb||0).toFixed(2)}MB`;
-  document.getElementById('kpi-retention-items').textContent=`${summary.deleted||0} / ${summary.archived||0}`;
+  setText('kpi-retention-usage',`${Number(runs.size_mb||0).toFixed(2)}MB / ${Number(mem.size_mb||0).toFixed(2)}MB / ${Number(lives.size_mb||0).toFixed(2)}MB`);
+  setText('kpi-retention-last-purge',String(lastPurge?.at||'jamais'));
+  setText('kpi-retention-freed',`${Number(summary.freed_mb||0).toFixed(2)}MB`);
+  setText('kpi-retention-items',`${summary.deleted||0} / ${summary.archived||0}`);
   const thresholdLabel=`runs≤${thresholds.max_runs??na()} · age≤${thresholds.max_run_age_days??na()}j · size≤${thresholds.max_total_runs_size_mb??na()}MB`;
-  document.getElementById('kpi-retention-thresholds').textContent=exceeded.length?`${thresholdLabel} · dépassement: ${exceeded.join(', ')}`:thresholdLabel;
+  setText('kpi-retention-thresholds',exceeded.length?`${thresholdLabel} · dépassement: ${exceeded.join(', ')}`:thresholdLabel);
 });
 
 export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJson(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc'))]).then(([eco,lives])=>{
@@ -205,26 +211,25 @@ export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJs
   const total=Number(counts.total_lives||0);
   const alive=Number(counts.alive_lives||0);
   const dead=Number(counts.dead_lives||0);
-  document.getElementById('eco-total-lives').textContent=String(total);
-  document.getElementById('eco-alive-lives').textContent=String(alive);
-  document.getElementById('eco-dead-lives').textContent=String(dead);
+  setText('eco-total-lives',String(total));
+  setText('eco-alive-lives',String(alive));
+  setText('eco-dead-lives',String(dead));
   operatorSummaryState.eco=eco;
   operatorSummaryState.lives=lives;
   renderOperatorSummary();
   const rows=lives.table||[];
   const selected=rows.find(row=>row.selected_life===true);
-  document.getElementById('eco-selected-life').textContent=selected?.life||'Aucune';
+  setText('eco-selected-life',selected?.life||'Aucune');
   const latestRow=rows.find(row=>row.last_activity);
-  document.getElementById('eco-last-activity').textContent=latestRow?.last_activity||na();
-  document.getElementById('eco-total-lives').title=labels.total_lives||'Vies totales';
-  document.getElementById('eco-alive-lives').title=labels.alive_lives||'Vies vivantes';
-  document.getElementById('eco-dead-lives').title=labels.dead_lives||'Vies mortes';
+  setText('eco-last-activity',latestRow?.last_activity||na());
+  setTitle('eco-total-lives',labels.total_lives||'Vies totales');
+  setTitle('eco-alive-lives',labels.alive_lives||'Vies vivantes');
+  setTitle('eco-dead-lives',labels.dead_lives||'Vies mortes');
   const organisms=eco.organisms||{};
-  const list=document.getElementById('organisms-list');
-  list.innerHTML='';
-  for(const [name,payload] of Object.entries(organisms)){const li=document.createElement('li');const status=payload.status||'alive';const energy=payload.energy??na();const resources=payload.resources??na();li.textContent=`${name} · statut=${status} · énergie=${energy} · ressources=${resources}`;list.appendChild(li);} 
-  if(Object.keys(organisms).length===0){const li=document.createElement('li');li.textContent='Aucun organisme détecté.';list.appendChild(li);} 
-  document.getElementById('raw-eco-json').textContent=JSON.stringify(eco,null,2);
+  const list=clearElement('organisms-list');
+  if(list){for(const [name,payload] of Object.entries(organisms)){const li=document.createElement('li');const status=payload.status||'alive';const energy=payload.energy??na();const resources=payload.resources??na();li.textContent=`${name} · statut=${status} · énergie=${energy} · ressources=${resources}`;list.appendChild(li);} 
+  if(Object.keys(organisms).length===0){const li=document.createElement('li');li.textContent='Aucun organisme détecté.';list.appendChild(li);} } 
+  setText('raw-eco-json',JSON.stringify(eco,null,2));
 });
 
 export const loadQuests=()=>Promise.all([
@@ -252,12 +257,14 @@ export const loadCockpit=()=>Promise.all([
 ]).then(([essential,d])=>{
   if(!d||typeof d!=='object'){setPanelState('cockpit','empty','Aucune donnée cockpit disponible.');return;}
   const essentialPayload=(essential&&typeof essential==='object')?essential:{};
-  const statusBox=document.getElementById('cockpit-status');
+  const statusBox=byId('cockpit-status');
   const globalStatus=essentialPayload.global_status||d.global_status;
-  statusBox.textContent=`Statut global: ${globalStatus||na()}`;
-  if(globalStatus==='stable'){setStatusTone(statusBox,'good');applyStatusIndicator(statusBox,'good');}
-  else if(globalStatus==='warning'){setStatusTone(statusBox,'warn');applyStatusIndicator(statusBox,'warn');}
-  else if(globalStatus==='critical'){setStatusTone(statusBox,'bad');applyStatusIndicator(statusBox,'bad');}
+  if(statusBox){
+    statusBox.textContent=`Statut global: ${globalStatus||na()}`;
+    if(globalStatus==='stable'){setStatusTone(statusBox,'good');applyStatusIndicator(statusBox,'good');}
+    else if(globalStatus==='warning'){setStatusTone(statusBox,'warn');applyStatusIndicator(statusBox,'warn');}
+    else if(globalStatus==='critical'){setStatusTone(statusBox,'bad');applyStatusIndicator(statusBox,'bad');}
+  }
 
   const healthValue=d.health_score===null?na():Number(d.health_score).toFixed(1);
   const trend=d.trend||na();
@@ -272,32 +279,32 @@ export const loadCockpit=()=>Promise.all([
 
   operatorSummaryState.cockpit={trend,liveness_index:livenessIndex,selected_life:essentialPayload.selected_life};
   renderOperatorSummary();
-  document.getElementById('kpi-health').textContent=healthValue;
-  document.getElementById('kpi-trend').textContent=trend;
-  document.getElementById('kpi-accepted').textContent=accepted;
-  document.getElementById('kpi-alerts').textContent=String(alertsCount);
-  document.getElementById('kpi-liveness-index').textContent=livenessIndex;
-  document.getElementById('kpi-next-action').textContent=essentialPayload.next_action||d.next_action||na();
+  setText('kpi-health',healthValue);
+  setText('kpi-trend',trend);
+  setText('kpi-accepted',accepted);
+  setText('kpi-alerts',String(alertsCount));
+  setText('kpi-liveness-index',livenessIndex);
+  setText('kpi-next-action',essentialPayload.next_action||d.next_action||na());
   const selectedLifeEl=document.getElementById('essential-selected-life');
   if(selectedLifeEl){selectedLifeEl.textContent=String(essentialPayload.selected_life||'Aucune');}
   const incidentsEl=document.getElementById('essential-active-incidents');
   if(incidentsEl){incidentsEl.textContent=String(essentialPayload.active_incidents_count??alertsCount);}
-  document.getElementById('kpi-autonomy-proactive').textContent=fmtPct(autonomy.proactive_initiative_rate);
-  document.getElementById('kpi-autonomy-stability').textContent=fmtPct(autonomy.long_term_stability);
-  document.getElementById('kpi-autonomy-decision').textContent=`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`;
-  document.getElementById('kpi-autonomy-latency').textContent=fmtNum(autonomy.perception_to_action_latency_ms,' ms');
-  document.getElementById('kpi-autonomy-cost').textContent=fmtNum(autonomy.resource_cost_per_gain);
+  setText('kpi-autonomy-proactive',fmtPct(autonomy.proactive_initiative_rate));
+  setText('kpi-autonomy-stability',fmtPct(autonomy.long_term_stability));
+  setText('kpi-autonomy-decision',`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`);
+  setText('kpi-autonomy-latency',fmtNum(autonomy.perception_to_action_latency_ms,' ms'));
+  setText('kpi-autonomy-cost',fmtNum(autonomy.resource_cost_per_gain));
   const behavior=d.behavioral_regulation_metrics||{};
   const behaviorAlerts=behavior.alerts||{};
   const behaviorCorr=behavior.decision_correlation||{};
-  document.getElementById('kpi-behavior-diversity').textContent=fmtPct(behavior.behavioral_diversity);
-  document.getElementById('kpi-behavior-robustness').textContent=fmtPct(behavior.perturbation_robustness);
-  document.getElementById('kpi-behavior-recovery').textContent=fmtNum(behavior.recovery_time_seconds,' s');
-  document.getElementById('kpi-behavior-goals').textContent=fmtPct(behavior.goal_generation_autonomy);
-  document.getElementById('kpi-behavior-homeostasis').textContent=fmtPct(behavior.homeostatic_stability);
-  document.getElementById('kpi-behavior-trend').textContent=String(behavior.temporal_trend||na());
-  document.getElementById('kpi-behavior-correlation').textContent=`${behaviorCorr.major_decisions_count??0} décisions majeures`;
-  if(behaviorAlerts.homeostasis_unstable||behaviorAlerts.robustness_low){setStatusTone(document.getElementById('kpi-behavior-homeostasis'),'bad');}
+  setText('kpi-behavior-diversity',fmtPct(behavior.behavioral_diversity));
+  setText('kpi-behavior-robustness',fmtPct(behavior.perturbation_robustness));
+  setText('kpi-behavior-recovery',fmtNum(behavior.recovery_time_seconds,' s'));
+  setText('kpi-behavior-goals',fmtPct(behavior.goal_generation_autonomy));
+  setText('kpi-behavior-homeostasis',fmtPct(behavior.homeostatic_stability));
+  setText('kpi-behavior-trend',String(behavior.temporal_trend||na()));
+  setText('kpi-behavior-correlation',`${behaviorCorr.major_decisions_count??0} décisions majeures`);
+  if(behaviorAlerts.homeostasis_unstable||behaviorAlerts.robustness_low){setTone('kpi-behavior-homeostasis','bad');}
   const vital=d.vital_timeline||{};
   const skillLifecycle=d.skills_lifecycle||{};
   const vitalMetrics=d.vital_metrics||{};
@@ -310,41 +317,37 @@ export const loadCockpit=()=>Promise.all([
   const energyResources=vitalMetrics.energy_resources||{};
   const codeGeneration=vitalMetrics.code_generation||{};
   const risks=vitalMetrics.risks||[];
-  document.getElementById('kpi-vital-age').textContent=String(vital.age??0);
-  document.getElementById('kpi-vital-risk').textContent=String(vital.risk_level||na());
-  document.getElementById('kpi-vital-terminal').textContent=vital.terminal===true?'oui':'non';
-  document.getElementById('kpi-vital-causes').textContent=(vital.causes||[]).join(', ')||na();
-  document.getElementById('kpi-circadian-phase').textContent=String((vitalMetrics.circadian_cycle||{}).phase||na());
-  document.getElementById('kpi-active-objectives-count').textContent=String(objectives.count||0);
-  document.getElementById('kpi-quests-progress').textContent=`${objectives.count||0} actifs`;
-  document.getElementById('kpi-energy-total').textContent=fmtNum(energyResources.total_energy);
-  document.getElementById('kpi-resources-total').textContent=fmtNum(energyResources.total_resources);
-  document.getElementById('kpi-code-progression').textContent=String(codeGeneration.progression||na());
-  document.getElementById('kpi-code-risks').textContent=risks.length?risks.join(', '):String(codeGeneration.risk_level||na());
-  document.getElementById('kpi-skills-active').textContent=String(skillLifecycle.active||0);
-  document.getElementById('kpi-skills-dormant').textContent=String(skillLifecycle.dormant||0);
-  document.getElementById('kpi-skills-archived').textContent=String(skillLifecycle.archived||0);
+  setText('kpi-vital-age',String(vital.age??0));
+  setText('kpi-vital-risk',String(vital.risk_level||na()));
+  setText('kpi-vital-terminal',vital.terminal===true?'oui':'non');
+  setText('kpi-vital-causes',(vital.causes||[]).join(', ')||na());
+  setText('kpi-circadian-phase',String((vitalMetrics.circadian_cycle||{}).phase||na()));
+  setText('kpi-active-objectives-count',String(objectives.count||0));
+  setText('kpi-quests-progress',`${objectives.count||0} actifs`);
+  setText('kpi-energy-total',fmtNum(energyResources.total_energy));
+  setText('kpi-resources-total',fmtNum(energyResources.total_resources));
+  setText('kpi-code-progression',String(codeGeneration.progression||na()));
+  setText('kpi-code-risks',risks.length?risks.join(', '):String(codeGeneration.risk_level||na()));
+  setText('kpi-skills-active',String(skillLifecycle.active||0));
+  setText('kpi-skills-dormant',String(skillLifecycle.dormant||0));
+  setText('kpi-skills-archived',String(skillLifecycle.archived||0));
   renderDailySkills(d.daily_skills||{});
-  const objectivesList=document.getElementById('kpi-active-objectives-list');
-  objectivesList.innerHTML='';
-  for(const item of (objectives.items||[])){const li=document.createElement('li');li.textContent=String(item.name||item.id||'objectif');objectivesList.appendChild(li);} 
-  if(!(objectives.items||[]).length){const li=document.createElement('li');li.textContent='Aucun objectif actif';objectivesList.appendChild(li);} 
-  document.getElementById('kpi-trajectory-in-progress').textContent=String(trajectoryCounts.in_progress||0);
-  document.getElementById('kpi-trajectory-abandoned').textContent=String(trajectoryCounts.abandoned||0);
-  document.getElementById('kpi-trajectory-completed').textContent=String(trajectoryCounts.completed||0);
-  document.getElementById('kpi-trajectory-priority-count').textContent=String(priorityChanges.length||0);
-  document.getElementById('kpi-trajectory-links-count').textContent=String(objectiveLinks.length||0);
-  const priorityList=document.getElementById('kpi-priority-changes-list');
-  priorityList.innerHTML='';
-  for(const change of priorityChanges.slice(-5).reverse()){const li=document.createElement('li');li.textContent=`${change.objective||'objectif'} · ${change.from??na()} → ${change.to??na()} (${change.at||na()})`;priorityList.appendChild(li);} 
-  if(!priorityChanges.length){const li=document.createElement('li');li.textContent='Aucun changement détecté';priorityList.appendChild(li);} 
-  const linksList=document.getElementById('kpi-objective-links-list');
-  linksList.innerHTML='';
-  for(const link of objectiveLinks.slice(-5).reverse()){const li=document.createElement('li');li.textContent=`${link.objective||'objectif'} ↔ ${link.event||'événement'} (${link.at||na()})`;linksList.appendChild(li);} 
-  if(!objectiveLinks.length){const li=document.createElement('li');li.textContent='Aucun lien narratif détecté';linksList.appendChild(li);} 
-  const livenessProofsEl=document.getElementById('kpi-liveness-proofs');
-  livenessProofsEl.innerHTML='';
-  for(const proof of livenessProofs.slice(0,5)){
+  const objectivesList=clearElement('kpi-active-objectives-list');
+  if(objectivesList){for(const item of (objectives.items||[])){const li=document.createElement('li');li.textContent=String(item.name||item.id||'objectif');objectivesList.appendChild(li);} 
+  if(!(objectives.items||[]).length){const li=document.createElement('li');li.textContent='Aucun objectif actif';objectivesList.appendChild(li);} } 
+  setText('kpi-trajectory-in-progress',String(trajectoryCounts.in_progress||0));
+  setText('kpi-trajectory-abandoned',String(trajectoryCounts.abandoned||0));
+  setText('kpi-trajectory-completed',String(trajectoryCounts.completed||0));
+  setText('kpi-trajectory-priority-count',String(priorityChanges.length||0));
+  setText('kpi-trajectory-links-count',String(objectiveLinks.length||0));
+  const priorityList=clearElement('kpi-priority-changes-list');
+  if(priorityList){for(const change of priorityChanges.slice(-5).reverse()){const li=document.createElement('li');li.textContent=`${change.objective||'objectif'} · ${change.from??na()} → ${change.to??na()} (${change.at||na()})`;priorityList.appendChild(li);} 
+  if(!priorityChanges.length){const li=document.createElement('li');li.textContent='Aucun changement détecté';priorityList.appendChild(li);} } 
+  const linksList=clearElement('kpi-objective-links-list');
+  if(linksList){for(const link of objectiveLinks.slice(-5).reverse()){const li=document.createElement('li');li.textContent=`${link.objective||'objectif'} ↔ ${link.event||'événement'} (${link.at||na()})`;linksList.appendChild(li);} 
+  if(!objectiveLinks.length){const li=document.createElement('li');li.textContent='Aucun lien narratif détecté';linksList.appendChild(li);} } 
+  const livenessProofsEl=clearElement('kpi-liveness-proofs');
+  if(livenessProofsEl){for(const proof of livenessProofs.slice(0,5)){
     const li=document.createElement('li');
     li.textContent=`${proof.ts||na()} · ${proof.evidence||'preuve'} (${proof.component||'signal'})`;
     livenessProofsEl.appendChild(li);
@@ -353,14 +356,13 @@ export const loadCockpit=()=>Promise.all([
     const li=document.createElement('li');
     li.textContent='Aucune preuve récente.';
     livenessProofsEl.appendChild(li);
-  }
-  setStatusTone(document.getElementById('kpi-trend'),trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
+  }}
+  setTone('kpi-trend',trend==='amélioration'?'good':(trend==='dégradation'?'bad':'warn'));
   const notable=d.last_notable_mutation;
-  if(notable){const acceptedBadge=notable.accepted===true?'acceptée':(notable.accepted===false?'refusée':na());document.getElementById('kpi-notable-summary').textContent=`${notable.timestamp||na()} · ${notable.life||na()} · ${notable.operator||na()} · ${acceptedBadge} · Δ=${notable.impact_delta??na()}`;}
-  else{document.getElementById('kpi-notable-summary').textContent='Aucune mutation notable';}
-  const actionsEl=document.getElementById('kpi-actions');
-  actionsEl.innerHTML='';
-  for(const action of (d.suggested_actions||[])){const li=document.createElement('li');li.textContent=String(action);actionsEl.appendChild(li);} 
-  if((d.suggested_actions||[]).length===0){const li=document.createElement('li');li.textContent='Aucune action suggérée';actionsEl.appendChild(li);} 
-  document.getElementById('raw-cockpit-json').textContent=JSON.stringify(d,null,2);
+  if(notable){const acceptedBadge=notable.accepted===true?'acceptée':(notable.accepted===false?'refusée':na());setText('kpi-notable-summary',`${notable.timestamp||na()} · ${notable.life||na()} · ${notable.operator||na()} · ${acceptedBadge} · Δ=${notable.impact_delta??na()}`);}
+  else{setText('kpi-notable-summary','Aucune mutation notable');}
+  const actionsEl=clearElement('kpi-actions');
+  if(actionsEl){for(const action of (d.suggested_actions||[])){const li=document.createElement('li');li.textContent=String(action);actionsEl.appendChild(li);} 
+  if((d.suggested_actions||[]).length===0){const li=document.createElement('li');li.textContent='Aucune action suggérée';actionsEl.appendChild(li);} } 
+  setText('raw-cockpit-json',JSON.stringify(d,null,2));
 });

--- a/src/singular/dashboard/static/render-conversations.js
+++ b/src/singular/dashboard/static/render-conversations.js
@@ -30,6 +30,8 @@ const STATUS_LABELS={
   message_missing:'indisponible',
 };
 
+const setText=(id,text)=>{const el=document.getElementById(id);if(el){el.textContent=text;}return el;};
+
 const escapeHtml=value=>String(value??'').replace(/[&<>'"]/g,char=>({
   '&':'&amp;',
   '<':'&lt;',
@@ -80,12 +82,12 @@ const renderHistory=(life)=>{
 
 const renderMeta=(life)=>{
   const meta=conversationState.lastMetaByLife.get(life)||{};
-  document.getElementById('conversation-selected-life').textContent=`Vie: ${life||'aucune sélection'}`;
-  document.getElementById('conversation-availability').textContent=`Disponibilité: ${meta.status||'inconnue'}`;
-  document.getElementById('conversation-last-activity').textContent=`Activité récente: ${meta.last_update||meta.last_activity||'non disponible'}`;
+  setText('conversation-selected-life',`Vie: ${life||'aucune sélection'}`);
+  setText('conversation-availability',`Disponibilité: ${meta.status||'inconnue'}`);
+  setText('conversation-last-activity',`Activité récente: ${meta.last_update||meta.last_activity||'non disponible'}`);
   const history=conversationState.historyByLife.get(life)||[];
   const lastMsg=history.length?history[history.length-1].text:'aucun';
-  document.getElementById('conversation-last-message').textContent=`Dernier message: ${lastMsg}`;
+  setText('conversation-last-message',`Dernier message: ${lastMsg}`);
   setFlowState(inferFlow(meta));
   renderHistory(life);
 };

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -1,6 +1,10 @@
 import {fetchJson} from './api.js';
 import {BADGE_TONE,liveState,livesTableState,na,scopeState,setPanelState} from './state.js';
 
+const byId=id=>document.getElementById(id);
+const setText=(id,text)=>{const el=byId(id);if(el){el.textContent=text;}return el;};
+const setTitle=(id,text)=>{const el=byId(id);if(el){el.title=text;}return el;};
+
 const badge=(label,tone)=>`<span class='badge ${tone}'>${label}</span>`;
 const safeText=value=>String(value??na());
 const escapeHtml=value=>safeText(value).replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;').replaceAll("'",'&#39;');
@@ -133,20 +137,21 @@ const renderLivesBuckets=(rows,contract)=>{
   const labels=contract?.labels||{};
   const aliveList=document.getElementById('alive-lives');
   const deadList=document.getElementById('dead-lives');
-  document.getElementById('alive-count').textContent=String(counts.alive_lives??activeInRegistry.length);
-  document.getElementById('dead-count').textContent=String(counts.dead_lives??extinctInRuns.length);
-  document.getElementById('alive-count').title=labels.alive_lives||'Vies vivantes';
-  document.getElementById('dead-count').title=labels.dead_lives||'Vies mortes';
-  aliveList.innerHTML='';
-  deadList.innerHTML='';
-  for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||na();aliveList.appendChild(li);} 
-  for(const row of extinctInRuns){const li=document.createElement('li');li.textContent=row.life||na();deadList.appendChild(li);} 
-  if(!activeInRegistry.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);} 
-  if(!extinctInRuns.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);} 
+  setText('alive-count',String(counts.alive_lives??activeInRegistry.length));
+  setText('dead-count',String(counts.dead_lives??extinctInRuns.length));
+  setTitle('alive-count',labels.alive_lives||'Vies vivantes');
+  setTitle('dead-count',labels.dead_lives||'Vies mortes');
+  if(aliveList){aliveList.innerHTML='';}
+  if(deadList){deadList.innerHTML='';}
+  if(aliveList){for(const row of activeInRegistry){const li=document.createElement('li');li.textContent=row.life||na();aliveList.appendChild(li);}} 
+  if(deadList){for(const row of extinctInRuns){const li=document.createElement('li');li.textContent=row.life||na();deadList.appendChild(li);}} 
+  if(aliveList&&!activeInRegistry.length){const li=document.createElement('li');li.textContent='Aucune';aliveList.appendChild(li);} 
+  if(deadList&&!extinctInRuns.length){const li=document.createElement('li');li.textContent='Aucune';deadList.appendChild(li);} 
 };
 
 const renderLivesTable=(rows)=>{
-  const body=document.getElementById('lives-table-body');
+  const body=byId('lives-table-body');
+  if(!body){return;}
   body.innerHTML='';
   for(const row of rows||[]){
     const tr=document.createElement('tr');
@@ -240,12 +245,12 @@ const renderUnattachedRuns=(payload)=>{
   const runs=(payload?.runs)||[];
   const runsCount=Number(payload?.runs_count||0);
   const recordsCount=Number(payload?.records_count||0);
-  document.getElementById('unattached-runs-count').textContent=String(runsCount);
-  document.getElementById('unattached-records-count').textContent=String(recordsCount);
-  list.innerHTML='';
-  if(!runsCount){panel.classList.add('panel-hidden');return;}
-  panel.classList.remove('panel-hidden');
-  for(const item of runs){const li=document.createElement('li');li.textContent=`${item.run_id||'unknown'} · ${item.records_count||0} enregistrements`;list.appendChild(li);} 
+  setText('unattached-runs-count',String(runsCount));
+  setText('unattached-records-count',String(recordsCount));
+  if(list){list.innerHTML='';}
+  if(!runsCount){panel?.classList.add('panel-hidden');return;}
+  panel?.classList.remove('panel-hidden');
+  if(list){for(const item of runs){const li=document.createElement('li');li.textContent=`${item.run_id||'unknown'} · ${item.records_count||0} enregistrements`;list.appendChild(li);}} 
 };
 
 export const loadLivesBoard=()=>{
@@ -254,7 +259,7 @@ export const loadLivesBoard=()=>{
   const preset=SORT_PRESETS[presetKey]||SORT_PRESETS.watch;
   q.set('sort_by',preset.sortBy??livesTableState.sortBy);
   q.set('sort_order',preset.sortOrder??livesTableState.sortOrder);
-  const timeWindow=document.getElementById('filter-time-window').value||'all';
+  const timeWindow=byId('filter-time-window')?.value||'all';
   q.set('time_window',timeWindow);
   if(livesUiState.quickFilter==='active'){q.set('active_only','true');}
   if(livesUiState.quickFilter==='degrading'){q.set('degrading_only','true');}
@@ -298,15 +303,16 @@ export const loadLivesBoard=()=>{
 };
 
 export const renderLiveEvents=()=>{
-  const pre=document.getElementById('live-events');
+  const pre=byId('live-events');
+  if(!pre){return;}
   const rows=liveState.events.map(item=>`${item.ts||na()} | ${item.run_id||na()} | ${item.event||'unknown'}`);
   pre.textContent=rows.join('\n');
   if(liveState.autoScroll){pre.scrollTop=pre.scrollHeight;}
 };
 
 export const updateLiveStatus=()=>{
-  document.getElementById('live-status').textContent=liveState.paused?'Pause activée':'Lecture en direct';
-  document.getElementById('live-toggle').textContent=liveState.paused?'Reprendre':'Pause';
+  setText('live-status',liveState.paused?'Pause activée':'Lecture en direct');
+  setText('live-toggle',liveState.paused?'Reprendre':'Pause');
 };
 
 export const renderGenealogyTree=(payload)=>{
@@ -319,9 +325,9 @@ export const renderGenealogyTree=(payload)=>{
   const relationships=payload?.relationships||[];
   const relationRows=payload?.active_relations||[];
   if(!nodes.length){
-    treeEl.textContent='Aucune lignée enregistrée.';
-    socialEl.textContent='Aucun réseau social.';
-    conflictsEl.textContent='Aucun conflit.';
+    if(treeEl){treeEl.textContent='Aucune lignée enregistrée.';}
+    if(socialEl){socialEl.textContent='Aucun réseau social.';}
+    if(conflictsEl){conflictsEl.textContent='Aucun conflit.';}
     if(relationsBody){relationsBody.innerHTML=\"<tr><td colspan='6'>Aucune relation active.</td></tr>\";}
     return;
   }
@@ -335,16 +341,16 @@ export const renderGenealogyTree=(payload)=>{
   for(const root of roots){visit(root,0);} 
   const detached=nodes.filter(node=>!roots.includes(node.slug)&&!(node.parents||[]).every(parent=>bySlug.has(parent)));
   for(const node of detached){lines.push(`• ${node.name} (${node.slug}) [orphan]`);} 
-  treeEl.textContent=lines.join('\n');
+  if(treeEl){treeEl.textContent=lines.join('\n');}
   const socialLines=[];
   for(const node of nodes){
     const allies=relationships.filter(item=>item.type==='alliance'&&(item.source===node.slug||item.target===node.slug)).map(item=>item.source===node.slug?item.target:item.source).join(', ')||'-';
     const rivals=relationships.filter(item=>item.type==='rivalry'&&(item.source===node.slug||item.target===node.slug)).map(item=>item.source===node.slug?item.target:item.source).join(', ')||'-';
     socialLines.push(`${node.slug} | statut=${node.status} | proximité=${Number(node.proximity_score||0.5).toFixed(2)} | alliés: ${allies} | rivaux: ${rivals}`);
   } 
-  socialEl.textContent=socialLines.join('\n');
+  if(socialEl){socialEl.textContent=socialLines.join('\n');}
   const conflicts=payload?.active_conflicts||[];
-  conflictsEl.textContent=conflicts.length?conflicts.map(c=>`${c.life_a} ⚔ ${c.life_b} | sévérité=${c.severity??'-'} | MAJ=${c.updated_at||'n/a'}`).join('\n'):'Aucun conflit actif.';
+  if(conflictsEl){conflictsEl.textContent=conflicts.length?conflicts.map(c=>`${c.life_a} ⚔ ${c.life_b} | sévérité=${c.severity??'-'} | MAJ=${c.updated_at||'n/a'}`).join('\n'):'Aucun conflit actif.';}
   if(relationsBody){
     if(!relationRows.length){relationsBody.innerHTML=\"<tr><td colspan='6'>Aucune relation active pour ce filtre.</td></tr>\";}
     else{
@@ -359,12 +365,12 @@ export const renderGenealogyTree=(payload)=>{
     lifeFilterEl.onchange=()=>{
       const selected=lifeFilterEl.value;
       const route=selected&&selected!=='all'?`/lives/genealogy?life=${encodeURIComponent(selected)}`:'/lives/genealogy';
-      fetchJson(route).then(renderGenealogyTree).catch(error=>{document.getElementById('genealogy-tree').textContent='Impossible de charger la généalogie.';throw error;});
+      fetchJson(route).then(renderGenealogyTree).catch(error=>{setText('genealogy-tree','Impossible de charger la généalogie.');throw error;});
     };
   }
 };
 
-export const loadGenealogy=()=>fetchJson('/lives/genealogy').then(renderGenealogyTree).catch(error=>{document.getElementById('genealogy-tree').textContent='Impossible de charger la généalogie.';throw error;});
+export const loadGenealogy=()=>fetchJson('/lives/genealogy').then(renderGenealogyTree).catch(error=>{setText('genealogy-tree','Impossible de charger la généalogie.');throw error;});
 
 export const bindLivesHandlers=(reload=loadLivesBoard)=>{
   for(const button of document.querySelectorAll('#lives-table [data-sort]')){
@@ -399,12 +405,16 @@ export const bindLivesHandlers=(reload=loadLivesBoard)=>{
       reload();
     };
   });
-  document.getElementById('filter-sort-preset').onchange=()=>reload();
-  document.getElementById('filter-time-window').onchange=()=>reload();
+  const presetSelect=byId('filter-sort-preset');
+  if(presetSelect){presetSelect.onchange=()=>reload();}
+  const timeWindowSelect=byId('filter-time-window');
+  if(timeWindowSelect){timeWindowSelect.onchange=()=>reload();}
   document.getElementById('lives-reset-filters')?.addEventListener('click',()=>resetLivesFilters(reload));
 };
 
 export const bindLiveStreamHandlers=()=>{
-  document.getElementById('live-toggle').onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};
-  document.getElementById('live-autoscroll').onchange=e=>{liveState.autoScroll=Boolean(e.target.checked);if(liveState.autoScroll){renderLiveEvents();}};
+  const toggle=byId('live-toggle');
+  if(toggle){toggle.onclick=()=>{liveState.paused=!liveState.paused;updateLiveStatus();if(!liveState.paused){renderLiveEvents();}};}
+  const autoscroll=byId('live-autoscroll');
+  if(autoscroll){autoscroll.onchange=e=>{liveState.autoScroll=Boolean(e.target.checked);if(liveState.autoScroll){renderLiveEvents();}};}
 };

--- a/src/singular/dashboard/static/render-reflections.js
+++ b/src/singular/dashboard/static/render-reflections.js
@@ -4,9 +4,9 @@ import {na,setPanelState} from './state.js';
 export const loadReflections=()=>fetchJson(withScope('/runs/latest')).then(meta=>{
   if(!meta.run){return {run_id:null,items:[]};}
   const q=new URLSearchParams();
-  const objective=document.getElementById('reflection-objective').value;
-  const mood=document.getElementById('reflection-mood').value;
-  const success=document.getElementById('reflection-success').value;
+  const objective=document.getElementById('reflection-objective')?.value||'';
+  const mood=document.getElementById('reflection-mood')?.value||'';
+  const success=document.getElementById('reflection-success')?.value||'';
   if(objective){q.set('objective',objective);}
   if(mood){q.set('mood',mood);}
   if(success){q.set('success',success);}
@@ -15,6 +15,7 @@ export const loadReflections=()=>fetchJson(withScope('/runs/latest')).then(meta=
 }).then(data=>{
   const wrap=document.getElementById('reflections-timeline');
   const detail=document.getElementById('reflections-detail');
+  if(!wrap||!detail){return;}
   wrap.innerHTML='';
   for(const item of data.items||[]){
     const row=document.createElement('div');
@@ -24,7 +25,7 @@ export const loadReflections=()=>fetchJson(withScope('/runs/latest')).then(meta=
     const mood=item.emotional_state?.mood||na();
     const objective=item.objective||na();
     btn.textContent=`${item.ts||na()} · ${objective} · ${mood}`;
-    btn.onclick=()=>{detail.textContent=JSON.stringify(item,null,2);};
+    btn.onclick=()=>{if(detail){detail.textContent=JSON.stringify(item,null,2);}};
     row.appendChild(btn);
     wrap.appendChild(row);
   }

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DASHBOARD_STATIC = Path("src/singular/dashboard/static")
+DASHBOARD_TEMPLATE = Path("src/singular/dashboard/templates/dashboard.html")
+AUDITED_JS = [
+    DASHBOARD_STATIC / "bootstrap.js",
+    DASHBOARD_STATIC / "actions.js",
+    DASHBOARD_STATIC / "render-cockpit.js",
+    DASHBOARD_STATIC / "render-lives.js",
+    DASHBOARD_STATIC / "render-conversations.js",
+    DASHBOARD_STATIC / "render-reflections.js",
+]
+
+
+def _ids_declared_in(text: str) -> set[str]:
+    return set(re.findall(r"\bid=[\"']([^\"']+)[\"']", text))
+
+
+def test_dashboard_bootstrap_literal_ids_exist_or_are_created() -> None:
+    """Smoke check: bootstrap literal DOM IDs are backed by dashboard HTML or injected controls."""
+    html_ids = _ids_declared_in(DASHBOARD_TEMPLATE.read_text(encoding="utf-8"))
+    bootstrap = (DASHBOARD_STATIC / "bootstrap.js").read_text(encoding="utf-8")
+    bootstrap_created_ids = _ids_declared_in(bootstrap)
+    literal_refs = set(
+        re.findall(r"document\.getElementById\([\"']([A-Za-z0-9_-]+)[\"']\)", bootstrap)
+    )
+
+    missing = literal_refs - html_ids - bootstrap_created_ids
+    unprotected_missing = {
+        element_id
+        for element_id in missing
+        if re.search(rf"document\.getElementById\([\"']{re.escape(element_id)}[\"']\)\.", bootstrap)
+    }
+    assert not unprotected_missing, (
+        "Bootstrap references missing dashboard IDs without a guard: "
+        f"{sorted(unprotected_missing)}"
+    )
+
+
+def test_dashboard_js_uses_guards_for_direct_get_element_access() -> None:
+    """Smoke check: direct getElementById(...).property writes are replaced by guarded variables/helpers."""
+    offenders: list[str] = []
+    direct_access = re.compile(r"document\.getElementById\([^\n]+?\)\.(?!\?)")
+    for path in AUDITED_JS:
+      text = path.read_text(encoding="utf-8")
+      for match in direct_access.finditer(text):
+          line = text.count("\n", 0, match.start()) + 1
+          offenders.append(f"{path}:{line}: {match.group(0)}")
+
+    assert not offenders, "Unprotected direct DOM access remains:\n" + "\n".join(offenders)
+
+
+def test_dashboard_quests_websocket_targets_existing_raw_panel() -> None:
+    bootstrap = (DASHBOARD_STATIC / "bootstrap.js").read_text(encoding="utf-8")
+    assert "getElementById('quests')" not in bootstrap
+    assert "getElementById('quests-json-raw')" in bootstrap or "loadQuests()" in bootstrap


### PR DESCRIPTION
### Motivation
- Éviter des erreurs runtime quand certaines portions du HTML sont optionnelles en protégeant tous les accès directs à `document.getElementById(...)` par des guards/helpers.
- Corriger le handler websocket qui publiait directement dans `document.getElementById('quests')` pour cibler un élément existant ou retomber sur le loader de quêtes.
- S'assurer que l'assignation de handlers aux boutons d'action vérifie l'existence des éléments afin d'éviter des exceptions sur rendu partiel.
- Ajouter un test smoke côté static JS/HTML pour détecter les accès directs non protégés et références d'IDs manquantes.

### Description
- `src/singular/dashboard/static/bootstrap.js`: protégé l’écriture dans `psyche`, corrigé le handler `m.type === 'quests'` pour écrire dans `quests-json-raw` ou appeler `loadQuests()`, et gardé l'injection du bouton `updates-toggle` avant d'assigner `.onclick`.
- `src/singular/dashboard/static/actions.js`: remplacé les assignations directes par un helper `bind(id, handler)` qui vérifie l'existence du bouton, et rendu les lectures de champs d'entrée optionnelles (`?.value`).
- `src/singular/dashboard/static/render-cockpit.js`: ajouté helpers DOM (`byId`, `setText`, `setTitle`, `clearElement`, `setTone`) et remplacé la plupart des écritures directes sur `getElementById(...).textContent`/`.title` par des appels gardés; renforcé la tolérance sur éléments absents (ex. adaptation capteurs, listes).
- `src/singular/dashboard/static/render-lives.js`: ajouté helpers similaires, protégé listes/compteurs et handlers d'UI (filtres, live stream) pour ne rien faire si les éléments n'existent pas.
- `src/singular/dashboard/static/render-conversations.js` et `src/singular/dashboard/static/render-reflections.js`: ajouté petits guards et `setText` utilitaire pour éviter d'écrire sur des éléments absents et protéger les callbacks.
- `tests/test_dashboard_static_smoke.py`: nouveau test smoke qui vérifie que les IDs littéraux référencés par `bootstrap.js` existent (ou sont créés) et détecte les accès directs non protégés `document.getElementById(...).property` dans les fichiers audités, et vérifie le traitement websocket `quests`.

### Testing
- `node --check` sur les fichiers modifiés (`bootstrap.js`, `actions.js`, `render-*.js`) : OK.
- Nouveau smoke tests : `pytest -q tests/test_dashboard_static_smoke.py` : OK.
- Smoke e2e dashboard tests : `pytest -q tests/test_dashboard_static_smoke.py tests/test_dashboard_smoke_e2e.py` : OK.
- Rappel exécuté : `python -m pytest -q tests/test_dashboard_static_smoke.py` : OK.
- Tests serveur dashboard plus larges (`pytest -q tests/test_dashboard.py tests/test_dashboard_services.py tests/test_dashboard_run_records_repository.py`) : ont révélé 6 échecs existants dans des assertions côté serveur non liés aux ajustements JS (signalés pour information, ces échecs préexistent à l'objectif des guards).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0232c0f1c0832a91ecbf3cc52e24e2)