### PR TITLE
Inclure les runs temporaires (*.jsonl.tmp) dans le dashboard

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -289,52 +289,35 @@ def create_app(
 
     def _compute_ecosystem(current_life_only: bool = False) -> dict:
         organisms: dict[str, dict[str, object]] = {}
-        for directory in _runs_dirs(current_life_only=current_life_only):
-            if not directory.exists():
-                continue
-            for file in directory.iterdir():
-                if not file.is_file() or not is_run_jsonl_file(file):
-                    continue
-                for line in file.read_text(encoding="utf-8").splitlines():
-                    if not line.strip():
-                        continue
-                    try:
-                        record = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
+        for record in _load_run_records(current_life_only=current_life_only):
+            event = record.get("event")
+            interaction = record.get("interaction")
 
-                    event = record.get("event")
-                    interaction = record.get("interaction")
-
-                    if event == "interaction" and isinstance(
-                        record.get("organism"), str
-                    ):
-                        name = str(record["organism"])
-                        state = organisms.setdefault(name, {"status": "alive"})
-                        if "energy" in record:
-                            state["energy"] = record["energy"]
-                        if "resources" in record:
-                            state["resources"] = record["resources"]
-                        if "score" in record:
-                            state["score"] = record["score"]
-                        if "alive" in record:
-                            state["status"] = (
-                                "alive" if bool(record["alive"]) else "extinct"
-                            )
-                        if interaction:
-                            state["last_interaction"] = interaction
-                    elif event == "death":
-                        skill = str(record.get("skill", ""))
-                        if ":" in skill:
-                            name, _ = skill.split(":", 1)
-                            state = organisms.setdefault(name, {})
-                            state["status"] = "extinct"
-                    elif event is None and isinstance(record.get("skill"), str):
-                        skill = record["skill"]
-                        if ":" in skill:
-                            name, _ = skill.split(":", 1)
-                            state = organisms.setdefault(name, {"status": "alive"})
-                            state["score"] = record.get("score_new")
+            if event == "interaction" and isinstance(record.get("organism"), str):
+                name = str(record["organism"])
+                state = organisms.setdefault(name, {"status": "alive"})
+                if "energy" in record:
+                    state["energy"] = record["energy"]
+                if "resources" in record:
+                    state["resources"] = record["resources"]
+                if "score" in record:
+                    state["score"] = record["score"]
+                if "alive" in record:
+                    state["status"] = "alive" if bool(record["alive"]) else "extinct"
+                if interaction:
+                    state["last_interaction"] = interaction
+            elif event == "death":
+                skill = str(record.get("skill", ""))
+                if ":" in skill:
+                    name, _ = skill.split(":", 1)
+                    state = organisms.setdefault(name, {})
+                    state["status"] = "extinct"
+            elif event is None and isinstance(record.get("skill"), str):
+                skill = record["skill"]
+                if ":" in skill:
+                    name, _ = skill.split(":", 1)
+                    state = organisms.setdefault(name, {"status": "alive"})
+                    state["score"] = record.get("score_new")
 
         alive = sum(1 for state in organisms.values() if state.get("status") != "extinct")
         total_energy = sum(
@@ -416,13 +399,19 @@ def create_app(
 
     def _timeline_entry(record: dict[str, object], run_id: str) -> dict[str, object] | None:
         event = _event_type(record)
+        interaction_event = _record_event_name(record)
+        visible_interaction_events = {"sandbox_violation", "mutation_halted"}
+        if event == "interaction" and interaction_event in visible_interaction_events:
+            event = interaction_event
         if event not in {
             "mutation",
             "delay",
             "refuse",
             "death",
             "interaction",
+            "sandbox_violation",
             "governance.circuit_breaker_opened",
+            "mutation_halted",
         }:
             return None
 
@@ -2162,6 +2151,10 @@ def create_app(
 
         def _normalize_stream_event(file: Path, payload: dict[str, object]) -> dict[str, object] | None:
             event = _event_type(payload)
+            interaction_event = _record_event_name(payload)
+            visible_interaction_events = {"sandbox_violation", "mutation_halted"}
+            if event == "interaction" and interaction_event in visible_interaction_events:
+                event = interaction_event
             if event is None:
                 return None
             ts = payload.get("ts")
@@ -2189,21 +2182,16 @@ def create_app(
                         await ws.send_json({"type": "quests", "data": data})
 
                 incremental_events: list[dict[str, object]] = []
-                run_directories = _runs_dirs()
-                if run_directories:
+                run_files = _iter_run_files()
+                if run_files:
                     current_files: set[str] = set()
-                    for directory in run_directories:
-                        if not directory.exists():
-                            continue
-                        for file in directory.iterdir():
-                            if not file.is_file() or not is_run_jsonl_file(file):
-                                continue
-                            key = f"{directory.parent.name}/{file.name}"
-                            current_files.add(key)
-                            entries, next_cursor = await asyncio.to_thread(
-                                _read_new_entries, file, log_cursors.get(key)
-                            )
-                            log_cursors[key] = next_cursor
+                    for file in run_files:
+                        key = str(file)
+                        current_files.add(key)
+                        entries, next_cursor = await asyncio.to_thread(
+                            _read_new_entries, file, log_cursors.get(key)
+                        )
+                        log_cursors[key] = next_cursor
                         for line in entries:
                             try:
                                 payload = json.loads(line)

--- a/src/singular/dashboard/repositories/run_records.py
+++ b/src/singular/dashboard/repositories/run_records.py
@@ -9,10 +9,11 @@ from typing import Callable
 def is_run_jsonl_file(path: Path) -> bool:
     """Return whether *path* is a persisted or in-progress run JSONL file."""
 
+    name = path.name
     return (
-        not path.name.endswith(".consciousness.jsonl")
-        and not path.name.endswith(".consciousness.jsonl.tmp")
-        and (path.suffix == ".jsonl" or path.suffixes[-2:] == [".jsonl", ".tmp"])
+        not name.endswith(".consciousness.jsonl")
+        and not name.endswith(".consciousness.jsonl.tmp")
+        and (name.endswith(".jsonl") or name.endswith(".jsonl.tmp"))
     )
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -303,6 +303,81 @@ def test_dashboard_includes_temporary_jsonl_run_files(tmp_path: Path) -> None:
     assert ecosystem_payload["organisms"]["temp-life"]["energy"] == 7
 
 
+def test_dashboard_surfaces_sandbox_events_from_temporary_run(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    run_file = runs_dir / "run-live-20260511090000.jsonl.tmp"
+    run_file.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T09:00:00+00:00",
+                        "event": "interaction",
+                        "interaction": "sandbox_violation",
+                        "organism": "temp-life",
+                        "skill": "temp-life:skills/bad.py",
+                        "severity": "critical",
+                        "category": "sandbox_violation",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T09:01:00+00:00",
+                        "event": "governance.circuit_breaker_opened",
+                        "category": "sandbox_violation",
+                        "severity": "critical",
+                        "threshold": 3,
+                        "cooldown_seconds": 300.0,
+                        "open_until": "2099-05-11T09:06:00+00:00",
+                        "corrective_action": "halt mutations until cooldown",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T09:02:00+00:00",
+                        "event": "interaction",
+                        "interaction": "mutation_halted",
+                        "organism": "temp-life",
+                        "target": "temp-life:skills/bad.py",
+                        "severity": "critical",
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+
+    cockpit_payload = app._routes["/api/cockpit"]()
+    governance = cockpit_payload["sandbox_governance"]
+    assert governance["circuit_breaker_status"] == "ouvert"
+    assert governance["recent_violations_count"] == 2
+    assert governance["last_faulty_skill"] == "temp-life:skills/bad.py"
+    assert {item["event"] for item in governance["events"]} >= {
+        "sandbox_violation",
+        "governance.circuit_breaker_opened",
+        "mutation_halted",
+    }
+
+    timeline_payload = app._routes["/api/runs/{run_id}/timeline"](run_id="run-live")
+    assert [item["event"] for item in timeline_payload["items"]] == [
+        "sandbox_violation",
+        "governance.circuit_breaker_opened",
+        "mutation_halted",
+    ]
+
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as ws:
+        assert [_receive_with_timeout(ws)["event"] for _ in range(3)] == [
+            "sandbox_violation",
+            "governance.circuit_breaker_opened",
+            "mutation_halted",
+        ]
+
+
 def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Permettre au dashboard d’observer et d’afficher les événements produits par un run encore en cours (`*.jsonl.tmp`) afin de suivre les violations de sandbox et l’ouverture du circuit pendant `singular orchestrate run`.
- Réunifier la lecture des fichiers de run via un repository central (`RunRecordsRepository`) pour garantir un périmètre cohérent entre endpoints, timeline et websocket.

### Description
- Acceptation explicite des fichiers temporaires dans le prédicat de fichier de run en `RunRecordsRepository.is_run_jsonl_file` (prise en compte de `*.jsonl.tmp`).
- `_compute_ecosystem()` lit désormais les enregistrements via ` _load_run_records(current_life_only=...)` au lieu d’itérer manuellement les fichiers, ce qui inclut les runs temporaires dans le calcul d’écosystème (`src/singular/dashboard/__init__.py`).
- La timeline expose maintenant les interactions critiques dérivées d’un `interaction` (`sandbox_violation`, `mutation_halted`) comme événements visibles, et les inclut dans les éléments retournés par `_timeline_entry` (`src/singular/dashboard/__init__.py`).
- La boucle websocket lit les fichiers via `_iter_run_files()`, normalise aussi les interactions sandbox en événements websocket explicites et maintient des curseurs par fichier pour suivre les ajouts dans les fichiers temporaires (`src/singular/dashboard/__init__.py`).
- Ajout d’un test d’intégration `test_dashboard_surfaces_sandbox_events_from_temporary_run` qui crée un run `*.jsonl.tmp` contenant `sandbox_violation`, `governance.circuit_breaker_opened` et `mutation_halted` et vérifie leur visibilité dans le cockpit, la timeline et le flux websocket (`tests/test_dashboard.py`).

### Testing
- Exécution ciblée des tests modifiés: `pytest -q tests/test_dashboard.py::test_dashboard_surfaces_sandbox_events_from_temporary_run tests/test_dashboard.py::test_dashboard_includes_temporary_jsonl_run_files tests/test_dashboard.py::test_websocket_stream_incremental_events_and_growth_stability` — tous les 3 tests sont passés (3 passed).
- Exécution plus large de `pytest -q tests/test_dashboard.py` a été tentée pour diagnostic et a mis en évidence 5 échecs existants non liés à cette modification (tests d’affichage/index et de comparaison de vies), ces échecs n’étant pas causés par la lecture des runs temporaires introduite ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02df0a2d54832abbe37debb52a531f)