### PR TITLE
Add sandbox violation diagnostics and structured scoring result

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -83,6 +83,50 @@ SKILL_GENESIS_FAILURE_STREAK_THRESHOLD = 3
 SKILL_GENESIS_COVERAGE_GAP_THRESHOLD = 0.6
 
 
+@dataclass(frozen=True)
+class ScoreCodeResult:
+    """Sandbox scoring outcome with a machine-readable failure reason."""
+
+    score: float
+    failed: bool = False
+    error_reason: str | None = None
+    exception_type: str | None = None
+    exception_message: str | None = None
+
+
+def _score_failure(
+    reason: str,
+    exception: BaseException | None = None,
+    *,
+    message: str | None = None,
+) -> ScoreCodeResult:
+    """Build a failed scoring result with optional exception metadata."""
+
+    return ScoreCodeResult(
+        score=float("-inf"),
+        failed=True,
+        error_reason=reason,
+        exception_type=type(exception).__name__ if exception is not None else None,
+        exception_message=str(exception) if exception is not None else message,
+    )
+
+
+def _classify_score_exception(exception: BaseException) -> str:
+    """Map sandbox exceptions to stable diagnostic categories."""
+
+    if isinstance(exception, TimeoutError):
+        return "timeout"
+    if isinstance(exception, SyntaxError):
+        return "forbidden_syntax"
+    if isinstance(exception, sandbox.SandboxError):
+        message = str(exception).lower()
+        if "forbidden syntax" in message:
+            return "forbidden_syntax"
+        if "forbidden" in message:
+            return "forbidden_name"
+    return "runtime_exception"
+
+
 @dataclass
 class Checkpoint:
     """Simple persistent state for the evolutionary loop."""
@@ -455,20 +499,36 @@ def select_operator(
     return max(names, key=expected)
 
 
+def score_code_with_error(code: str) -> ScoreCodeResult:
+    """Execute ``code`` in the sandbox and return score plus failure details.
+
+    Failure reasons are intentionally stable for diagnostics: forbidden syntax,
+    forbidden names, timeout, runtime exception, non-numeric result, or non-finite
+    result.
+    """
+
+    try:
+        result = sandbox.run(code)
+    except Exception as exc:
+        return _score_failure(_classify_score_exception(exc), exc)
+    if not isinstance(result, (int, float)):
+        return _score_failure(
+            "non_numeric_result",
+            message=f"sandbox result type is {type(result).__name__}",
+        )
+    score = float(result)
+    if not math.isfinite(score):
+        return _score_failure("non_finite_result", message=f"sandbox result is {score}")
+    return ScoreCodeResult(score=score)
+
+
 def score_code(code: str) -> float:
     """Execute ``code`` in the sandbox and return a numeric score.
 
     Non-numeric or failing executions yield ``-inf``.
     """
 
-    try:
-        result = sandbox.run(code)
-    except Exception:
-        return float("-inf")
-    if not isinstance(result, (int, float)):
-        return float("-inf")
-    score = float(result)
-    return score if math.isfinite(score) else float("-inf")
+    return score_code_with_error(code).score
 
 
 def manage_resources(
@@ -1117,10 +1177,12 @@ def run(
             org = world.organisms[org_name]
 
             t0 = time.perf_counter()
-            base_score = score_code(original)
+            base_score_result = score_code_with_error(original)
+            base_score = base_score_result.score
             ms_base = (time.perf_counter() - t0) * 1000
             t0 = time.perf_counter()
-            mutated_score = score_code(mutated)
+            mutated_score_result = score_code_with_error(mutated)
+            mutated_score = mutated_score_result.score
             ms_new = (time.perf_counter() - t0) * 1000
 
             if mutated_score == float("-inf"):
@@ -1501,11 +1563,38 @@ def run(
                     payload_version=1,
                 )
 
-            sandbox_failure = (
-                base_score == float("-inf") or mutated_score == float("-inf")
+            base_failed = base_score_result.failed or base_score == float("-inf")
+            mutation_failed = (
+                mutated_score_result.failed or mutated_score == float("-inf")
             )
+            sandbox_failure = base_failed or mutation_failed
+            sandbox_diagnostic = {
+                "organism": org_name,
+                "skill_path": str(skill_path),
+                "operator": op_name,
+                "base_score": base_score,
+                "mutated_score": mutated_score,
+                "base_failed": base_failed,
+                "mutation_failed": mutation_failed,
+                "base_failure_reason": base_score_result.error_reason,
+                "mutation_failure_reason": mutated_score_result.error_reason,
+                "base_exception_type": base_score_result.exception_type,
+                "base_exception_message": base_score_result.exception_message,
+                "mutation_exception_type": mutated_score_result.exception_type,
+                "mutation_exception_message": mutated_score_result.exception_message,
+                "sandbox_violation_streak": org.sandbox_violation_streak,
+                "governance_circuit_breaker_threshold": getattr(
+                    governance_policy,
+                    "circuit_breaker_threshold",
+                    None,
+                ),
+            }
             if sandbox_failure:
                 org.sandbox_violation_streak += 1
+                sandbox_diagnostic["sandbox_violation_streak"] = (
+                    org.sandbox_violation_streak
+                )
+                logger.log_interaction("sandbox_violation", **sandbox_diagnostic)
                 governance_policy.record_violation(
                     category="sandbox_violation",
                     severity="critical",

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -614,12 +614,26 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
 
     score_calls = {"n": 0}
 
-    def failing_score(_code: str) -> float:
+    def failing_score(_code: str) -> life_loop.ScoreCodeResult:
         score_calls["n"] += 1
-        return float("-inf") if score_calls["n"] % 2 == 1 else 0.0
+        if score_calls["n"] % 2 == 1:
+            return life_loop.ScoreCodeResult(
+                score=float("-inf"),
+                failed=True,
+                error_reason="runtime_exception",
+                exception_type="RuntimeError",
+                exception_message="synthetic sandbox failure",
+            )
+        return life_loop.ScoreCodeResult(score=0.0)
 
-    monkeypatch.setattr(life_loop, "score_code", failing_score)
+    monkeypatch.setattr(life_loop, "score_code_with_error", failing_score)
     monkeypatch.setattr(life_loop, "propose_mutations", lambda *_a, **_k: [])
+
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(RL, root=tmp_path / "logs")
+    )
 
     class StablePsyche:
         energy = 1000.0
@@ -657,7 +671,7 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
             self.max_failures = max_failures
             self.failures = 0
 
-        def check(self, iteration, psyche, action_succeeded, resources=None):
+        def check(self, iteration, psyche, action_succeeded, resources=None, **_kwargs):
             if not action_succeeded:
                 self.failures += 1
             else:
@@ -669,7 +683,7 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
     state = life_loop.run(
         skills_dir,
         checkpoint,
-        budget_seconds=2.0,
+        budget_seconds=10.0,
         max_iterations=4,
         rng=random.Random(0),
         operators={"noop": _noop_operator},
@@ -691,6 +705,32 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
     assert events
     assert events[0]["sandbox_violation_streak"] >= life_loop.SANDBOX_DEGRADED_MODE_THRESHOLD
 
+    events_path = tmp_path / "logs" / "loop" / "events.jsonl"
+    run_events = [
+        json.loads(line)
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    diagnostics = [
+        event["payload"]
+        for event in run_events
+        if event.get("event_type") == "interaction"
+        and event.get("payload", {}).get("interaction") == "sandbox_violation"
+    ]
+    assert diagnostics
+    diagnostic = diagnostics[0]
+    assert diagnostic["organism"] == skills_dir.name
+    assert diagnostic["skill_path"] == str(skills_dir / "foo.py")
+    assert diagnostic["operator"] == "noop"
+    assert diagnostic["base_score"] == float("-inf")
+    assert diagnostic["mutated_score"] == 0.0
+    assert diagnostic["base_failed"] is True
+    assert diagnostic["mutation_failed"] is False
+    assert diagnostic["sandbox_violation_streak"] >= 1
+    assert diagnostic["governance_circuit_breaker_threshold"] == 3
+    assert diagnostic["base_failure_reason"] == "runtime_exception"
+    assert diagnostic["base_exception_type"] == "RuntimeError"
+    assert diagnostic["base_exception_message"] == "synthetic sandbox failure"
+
 
 def test_prolonged_sandbox_violation_persistence_triggers_controlled_extinction(
     tmp_path: Path, monkeypatch
@@ -702,11 +742,17 @@ def test_prolonged_sandbox_violation_persistence_triggers_controlled_extinction(
 
     score_calls = {"n": 0}
 
-    def failing_score(_code: str) -> float:
+    def failing_score(_code: str) -> life_loop.ScoreCodeResult:
         score_calls["n"] += 1
-        return float("-inf") if score_calls["n"] % 2 == 1 else 0.0
+        if score_calls["n"] % 2 == 1:
+            return life_loop.ScoreCodeResult(
+                score=float("-inf"),
+                failed=True,
+                error_reason="runtime_exception",
+            )
+        return life_loop.ScoreCodeResult(score=0.0)
 
-    monkeypatch.setattr(life_loop, "score_code", failing_score)
+    monkeypatch.setattr(life_loop, "score_code_with_error", failing_score)
     monkeypatch.setattr(life_loop, "propose_mutations", lambda *_a, **_k: [])
     monkeypatch.setattr(life_loop, "SANDBOX_DEGRADED_MODE_THRESHOLD", 1)
     monkeypatch.setattr(life_loop, "SANDBOX_EXTINCTION_THRESHOLD", 2)
@@ -740,7 +786,7 @@ def test_prolonged_sandbox_violation_persistence_triggers_controlled_extinction(
             self.max_failures = max_failures
             self.failures = 0
 
-        def check(self, iteration, psyche, action_succeeded, resources=None):
+        def check(self, iteration, psyche, action_succeeded, resources=None, **_kwargs):
             if not action_succeeded:
                 self.failures += 1
             else:
@@ -752,7 +798,7 @@ def test_prolonged_sandbox_violation_persistence_triggers_controlled_extinction(
     state = life_loop.run(
         skills_dir,
         checkpoint,
-        budget_seconds=2.0,
+        budget_seconds=10.0,
         max_iterations=12,
         rng=random.Random(0),
         operators={"noop": _noop_operator},


### PR DESCRIPTION
### Motivation

- Améliorer le diagnostic quand l'exécution sandbox échoue afin de permettre un traitement et une journalisation exploitables (raison d'échec, type/message d'exception, flags d'échec). 
- Permettre au loop d'émettre un événement structuré `sandbox_violation` contenant le contexte nécessaire pour la gouvernance et le debugging.

### Description

- Ajout d'un `ScoreCodeResult` immuable et d'un helper `_score_failure` pour représenter le score et métadonnées d'échec, plus la fonction `_classify_score_exception` pour catégoriser les exceptions sandbox. (nouveau code dans `src/singular/life/loop.py`).
- Introduction de `score_code_with_error()` qui retourne un `ScoreCodeResult` et maintien de `score_code()` comme wrapper de compatibilité retournant uniquement le score float. 
- Le loop utilise désormais les résultats enrichis pour `base_score` et `mutated_score` et construit un payload `sandbox_diagnostic` contenant au minimum `organism`, `skill_path`, `operator`, `base_score`, `mutated_score`, `base_failed`, `mutation_failed`, `sandbox_violation_streak` et `governance_circuit_breaker_threshold` ainsi que raisons/metadata d'exception, puis le logge via `logger.log_interaction("sandbox_violation", **payload)`. 
- Mise à jour des tests concernés (`tests/test_loop.py`) pour mocker `score_code_with_error()` et vérifier la présence et le contenu du diagnostic `sandbox_violation` dans les events JSONL, plus ajustements mineurs de tests (monitor `check` signature tolerance et durées de budget pour rendre l'exécution déterministe dans le contexte de test). 

### Testing

- `python -m py_compile src/singular/life/loop.py tests/test_loop.py` — success.
- `python -m pytest tests/test_loop.py::test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extinction tests/test_loop.py::test_prolonged_sandbox_violation_persistence_triggers_controlled_extinction -q` — both tests passed.
- The full `tests/test_loop.py` run initially exposed a flaky unrelated `test_irrational_delay` which was re-run and passed; no regressions were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02395bdc70832ab0e6dc7f77b26506)