### PR TITLE
test: cover dashboard interactive contracts

### DIFF
--- a/tests/test_dashboard_smoke_e2e.py
+++ b/tests/test_dashboard_smoke_e2e.py
@@ -185,3 +185,206 @@ def test_smoke_dashboard_e2e_capacites_critiques(
     essential_payload = essential.json()
     assert essential_payload["schema_version"] == "2026-04-15"
     assert "global_status" in essential_payload
+
+
+@pytest.fixture
+def active_run_dashboard(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[TestClient, dict[str, Path]]:
+    root = tmp_path / "registry-root"
+    root.mkdir(parents=True)
+    life_a = tmp_path / "life-a"
+    life_b = tmp_path / "life-b"
+    for life in (life_a, life_b):
+        (life / "runs").mkdir(parents=True)
+        (life / "mem").mkdir(parents=True)
+
+    active_run = life_a / "runs" / "active-smoke.jsonl.tmp"
+    active_run.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T09:00:00+00:00",
+                        "run_id": "active-smoke",
+                        "life": "life-a",
+                        "event": "mutation",
+                        "operator": "flip",
+                        "accepted": True,
+                        "score_base": 12.0,
+                        "score_new": 10.0,
+                        "health": {"score": 84.0, "sandbox_stability": 0.95},
+                        "objective": "stabiliser le cockpit",
+                        "objective_status": "in_progress",
+                        "objective_priority": "high",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T09:01:00+00:00",
+                        "run_id": "active-smoke",
+                        "life": "life-a",
+                        "event": "interaction",
+                        "interaction": "resource.share",
+                        "organism": "org-active",
+                        "energy": 8,
+                        "resources": 5,
+                        "score": 91,
+                        "alive": True,
+                        "accepted": True,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    os.utime(active_run, ns=(1_900_100_000_000_000_000, 1_900_100_000_000_000_000))
+
+    (life_b / "runs" / "background.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-05-11T08:30:00+00:00",
+                "run_id": "background",
+                "life": "life-b",
+                "operator": "swap",
+                "accepted": True,
+                "score_base": 11.0,
+                "score_new": 10.4,
+                "health": {"score": 79.0, "sandbox_stability": 0.9},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    registry_payload = {
+        "active": "life-a",
+        "lives": {
+            "life-a": LifeMetadata(
+                name="Life A",
+                slug="life-a",
+                path=life_a,
+                created_at="2026-05-11T08:00:00+00:00",
+                status="active",
+                parents=(),
+                children=("life-b",),
+                allies=("life-b",),
+                rivals=(),
+                proximity_score=0.8,
+                lineage_depth=0,
+            ),
+            "life-b": LifeMetadata(
+                name="Life B",
+                slug="life-b",
+                path=life_b,
+                created_at="2026-05-11T08:10:00+00:00",
+                status="active",
+                parents=("life-a",),
+                children=(),
+                allies=("life-a",),
+                rivals=(),
+                proximity_score=0.5,
+                lineage_depth=1,
+            ),
+        },
+    }
+
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    monkeypatch.setenv("SINGULAR_HOME", str(life_a))
+    monkeypatch.setattr("singular.dashboard.load_registry", lambda: registry_payload)
+
+    app = create_app(psyche_file=life_a / "mem" / "psyche.json")
+    return TestClient(app), {
+        "active_run": active_run,
+        "life_a": life_a,
+        "life_b": life_b,
+    }
+
+
+def test_dashboard_index_exposes_interactive_contracts(tmp_path: Path) -> None:
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    response = TestClient(app).get("/")
+
+    assert response.status_code == 200
+    body = response.json()
+
+    tab_contracts = {
+        "tab-btn-decider": ("decider-maintenant", "tab-decider-maintenant"),
+        "tab-btn-diagnostiquer": ("diagnostiquer", "tab-diagnostiquer"),
+        "tab-btn-comparer": ("comparer-vies", "tab-comparer-vies"),
+        "tab-btn-technique": ("technique", "tab-technique"),
+    }
+    assert "role='tablist'" in body
+    for trigger_id, (tab_id, panel_id) in tab_contracts.items():
+        assert f"id='{trigger_id}'" in body
+        assert "class='tab-trigger'" in body
+        assert f"data-tab='{tab_id}'" in body
+        assert f"aria-controls='{panel_id}'" in body
+        assert f"id='{panel_id}'" in body
+        assert "role='tabpanel'" in body
+        assert f"aria-labelledby='{trigger_id}'" in body
+
+    for toggle_id in ("toggle-essential", "toggle-technical-details"):
+        assert f"id='{toggle_id}'" in body
+        assert "class='nav-mode-toggle'" in body
+        assert "aria-pressed='false'" in body
+
+    critical_actions = {
+        "critical-birth": "birth",
+        "critical-archive": "archive",
+        "critical-talk": "talk",
+        "critical-emergency-stop": "emergency_stop",
+    }
+    for action_id, action_name in critical_actions.items():
+        assert f"id='{action_id}'" in body
+        assert f"data-dashboard-action='{action_name}'" in body
+    assert "id='critical-action-result'" in body
+    assert "data-confirm=" in body
+    assert "data-confirm-again=" in body
+
+    for target_id in ("cockpit-detail-json", "cockpit-context-more"):
+        assert f"data-expand-target='{target_id}'" in body
+        assert f"id='{target_id}' class='panel-hidden'" in body
+    assert "toggle-more-btn" in body
+    assert "aria-expanded='false'" in body
+
+
+def test_active_tmp_run_feeds_dashboard_endpoints(
+    active_run_dashboard: tuple[TestClient, dict[str, Path]],
+) -> None:
+    client, paths = active_run_dashboard
+    assert paths["active_run"].name.endswith(".jsonl.tmp")
+
+    cockpit_response = client.get("/api/cockpit")
+    assert cockpit_response.status_code == 200
+    cockpit = cockpit_response.json()
+    assert cockpit["run"] == "active-smoke"
+    assert cockpit["health_score"] == 84.0
+    assert cockpit["accepted_mutation_rate"] == 1.0
+    assert cockpit["next_action"]
+    assert cockpit["vital_metrics"]["energy_resources"]["total_energy"] > 0
+    assert cockpit["life_metrics_contract"]["counts"]["total_lives"] >= 2
+
+    context_response = client.get("/dashboard/context")
+    assert context_response.status_code == 200
+    context = context_response.json()
+    assert context["registry_lives_count"] == 2
+    assert context["registry_lives"]
+    assert context["registry_state"]["active"] == "life-a"
+    assert context["registry_state"]["active_valid"] is True
+
+    ecosystem_response = client.get("/ecosystem")
+    assert ecosystem_response.status_code == 200
+    ecosystem = ecosystem_response.json()
+    assert ecosystem["organisms"]["org-active"]["energy"] == 8
+    assert ecosystem["summary"]["total_energy"] == 8.0
+    assert ecosystem["life_metrics_contract"]["counts"]["alive_lives"] >= 1
+
+    comparison_response = client.get("/lives/comparison")
+    assert comparison_response.status_code == 200
+    comparison = comparison_response.json()
+    assert comparison["table"]
+    assert {row["life"] for row in comparison["table"]} >= {"life-a", "life-b"}
+    assert comparison["lives"]["life-a"]["current_health_score"] == 84.0
+    assert comparison["life_metrics_contract"]["counts"]["total_lives"] >= 2


### PR DESCRIPTION
### Motivation

- Ajouter une couverture de tests pour s’assurer que la page `/` expose les contrats interactifs (onglets, toggles, actions critiques, toggles "Voir plus") et que les endpoints dashboard consomment correctement un run en cours (`.jsonl.tmp`).

### Description

- Ajout d’une fixture `active_run_dashboard` qui crée un run actif `active-smoke.jsonl.tmp`, un run de fond et un registre multi-vies (`life-a`, `life-b`) sous `tests/test_dashboard_smoke_e2e.py`.
- Ajout du test `test_dashboard_index_exposes_interactive_contracts` qui vérifie la présence des `tab-trigger`/panel contracts, des boutons `toggle-essential`/`toggle-technical-details`, des actions critiques avec `data-dashboard-action` et des expanders `data-expand-target`.
- Ajout du test `test_active_tmp_run_feeds_dashboard_endpoints` qui vérifie que `/api/cockpit`, `/dashboard/context`, `/ecosystem` et `/lives/comparison` retournent des valeurs non vides et cohérentes pendant qu’un run `.jsonl.tmp` est actif.
- Formatage du fichier de test avec `black` avant validation.

### Testing

- `python -m black tests/test_dashboard_smoke_e2e.py` — succès.
- `pytest -q tests/test_dashboard_smoke_e2e.py` — succès (`3 passed`, 1 warning).
- `pytest -q tests/test_dashboard_smoke_e2e.py tests/test_dashboard.py::test_dashboard_index_contains_cockpit_cards` — le nouveau fichier de tests passe, mais l’exécution combinée montre une assertion existante dans `tests/test_dashboard.py::test_dashboard_index_contains_cockpit_cards` qui attend littéralement `"Cockpit"` dans le rendu et échoue; il s’agit d’un échec préexistant non lié aux nouvelles assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0236d1a6ec832aa744c751c95cc671)