### PR TITLE
Quarantine skills after repeated sandbox failures

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -25,7 +25,14 @@ from singular.beliefs.meta_learning import (
     register_run_result,
 )
 from singular.events import EventBus, get_global_event_bus
-from singular.memory import add_causal_trace, add_episode, register_memory_event_handlers, update_score
+from singular.memory import (
+    add_causal_trace,
+    add_episode,
+    read_skills,
+    register_memory_event_handlers,
+    temporarily_disable_skill,
+    update_score,
+)
 from singular.psyche import Psyche, Mood
 from singular.runs.logger import RunLogger
 from singular.runs.explain import summarize_mutation
@@ -81,6 +88,12 @@ DEGRADED_DELAY_SECONDS = 0.05
 SKILL_GENESIS_TECH_DEBT_THRESHOLD = 8
 SKILL_GENESIS_FAILURE_STREAK_THRESHOLD = 3
 SKILL_GENESIS_COVERAGE_GAP_THRESHOLD = 0.6
+SKILL_SANDBOX_QUARANTINE_THRESHOLD = int(
+    os.environ.get("SINGULAR_SKILL_SANDBOX_QUARANTINE_THRESHOLD", "3")
+)
+SKILL_SANDBOX_QUARANTINE_HOURS = int(
+    os.environ.get("SINGULAR_SKILL_SANDBOX_QUARANTINE_HOURS", "1")
+)
 
 
 @dataclass(init=False, frozen=True)
@@ -781,10 +794,41 @@ def _compute_loop_modifications(original: str, mutated: str) -> dict[str, int]:
     }
 
 
+def _skill_memory_key(org_name: str, skill_path: Path, organism_count: int) -> str:
+    """Return the memory key used for a selected skill."""
+
+    return f"{org_name}:{skill_path.stem}" if organism_count > 1 else skill_path.stem
+
+
+def _inactive_skill_keys(skills_state: Mapping[str, object]) -> set[str]:
+    """Return skills that lifecycle metadata says should not be selected."""
+
+    inactive: set[str] = set()
+    for skill, raw_entry in skills_state.items():
+        entry = raw_entry if isinstance(raw_entry, Mapping) else {}
+        lifecycle = (
+            entry.get("lifecycle")
+            if isinstance(entry.get("lifecycle"), Mapping)
+            else {}
+        )
+        if lifecycle.get("state") in {"archived", "deleted", "temporarily_disabled"}:
+            inactive.add(str(skill))
+    return inactive
+
+
+def _first_sandbox_error_type(
+    base_result: SandboxScore, mutated_result: SandboxScore
+) -> str | None:
+    """Prefer mutation diagnostics, falling back to source diagnostics."""
+
+    return mutated_result.error_type or base_result.error_type
+
+
 def _choose_skill(
     rng: random.Random,
     organisms: Dict[str, Organism],
     skill_reputation: Mapping[str, Mapping[str, float | int]] | None = None,
+    excluded_skill_keys: set[str] | None = None,
 ) -> tuple[str, Path]:
     """Choose a skill with utility-aware priority and exploration fallback."""
 
@@ -792,19 +836,19 @@ def _choose_skill(
         raise RuntimeError("no organisms available")
 
     candidates: list[tuple[str, Path]] = []
+    excluded = excluded_skill_keys or set()
     for org_name, org in organisms.items():
         available = list(org.skills_dir.glob("*.py"))
         for skill_path in available:
+            key = _skill_memory_key(org_name, skill_path, len(organisms))
+            if key in excluded or str(skill_path) in excluded:
+                continue
             candidates.append((org_name, skill_path))
     if not candidates:
         raise RuntimeError("no skills available for any organism")
 
     def priority(org_name: str, skill_path: Path) -> float:
-        key = (
-            f"{org_name}:{skill_path.stem}"
-            if len(organisms) > 1
-            else skill_path.stem
-        )
+        key = _skill_memory_key(org_name, skill_path, len(organisms))
         rep = dict((skill_reputation or {}).get(key, {}))
         quality = float(rep.get("mean_quality", 0.5))
         use_count = float(rep.get("use_count", 0.0))
@@ -975,6 +1019,8 @@ def run(
         propose_mutations([])
     mortality = mortality or DeathMonitor()
     seen_diffs: set[str] = set()
+    skill_sandbox_failures: dict[str, int] = {}
+    quarantined_skill_keys: set[str] = set()
     sleep_ticks_remaining = 0
     intrinsic_goals = IntrinsicGoals(value_weights=value_weights)
     if coevolve_tests and test_pool is None:
@@ -1022,15 +1068,39 @@ def run(
                 _, org_name, skill_path = heapq.heappop(delayed)
                 decision = Psyche.Decision.ACCEPT
             else:
-                org_name, skill_path = _choose_skill(
-                    rng,
-                    world.organisms,
-                    skill_reputation=logger.skill_reputation(),
-                )
+                quarantined_skill_keys.update(_inactive_skill_keys(read_skills()))
+                try:
+                    org_name, skill_path = _choose_skill(
+                        rng,
+                        world.organisms,
+                        skill_reputation=logger.skill_reputation(),
+                        excluded_skill_keys=quarantined_skill_keys,
+                    )
+                except RuntimeError as exc:
+                    logger.log_interaction(
+                        "skill.quarantine_exhausted",
+                        reason=str(exc),
+                        excluded_skills=sorted(quarantined_skill_keys),
+                        alive=True,
+                    )
+                    break
                 decision = Psyche.Decision.ACCEPT
                 if hasattr(psyche, "irrational_decision"):
                     decision = psyche.irrational_decision(rng)
             selected_org = world.organisms[org_name]
+            selected_skill_key = _skill_memory_key(
+                org_name, skill_path, len(world.organisms)
+            )
+            if selected_skill_key in quarantined_skill_keys:
+                logger.log_interaction(
+                    "skill.quarantine_skip",
+                    organism=org_name,
+                    skill=selected_skill_key,
+                    skill_path=str(skill_path),
+                    alive=True,
+                )
+                tick_count += 1
+                continue
             for penalty in persistent_world_state.consume_due_penalties(state.iteration):
                 selected_org.energy += penalty.energy_delta
                 persistent_world_state.mortality_pressure = max(
@@ -1681,27 +1751,69 @@ def run(
             }
             if sandbox_failure:
                 org.sandbox_violation_streak += 1
+                attempts = skill_sandbox_failures.get(selected_skill_key, 0) + 1
+                skill_sandbox_failures[selected_skill_key] = attempts
                 sandbox_diagnostic["sandbox_violation_streak"] = (
                     org.sandbox_violation_streak
                 )
+                sandbox_diagnostic["skill_sandbox_failure_streak"] = attempts
                 logger.log_interaction("sandbox_violation", **sandbox_diagnostic)
-                breaker_state = governance_policy.record_violation(
-                    category="sandbox_violation",
-                    severity="critical",
+                quarantine_triggered = attempts >= max(
+                    SKILL_SANDBOX_QUARANTINE_THRESHOLD, 1
                 )
-                if breaker_state is not None:
-                    breaker_payload = breaker_state.to_payload()
-                    breaker_payload["last_sandbox_diagnostics"] = dict(sandbox_diagnostic)
-                    logger.log_event("governance.circuit_breaker_opened", **breaker_payload)
+                if quarantine_triggered:
+                    reason = "consecutive_sandbox_failures"
+                    skills_after_disable = temporarily_disable_skill(
+                        selected_skill_key,
+                        duration_hours=SKILL_SANDBOX_QUARANTINE_HOURS,
+                        reason=reason,
+                    )
+                    lifecycle = skills_after_disable[selected_skill_key]["lifecycle"]
+                    disabled_until = lifecycle.get("disabled_until")
+                    quarantined_skill_keys.add(selected_skill_key)
+                    quarantine_payload = {
+                        "skill": selected_skill_key,
+                        "reason": reason,
+                        "sandbox_error_type": _first_sandbox_error_type(
+                            base_score_result,
+                            mutated_score_result,
+                        ),
+                        "disabled_until": disabled_until,
+                        "attempts": attempts,
+                    }
+                    logger.log_event("skill.quarantined", **quarantine_payload)
                     event_bus.publish(
-                        "governance.circuit_breaker_opened",
+                        "skill.quarantined",
                         {
                             "life": org_name,
                             "iteration": state.iteration,
-                            **breaker_payload,
+                            "skill_path": str(skill_path),
+                            **quarantine_payload,
                         },
                         payload_version=1,
                     )
+                else:
+                    breaker_state = governance_policy.record_violation(
+                        category="sandbox_violation",
+                        severity="critical",
+                    )
+                    if breaker_state is not None:
+                        breaker_payload = breaker_state.to_payload()
+                        breaker_payload["last_sandbox_diagnostics"] = dict(
+                            sandbox_diagnostic
+                        )
+                        logger.log_event(
+                            "governance.circuit_breaker_opened", **breaker_payload
+                        )
+                        event_bus.publish(
+                            "governance.circuit_breaker_opened",
+                            {
+                                "life": org_name,
+                                "iteration": state.iteration,
+                                **breaker_payload,
+                            },
+                            payload_version=1,
+                        )
                 if (
                     org.sandbox_violation_streak >= SANDBOX_DEGRADED_MODE_THRESHOLD
                     and not org.degraded_mode
@@ -1730,6 +1842,7 @@ def run(
             elif org.sandbox_violation_streak > 0:
                 org.sandbox_violation_streak = 0
                 org.degraded_mode = False
+                skill_sandbox_failures[selected_skill_key] = 0
             failed = sandbox_failure or (not accepted)
             health_snapshot = health_tracker.update(
                 iteration=state.iteration,
@@ -1764,11 +1877,7 @@ def run(
                 alive=True,
             )
 
-            key = (
-                f"{org_name}:{skill_path.stem}"
-                if len(world.organisms) > 1
-                else skill_path.stem
-            )
+            key = selected_skill_key
             update_score(key, mutated_score)
             mutation_payload = {
                 "iteration": state.iteration,

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -414,10 +414,11 @@ def record_skill_metric(
     metrics["average_cost"] = metrics["total_cost"] / usage_count
     metrics["last_used_at"] = _utc_now_iso()
 
-    lifecycle["state"] = "active"
-    lifecycle["state_reason"] = "recent_usage"
-    lifecycle["disabled_until"] = None
-    lifecycle["last_transition_at"] = _utc_now_iso()
+    if lifecycle.get("state") not in {"temporarily_disabled", "deleted"}:
+        lifecycle["state"] = "active"
+        lifecycle["state_reason"] = "recent_usage"
+        lifecycle["disabled_until"] = None
+        lifecycle["last_transition_at"] = _utc_now_iso()
 
     skills[skill] = entry
     write_skills(skills, path)

--- a/tests/test_skill_quarantine.py
+++ b/tests/test_skill_quarantine.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import ast
+import functools
+import json
+import random
+from pathlib import Path
+
+import singular.life.loop as life_loop
+from singular.runs.logger import RunLogger as BaseRunLogger
+
+
+def _noop_operator(tree: ast.AST, rng=None) -> ast.AST:
+    return tree
+
+
+def test_loop_quarantines_skill_after_repeated_sandbox_failures(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(BaseRunLogger, root=tmp_path / "runs")
+    )
+    monkeypatch.setattr(
+        life_loop.Psyche, "load_state", staticmethod(lambda: life_loop.Psyche())
+    )
+    monkeypatch.setattr(life_loop, "SKILL_SANDBOX_QUARANTINE_THRESHOLD", 2)
+    monkeypatch.setattr(life_loop, "SKILL_SANDBOX_QUARANTINE_HOURS", 1)
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "unsafe.py").write_text("import os\nresult = 1\n", encoding="utf-8")
+
+    life_loop.run(
+        skills_dirs=skills_dir,
+        checkpoint_path=tmp_path / "checkpoint.json",
+        budget_seconds=10.0,
+        rng=random.Random(0),
+        run_id="quarantine",
+        operators={"noop": _noop_operator},
+        max_iterations=2,
+    )
+
+    skills = json.loads((tmp_path / "mem" / "skills.json").read_text(encoding="utf-8"))
+    lifecycle = skills["unsafe"]["lifecycle"]
+    assert lifecycle["state"] == "temporarily_disabled"
+    assert lifecycle["state_reason"] == "consecutive_sandbox_failures"
+    assert lifecycle["disabled_until"] is not None
+
+    events = [
+        json.loads(line)
+        for line in (tmp_path / "runs" / "quarantine" / "events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line
+    ]
+    quarantines = [
+        event for event in events if event.get("event_type") == "skill.quarantined"
+    ]
+    assert quarantines
+    payload = quarantines[-1]["payload"]
+    assert payload["skill"] == "unsafe"
+    assert payload["reason"] == "consecutive_sandbox_failures"
+    assert payload["sandbox_error_type"] == "sandbox_error"
+    assert payload["disabled_until"] == lifecycle["disabled_until"]
+    assert payload["attempts"] == 2


### PR DESCRIPTION
### Motivation

- Empêcher qu’un skill défaillant en sandbox déclenche uniquement le breaker global en ajoutant une désactivation ciblée quand un skill accumule des échecs sandbox consécutifs.

### Description

- Introduit deux paramètres configurables `SINGULAR_SKILL_SANDBOX_QUARANTINE_THRESHOLD` et `SINGULAR_SKILL_SANDBOX_QUARANTINE_HOURS` et le compteur local de pannes par skill dans `src/singular/life/loop.py`.
- Suivi par clé de skill (`org_name:skill`) et exclusion des skills dont le lifecycle est `archived`, `deleted` ou `temporarily_disabled` lors de la sélection (`_choose_skill`) pour éviter de resélectionner des skills mis en quarantaine.
- Quand un skill dépasse le seuil d’échecs consécutifs, on appelle `temporarily_disable_skill(...)` (réutilisation des helpers dans `src/singular/memory.py`), on ajoute la clé en quarantaine et on émet un événement/log `skill.quarantined` contenant `skill`, `reason`, `sandbox_error_type`, `disabled_until` et `attempts` (à la fois via `RunLogger.log_event` et `event_bus.publish`).
- Préserve le comportement précédent du circuit breaker : si la quarantaine n’est pas déclenchée, on continue d’enregistrer la violation globale via `governance.record_violation` comme avant.
- Empêche que l’enregistrement métrique remette immédiatement `temporarily_disabled` en `active` en adaptant `record_skill_metric` pour ne pas réactiver les entries dont `state` est `temporarily_disabled` ou `deleted`.
- Ajout d’un test de régression `tests/test_skill_quarantine.py` qui vérifie la mise en quarantaine après 2 échecs et la présence du payload `skill.quarantined`.

### Testing

- Ajout et exécution du test unitaire `tests/test_skill_quarantine.py`, qui passe avec succès.
- Validation de non-régression via `tests/test_generations_registry.py::test_generation_registry_stays_coherent_with_run_events`, qui a été exécuté et est passé.
- Vérification de la syntaxe/compilation de `src/singular/life/loop.py`, `src/singular/memory.py` et `src/singular/skills/runtime.py` via `python -m py_compile`, sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02415c3608832a873e457d15c7c628)