### PR TITLE
Expose governance circuit breaker run events

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -416,7 +416,14 @@ def create_app(
 
     def _timeline_entry(record: dict[str, object], run_id: str) -> dict[str, object] | None:
         event = _event_type(record)
-        if event not in {"mutation", "delay", "refuse", "death", "interaction"}:
+        if event not in {
+            "mutation",
+            "delay",
+            "refuse",
+            "death",
+            "interaction",
+            "governance.circuit_breaker_opened",
+        }:
             return None
 
         accepted: bool | None = None
@@ -444,6 +451,13 @@ def create_app(
             "score_after": score_after,
             "interaction": record.get("interaction"),
             "resume_at": record.get("resume_at"),
+            "category": record.get("category"),
+            "severity": record.get("severity"),
+            "threshold": record.get("threshold"),
+            "cooldown_seconds": record.get("cooldown_seconds"),
+            "open_until": record.get("open_until"),
+            "corrective_action": record.get("corrective_action"),
+            "last_sandbox_diagnostics": record.get("last_sandbox_diagnostics"),
         }
 
     def _normalize_mutation_metrics(record: dict[str, object]) -> dict[str, object]:

--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -254,6 +254,7 @@ button:hover {
 .fallback-box { margin-top:8px; padding:8px; border-radius:8px; }
 .timeline-item { display:inline-flex; gap:4px; }
 .timeline-button { padding:6px; }
+.timeline-button-critical { border-color:#dc2626; color:#b91c1c; font-weight:700; }
 .timeline-link { align-self:center; }
 .diff-added { color:#3ff9a8; }
 .diff-removed { color:#ff6b8d; }

--- a/src/singular/dashboard/static/render-timeline.js
+++ b/src/singular/dashboard/static/render-timeline.js
@@ -17,6 +17,24 @@ export const showMutationDetail=(runId,index)=>fetch(`/api/runs/${runId}/mutatio
   document.getElementById('timeline-diff').innerHTML=paintDiff(d.diff)||'Aucun diff.';
 });
 
+
+const showGovernanceBreakerDetail=(item)=>{
+  const summary=document.getElementById('timeline-summary');
+  const impact=document.getElementById('timeline-impact');
+  const diff=document.getElementById('timeline-diff');
+  summary.textContent=`Breaker gouvernance ouvert (${item.category||na()} · ${item.severity||na()}) jusqu'à ${item.open_until||na()}.`;
+  impact.textContent=JSON.stringify({
+    category:item.category,
+    severity:item.severity,
+    threshold:item.threshold,
+    cooldown_seconds:item.cooldown_seconds,
+    open_until:item.open_until,
+    corrective_action:item.corrective_action,
+    last_sandbox_diagnostics:item.last_sandbox_diagnostics,
+  },null,2);
+  diff.textContent='';
+};
+
 export const loadTimeline=()=>fetchJson(withScope('/runs/latest')).then(meta=>{
   if(!meta.run){return {run_id:null,items:[]};}
   return fetchJson(`/api/runs/${meta.run}/timeline?page=1&page_size=120`);
@@ -33,6 +51,12 @@ export const loadTimeline=()=>fetchJson(withScope('/runs/latest')).then(meta=>{
     const btn=document.createElement('button');
     btn.className='timeline-button';
     btn.textContent=`${item.event} · ${item.timestamp||na()}`;
+    if(item.event==='governance.circuit_breaker_opened'){
+      row.classList.add('timeline-item-critical');
+      btn.classList.add('timeline-button-critical');
+      btn.title='Circuit breaker gouvernance ouvert';
+      btn.onclick=()=>showGovernanceBreakerDetail(item);
+    }
     row.appendChild(btn);
     if(item.event==='mutation'&&data.run_id){
       const currentIndex=mutationIndex;

--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -575,6 +575,30 @@ def _dump_policy_payload(payload: Mapping[str, Any]) -> str:
     return yaml.safe_dump(dict(payload), sort_keys=False)
 
 
+
+
+@dataclass(frozen=True)
+class CircuitBreakerState:
+    """Structured state emitted when the governance circuit breaker opens."""
+
+    category: str
+    severity: str
+    threshold: int
+    cooldown_seconds: float
+    open_until: str
+    corrective_action: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "category": self.category,
+            "severity": self.severity,
+            "threshold": self.threshold,
+            "cooldown_seconds": self.cooldown_seconds,
+            "open_until": self.open_until,
+            "corrective_action": self.corrective_action,
+        }
+
+
 @dataclass(frozen=True)
 class GovernanceDecision:
     """Decision returned by policy simulation or enforcement."""
@@ -768,6 +792,7 @@ class MutationGovernancePolicy:
         self._skill_creation_timestamps: deque[datetime] = deque()
         self._violation_timestamps: deque[datetime] = deque()
         self._circuit_open_until: datetime | None = None
+        self._last_circuit_breaker_state: CircuitBreakerState | None = None
         self._runtime_call_timestamps: deque[datetime] = deque()
         self._skill_failure_timestamps: dict[str, deque[datetime]] = {}
         self._skill_cost_totals: dict[str, float] = {}
@@ -924,13 +949,36 @@ class MutationGovernancePolicy:
         if self._social_prudent_until is not None and now >= self._social_prudent_until:
             self._social_prudent_until = None
 
-    def record_violation(self, *, category: str, severity: str = "high") -> None:
+    def last_circuit_breaker_state(self) -> CircuitBreakerState | None:
+        """Return the latest circuit-breaker opening state, if any."""
+
+        return self._last_circuit_breaker_state
+
+    def record_violation(
+        self, *, category: str, severity: str = "high"
+    ) -> CircuitBreakerState | None:
+        """Record a policy violation and return state when the breaker opens.
+
+        The Python log remains the human-facing alert, while the returned value
+        and :meth:`last_circuit_breaker_state` expose a structured signal that
+        callers such as the life loop can turn into run events.
+        """
+
         self._prune_history()
         now = self._now()
         was_open = self._circuit_open_until is not None and now < self._circuit_open_until
         self._violation_timestamps.append(now)
         if not was_open and len(self._violation_timestamps) >= self.circuit_breaker_threshold:
             self._circuit_open_until = now + timedelta(seconds=self.circuit_breaker_cooldown_seconds)
+            state = CircuitBreakerState(
+                category=category,
+                severity=severity,
+                threshold=self.circuit_breaker_threshold,
+                cooldown_seconds=self.circuit_breaker_cooldown_seconds,
+                open_until=self._circuit_open_until.isoformat(),
+                corrective_action="halt mutations until the circuit-breaker cooldown expires",
+            )
+            self._last_circuit_breaker_state = state
             log.error(
                 "governance circuit breaker opened: category=%s severity=%s threshold=%s cooldown=%ss",
                 category,
@@ -938,6 +986,8 @@ class MutationGovernancePolicy:
                 self.circuit_breaker_threshold,
                 self.circuit_breaker_cooldown_seconds,
             )
+            return state
+        return None
 
     def _relative(self, target: Path, root: Path) -> Path:
         target_resolved = target.resolve()

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -1685,10 +1685,23 @@ def run(
                     org.sandbox_violation_streak
                 )
                 logger.log_interaction("sandbox_violation", **sandbox_diagnostic)
-                governance_policy.record_violation(
+                breaker_state = governance_policy.record_violation(
                     category="sandbox_violation",
                     severity="critical",
                 )
+                if breaker_state is not None:
+                    breaker_payload = breaker_state.to_payload()
+                    breaker_payload["last_sandbox_diagnostics"] = dict(sandbox_diagnostic)
+                    logger.log_event("governance.circuit_breaker_opened", **breaker_payload)
+                    event_bus.publish(
+                        "governance.circuit_breaker_opened",
+                        {
+                            "life": org_name,
+                            "iteration": state.iteration,
+                            **breaker_payload,
+                        },
+                        payload_version=1,
+                    )
                 if (
                     org.sandbox_violation_streak >= SANDBOX_DEGRADED_MODE_THRESHOLD
                     and not org.degraded_mode

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -423,6 +423,18 @@ class RunLogger:
         self._write_event("interaction", record, record["ts"])
         add_episode(record)
 
+    def log_event(self, event: str, **info: Any) -> None:
+        """Record a named run event without wrapping it as an interaction."""
+
+        record: dict[str, Any] = {
+            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "event": event,
+            **info,
+        }
+        self._write_record(record)
+        self._write_event(event, record, record["ts"])
+        add_episode(record)
+
     def log_test_coevolution(
         self,
         *,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -798,6 +798,19 @@ def test_run_timeline_endpoint_filters_pagination_and_event_coherence(tmp_path: 
                 ),
                 json.dumps(
                     {
+                        "ts": "2026-04-11T09:05:00",
+                        "event": "governance.circuit_breaker_opened",
+                        "category": "sandbox_violation",
+                        "severity": "critical",
+                        "threshold": 3,
+                        "cooldown_seconds": 300.0,
+                        "open_until": "2026-04-11T09:10:00+00:00",
+                        "corrective_action": "halt mutations until cooldown",
+                        "last_sandbox_diagnostics": {"sandbox_violation_streak": 3},
+                    }
+                ),
+                json.dumps(
+                    {
                         "ts": "2026-04-11T09:10:00",
                         "skill": "orgb:skills/b.py",
                         "operator": "swap",
@@ -819,7 +832,7 @@ def test_run_timeline_endpoint_filters_pagination_and_event_coherence(tmp_path: 
     route = app._routes["/api/runs/{run_id}/timeline"]
 
     all_payload = route(run_id="run-42", page=1, page_size=2)
-    assert all_payload["pagination"] == {"page": 1, "page_size": 2, "total": 6, "total_pages": 3}
+    assert all_payload["pagination"] == {"page": 1, "page_size": 2, "total": 7, "total_pages": 4}
     assert [item["event"] for item in all_payload["items"]] == ["mutation", "delay"]
 
     page_two = route(run_id="run-42", page=2, page_size=2)
@@ -844,7 +857,24 @@ def test_run_timeline_endpoint_filters_pagination_and_event_coherence(tmp_path: 
     assert item["score_after"] == 6.0
 
     event_types = {entry["event"] for entry in route(run_id="run-42")["items"]}
-    assert {"mutation", "delay", "refuse", "death", "interaction"}.issubset(event_types)
+    assert {
+        "mutation",
+        "delay",
+        "refuse",
+        "death",
+        "interaction",
+        "governance.circuit_breaker_opened",
+    }.issubset(event_types)
+    breaker_item = next(
+        entry for entry in route(run_id="run-42")["items"]
+        if entry["event"] == "governance.circuit_breaker_opened"
+    )
+    assert breaker_item["category"] == "sandbox_violation"
+    assert breaker_item["severity"] == "critical"
+    assert breaker_item["threshold"] == 3
+    assert breaker_item["cooldown_seconds"] == 300.0
+    assert breaker_item["open_until"] == "2026-04-11T09:10:00+00:00"
+    assert breaker_item["last_sandbox_diagnostics"] == {"sandbox_violation_streak": 3}
 
 
 def test_run_mutation_detail_endpoint_returns_diff_metrics_and_ast(tmp_path: Path) -> None:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -768,6 +768,21 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
     assert diagnostic["governance_circuit_breaker_threshold"] == 3
     assert diagnostic["source_error_type"] == "runtime_exception"
     assert diagnostic["source_error_message"] == "synthetic sandbox failure"
+    breaker_events = [
+        event["payload"]
+        for event in run_events
+        if event.get("event_type") == "governance.circuit_breaker_opened"
+    ]
+    assert breaker_events
+    breaker = breaker_events[0]
+    assert breaker["category"] == "sandbox_violation"
+    assert breaker["severity"] == "critical"
+    assert breaker["threshold"] == 3
+    assert breaker["cooldown_seconds"] == 300.0
+    assert breaker["open_until"]
+    assert breaker["corrective_action"]
+    assert breaker["last_sandbox_diagnostics"]["organism"] == skills_dir.name
+
     assert diagnostic["mutation_error_type"] is None
     assert diagnostic["mutation_error_message"] is None
     assert diagnostic["base_failure_reason"] == "runtime_exception"

--- a/tests/test_values_schema.py
+++ b/tests/test_values_schema.py
@@ -131,10 +131,22 @@ def test_policy_logs_circuit_breaker_opened_only_once_when_already_open(
     policy._now = lambda: clock["now"]  # type: ignore[method-assign]
     caplog.set_level(logging.ERROR, logger="singular.governance.policy")
 
+    first = policy.record_violation(category="quota", severity="high")
+    opened = policy.record_violation(category="quota", severity="high")
+    repeated = policy.record_violation(category="quota", severity="high")
     policy.record_violation(category="quota", severity="high")
-    policy.record_violation(category="quota", severity="high")
-    policy.record_violation(category="quota", severity="high")
-    policy.record_violation(category="quota", severity="high")
+
+    assert first is None
+    assert opened is not None
+    assert opened.category == "quota"
+    assert opened.severity == "high"
+    assert opened.threshold == 2
+    assert opened.cooldown_seconds == 120.0
+    assert opened.open_until == "2026-01-01T00:02:00+00:00"
+    assert opened.corrective_action
+    assert opened.to_payload()["open_until"] == opened.open_until
+    assert policy.last_circuit_breaker_state() == opened
+    assert repeated is None
 
     opened_events = [
         record for record in caplog.records if "governance circuit breaker opened" in record.message


### PR DESCRIPTION
### Motivation

- Donner aux consommateurs de la boucle un signal structuré et consultable quand la politique ouvre un circuit-breaker suite à des violations sandbox, afin de piloter la boucle sans parser les logs.
- Émettre un événement de run clair pour tracer l’ouverture du breaker avec diagnostics exploitables par le dashboard et autres abonnés.

### Description

- Ajout de la dataclass `CircuitBreakerState` et d’une API : `MutationGovernancePolicy.record_violation(...)` retourne un `CircuitBreakerState` quand le breaker s’ouvre et `last_circuit_breaker_state()` expose le dernier état ouvert.
- Ajout de `RunLogger.log_event()` pour écrire des événements nommés (non encapsulés en `interaction`) et écriture d’un événement `governance.circuit_breaker_opened` dans le run file lorsque le breaker s’ouvre.
- Dans la boucle (`src/singular/life/loop.py`) on capte la valeur de retour de `record_violation(...)`, on enrichit la charge (`last_sandbox_diagnostics`) et on publie à la fois un enregistrement de run et l’événement sur l’event-bus (`governance.circuit_breaker_opened`).
- Surface côté dashboard : l’API timeline accepte le nouvel événement et renvoie les champs `category`, `severity`, `threshold`, `cooldown_seconds`, `open_until`, `corrective_action`, `last_sandbox_diagnostics`; l’UI statique affiche un bouton critique cliquable avec détail et style (JS + CSS mis à jour).

### Testing

- Compilation vérifiée avec `python -m compileall src/singular/governance/policy.py src/singular/life/loop.py src/singular/runs/logger.py src/singular/dashboard/__init__.py` (succès).
- Suite ciblée exécutée avec `pytest -q tests/test_values_schema.py tests/test_dashboard.py::test_run_timeline_endpoint_filters_pagination_and_event_coherence tests/test_dashboard_static_smoke.py tests/test_loop.py::test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extinction tests/test_runs_logger.py`, résultat : all tests passed (`26 passed`) with existing datetime deprecation warnings only.
- Principaux fichiers modifiés : `src/singular/governance/policy.py`, `src/singular/life/loop.py`, `src/singular/runs/logger.py`, `src/singular/dashboard/__init__.py`, `src/singular/dashboard/static/render-timeline.js`, `src/singular/dashboard/static/dashboard.css`, plus tests mis à jour pour couvrir le nouveau comportement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023ebe6a08832aa6afc6b9029b9dfd)