### PR TITLE
Keep lives comparison visible by default

### DIFF
--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -301,6 +301,7 @@ button:hover {
 .status-legend { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 8px; }
 .status-pill { border: 1px solid var(--panel-border); border-radius: 999px; padding: 2px 10px; font-size: 0.82rem; font-weight: 600; }
 .status-with-icon::before { content: attr(data-status-icon); margin-right: 6px; }
+body[data-dashboard-mode='operator'] .technical-only,
 body.essential-mode .technical-only { display: none !important; }
 
 @media (max-width: 1080px) {

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -161,13 +161,12 @@ const renderLivesTable=(rows)=>{
     if(row.life&&row.life===livesUiState.selectedLife){tr.classList.add('selected');}
     const score=row.current_health_score===null||row.current_health_score===undefined?na():Number(row.current_health_score).toFixed(1);
     const liveness=row.life_liveness_index===null||row.life_liveness_index===undefined?na():Number(row.life_liveness_index).toFixed(1);
-    const stability=row.stability===null||row.stability===undefined?na():`${(Number(row.stability)*100).toFixed(1)}%`;
     const lastActivity=row.last_activity||na();
     const state=rowStateSummary(row);
     const risk=rowRiskSummary(row);
     const activity=rowActivitySummary(row);
     const codeEvolutionEndpoint=row.code_evolution_endpoint||`/api/lives/${encodeURIComponent(row.life||'')}/code-evolution`;
-    tr.innerHTML=`<td>${escapeHtml(row.life||na())}<br/><a href='${escapeHtml(codeEvolutionEndpoint)}' target='_blank' rel='noopener noreferrer'>audit code</a></td><td>${score}</td><td>${escapeHtml(row.trend||na())}</td><td>${stability}</td><td>${escapeHtml(lastActivity)}</td><td>${row.iterations??0}</td><td>${liveness}</td><td><span class='summary-pill ${state.tone}'>${state.label}</span></td><td><span class='summary-pill ${risk.tone}'>${risk.label}</span></td><td><span class='summary-pill ${activity.tone}'>${activity.label}</span></td>`;
+    tr.innerHTML=`<td>${escapeHtml(row.life||na())}<br/><a href='${escapeHtml(codeEvolutionEndpoint)}' target='_blank' rel='noopener noreferrer'>audit code</a></td><td>${score}</td><td>${escapeHtml(lastActivity)}</td><td>${liveness}</td><td><span class='summary-pill ${state.tone}'>${state.label}</span></td><td><span class='summary-pill ${risk.tone}'>${risk.label}</span></td><td><span class='summary-pill ${activity.tone}'>${activity.label}</span></td>`;
     tr.onclick=()=>showLifeDetails(row.life||'');
     tr.onkeydown=event=>{
       if(event.key==='Enter'||event.key===' '){
@@ -177,7 +176,7 @@ const renderLivesTable=(rows)=>{
     };
     body.appendChild(tr);
   }
-  if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='10'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}
+  if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}
 };
 
 const renderEssentialLivesSummary=rows=>{
@@ -204,22 +203,25 @@ const showLifeDetails=lifeName=>{
   }
   panel.classList.remove('panel-hidden');
   livesUiState.selectedLife=lifeName;
-  const metadata=[
+  const operatorMetadata=[
     ['Vie',row.life],
     ['Statut registre',row.life_status],
     ['Score courant',row.current_health_score===null||row.current_health_score===undefined?na():Number(row.current_health_score).toFixed(1)],
-    ['Stabilité',row.stability===null||row.stability===undefined?na():`${(Number(row.stability)*100).toFixed(1)}%`],
-    ['Tendance',row.trend],
     ['Dernière activité',row.last_activity],
-    ['Itérations',row.iterations??0],
     ['Life liveness index',row.life_liveness_index===null||row.life_liveness_index===undefined?na():Number(row.life_liveness_index).toFixed(1)],
     ['Alertes',row.alerts_count??0],
+  ];
+  const expertMetadata=[
+    ['Stabilité',row.stability===null||row.stability===undefined?na():`${(Number(row.stability)*100).toFixed(1)}%`],
+    ['Tendance',row.trend],
+    ['Itérations',row.iterations??0],
     ['Run terminé',row.run_terminated?'oui':'non'],
     ['Extinction runs',row.extinction_seen_in_runs?'oui':'non'],
     ['Audit code evolution',row.code_evolution_endpoint||`/api/lives/${encodeURIComponent(row.life||'')}/code-evolution`],
   ];
-  const metadataRows=metadata.map(([key,value])=>`<tr><th>${escapeHtml(key)}</th><td>${escapeHtml(value)}</td></tr>`).join('');
-  content.innerHTML=`<div class='detail-badges'>${summarizeBadges(row)||badge('Aucun badge',BADGE_TONE.info)}</div><table class='table-base life-meta-table'><tbody>${metadataRows}</tbody></table><h4>Timeline vitale</h4><pre>${escapeHtml(JSON.stringify(row.vital_timeline||{},null,2))}</pre>`;
+  const metadataRows=operatorMetadata.map(([key,value])=>`<tr><th>${escapeHtml(key)}</th><td>${escapeHtml(value)}</td></tr>`).join('');
+  const expertRows=expertMetadata.map(([key,value])=>`<tr><th>${escapeHtml(key)}</th><td>${escapeHtml(value)}</td></tr>`).join('');
+  content.innerHTML=`<div class='detail-badges'>${summarizeBadges(row)||badge('Aucun badge',BADGE_TONE.info)}</div><table class='table-base life-meta-table'><tbody>${metadataRows}</tbody></table><section class='technical-only' aria-label='Métriques expertes de la vie'><h4>Métriques expertes</h4><table class='table-base life-meta-table'><tbody>${expertRows}</tbody></table><h4>Timeline vitale</h4><pre>${escapeHtml(JSON.stringify(row.vital_timeline||{},null,2))}</pre></section>`;
   if(proofs){
     proofs.innerHTML='';
     const recentProofs=Array.isArray(row.life_liveness_proofs)?row.life_liveness_proofs:[];

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -275,18 +275,15 @@
       </div>
       <pre id='lives-filter-diagnostics'>Chargement du breakdown…</pre>
     </div>
-    <div class='lives-grid technical-only' data-essential-level='3'>
+    <div class='lives-grid' data-essential-level='2'>
       <table id='lives-table' class='table-base table-spacing-top'>
         <thead><tr>
-          <th><button data-sort='life'>Vie</button></th>
-          <th><button data-sort='score'>Score</button></th>
-          <th><button data-sort='trend'>Tendance</button></th>
-          <th><button data-sort='stability'>Stabilité</button></th>
+          <th><button data-sort='life'>Nom</button></th>
+          <th><button data-sort='score'>Score / santé</button></th>
           <th><button data-sort='last_activity'>Dernière activité</button></th>
-          <th><button data-sort='iterations'>Itérations</button></th>
           <th><button data-sort='liveness'>Liveness</button></th>
-          <th>État</th>
-          <th>Risque</th>
+          <th>Statut</th>
+          <th>Risques</th>
           <th>Activité</th>
         </tr></thead><tbody id='lives-table-body'></tbody>
       </table>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -646,6 +646,12 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Nouvelles" in body
     assert "filter-time-window" in body
     assert "life-detail-panel" in body
+    assert "<th><button data-sort='life'>Nom</button></th>" in body
+    assert "<th><button data-sort='score'>Score / santé</button></th>" in body
+    assert "<th><button data-sort='last_activity'>Dernière activité</button></th>" in body
+    assert "<th><button data-sort='liveness'>Liveness</button></th>" in body
+    assert "<th>Statut</th>" in body
+    assert "<th>Risques</th>" in body
     assert "essential-selected-life" in body
     assert "essential-active-incidents" in body
     assert "data-essential-level='1'" in body
@@ -667,7 +673,8 @@ def test_dashboard_essential_mode_critical_blocks_and_visibility_markers(tmp_pat
         assert marker in body
 
     assert "id='cockpit-detail' class='panel level-panel technical-only' data-essential-level='3'" in body
-    assert "class='lives-grid technical-only' data-essential-level='3'" in body
+    assert "class='lives-grid' data-essential-level='2'" in body
+    assert "class='lives-grid technical-only'" not in body
 
 
 def test_dashboard_index_renders_main_sections(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Make the lives comparison grid and detail panel visible to operator users by default while keeping truly expert-only fields hidden in a technical-only subsection, so the `Comparer les vies` view presents name, status, score/health, last activity, liveness, risks and a selectable detail panel without requiring expert mode.

### Description
- Removed `technical-only` from the `.lives-grid` container and lowered its `data-essential-level` in `src/singular/dashboard/templates/dashboard.html` so the table is operator-visible by default.
- Reduced the default table columns to operator-facing fields (name, score/health, last activity, liveness, status, risks, activity) and fixed the empty-state `colspan` in `src/singular/dashboard/static/render-lives.js`.
- Extracted expert-only metadata (stability, trend, iterations, run/ extinction flags and audit endpoint) into a `.technical-only` subsection inside the life detail panel in `src/singular/dashboard/static/render-lives.js`.
- Added a CSS rule to hide `.technical-only` content in operator mode via `body[data-dashboard-mode='operator'] .technical-only` in `src/singular/dashboard/static/dashboard.css` and updated HTML assertions in `tests/test_dashboard.py` to reflect the new visible table structure.

### Testing
- Ran `node --check src/singular/dashboard/static/render-lives.js` and `node --check src/singular/dashboard/static/bootstrap.js`, both succeeded.
- Ran `pytest tests/test_dashboard.py::test_dashboard_essential_mode_critical_blocks_and_visibility_markers`, which passed after the changes.
- Ran the broader `pytest tests/test_dashboard.py` earlier and observed several pre-existing, unrelated failures around legacy HTML markers and lives/genealogy payload expectations that are outside the scope of this UX-focused change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02e8a0d668832a948e5bd0385f98bd)