### PR TITLE
Ajouter synthèse « sandbox_governance » au cockpit et carte dashboard

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -505,6 +505,134 @@ def create_app(
             },
         }
 
+
+    def _record_event_name(record: dict[str, object]) -> str:
+        event = record.get("event")
+        interaction = record.get("interaction")
+        if event == "interaction" and isinstance(interaction, str):
+            return interaction
+        if isinstance(event, str):
+            return event
+        if isinstance(interaction, str):
+            return interaction
+        return ""
+
+    def _seconds_until(value: object, *, now: datetime | None = None) -> int:
+        parsed = _parse_iso8601(value)
+        if parsed is None:
+            return 0
+        reference = now or datetime.now(timezone.utc)
+        return max(0, int((parsed.astimezone(timezone.utc) - reference).total_seconds()))
+
+    def _summarize_sandbox_governance(records: list[dict[str, object]]) -> dict[str, object]:
+        target_events = {
+            "sandbox_violation",
+            "governance.circuit_breaker_opened",
+            "skill.quarantined",
+            "mutation_halted",
+        }
+        now = datetime.now(timezone.utc)
+        latest_ts = None
+        for record in records:
+            parsed = _parse_iso8601(record.get("ts") or record.get("timestamp"))
+            if parsed is not None and (latest_ts is None or parsed > latest_ts):
+                latest_ts = parsed
+
+        recent_cutoff = (latest_ts or now) - timedelta(hours=24)
+        events: list[dict[str, object]] = []
+        sandbox_violations: list[dict[str, object]] = []
+        breaker_events: list[dict[str, object]] = []
+        quarantine_events: list[dict[str, object]] = []
+        halted_events: list[dict[str, object]] = []
+
+        for record in records:
+            event_name = _record_event_name(record)
+            category = str(record.get("category", ""))
+            is_target = event_name in target_events
+            is_sandbox_violation = event_name == "sandbox_violation" or (
+                event_name == "governance.circuit_breaker_opened"
+                and "sandbox" in category.lower()
+            )
+            if not is_target and not is_sandbox_violation:
+                continue
+
+            ts_value = record.get("ts") or record.get("timestamp")
+            parsed_ts = _parse_iso8601(ts_value)
+            skill = record.get("skill") or record.get("skill_path") or record.get("target")
+            event_item = {
+                "event": event_name or "sandbox_violation",
+                "timestamp": ts_value,
+                "life": _record_life(record),
+                "skill": str(skill) if isinstance(skill, str) and skill else None,
+                "severity": record.get("severity"),
+                "category": record.get("category"),
+                "reason": record.get("reason"),
+                "cooldown_seconds": record.get("cooldown_seconds"),
+                "open_until": record.get("open_until"),
+                "disabled_until": record.get("disabled_until"),
+                "corrective_action": record.get("corrective_action"),
+            }
+            events.append(event_item)
+            if is_sandbox_violation and (parsed_ts is None or parsed_ts >= recent_cutoff):
+                sandbox_violations.append(event_item)
+            if event_name == "governance.circuit_breaker_opened":
+                breaker_events.append(event_item)
+            elif event_name == "skill.quarantined":
+                quarantine_events.append(event_item)
+            elif event_name == "mutation_halted":
+                halted_events.append(event_item)
+
+        latest_breaker = breaker_events[-1] if breaker_events else None
+        latest_quarantine = quarantine_events[-1] if quarantine_events else None
+        latest_halted = halted_events[-1] if halted_events else None
+        latest_fault = None
+        for event_item in reversed(events):
+            if event_item.get("skill") and event_item.get("event") in {
+                "sandbox_violation",
+                "skill.quarantined",
+                "mutation_halted",
+            }:
+                latest_fault = event_item
+                break
+
+        cooldown_remaining = 0
+        if latest_breaker:
+            cooldown_remaining = max(
+                cooldown_remaining, _seconds_until(latest_breaker.get("open_until"), now=now)
+            )
+        if latest_quarantine:
+            cooldown_remaining = max(
+                cooldown_remaining, _seconds_until(latest_quarantine.get("disabled_until"), now=now)
+            )
+
+        breaker_status = "fermé"
+        if latest_breaker and cooldown_remaining > 0:
+            breaker_status = "ouvert"
+        elif latest_breaker:
+            breaker_status = "fermé (cooldown expiré)"
+        if latest_halted and not latest_breaker:
+            breaker_status = "mutations arrêtées"
+
+        corrective_action = "Surveiller le prochain run."
+        if latest_breaker and latest_breaker.get("corrective_action"):
+            corrective_action = str(latest_breaker["corrective_action"])
+        elif latest_quarantine:
+            corrective_action = "Inspecter la skill en quarantaine avant réactivation."
+        elif sandbox_violations:
+            corrective_action = "Auditer la sandbox, les chemins modifiables et les quotas avant reprise."
+        elif latest_halted:
+            corrective_action = "Attendre la fin du verrou de mutation puis relancer une mutation sûre."
+
+        return {
+            "circuit_breaker_status": breaker_status,
+            "recent_violations_count": len(sandbox_violations),
+            "last_faulty_skill": latest_fault.get("skill") if latest_fault else None,
+            "cooldown_remaining_seconds": cooldown_remaining,
+            "recommended_corrective_action": corrective_action,
+            "empty_state": "aucune violation sandbox récente" if not sandbox_violations else None,
+            "events": events[-10:],
+        }
+
     def _summarize_cockpit(current_life_only: bool = False) -> dict[str, object]:
         latest = _latest_run_file(current_life_only=current_life_only)
         if latest is None:
@@ -514,6 +642,7 @@ def create_app(
                 "trend": "plateau",
                 "accepted_mutation_rate": None,
                 "critical_alerts": [],
+                "sandbox_governance": _summarize_sandbox_governance([]),
                 "last_notable_mutation": None,
                 "next_action": "Aucune donnée: démarrer un run pour remplir le cockpit.",
                 "suggested_actions": [
@@ -598,6 +727,7 @@ def create_app(
             for alert in alerts
             if str(alert.get("severity", "")).lower() in {"critical", "high"}
         ]
+        sandbox_governance = _summarize_sandbox_governance(records)
 
         last_notable_mutation = None
         for record in reversed(mutations):
@@ -730,6 +860,7 @@ def create_app(
             "trend": trend,
             "accepted_mutation_rate": accepted_rate,
             "critical_alerts": critical_alerts,
+            "sandbox_governance": sandbox_governance,
             "last_notable_mutation": last_notable_mutation,
             "next_action": next_action,
             "suggested_actions": suggested_actions,

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -66,6 +66,38 @@ const extractEnergy=(row,eco)=>{
   return firstDefined(row?.emotional_state?.energy,row?.energy,row?.psyche?.energy,organism?.energy);
 };
 
+
+const formatCooldownSeconds=value=>{
+  const seconds=Number(value||0);
+  if(!Number.isFinite(seconds)||seconds<=0){return '0 s';}
+  const minutes=Math.floor(seconds/60);
+  const remainingSeconds=Math.floor(seconds%60);
+  if(minutes<=0){return `${remainingSeconds} s`;}
+  const hours=Math.floor(minutes/60);
+  const remainingMinutes=minutes%60;
+  if(hours<=0){return `${minutes} min ${remainingSeconds} s`; }
+  return `${hours} h ${remainingMinutes} min`;
+};
+
+const renderSandboxGovernance=governance=>{
+  const payload=(governance&&typeof governance==='object')?governance:{};
+  const violations=Number(payload.recent_violations_count||0);
+  const status=String(payload.circuit_breaker_status||'fermé');
+  const emptyEl=byId('sandbox-governance-empty');
+  if(emptyEl){
+    emptyEl.textContent=violations>0?'Violations sandbox récentes détectées.':(payload.empty_state||'aucune violation sandbox récente');
+  }
+  setText('sandbox-breaker-status',status);
+  setText('sandbox-recent-violations',String(violations));
+  setText('sandbox-last-skill',payload.last_faulty_skill||na());
+  setText('sandbox-cooldown-remaining',formatCooldownSeconds(payload.cooldown_remaining_seconds));
+  setText('sandbox-corrective-action',payload.recommended_corrective_action||'Surveiller le prochain run.');
+  const riskTone=status.includes('ouvert')||status.includes('arrêtées')?'bad':(violations>0?'warn':'good');
+  setTone('sandbox-breaker-status',riskTone);
+  setTone('sandbox-recent-violations',violations>0?'warn':'good');
+  setTone('sandbox-cooldown-remaining',Number(payload.cooldown_remaining_seconds||0)>0?'warn':'good');
+};
+
 const renderOperatorSummary=()=>{
   const root=document.getElementById('operator-lives-summary');
   if(!root){return;}
@@ -266,6 +298,7 @@ export const loadCockpit=()=>Promise.all([
     else if(globalStatus==='critical'){setStatusTone(statusBox,'bad');applyStatusIndicator(statusBox,'bad');}
   }
 
+  renderSandboxGovernance(d.sandbox_governance||{});
   const healthValue=d.health_score===null?na():Number(d.health_score).toFixed(1);
   const trend=d.trend||na();
   const accepted=d.accepted_mutation_rate===null?na():`${(d.accepted_mutation_rate*100).toFixed(1)}%`;

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -100,8 +100,8 @@
     <pre id='conversations-json-raw' class='panel-hidden content-top-gap'>{"items":[]}</pre>
   </section>
 
-  <section id='cockpit'>
-    <h2>État de l’écosystème</h2>
+  <section id="cockpit">
+    <h2>Cockpit · État de l’écosystème</h2>
     <p class='section-help'>Vue synthétique d’observation de l’écosystème (sans prescriptions opérateur).</p>
     <div class='status-legend'>
       <span class='status-pill status-good'>● OK</span>
@@ -116,6 +116,26 @@
         <div class='card'><div class='card-label kpi-label' title='Cohérence observée entre les vies actives'>Stabilité collective</div><div id='kpi-active-lives' class='card-value'>0</div></div>
         <div class='card'><div class='card-label kpi-label' title='Nombre d’incidents critiques en cours'>Incidents critiques</div><div id='kpi-alerts' class='card-value'>0</div></div>
         <div class='card'><div class='card-label kpi-label' title='Évolution récente du système'>Tendance</div><div id='kpi-trend' class='card-value'>Non disponible</div></div>
+      </div>
+    </div>
+
+
+    <div id='sandbox-governance-card' class='panel level-panel' data-essential-level='1' aria-live='polite'>
+      <h3 class='heading-reset-top'>Gouvernance sandbox</h3>
+      <p id='sandbox-governance-empty' class='section-help'>aucune violation sandbox récente</p>
+      <div class='cards-grid'>
+        <div class='card'><div class='card-label'>Statut circuit breaker</div><div id='sandbox-breaker-status' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Violations récentes</div><div id='sandbox-recent-violations' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Dernière skill fautive</div><div id='sandbox-last-skill' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Cooldown restant</div><div id='sandbox-cooldown-remaining' class='card-value'>Chargement…</div></div>
+      </div>
+      <div class='card content-top-gap'>
+        <div class='card-label'>Action corrective recommandée</div>
+        <div id='sandbox-corrective-action' class='card-value'>Chargement…</div>
+      </div>
+      <div class='card content-top-gap'>
+        <div class='card-label'>Prochaine action</div>
+        <div id='kpi-next-action' class='card-value'>Chargement…</div>
       </div>
     </div>
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -360,6 +360,94 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert "objective_narrative_links" in payload["trajectory"]
 
 
+def test_dashboard_cockpit_sandbox_governance_summary(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "sandbox.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T08:00:00+00:00",
+                        "event": "interaction",
+                        "interaction": "sandbox_violation",
+                        "organism": "life-a",
+                        "skill": "life-a:skills/bad.py",
+                        "severity": "critical",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T08:05:00+00:00",
+                        "event": "governance.circuit_breaker_opened",
+                        "category": "sandbox_violation",
+                        "severity": "critical",
+                        "cooldown_seconds": 300.0,
+                        "open_until": "2099-05-11T08:10:00+00:00",
+                        "corrective_action": "halt mutations until cooldown",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T08:06:00+00:00",
+                        "event": "skill.quarantined",
+                        "skill": "life-a:skills/bad.py",
+                        "disabled_until": "2099-05-11T09:00:00+00:00",
+                        "reason": "consecutive_sandbox_failures",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T08:07:00+00:00",
+                        "event": "interaction",
+                        "interaction": "mutation_halted",
+                        "organism": "life-a",
+                        "target": "life-a:skills/bad.py",
+                        "severity": "critical",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get(
+        "/api/cockpit"
+    ).json()
+
+    governance = payload["sandbox_governance"]
+    assert governance["circuit_breaker_status"] == "ouvert"
+    assert governance["recent_violations_count"] == 2
+    assert governance["last_faulty_skill"] == "life-a:skills/bad.py"
+    assert governance["cooldown_remaining_seconds"] > 0
+    assert governance["recommended_corrective_action"] == "halt mutations until cooldown"
+    assert governance["empty_state"] is None
+    assert {item["event"] for item in governance["events"]} >= {
+        "sandbox_violation",
+        "governance.circuit_breaker_opened",
+        "skill.quarantined",
+        "mutation_halted",
+    }
+
+
+def test_dashboard_cockpit_sandbox_governance_empty_state(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "empty-sandbox.jsonl").write_text(
+        json.dumps({"ts": "2026-05-11T08:00:00+00:00", "health": {"score": 99.0}}) + "\n",
+        encoding="utf-8",
+    )
+
+    payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get(
+        "/api/cockpit"
+    ).json()
+
+    governance = payload["sandbox_governance"]
+    assert governance["recent_violations_count"] == 0
+    assert governance["empty_state"] == "aucune violation sandbox récente"
+
+
 def test_dashboard_cockpit_essential_projection_schema(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
@@ -419,6 +507,9 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     body = response.json()
     assert "kpi-retention-usage" in body
     assert "kpi-retention-thresholds" in body
+    assert "sandbox-governance-card" in body
+    assert "aucune violation sandbox récente" in body
+    assert "Action corrective recommandée" in body
     assert "Cockpit" in body
     assert "Prochaine action" in body
     assert "Métriques d’autonomie" in body


### PR DESCRIPTION
### Motivation
- Fournir une vue synthétique des incidents liés à la sandbox et à la gouvernance (violations sandbox, ouverture du circuit‑breaker, skills en quarantaine, mutations arrêtées) directement dans le cockpit pour aider à la prise de décision opérateur.
- Exposer un état vide explicite quand aucune violation sandbox récente n’a été observée afin d’éviter les ambiguïtés d’affichage.

### Description
- Ajout de l’agrégateur ` _summarize_sandbox_governance`, plus des helpers `_record_event_name` et `_seconds_until`, dans `src/singular/dashboard/__init__.py` et inclusion du résumé `sandbox_governance` dans la projection `/api/cockpit` (charge vide et charge réelle). 
- Ajout d’une carte visible dans la vue `#tab-decider-maintenant` (`sandbox-governance-card`) dans `src/singular/dashboard/templates/dashboard.html` affichant : statut du circuit breaker, nombre de violations récentes, dernière skill fautive, cooldown restant et action corrective recommandée, ainsi qu’un état vide `aucune violation sandbox récente`.
- Remplissage côté client dans `src/singular/dashboard/static/render-cockpit.js` : fonctions `formatCooldownSeconds` et `renderSandboxGovernance` et appel pour hydrater la carte depuis `d.sandbox_governance` renvoyé par `/api/cockpit` ; tonalités visuelles appliquées selon le niveau de risque.
- Ajout de tests unitaires dans `tests/test_dashboard.py` pour couvrir le résumé sandbox peuplé et le cas vide, et mise à jour minimale du template pour exposer le nouveau contenu.

### Testing
- Exécution ciblée des nouveaux tests : `python -m pytest tests/test_dashboard.py::test_dashboard_cockpit_sandbox_governance_summary tests/test_dashboard.py::test_dashboard_cockpit_sandbox_governance_empty_state -q` — réussite (2 passed). 
- Vérifications statiques : `python -m py_compile src/singular/dashboard/__init__.py` et `node --check src/singular/dashboard/static/render-cockpit.js` — réussite.
- Exécution du fichier de tests complet `tests/test_dashboard.py` : les deux nouveaux tests passent mais la suite complète signale 5 échecs restants qui semblent liés à attentes préexistantes sur l’index / agrégations lives/genealogy et non aux changements sandbox (tests listés dans la sortie de pytest).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024ef22f30832aaa0adee8a81ae617)