### PR TITLE
Add sandbox diagnosis CLI

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -285,6 +285,123 @@ def _normalize_windows_path_entry(entry: str) -> str:
     return os.path.normcase(os.path.normpath(entry.strip().strip('"')))
 
 
+def _short_diagnostic_message(message: str | None, *, limit: int = 96) -> str:
+    """Return a compact one-line diagnostic message for CLI tables."""
+
+    if not message:
+        return "-"
+    compact = " ".join(str(message).split())
+    if len(compact) <= limit:
+        return compact
+    return f"{compact[: max(0, limit - 1)]}…"
+
+
+def _sandbox_diagnosis_recommendation(
+    error_type: str | None, message: str | None
+) -> str:
+    """Map a structured sandbox scoring failure to an actionable recommendation."""
+
+    if error_type is None:
+        return "Aucune correction nécessaire."
+
+    message_lower = (message or "").lower()
+    recommendations = {
+        "missing_result": "Ajoutez une affectation numérique `result = ...` en fin de skill.",
+        "non_numeric_result": "Convertissez `result` en nombre (`int` ou `float`).",
+        "non_finite_result": "Retournez un nombre fini; évitez `inf`, `-inf` et `nan`.",
+        "timeout": "Réduisez les boucles ou ajoutez une borne de calcul déterministe.",
+        "syntax_error": "Corrigez la syntaxe Python du fichier.",
+        "runtime_exception": "Corrigez l'exception levée pendant l'exécution sandboxée.",
+    }
+    if error_type == "sandbox_error":
+        if "forbidden syntax" in message_lower:
+            return "Supprimez les imports/with; n'utilisez que le sous-ensemble sandbox autorisé."
+        if "forbidden" in message_lower:
+            return "Supprimez l'accès au nom interdit ou remplacez-le par une API autorisée."
+        return "Adaptez le code aux restrictions de la sandbox."
+    return recommendations.get(
+        error_type, "Inspectez le fichier puis adaptez-le au contrat sandbox."
+    )
+
+
+def _iter_sandbox_skill_files(skills_dir: Path) -> list[Path]:
+    """Return skill files that can be submitted to the Python sandbox."""
+
+    if not skills_dir.exists():
+        return []
+    return sorted(
+        path
+        for path in skills_dir.iterdir()
+        if path.is_file() and path.suffix == ".py" and not path.name.startswith(".")
+    )
+
+
+def _diagnose_sandbox(*, output_format: str = "plain") -> int:
+    """Run every skill in ``SINGULAR_HOME/skills`` through structured sandbox scoring."""
+
+    from .life.loop import SandboxScore, score_code_with_error
+
+    singular_home = Path(os.environ.get("SINGULAR_HOME", ".")).expanduser()
+    skills_dir = singular_home / "skills"
+    files = _iter_sandbox_skill_files(skills_dir)
+
+    if not skills_dir.exists():
+        print(f"Dossier skills introuvable: {skills_dir}", file=sys.stderr)
+        return 1
+
+    rows: list[dict[str, Any]] = []
+    for skill_file in files:
+        try:
+            source = skill_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            result = SandboxScore(
+                score=float("-inf"),
+                ok=False,
+                error_type="read_error",
+                error_message=f"{type(exc).__name__}: {exc}",
+            )
+        else:
+            result = score_code_with_error(source)
+
+        recommendation = _sandbox_diagnosis_recommendation(
+            result.error_type, result.error_message
+        )
+        rows.append(
+            {
+                "file": skill_file.name,
+                "status": "OK" if result.ok else "KO",
+                "score": result.score if result.ok else None,
+                "error_type": result.error_type,
+                "message": _short_diagnostic_message(result.error_message),
+                "recommendation": recommendation,
+            }
+        )
+
+    if output_format == "json":
+        print(
+            json.dumps(
+                {"skills_dir": str(skills_dir), "diagnostics": rows},
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    else:
+        print(f"Diagnostic sandbox skills: {skills_dir}")
+        if not rows:
+            print("Aucun fichier .py compatible trouvé.")
+            return 0
+        print("fichier | statut | score | type_erreur | message | recommandation")
+        print("--- | --- | --- | --- | --- | ---")
+        for row in rows:
+            score = "-" if row["score"] is None else f"{float(row['score']):g}"
+            print(
+                f"{row['file']} | {row['status']} | {score} | "
+                f"{row['error_type'] or '-'} | {row['message']} | {row['recommendation']}"
+            )
+
+    return 0 if all(row["status"] == "OK" for row in rows) else 1
+
+
 def _doctor_fix_windows_user_path(scripts_path: Path) -> bool:
     """Add scripts_path to the Windows user Path variable when missing."""
 
@@ -1030,6 +1147,17 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Active les phases sans exécuter la mutation",
     )
+    diagnose_parser = subparsers.add_parser(
+        "diagnose", help="Exécuter des diagnostics techniques"
+    )
+    diagnose_subparsers = diagnose_parser.add_subparsers(
+        dest="diagnose_command", required=True
+    )
+    diagnose_subparsers.add_parser(
+        "sandbox",
+        help="Diagnostiquer les skills de SINGULAR_HOME/skills via la sandbox",
+    )
+
     retention_parser = subparsers.add_parser(
         "retention",
         help="Inspecte ou exécute la purge de rétention",
@@ -1495,6 +1623,10 @@ def main(argv: list[str] | None = None) -> int:
                 dry_run=args.dry_run,
                 safe_mode=args.safe_mode,
             )
+
+    elif args.command == "diagnose":
+        if args.diagnose_command == "sandbox":
+            return _diagnose_sandbox(output_format=args.output_format)
 
     elif args.command == "retention":
         _ensure_active_life(resolve_life, args.life)

--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -77,7 +77,10 @@ def _sandbox_worker(
     """Execute sandboxed code in a child process and return output through *queue*."""
     if resource_module is not None and sys.platform != "win32":
         resource_module.setrlimit(resource_module.RLIMIT_AS, (memory_limit, memory_limit))
-        cpu_seconds = max(1, int(timeout))
+        # Keep the OS CPU limit slightly above the parent wall-clock timeout so
+        # tight loops are reported as sandbox timeouts instead of opaque worker
+        # exits on platforms that enforce RLIMIT_CPU aggressively.
+        cpu_seconds = max(1, int(timeout) + 1)
         resource_module.setrlimit(resource_module.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
 
     tree = ast.parse(code, mode="exec")

--- a/tests/test_cli_diagnose_sandbox.py
+++ b/tests/test_cli_diagnose_sandbox.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import singular.cli as cli
+
+
+def _write_skill(home: Path, name: str, source: str) -> None:
+    skills = home / "skills"
+    skills.mkdir(parents=True, exist_ok=True)
+    (skills / name).write_text(source, encoding="utf-8")
+
+
+def test_diagnose_sandbox_reports_ok_skill(monkeypatch, tmp_path, capsys) -> None:
+    home = tmp_path / "life"
+    _write_skill(home, "ok.py", "result = 1\n")
+
+    exit_code = cli.main(["--home", str(home), "diagnose", "sandbox"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Diagnostic sandbox skills" in out
+    assert "ok.py | OK | 1 | - | - | Aucune correction nécessaire." in out
+
+
+def test_diagnose_sandbox_reports_missing_result(monkeypatch, tmp_path, capsys) -> None:
+    home = tmp_path / "life"
+    _write_skill(home, "missing.py", "value = 1\n")
+
+    exit_code = cli.main(["--home", str(home), "diagnose", "sandbox"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "missing.py | KO | - | missing_result" in out
+    assert "Ajoutez une affectation numérique" in out
+
+
+def test_diagnose_sandbox_reports_forbidden_import(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    home = tmp_path / "life"
+    _write_skill(home, "import_os.py", "import os\nresult = 1\n")
+
+    exit_code = cli.main(["--home", str(home), "diagnose", "sandbox"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "import_os.py | KO | - | sandbox_error" in out
+    assert "forbidden syntax detected" in out
+    assert "Supprimez les imports/with" in out
+
+
+def test_diagnose_sandbox_reports_non_numeric_result(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    home = tmp_path / "life"
+    _write_skill(home, "text.py", 'result = "texte"\n')
+
+    exit_code = cli.main(["--home", str(home), "diagnose", "sandbox"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "text.py | KO | - | non_numeric_result" in out
+    assert "Convertissez `result` en nombre" in out
+
+
+def test_diagnose_sandbox_reports_timeout(monkeypatch, tmp_path, capsys) -> None:
+    home = tmp_path / "life"
+    _write_skill(home, "timeout.py", "while True:\n    pass\n")
+
+    exit_code = cli.main(["--home", str(home), "diagnose", "sandbox"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "timeout.py | KO | - | timeout" in out
+    assert "Réduisez les boucles" in out


### PR DESCRIPTION
### Motivation

- Provide an actionable CLI to scan user skills under `SINGULAR_HOME/skills` and surface sandbox execution issues before they affect the evolutionary loop. 

### Description

- Add `singular diagnose sandbox` command and CLI wiring to `src/singular/cli.py` that iterates `SINGULAR_HOME/skills`, runs each `.py` through the structured scoring helper and prints file, OK/KO status, score, error type, short message and a correction recommendation. 
- Reuse the structured sandbox scoring logic via `score_code_with_error` from `src/singular/life/loop.py` and render results in plain table or JSON. 
- Add helper utilities in `src/singular/cli.py` for compact diagnostic messages, mapping error types to human recommendations, and enumerating skill files. 
- Tweak sandbox CPU RLIMIT in `src/singular/life/sandbox.py` to set CPU limit slightly above the wall-clock timeout so tight infinite loops surface as `timeout` diagnostics instead of opaque worker exits. 
- Add unit tests `tests/test_cli_diagnose_sandbox.py` covering: OK skill (`result = 1`), missing `result`, forbidden import (`import os`), non-numeric `result`, and a timeout skill.

### Testing

- Compiled modified files: `python -m py_compile src/singular/cli.py src/singular/life/sandbox.py` succeeded. 
- Ran targeted pytest set: `pytest -q tests/test_cli_diagnose_sandbox.py tests/test_sandbox.py tests/test_loop.py::test_score_code_with_error_returns_structured_sandbox_score tests/test_skill_quarantine.py` and all tests passed. 
- Ran broader test subset during development; relevant test runs completed successfully (no regressions observed in sandbox/loop-related tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0247ce4fe8832a822f48104c8e4993)