### PR TITLE
Add structured sandbox scoring diagnostics

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -83,31 +83,104 @@ SKILL_GENESIS_FAILURE_STREAK_THRESHOLD = 3
 SKILL_GENESIS_COVERAGE_GAP_THRESHOLD = 0.6
 
 
-@dataclass(frozen=True)
-class ScoreCodeResult:
-    """Sandbox scoring outcome with a machine-readable failure reason."""
+@dataclass(init=False, frozen=True)
+class SandboxScore:
+    """Structured sandbox scoring outcome.
+
+    ``score`` keeps the historical algorithmic contract: failed sandbox scoring
+    yields ``-inf``.  ``ok`` and the error fields carry diagnostics so callers
+    can distinguish a failing source from a failing mutation without parsing the
+    score itself.
+    """
 
     score: float
-    failed: bool = False
-    error_reason: str | None = None
-    exception_type: str | None = None
-    exception_message: str | None = None
+    ok: bool
+    error_type: str | None
+    error_message: str | None
+    _legacy_exception_type: str | None
+
+    def __init__(
+        self,
+        score: float,
+        ok: bool = True,
+        error_type: str | None = None,
+        error_message: str | None = None,
+        *,
+        failed: bool | None = None,
+        error_reason: str | None = None,
+        exception_type: str | None = None,
+        exception_message: str | None = None,
+    ) -> None:
+        """Create a score result, accepting legacy keyword names.
+
+        Older tests and extensions used ``ScoreCodeResult(failed=...,
+        error_reason=..., exception_message=...)``.  The compatibility keywords
+        are folded into the structured ``ok/error_type/error_message`` shape.
+        """
+
+        if failed is not None:
+            ok = not failed
+        resolved_error_type = error_type or error_reason
+        resolved_error_message = error_message or exception_message
+        if resolved_error_message is None and exception_type is not None:
+            resolved_error_message = exception_type
+        object.__setattr__(self, "score", score)
+        object.__setattr__(self, "ok", ok)
+        object.__setattr__(self, "error_type", resolved_error_type)
+        object.__setattr__(self, "error_message", resolved_error_message)
+        object.__setattr__(self, "_legacy_exception_type", exception_type)
+
+    @property
+    def failed(self) -> bool:
+        """Backward-compatible inverse of ``ok``."""
+
+        return not self.ok
+
+    @property
+    def error_reason(self) -> str | None:
+        """Backward-compatible alias for ``error_type``."""
+
+        return self.error_type
+
+    @property
+    def exception_type(self) -> str | None:
+        """Best-effort legacy exception type derived from ``error_type``."""
+
+        if self._legacy_exception_type is not None:
+            return self._legacy_exception_type
+        if self.error_type == "runtime_exception" and self.error_message:
+            # Runtime exception messages generated below include the concrete class.
+            return self.error_message.split(":", 1)[0]
+        return self.error_type
+
+    @property
+    def exception_message(self) -> str | None:
+        """Backward-compatible alias for ``error_message``."""
+
+        return self.error_message
+
+
+# Compatibility name retained for tests and downstream callers.
+ScoreCodeResult = SandboxScore
 
 
 def _score_failure(
-    reason: str,
+    error_type: str,
     exception: BaseException | None = None,
     *,
     message: str | None = None,
-) -> ScoreCodeResult:
-    """Build a failed scoring result with optional exception metadata."""
+) -> SandboxScore:
+    """Build a failed scoring result with a human-readable message."""
 
-    return ScoreCodeResult(
+    exception_type = type(exception).__name__ if exception is not None else None
+    if message is None and exception is not None:
+        message = f"{exception_type}: {exception}"
+    return SandboxScore(
         score=float("-inf"),
-        failed=True,
-        error_reason=reason,
-        exception_type=type(exception).__name__ if exception is not None else None,
-        exception_message=str(exception) if exception is not None else message,
+        ok=False,
+        error_type=error_type,
+        error_message=message,
+        exception_type=exception_type,
     )
 
 
@@ -117,13 +190,12 @@ def _classify_score_exception(exception: BaseException) -> str:
     if isinstance(exception, TimeoutError):
         return "timeout"
     if isinstance(exception, SyntaxError):
-        return "forbidden_syntax"
+        return "syntax_error"
     if isinstance(exception, sandbox.SandboxError):
         message = str(exception).lower()
-        if "forbidden syntax" in message:
-            return "forbidden_syntax"
-        if "forbidden" in message:
-            return "forbidden_name"
+        if "result" in message and ("missing" in message or "did not set" in message):
+            return "missing_result"
+        return "sandbox_error"
     return "runtime_exception"
 
 
@@ -499,7 +571,7 @@ def select_operator(
     return max(names, key=expected)
 
 
-def score_code_with_error(code: str) -> ScoreCodeResult:
+def score_code_with_error(code: str) -> SandboxScore:
     """Execute ``code`` in the sandbox and return score plus failure details.
 
     Failure reasons are intentionally stable for diagnostics: forbidden syntax,
@@ -511,15 +583,20 @@ def score_code_with_error(code: str) -> ScoreCodeResult:
         result = sandbox.run(code)
     except Exception as exc:
         return _score_failure(_classify_score_exception(exc), exc)
+    if result is None:
+        return _score_failure(
+            "missing_result",
+            message="sandbox code did not set a numeric result",
+        )
     if not isinstance(result, (int, float)):
         return _score_failure(
             "non_numeric_result",
-            message=f"sandbox result type is {type(result).__name__}",
+            message=f"sandbox result is not numeric (type: {type(result).__name__})",
         )
     score = float(result)
     if not math.isfinite(score):
         return _score_failure("non_finite_result", message=f"sandbox result is {score}")
-    return ScoreCodeResult(score=score)
+    return SandboxScore(score=score)
 
 
 def score_code(code: str) -> float:
@@ -572,6 +649,10 @@ def log_mutation(
     alternative_scores: list[tuple[int, str, float]] | None = None,
     decision_reason: str | None = None,
     health: dict[str, float | int] | None = None,
+    source_error_type: str | None = None,
+    source_error_message: str | None = None,
+    mutation_error_type: str | None = None,
+    mutation_error_message: str | None = None,
 ) -> None:
     """Record mutation outcome and notify observers."""
 
@@ -624,6 +705,10 @@ def log_mutation(
         loop_modifications=loop_modifications,
         health=health,
         usage_metrics=usage_metrics,
+        source_error_type=source_error_type,
+        source_error_message=source_error_message,
+        mutation_error_type=mutation_error_type,
+        mutation_error_message=mutation_error_message,
     )
 
 
@@ -1563,9 +1648,9 @@ def run(
                     payload_version=1,
                 )
 
-            base_failed = base_score_result.failed or base_score == float("-inf")
+            base_failed = (not base_score_result.ok) or base_score == float("-inf")
             mutation_failed = (
-                mutated_score_result.failed or mutated_score == float("-inf")
+                (not mutated_score_result.ok) or mutated_score == float("-inf")
             )
             sandbox_failure = base_failed or mutation_failed
             sandbox_diagnostic = {
@@ -1576,12 +1661,17 @@ def run(
                 "mutated_score": mutated_score,
                 "base_failed": base_failed,
                 "mutation_failed": mutation_failed,
-                "base_failure_reason": base_score_result.error_reason,
-                "mutation_failure_reason": mutated_score_result.error_reason,
+                "source_error_type": base_score_result.error_type,
+                "source_error_message": base_score_result.error_message,
+                "mutation_error_type": mutated_score_result.error_type,
+                "mutation_error_message": mutated_score_result.error_message,
+                # Legacy diagnostic names retained for existing consumers.
+                "base_failure_reason": base_score_result.error_type,
+                "mutation_failure_reason": mutated_score_result.error_type,
                 "base_exception_type": base_score_result.exception_type,
-                "base_exception_message": base_score_result.exception_message,
+                "base_exception_message": base_score_result.error_message,
                 "mutation_exception_type": mutated_score_result.exception_type,
-                "mutation_exception_message": mutated_score_result.exception_message,
+                "mutation_exception_message": mutated_score_result.error_message,
                 "sandbox_violation_streak": org.sandbox_violation_streak,
                 "governance_circuit_breaker_threshold": getattr(
                     governance_policy,
@@ -1761,6 +1851,10 @@ def run(
                 alternative_scores=reflection.alternative_scores,
                 decision_reason=reflection.decision_reason,
                 health=health_snapshot.to_dict(),
+                source_error_type=base_score_result.error_type,
+                source_error_message=base_score_result.error_message,
+                mutation_error_type=mutated_score_result.error_type,
+                mutation_error_message=mutated_score_result.error_message,
             )
 
             if hasattr(psyche, "consume"):

--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -90,7 +90,10 @@ def _sandbox_worker(
             env: Dict[str, Any] = {"__builtins__": allowed}
             try:
                 exec(compile(tree, "<sandbox>", "exec"), env, env)
-                queue.put(env.get("result"))
+                if "result" not in env:
+                    queue.put(SandboxError("sandbox code did not set a result"))
+                else:
+                    queue.put(env["result"])
             except Exception as exc:  # pragma: no cover - delivered to parent
                 queue.put(exc)
         finally:

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -307,6 +307,10 @@ class RunLogger:
         loop_modifications: dict[str, int] | None = None,
         health: dict[str, float | int] | None = None,
         usage_metrics: Mapping[str, float | bool] | None = None,
+        source_error_type: str | None = None,
+        source_error_message: str | None = None,
+        mutation_error_type: str | None = None,
+        mutation_error_message: str | None = None,
     ) -> None:
         """Append a mutation record to the log file."""
 
@@ -329,6 +333,10 @@ class RunLogger:
             "loop_modifications": loop_modifications or {},
             "health": health or {},
             "usage_metrics": dict(usage_metrics or {}),
+            "source_error_type": source_error_type,
+            "source_error_message": source_error_message,
+            "mutation_error_type": mutation_error_type,
+            "mutation_error_message": mutation_error_message,
         }
         self._write_record(record)
         self._write_event("mutation", record, ts)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -23,6 +23,45 @@ from singular.life.reproduction import ReproductionDecisionPolicy  # noqa: E402
 from singular.events import EventBus  # noqa: E402
 
 
+def test_score_code_with_error_returns_structured_sandbox_score():
+    ok = life_loop.score_code_with_error("result = 3")
+    assert ok == life_loop.SandboxScore(score=3.0)
+    assert ok.ok is True
+    assert ok.error_type is None
+    assert life_loop.score_code("result = 3") == 3.0
+
+    missing = life_loop.score_code_with_error("value = 3")
+    assert missing.score == float("-inf")
+    assert missing.ok is False
+    assert missing.error_type == "missing_result"
+    assert "result" in (missing.error_message or "")
+    assert life_loop.score_code("value = 3") == float("-inf")
+
+    non_numeric = life_loop.score_code_with_error("result = 'bad'")
+    assert non_numeric.score == float("-inf")
+    assert non_numeric.ok is False
+    assert non_numeric.error_type == "non_numeric_result"
+    assert "not numeric" in (non_numeric.error_message or "")
+
+
+def test_score_code_result_legacy_keywords_remain_supported():
+    result = life_loop.ScoreCodeResult(
+        score=float("-inf"),
+        failed=True,
+        error_reason="runtime_exception",
+        exception_type="RuntimeError",
+        exception_message="boom",
+    )
+
+    assert result.ok is False
+    assert result.failed is True
+    assert result.error_type == "runtime_exception"
+    assert result.error_reason == "runtime_exception"
+    assert result.error_message == "boom"
+    assert result.exception_type == "RuntimeError"
+    assert result.exception_message == "boom"
+
+
 def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
     for node in ast.walk(tree):
         if isinstance(node, ast.Constant) and isinstance(node.value, int):
@@ -727,6 +766,10 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
     assert diagnostic["mutation_failed"] is False
     assert diagnostic["sandbox_violation_streak"] >= 1
     assert diagnostic["governance_circuit_breaker_threshold"] == 3
+    assert diagnostic["source_error_type"] == "runtime_exception"
+    assert diagnostic["source_error_message"] == "synthetic sandbox failure"
+    assert diagnostic["mutation_error_type"] is None
+    assert diagnostic["mutation_error_message"] is None
     assert diagnostic["base_failure_reason"] == "runtime_exception"
     assert diagnostic["base_exception_type"] == "RuntimeError"
     assert diagnostic["base_exception_message"] == "synthetic sandbox failure"

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -11,6 +11,11 @@ def test_spawn_context_simple_execution():
     assert run("result = 1") == 1
 
 
+def test_missing_result_raises_sandbox_error():
+    with pytest.raises(SandboxError, match="result"):
+        run("value = 1")
+
+
 def test_forbidden_import():
     with pytest.raises(SandboxError):
         run("import os")


### PR DESCRIPTION
### Motivation
- Provide a structured, machine-readable result for sandbox scoring so callers can distinguish sandbox failures from normal scores. 
- Preserve the historical numeric contract (failing sandbox scoring still results in `score == -inf`) while exposing richer diagnostics. 
- Surface and propagate clear error categories/messages from the sandbox so loop logging and governance can distinguish source vs mutation failures.

### Description
- Introduced `SandboxScore(score, ok, error_type, error_message)` in `src/singular/life/loop.py` and kept `ScoreCodeResult` as a compatibility alias with legacy properties (`failed`, `error_reason`, etc.).
- Updated `score_code_with_error()` to return `SandboxScore` and kept `score_code()` as a float wrapper returning `SandboxScore.score`; added explicit handling for `missing_result`, `non_numeric_result`, and `non_finite_result` cases.
- Adjusted exception classification to emit stable diagnostic categories (e.g. `missing_result`, `syntax_error`, `sandbox_error`, `timeout`, `runtime_exception`).
- Made sandbox execution propagate a clear `SandboxError` when the executed code does not set `result` by modifying `src/singular/life/sandbox.py` to detect absent `result`.
- Threaded the structured error fields through `run()` diagnostics and `log_mutation()` and added corresponding fields to `RunLogger.log()` so `source_error_type/source_error_message` and `mutation_error_type/mutation_error_message` are recorded in mutation events and logs.
- Added/updated unit tests to assert the new structured return, legacy compatibility, missing-result behavior, and that loop diagnostics include source/mutation error fields (`tests/test_loop.py`, `tests/test_sandbox.py`).

### Testing
- Ran sandbox unit tests: `pytest tests/test_sandbox.py` and all sandbox tests passed. 
- Ran targeted loop tests including the new structured-score and diagnostic assertions in `tests/test_loop.py` and the sandbox-violation scenario tests, and they passed. 
- Ensured code compiles with `python -m compileall` for the modified modules. 
- No automated tests failed; a small number of deprecation warnings were observed from unrelated datetime usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023b2e470c832ab5bc425434eb693f)