### PR TITLE
Distinguish base and mutation sandbox failures

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -177,6 +177,65 @@ class SandboxScore:
 ScoreCodeResult = SandboxScore
 
 
+DANGEROUS_MUTATION_NAMES = frozenset(
+    {
+        "open",
+        "exec",
+        "eval",
+        "compile",
+        "__import__",
+        "input",
+        "os",
+        "sys",
+        "socket",
+        "subprocess",
+    }
+)
+
+
+def _has_explicit_dangerous_pattern(code: str) -> bool:
+    """Return True when code explicitly references dangerous capabilities."""
+
+    try:
+        tree = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id in DANGEROUS_MUTATION_NAMES:
+            return True
+        if isinstance(node, ast.Attribute) and node.attr in DANGEROUS_MUTATION_NAMES:
+            return True
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            names = [alias.name.split(".", 1)[0] for alias in node.names]
+            module = []
+            if isinstance(node, ast.ImportFrom) and node.module:
+                module.append(node.module.split(".", 1)[0])
+            if any(name in DANGEROUS_MUTATION_NAMES for name in [*names, *module]):
+                return True
+    return False
+
+
+def _sandbox_failure_category(
+    base_failed: bool, mutation_failed: bool, mutated: str
+) -> tuple[str | None, str | None, bool]:
+    """Classify sandbox failures for governance escalation.
+
+    Returns ``(category, severity, record_global_violation)``. Original-code
+    failures mean the active skill is broken and remain critical. A failed
+    mutation over a healthy base is usually just a rejected candidate and should
+    not feed the global circuit breaker unless it explicitly contains dangerous
+    capabilities.
+    """
+
+    if base_failed:
+        return "source_sandbox_violation", "critical", True
+    if mutation_failed:
+        if _has_explicit_dangerous_pattern(mutated):
+            return "dangerous_mutation_violation", "critical", True
+        return "invalid_mutation_rejected", "medium", False
+    return None, None, False
+
+
 def _score_failure(
     error_type: str,
     exception: BaseException | None = None,
@@ -1340,6 +1399,17 @@ def run(
             mutated_score = mutated_score_result.score
             ms_new = (time.perf_counter() - t0) * 1000
 
+            base_failed = (not base_score_result.ok) or base_score == float("-inf")
+            mutation_failed = (
+                (not mutated_score_result.ok) or mutated_score == float("-inf")
+            )
+            (
+                sandbox_violation_category,
+                sandbox_violation_severity,
+                record_global_sandbox_violation,
+            ) = _sandbox_failure_category(base_failed, mutation_failed, mutated)
+            critical_sandbox_failure = sandbox_violation_severity == "critical"
+
             if mutated_score == float("-inf"):
                 if hasattr(psyche, "feel"):
                     psyche.feel(Mood.PAIN)
@@ -1386,9 +1456,13 @@ def run(
                 seen_diffs.add(diff)
 
             accepted = (
-                map_elites.add(mutated, mutated_score)
-                if map_elites
-                else mutated_score <= base_score
+                False
+                if mutation_failed
+                else (
+                    map_elites.add(mutated, mutated_score)
+                    if map_elites
+                    else mutated_score <= base_score
+                )
             )
             world_effects: list[dict[str, object]] = []
             security_metadata: dict[str, object] = {
@@ -1399,6 +1473,8 @@ def run(
                 "corrective_action": None,
             }
             detection_rate = 0.0
+            combined_base = base_score
+            combined_mutated = mutated_score
             test_delta = {"added": 0, "removed": 0}
             if coevolve_tests and test_pool is not None and not selected_org.degraded_mode:
                 can_run_coevo, coevo_state = resource_manager.apply_capability_cost("test_coevolution")
@@ -1425,6 +1501,7 @@ def run(
                     score_combined_base=combined_base,
                     score_combined_new=combined_mutated,
                 )
+            accepted = accepted and not mutation_failed
             org.last_score = mutated_score
             if accepted:
                 governance_root = skill_path.parent.parent if skill_path.parent.name == "skills" else skill_path.parent
@@ -1718,10 +1795,6 @@ def run(
                     payload_version=1,
                 )
 
-            base_failed = (not base_score_result.ok) or base_score == float("-inf")
-            mutation_failed = (
-                (not mutated_score_result.ok) or mutated_score == float("-inf")
-            )
             sandbox_failure = base_failed or mutation_failed
             sandbox_diagnostic = {
                 "organism": org_name,
@@ -1742,6 +1815,14 @@ def run(
                 "base_exception_message": base_score_result.error_message,
                 "mutation_exception_type": mutated_score_result.exception_type,
                 "mutation_exception_message": mutated_score_result.error_message,
+                "sandbox_violation_category": sandbox_violation_category,
+                "sandbox_violation_severity": sandbox_violation_severity,
+                "sandbox_violation_global_recorded": record_global_sandbox_violation,
+                "dangerous_mutation_pattern": (
+                    mutation_failed
+                    and not base_failed
+                    and sandbox_violation_category == "dangerous_mutation_violation"
+                ),
                 "sandbox_violation_streak": org.sandbox_violation_streak,
                 "governance_circuit_breaker_threshold": getattr(
                     governance_policy,
@@ -1750,15 +1831,17 @@ def run(
                 ),
             }
             if sandbox_failure:
-                org.sandbox_violation_streak += 1
-                attempts = skill_sandbox_failures.get(selected_skill_key, 0) + 1
-                skill_sandbox_failures[selected_skill_key] = attempts
+                attempts = skill_sandbox_failures.get(selected_skill_key, 0)
+                if critical_sandbox_failure:
+                    org.sandbox_violation_streak += 1
+                    attempts += 1
+                    skill_sandbox_failures[selected_skill_key] = attempts
                 sandbox_diagnostic["sandbox_violation_streak"] = (
                     org.sandbox_violation_streak
                 )
                 sandbox_diagnostic["skill_sandbox_failure_streak"] = attempts
                 logger.log_interaction("sandbox_violation", **sandbox_diagnostic)
-                quarantine_triggered = attempts >= max(
+                quarantine_triggered = critical_sandbox_failure and attempts >= max(
                     SKILL_SANDBOX_QUARANTINE_THRESHOLD, 1
                 )
                 if quarantine_triggered:
@@ -1792,10 +1875,10 @@ def run(
                         },
                         payload_version=1,
                     )
-                else:
+                elif record_global_sandbox_violation:
                     breaker_state = governance_policy.record_violation(
-                        category="sandbox_violation",
-                        severity="critical",
+                        category=sandbox_violation_category or "sandbox_violation",
+                        severity=sandbox_violation_severity or "high",
                     )
                     if breaker_state is not None:
                         breaker_payload = breaker_state.to_payload()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -388,6 +388,206 @@ def _noop_operator(tree: ast.AST, rng=None) -> ast.AST:
     return tree
 
 
+def _missing_result_operator(tree: ast.AST, rng=None) -> ast.AST:
+    return ast.parse("value = 1")
+
+
+def _dangerous_open_operator(tree: ast.AST, rng=None) -> ast.AST:
+    return ast.parse("result = open('secret.txt')")
+
+
+def _stable_psyche(monkeypatch):
+    class StablePsyche:
+        energy = 1000.0
+        curiosity = 1.0
+        patience = 1.0
+        playfulness = 1.0
+        sleeping = False
+
+        def mutation_policy(self):
+            return "default"
+
+        def process_run_record(self, record):
+            pass
+
+        def save_state(self):
+            pass
+
+        def consume(self):
+            pass
+
+        def feel(self, mood):
+            pass
+
+    monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: StablePsyche()))
+
+
+def _run_sandbox_case(
+    tmp_path: Path,
+    monkeypatch,
+    operator,
+    *,
+    max_iterations: int = 1,
+    score_func=None,
+    governance_policy=None,
+):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "foo.py").write_text("result = 1", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setattr(life_loop, "propose_mutations", lambda *_a, **_k: [])
+    monkeypatch.setattr(life_loop, "SKILL_GENESIS_TECH_DEBT_THRESHOLD", 10_000)
+    monkeypatch.setattr(life_loop, "SKILL_GENESIS_FAILURE_STREAK_THRESHOLD", 10_000)
+    monkeypatch.setattr(life_loop, "SKILL_GENESIS_COVERAGE_GAP_THRESHOLD", 10_000.0)
+    if score_func is not None:
+        monkeypatch.setattr(life_loop, "score_code_with_error", score_func)
+    _stable_psyche(monkeypatch)
+
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(RL, root=tmp_path / "logs")
+    )
+
+    state = life_loop.run(
+        skills_dir,
+        checkpoint,
+        budget_seconds=10.0,
+        max_iterations=max_iterations,
+        rng=random.Random(0),
+        operators={"case": operator},
+        governance_policy=governance_policy,
+    )
+    events_path = tmp_path / "logs" / "loop" / "events.jsonl"
+    events = [
+        json.loads(line)
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+    ]
+    return state, events
+
+
+def _event_payloads(events: list[dict], event_type: str) -> list[dict]:
+    return [event["payload"] for event in events if event.get("event_type") == event_type]
+
+
+def _sandbox_diagnostics(events: list[dict]) -> list[dict]:
+    return [
+        payload
+        for payload in _event_payloads(events, "interaction")
+        if payload.get("interaction") == "sandbox_violation"
+    ]
+
+
+def test_base_ok_mutation_failure_is_noncritical_rejection(tmp_path: Path, monkeypatch):
+    _state, events = _run_sandbox_case(
+        tmp_path,
+        monkeypatch,
+        _missing_result_operator,
+        max_iterations=1,
+    )
+
+    diagnostics = _sandbox_diagnostics(events)
+    assert diagnostics
+    diagnostic = diagnostics[0]
+    assert diagnostic["base_score"] == 1.0
+    assert diagnostic["mutated_score"] == float("-inf")
+    assert diagnostic["base_failed"] is False
+    assert diagnostic["mutation_failed"] is True
+    assert diagnostic["sandbox_violation_category"] == "invalid_mutation_rejected"
+    assert diagnostic["sandbox_violation_severity"] == "medium"
+    assert diagnostic["sandbox_violation_global_recorded"] is False
+    assert diagnostic["dangerous_mutation_pattern"] is False
+    assert diagnostic["sandbox_violation_streak"] == 0
+    assert not _event_payloads(events, "governance.circuit_breaker_opened")
+
+
+def test_base_failure_remains_critical_violation(tmp_path: Path, monkeypatch):
+    score_calls = {"n": 0}
+
+    def base_fails_first(_code: str) -> life_loop.ScoreCodeResult:
+        score_calls["n"] += 1
+        if score_calls["n"] % 2 == 1:
+            return life_loop.ScoreCodeResult(
+                score=float("-inf"),
+                failed=True,
+                error_reason="runtime_exception",
+                exception_type="RuntimeError",
+                exception_message="base is broken",
+            )
+        return life_loop.ScoreCodeResult(score=1.0)
+
+    policy = MutationGovernancePolicy(circuit_breaker_threshold=1)
+    _state, events = _run_sandbox_case(
+        tmp_path,
+        monkeypatch,
+        _noop_operator,
+        max_iterations=1,
+        score_func=base_fails_first,
+        governance_policy=policy,
+    )
+
+    diagnostic = _sandbox_diagnostics(events)[0]
+    assert diagnostic["base_failed"] is True
+    assert diagnostic["mutation_failed"] is False
+    assert diagnostic["sandbox_violation_category"] == "source_sandbox_violation"
+    assert diagnostic["sandbox_violation_severity"] == "critical"
+    assert diagnostic["sandbox_violation_global_recorded"] is True
+    breaker = _event_payloads(events, "governance.circuit_breaker_opened")[0]
+    assert breaker["category"] == "source_sandbox_violation"
+    assert breaker["severity"] == "critical"
+
+
+def test_dangerous_mutation_failure_can_escalate_to_critical(tmp_path: Path, monkeypatch):
+    policy = MutationGovernancePolicy(circuit_breaker_threshold=1)
+    _state, events = _run_sandbox_case(
+        tmp_path,
+        monkeypatch,
+        _dangerous_open_operator,
+        max_iterations=1,
+        governance_policy=policy,
+    )
+
+    diagnostic = _sandbox_diagnostics(events)[0]
+    assert diagnostic["base_failed"] is False
+    assert diagnostic["mutation_failed"] is True
+    assert diagnostic["mutation_error_type"] == "sandbox_error"
+    assert diagnostic["sandbox_violation_category"] == "dangerous_mutation_violation"
+    assert diagnostic["sandbox_violation_severity"] == "critical"
+    assert diagnostic["sandbox_violation_global_recorded"] is True
+    assert diagnostic["dangerous_mutation_pattern"] is True
+    breaker = _event_payloads(events, "governance.circuit_breaker_opened")[0]
+    assert breaker["category"] == "dangerous_mutation_violation"
+    assert breaker["severity"] == "critical"
+
+
+def test_noncritical_mutation_failures_do_not_immediately_block_orchestrator(
+    tmp_path: Path, monkeypatch
+):
+    policy = MutationGovernancePolicy(circuit_breaker_threshold=1)
+    state, events = _run_sandbox_case(
+        tmp_path,
+        monkeypatch,
+        _missing_result_operator,
+        max_iterations=4,
+        governance_policy=policy,
+    )
+
+    diagnostics = _sandbox_diagnostics(events)
+    assert len(diagnostics) == 4
+    assert state.iteration >= 4
+    assert all(
+        diagnostic["sandbox_violation_category"] == "invalid_mutation_rejected"
+        for diagnostic in diagnostics
+    )
+    assert all(
+        diagnostic["sandbox_violation_global_recorded"] is False
+        for diagnostic in diagnostics
+    )
+    assert not _event_payloads(events, "governance.circuit_breaker_opened")
+    assert policy.mutations_enabled() is True
+
+
 def test_run_nan_score_does_not_contaminate_stats(tmp_path: Path):
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()
@@ -775,7 +975,7 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
     ]
     assert breaker_events
     breaker = breaker_events[0]
-    assert breaker["category"] == "sandbox_violation"
+    assert breaker["category"] == "source_sandbox_violation"
     assert breaker["severity"] == "critical"
     assert breaker["threshold"] == 3
     assert breaker["cooldown_seconds"] == 300.0


### PR DESCRIPTION
### Motivation
- Clarifier la différence entre l’échec du code source actif (`base_score == -inf`) et l’échec d’une candidate mutée (`mutated_score == -inf`) pour éviter de traiter toutes les mutations invalides comme des pannes critiques.
- Préserver la sévérité élevée quand le code original est cassé afin de ne pas laisser une skill active cassée passer inaperçue.
- Empêcher l’ouverture trop rapide du breaker global sur des mutations simplement invalides tout en permettant d’escalader les mutations explici-tement dangereuses (ex. `open`, `socket`, `subprocess`).

### Description
- Ajout d’un ensemble `DANGEROUS_MUTATION_NAMES` et de la fonction ` _has_explicit_dangerous_pattern(code)` pour détecter les patterns dangereux explicites dans le code muté.
- Implémentation de `_sandbox_failure_category(base_failed, mutation_failed, mutated)` qui retourne `(category, severity, record_global_violation)` afin de classer les échecs en `source_sandbox_violation` (critique), `dangerous_mutation_violation` (critique) ou `invalid_mutation_rejected` (médium, non-global).
- Calcul séparé de `base_failed` et `mutation_failed` immédiatement après le scoring, refus explicite des mutations en échec (`mutation_failed`) pour éviter leur acceptation/persistance, et enrichissement des diagnostics avec `sandbox_violation_category`, `sandbox_violation_severity`, `sandbox_violation_global_recorded` et `dangerous_mutation_pattern`.
- Adaptation de l’appel à `governance_policy.record_violation()` pour n’enregistrer une violation globale que si la classification le demande (`record_global_violation`), et n’incrémenter la streak critique que pour des échecs critiques afin d’éviter des blocages excessifs.
- Tests ajoutés et helpers de test dans `tests/test_loop.py` couvrant les cas : base OK + mutation KO non critique, base KO critique, mutation contenant un pattern dangereux pouvant escalader, et accumulation de mutations non critiques sans blocage immédiat.

### Testing
- Exécutions automatiques effectuées : `python -m compileall -q src/singular/life/loop.py tests/test_loop.py` (succès) and `git diff --check` (aucun problème détecté).
- Suite de tests : `pytest -q tests/test_loop.py` a été lancée et a réussi (`36 passed`, warnings non bloquants).
- Tests ciblés (scénarios de sandbox et breaker) ont été exécutés pendant le développement et valident les nouveaux comportements (tous les cas ajoutés passent).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024aacf3ec832abe3b91b68e3fe2f6)