### PR TITLE
Ajouter diagnostics de politique de gouvernance au dashboard

### DIFF
--- a/docs/governance_circuit_breaker.md
+++ b/docs/governance_circuit_breaker.md
@@ -1,0 +1,51 @@
+# Diagnostic gouvernance et circuit breaker
+
+Le dashboard expose les paramètres actifs de gouvernance pour aider à comprendre pourquoi une mutation est ralentie, bloquée ou mise en quarantaine. Ces valeurs proviennent de `policy.yaml` et doivent être lues comme des garde-fous, pas comme des objectifs à atteindre.
+
+## Pourquoi le breaker s’ouvre
+
+Le circuit breaker s’ouvre quand trop de violations ou d’échecs de gouvernance sont observés dans une fenêtre courte. Les paramètres concernés sont :
+
+- `autonomy.circuit_breaker_threshold` : nombre de violations nécessaires pour ouvrir le breaker ;
+- `autonomy.circuit_breaker_window_seconds` : durée de la fenêtre d’observation ;
+- `autonomy.circuit_breaker_cooldown_seconds` : délai pendant lequel le système reste en refroidissement après ouverture ;
+- `autonomy.safe_mode` : mode prudent qui force davantage de contrôles ;
+- `autonomy.mutation_quota_per_window` : limite de mutations permises par fenêtre.
+
+Une ouverture du breaker signifie généralement qu’une skill tente une action interdite, écrit hors des chemins autorisés, dépasse un quota, échoue de façon répétée ou produit des mutations trop risquées.
+
+## Comment corriger une skill
+
+1. Identifier la skill fautive dans le diagnostic cockpit (`Dernière skill fautive`) et dans les derniers événements de run.
+2. Reproduire le scénario avec une mutation minimale ou un run ciblé.
+3. Vérifier que la skill respecte les chemins autorisés par `permissions.modifiable_paths` et n’écrit pas dans `permissions.forbidden_paths`.
+4. Réduire la portée de la mutation : une seule responsabilité, entrées validées, sorties bornées, pas d’effet de bord implicite.
+5. Ajouter ou ajuster les tests qui couvrent l’échec observé.
+6. Relancer après correction et surveiller que les violations ne réapparaissent pas pendant la fenêtre du breaker.
+
+## Ajuster les seuils dans `policy.yaml` si nécessaire
+
+Si les diagnostics montrent que les échecs sont maîtrisés et que le breaker est trop sensible pour une charge légitime, ajuster prudemment les clés de la section `autonomy` :
+
+```yaml
+autonomy:
+  circuit_breaker_threshold: 3
+  circuit_breaker_window_seconds: 180.0
+  circuit_breaker_cooldown_seconds: 300.0
+  safe_mode: false
+  mutation_quota_per_window: 25
+```
+
+Recommandations :
+
+- augmenter un seul paramètre à la fois ;
+- documenter la raison du changement ;
+- préférer un petit incrément plutôt qu’un grand saut ;
+- revenir au seuil précédent si les violations augmentent ;
+- garder `safe_mode` activable rapidement pendant une investigation.
+
+## Pourquoi augmenter les seuils ne doit pas être la première solution
+
+Augmenter les seuils masque souvent le symptôme au lieu de corriger la cause. Si une skill viole la sandbox, écrit dans une zone interdite ou génère des mutations instables, un seuil plus haut lui laisse simplement plus de temps pour produire des dégâts avant l’arrêt automatique.
+
+La bonne séquence est donc : diagnostiquer l’événement, corriger la skill, renforcer les tests, puis seulement ajuster les seuils si le comportement corrigé reste légitime mais trop fréquemment interrompu.

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -524,6 +524,16 @@ def create_app(
         reference = now or datetime.now(timezone.utc)
         return max(0, int((parsed.astimezone(timezone.utc) - reference).total_seconds()))
 
+    def _governance_policy_diagnostics() -> dict[str, object]:
+        policy = load_runtime_policy()
+        return {
+            "circuit_breaker_threshold": policy.circuit_breaker_threshold,
+            "circuit_breaker_window_seconds": policy.circuit_breaker_window_seconds,
+            "circuit_breaker_cooldown_seconds": policy.circuit_breaker_cooldown_seconds,
+            "safe_mode": policy.safe_mode,
+            "mutation_quota_per_window": policy.mutation_quota_per_window,
+        }
+
     def _summarize_sandbox_governance(records: list[dict[str, object]]) -> dict[str, object]:
         target_events = {
             "sandbox_violation",
@@ -643,6 +653,7 @@ def create_app(
                 "accepted_mutation_rate": None,
                 "critical_alerts": [],
                 "sandbox_governance": _summarize_sandbox_governance([]),
+                "governance_policy": _governance_policy_diagnostics(),
                 "last_notable_mutation": None,
                 "next_action": "Aucune donnée: démarrer un run pour remplir le cockpit.",
                 "suggested_actions": [
@@ -861,6 +872,7 @@ def create_app(
             "accepted_mutation_rate": accepted_rate,
             "critical_alerts": critical_alerts,
             "sandbox_governance": sandbox_governance,
+            "governance_policy": _governance_policy_diagnostics(),
             "last_notable_mutation": last_notable_mutation,
             "next_action": next_action,
             "suggested_actions": suggested_actions,
@@ -1305,6 +1317,7 @@ def create_app(
                 "message": registry_state["onboarding_message"],
             },
             "policy": policy.to_payload(),
+            "governance_policy": _governance_policy_diagnostics(),
             "policy_impact": policy.impact_summary(),
             "skills_lifecycle": _skill_lifecycle_summary(),
             "retention": retention,

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -79,6 +79,23 @@ const formatCooldownSeconds=value=>{
   return `${hours} h ${remainingMinutes} min`;
 };
 
+const renderGovernanceDiagnostics=diagnostics=>{
+  const policy=(diagnostics&&typeof diagnostics==='object')?diagnostics:{};
+  const fmtSeconds=value=>formatCooldownSeconds(value);
+  const threshold=policy.circuit_breaker_threshold??na();
+  const windowSeconds=policy.circuit_breaker_window_seconds??null;
+  const cooldownSeconds=policy.circuit_breaker_cooldown_seconds??null;
+  const safeMode=policy.safe_mode===true?'activé':(policy.safe_mode===false?'désactivé':na());
+  const quota=policy.mutation_quota_per_window??na();
+  setText('governance-breaker-threshold',`${threshold} violations`);
+  setText('governance-breaker-window',fmtSeconds(windowSeconds));
+  setText('governance-breaker-cooldown',fmtSeconds(cooldownSeconds));
+  setText('governance-safe-mode',safeMode);
+  setText('governance-mutation-quota',`${quota} mutations/fenêtre`);
+  setText('ctx-governance-diagnostics',`breaker=${threshold}/${fmtSeconds(windowSeconds)} · cooldown=${fmtSeconds(cooldownSeconds)} · safe_mode=${safeMode} · quota=${quota}`);
+  setTone('governance-safe-mode',policy.safe_mode===true?'warn':'good');
+};
+
 const renderSandboxGovernance=governance=>{
   const payload=(governance&&typeof governance==='object')?governance:{};
   const violations=Number(payload.recent_violations_count||0);
@@ -209,6 +226,7 @@ export const loadContext=()=>Promise.all([
   setText('ctx-policy-version',String(policy.version??na()));
   setText('ctx-policy-autonomy',`safe_mode=${autonomy.safe_mode?'on':'off'} · quota=${autonomy.mutation_quota_per_window??na()}/${autonomy.mutation_quota_window_seconds??na()}s`);
   setText('ctx-policy-permissions',`auto=${(permissions.modifiable_paths||[]).length} · review=${(permissions.review_required_paths||[]).length} · forbidden=${(permissions.forbidden_paths||[]).length}`);
+  renderGovernanceDiagnostics(ctx.governance_policy||{});
   const impactList=clearElement('ctx-policy-impact');
   if(impactList){for(const item of (ctx.policy_impact||[])){const li=document.createElement('li');li.textContent=String(item);impactList.appendChild(li);} 
   if(!(ctx.policy_impact||[]).length){const li=document.createElement('li');li.textContent='Aucun impact disponible.';impactList.appendChild(li);} } 
@@ -299,6 +317,7 @@ export const loadCockpit=()=>Promise.all([
   }
 
   renderSandboxGovernance(d.sandbox_governance||{});
+  renderGovernanceDiagnostics(d.governance_policy||{});
   const healthValue=d.health_score===null?na():Number(d.health_score).toFixed(1);
   const trend=d.trend||na();
   const accepted=d.accepted_mutation_rate===null?na():`${(d.accepted_mutation_rate*100).toFixed(1)}%`;

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -120,6 +120,19 @@
     </div>
 
 
+    <div id='governance-diagnostics-card' class='panel level-panel' data-essential-level='1' aria-live='polite'>
+      <h3 class='heading-reset-top'>Diagnostic gouvernance</h3>
+      <p class='section-help'>Paramètres de politique actifs qui encadrent les mutations et l’ouverture du breaker.</p>
+      <div class='cards-grid'>
+        <div class='card'><div class='card-label'>Seuil breaker</div><div id='governance-breaker-threshold' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Fenêtre breaker</div><div id='governance-breaker-window' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Cooldown breaker</div><div id='governance-breaker-cooldown' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Safe mode</div><div id='governance-safe-mode' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Quota mutations</div><div id='governance-mutation-quota' class='card-value'>Chargement…</div></div>
+      </div>
+    </div>
+
+
     <div id='sandbox-governance-card' class='panel level-panel' data-essential-level='1' aria-live='polite'>
       <h3 class='heading-reset-top'>Gouvernance sandbox</h3>
       <p id='sandbox-governance-empty' class='section-help'>aucune violation sandbox récente</p>
@@ -312,6 +325,7 @@
       <div><strong>Version politique</strong> : <span id='ctx-policy-version'>Non disponible</span></div>
       <div><strong>Autonomie</strong> : <span id='ctx-policy-autonomy'>Non disponible</span></div>
       <div><strong>Permissions</strong> : <span id='ctx-policy-permissions'>Non disponible</span></div>
+      <div><strong>Diagnostic gouvernance</strong> : <span id='ctx-governance-diagnostics'>Non disponible</span></div>
     </div>
     <h3>Impact des politiques actives</h3>
     <ul id='ctx-policy-impact'><li>Chargement…</li></ul>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -34,6 +34,13 @@ def test_dashboard_endpoints(tmp_path: Path, monkeypatch) -> None:
     context = client.get("/dashboard/context").json()
     assert context["policy"]["version"] == 1
     assert isinstance(context["policy_impact"], list)
+    assert context["governance_policy"] == {
+        "circuit_breaker_threshold": 3,
+        "circuit_breaker_window_seconds": 180.0,
+        "circuit_breaker_cooldown_seconds": 300.0,
+        "safe_mode": False,
+        "mutation_quota_per_window": 25,
+    }
     assert "skills_lifecycle" in context
     assert "retention" in context
     retention = client.get("/api/retention/status").json()
@@ -415,6 +422,12 @@ def test_dashboard_cockpit_sandbox_governance_summary(tmp_path: Path) -> None:
     payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get(
         "/api/cockpit"
     ).json()
+
+    assert payload["governance_policy"]["circuit_breaker_threshold"] == 3
+    assert payload["governance_policy"]["circuit_breaker_window_seconds"] == 180.0
+    assert payload["governance_policy"]["circuit_breaker_cooldown_seconds"] == 300.0
+    assert payload["governance_policy"]["safe_mode"] is False
+    assert payload["governance_policy"]["mutation_quota_per_window"] == 25
 
     governance = payload["sandbox_governance"]
     assert governance["circuit_breaker_status"] == "ouvert"


### PR DESCRIPTION
### Motivation
- Fournir aux opérateurs une visibilité directe des paramètres de politique qui gouvernent l’ouverture du circuit breaker et les quotas de mutation afin d’aider au diagnostic et à la remédiation.

### Description
- Expose un nouvel objet `governance_policy` (avec `circuit_breaker_threshold`, `circuit_breaker_window_seconds`, `circuit_breaker_cooldown_seconds`, `safe_mode`, `mutation_quota_per_window`) dans les payloads `/dashboard/context` et `/api/cockpit` (y compris la projection cockpit vide) via `src/singular/dashboard/__init__.py`.
- Ajoute une carte « Diagnostic gouvernance » dans l’interface HTML pour afficher les paramètres clefs (fichiers modifiés : `src/singular/dashboard/templates/dashboard.html`).
- Rend côté client ces diagnostics et les affiche à la fois dans le panneau paramètres et dans le cockpit via `src/singular/dashboard/static/render-cockpit.js` (nouvelle fonction `renderGovernanceDiagnostics` et appels depuis `loadContext` et `loadCockpit`).
- Ajoute une courte documentation expliquant pourquoi le breaker s’ouvre, comment corriger une skill, comment ajuster prudemment `policy.yaml` et pourquoi l’augmentation des seuils n’est pas la première solution (`docs/governance_circuit_breaker.md`).
- Met à jour les tests d’API dashboard pour vérifier la présence des nouveaux champs exposés (`tests/test_dashboard.py`).

### Testing
- Exécution ciblée : `pytest -q tests/test_dashboard.py::test_dashboard_endpoints tests/test_dashboard.py::test_dashboard_cockpit_sandbox_governance_summary` — succès (2 passed).
- Vérifications statiques : `node --check src/singular/dashboard/static/render-cockpit.js` et `python -m compileall -q src/singular/dashboard/__init__.py` — succès.
- Suite complète `pytest -q tests/test_dashboard.py` — échoue (5 tests en échec) sur assertions existantes non liées aux champs de gouvernance ajoutés (tests d’affichage/agrégation/généalogie du dashboard); ces échecs préexistaient dans l’intégration locale après ajout des nouvelles assertions de test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02dc5aaf64832a8f628860776b51f6)