### PR TITLE
Améliore le dashboard : contrôles opérateur pour actions sur les vies, validation et rafraîchissement

### DIFF
--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -388,6 +388,9 @@ class DashboardActionService:
 
     def _talk(self, params: dict[str, Any]) -> ActionResult:
         prompt = self._require_non_empty_text(params.get("prompt"), field="prompt", max_len=400)
+        name = params.get("name")
+        if name is not None:
+            name = self._require_non_empty_text(name, field="name", max_len=80)
         provider = params.get("provider")
         if provider is not None:
             provider = self._require_non_empty_text(provider, field="provider", max_len=40)
@@ -398,14 +401,14 @@ class DashboardActionService:
         from singular.lives import resolve_life
         from singular.organisms.talk import talk
 
-        life = resolve_life(None)
+        life = resolve_life(name)
         if life is None:
-            raise ValueError("no active life")
+            raise ValueError(f"unknown life: {name}" if name else "no active life")
         os.environ["SINGULAR_HOME"] = str(life)
 
         def _run() -> dict[str, Any]:
             talk(provider=provider, seed=seed, prompt=prompt)
-            return {"life": str(life), "prompt": prompt}
+            return {"life": str(life), "name": name, "prompt": prompt}
 
         data, log = self._capture(_run)
         return ActionResult(ok=True, action="talk", data=data, log=log)

--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -7,6 +7,87 @@ const writeActionResult=text=>{
   actionResultTargets().forEach(target=>{target.textContent=text;});
 };
 
+const readValue=(...ids)=>{
+  for(const id of ids){
+    const value=document.getElementById(id)?.value?.trim();
+    if(value){return value;}
+  }
+  return '';
+};
+
+const operatorLifeSelect=()=>document.getElementById('operator-action-life-select');
+const selectedOperatorLife=()=>readValue('operator-action-life-select','action-life-name');
+const operatorMessage=()=>readValue('operator-action-message','action-prompt');
+const birthName=()=>readValue('operator-birth-name','action-life-name');
+
+const validOperatorLives=()=>{
+  const select=operatorLifeSelect();
+  if(!select){return new Set();}
+  return new Set([...select.options].map(option=>option.value).filter(Boolean));
+};
+
+const hasValidSelectedLife=()=>{
+  const selected=operatorLifeSelect()?.value?.trim()||'';
+  if(!selected){return false;}
+  const lives=validOperatorLives();
+  return lives.size===0?false:lives.has(selected);
+};
+
+const setActionHelp=text=>{
+  const help=document.getElementById('operator-action-help');
+  if(help){help.textContent=text;}
+  if(text){writeActionResult(text);}
+};
+
+const requiresValidLife=action=>['archive','talk'].includes(action);
+
+export const updateOperatorActionState=()=>{
+  const hasSelection=hasValidSelectedLife();
+  const select=operatorLifeSelect();
+  const selected=select?.value?.trim()||'';
+  const help=document.getElementById('operator-action-help');
+  const helpText=hasSelection
+    ? `Vie ciblée: ${selected}. “Supprimer/archiver” et “Parler” sont disponibles.`
+    : 'Sélectionnez une vie existante pour activer “Supprimer/archiver” et “Parler”.';
+  if(help){help.textContent=helpText;}
+  ['critical-archive','critical-talk','act-archive','act-talk'].forEach(id=>{
+    const button=document.getElementById(id);
+    if(!button){return;}
+    button.disabled=false;
+    button.classList.toggle('is-disabled',!hasSelection);
+    button.setAttribute('aria-disabled',hasSelection?'false':'true');
+    button.title=hasSelection?'':helpText;
+  });
+};
+
+export const updateOperatorLifeOptions=(rows=[])=>{
+  const select=operatorLifeSelect();
+  if(!select){return;}
+  const previous=select.value;
+  const names=[...new Set((rows||[]).map(row=>{
+    if(typeof row==='string'){return row;}
+    return row?.life||row?.slug||row?.name||'';
+  }).map(name=>String(name||'').trim()).filter(Boolean))].sort((a,b)=>a.localeCompare(b));
+  select.innerHTML='';
+  const placeholder=document.createElement('option');
+  placeholder.value='';
+  placeholder.textContent=names.length?'Sélectionner une vie existante…':'Aucune vie disponible';
+  select.appendChild(placeholder);
+  for(const name of names){
+    const option=document.createElement('option');
+    option.value=name;
+    option.textContent=name;
+    select.appendChild(option);
+  }
+  if(previous&&names.includes(previous)){select.value=previous;}
+  else{
+    const selectedRow=(rows||[]).find(row=>row?.selected_life===true||row?.active===true||row?.is_registry_active_life===true);
+    const selectedName=selectedRow?.life||selectedRow?.slug||selectedRow?.name||'';
+    if(selectedName&&names.includes(selectedName)){select.value=selectedName;}
+  }
+  updateOperatorActionState();
+};
+
 export const runAction=(action,payload,{onAfterAction}={})=>{
   const token=document.getElementById('action-token')?.value||'';
   const q=new URLSearchParams();
@@ -23,13 +104,28 @@ export const runAction=(action,payload,{onAfterAction}={})=>{
   });
 };
 
-const actionPayload=(action,lifeName)=>{
-  if(action==='birth'){return {name:lifeName()||'Nouvelle vie'};}
-  if(action==='talk'){return {prompt:document.getElementById('action-prompt')?.value||''};}
+const actionPayload=(action,lifeName=selectedOperatorLife)=>{
+  if(action==='birth'){return {name:birthName()};}
+  if(action==='talk'){return {name:lifeName(),prompt:operatorMessage()};}
   if(action==='archive'){return {name:lifeName()};}
   if(action==='emergency_stop'){return {scope:'active_life'};}
   return {};
 };
+
+const validateAction=(action,payload)=>{
+  if(requiresValidLife(action)&&!hasValidSelectedLife()){
+    return 'Sélectionnez une vie valide dans le sélecteur opérateur avant de lancer cette action.';
+  }
+  if(action==='talk'&&!payload.prompt){
+    return 'Écrivez un message dans le champ “Parler à une vie” avant d’envoyer.';
+  }
+  if(action==='birth'&&!payload.name){
+    return 'Saisissez le nom exact de la vie à créer avant de confirmer la création.';
+  }
+  return '';
+};
+
+const confirmBirth=payload=>window.confirm(`Créer la vie nommée exactement “${payload.name}” ?`);
 
 const confirmCriticalAction=button=>{
   const message=button.dataset.confirm;
@@ -39,33 +135,53 @@ const confirmCriticalAction=button=>{
   return true;
 };
 
+const runValidatedAction=(action,payload,handlers,button=null)=>{
+  const help=validateAction(action,payload);
+  if(help){setActionHelp(help);updateOperatorActionState();return false;}
+  if(action==='birth'&&!confirmBirth(payload)){return false;}
+  if(button&&!confirmCriticalAction(button)){return false;}
+  return runAction(action,payload,handlers);
+};
+
 export const bindCriticalActionHandlers=(handlers)=>{
-  const lifeName=()=>document.getElementById('action-life-name')?.value||'';
+  const select=operatorLifeSelect();
+  if(select&&select.dataset.bound!=='true'){
+    select.dataset.bound='true';
+    select.addEventListener('change',updateOperatorActionState);
+  }
+  ['operator-action-message','operator-birth-name','action-life-name','action-prompt'].forEach(id=>{
+    const el=document.getElementById(id);
+    if(el&&el.dataset.actionBound!=='true'){
+      el.dataset.actionBound='true';
+      el.addEventListener('input',updateOperatorActionState);
+    }
+  });
+  updateOperatorActionState();
   document.querySelectorAll('.critical-actions-bar [data-dashboard-action]').forEach(button=>{
     if(button.offsetParent===null){return;}
     button.onclick=()=>{
-      if(button.disabled||!confirmCriticalAction(button)){return false;}
       const action=button.dataset.dashboardAction||'';
-      return runAction(action,actionPayload(action,lifeName),handlers);
+      const payload=actionPayload(action,selectedOperatorLife);
+      return runValidatedAction(action,payload,handlers,button);
     };
   });
 };
 
 export const bindActionHandlers=(handlers)=>{
-  const lifeName=()=>document.getElementById('action-life-name')?.value||'';
-  const prompt=()=>document.getElementById('action-prompt')?.value||'';
+  const lifeName=selectedOperatorLife;
+  const prompt=operatorMessage;
   const budget=()=>Number(document.getElementById('action-budget')?.value||0);
   const bind=(id,handler)=>{
     const button=document.getElementById(id);
     if(button){button.onclick=handler;}
   };
-  bind('act-birth',()=>runAction('birth',{name:lifeName()||'Nouvelle vie'},handlers));
-  bind('act-talk',()=>runAction('talk',{prompt:prompt()},handlers));
+  bind('act-birth',()=>runValidatedAction('birth',{name:birthName()},handlers));
+  bind('act-talk',()=>runValidatedAction('talk',{name:lifeName(),prompt:prompt()},handlers));
   bind('act-loop',()=>runAction('loop',{budget_seconds:budget()},handlers));
   bind('act-report',()=>runAction('report',{},handlers));
   bind('act-lives-list',()=>runAction('lives_list',{},handlers));
   bind('act-lives-use',()=>runAction('lives_use',{name:lifeName()},handlers));
-  bind('act-archive',()=>runAction('archive',{name:lifeName()},handlers));
+  bind('act-archive',()=>runValidatedAction('archive',{name:lifeName()},handlers));
   bind('act-memorial',()=>runAction('memorial',{name:lifeName(),message:'Merci pour ce cycle de vie.'},handlers));
   bind('act-clone',()=>runAction('clone',{name:lifeName(),new_name:`${lifeName()||'Vie'} clone`},handlers));
   bindCriticalActionHandlers(handlers);

--- a/src/singular/dashboard/static/bootstrap.js
+++ b/src/singular/dashboard/static/bootstrap.js
@@ -336,7 +336,7 @@ const bindCommonHandlers=()=>{
 export const bootstrapDashboard=()=>{
   bootstrapPauseControls();
   bootstrapViewPauseControls();
-  bindActionHandlers({onAfterAction:()=>Promise.all([loadEco(),loadCockpit(),loadTimeline()])});
+  bindActionHandlers({onAfterAction:()=>Promise.all([loadEco(),loadCockpit(),loadLivesBoard(),loadTimeline()])});
   bindLivesHandlers(loadLivesBoard);
   bindLiveStreamHandlers();
   bindReflectionHandlers(loadReflections);

--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -387,6 +387,57 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
   box-shadow: var(--glow);
 }
 
+
+
+.operator-action-form {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(180px, 1fr) minmax(240px, 2fr);
+  gap: 10px;
+  margin: -4px 0 14px;
+  padding: 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: 12px;
+  background: rgba(9, 16, 39, 0.92);
+}
+
+.operator-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.operator-field select,
+.operator-field input,
+.operator-field textarea {
+  width: 100%;
+}
+
+.operator-message-field {
+  grid-column: span 1;
+}
+
+.operator-action-help {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--warn);
+  font-size: 0.95rem;
+}
+
+.critical-action-btn.is-disabled,
+.critical-action-btn:disabled,
+.actions-panel button.is-disabled,
+.actions-panel button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  filter: grayscale(0.55);
+}
+
+@media (max-width: 820px) {
+  .operator-action-form {
+    grid-template-columns: 1fr;
+  }
+}
+
 .critical-action-result {
   margin: -4px 0 14px;
   padding: 10px 12px;

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -1,4 +1,5 @@
 import {fetchJson,withScope} from './api.js';
+import {updateOperatorLifeOptions} from './actions.js';
 import {HOST_SENSORS_THRESHOLD,na,setPanelState,setStatusTone,applyStatusIndicator} from './state.js';
 import {renderQuestsSection} from './render-quests.js';
 import {renderObjectivesSection} from './render-objectives.js';
@@ -266,6 +267,7 @@ export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchJs
   setText('eco-dead-lives',String(dead));
   operatorSummaryState.eco=eco;
   operatorSummaryState.lives=lives;
+  updateOperatorLifeOptions(lives.table||[]);
   renderOperatorSummary();
   const rows=lives.table||[];
   const selected=rows.find(row=>row.selected_life===true);
@@ -304,7 +306,8 @@ export const loadHostVitals=()=>fetchJson(withScope('/runs/latest')).then(data=>
 export const loadCockpit=()=>Promise.all([
   fetchJson(withScope('/api/cockpit/essential')),
   fetchJson(withScope('/api/cockpit')),
-]).then(([essential,d])=>{
+  fetchJson(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc')),
+]).then(([essential,d,lives])=>{
   if(!d||typeof d!=='object'){setPanelState('cockpit','empty','Aucune donnée cockpit disponible.');return;}
   const essentialPayload=(essential&&typeof essential==='object')?essential:{};
   const statusBox=byId('cockpit-status');
@@ -330,6 +333,8 @@ export const loadCockpit=()=>Promise.all([
   const fmtNum=(value,suffix='')=>value===null||value===undefined?na():`${Number(value).toFixed(2)}${suffix}`;
 
   operatorSummaryState.cockpit={trend,liveness_index:livenessIndex,selected_life:essentialPayload.selected_life};
+  operatorSummaryState.lives=lives||operatorSummaryState.lives;
+  updateOperatorLifeOptions(lives?.table||[]);
   renderOperatorSummary();
   setText('kpi-health',healthValue);
   setText('kpi-trend',trend);

--- a/src/singular/dashboard/static/render-conversations.js
+++ b/src/singular/dashboard/static/render-conversations.js
@@ -1,3 +1,4 @@
+import {updateOperatorLifeOptions} from './actions.js';
 import {normalizeItem} from './render-quests.js';
 
 const conversationState={
@@ -191,6 +192,7 @@ export const renderConversationsSection=payload=>{
     const selected=[...lives.entries()].find(([,meta])=>meta.active||meta.selected_life);
     conversationState.selectedLife=selected?.[0]||[...lives.keys()][0];
   }
+  updateOperatorLifeOptions([...lives.entries()].map(([life,meta])=>({life,...meta})));
   renderMeta(conversationState.selectedLife);
   bindSend();
 

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -1,4 +1,5 @@
 import {fetchJson} from './api.js';
+import {updateOperatorLifeOptions} from './actions.js';
 import {BADGE_TONE,liveState,livesTableState,na,scopeState,setPanelState} from './state.js';
 
 const byId=id=>document.getElementById(id);
@@ -281,6 +282,7 @@ export const loadLivesBoard=()=>{
     if(livesUiState.focus==='at_risk'){tableRows=tableRows.filter(row=>(row.__riskLevel||0)>=1);}
     clientSteps.push({step:'client_focus',label:`Après focus ${livesUiState.focus}`,applied:livesUiState.focus!=='all',count:tableRows.length});
     livesUiState.rowsByLife=new Map(mappedRows.map(row=>[row.life,row]));
+    updateOperatorLifeOptions(mappedRows);
     renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})),d.life_metrics_contract);
     renderLivesTable(tableRows);
     if(livesUiState.selectedLife&&livesUiState.rowsByLife.has(livesUiState.selectedLife)){showLifeDetails(livesUiState.selectedLife);}

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -40,6 +40,23 @@
     Arrêt d’urgence
   </button>
 </section>
+<section class='operator-action-form' aria-label='Paramètres opérateur des actions critiques'>
+  <div class='operator-field'>
+    <label for='operator-action-life-select'>Vie ciblée</label>
+    <select id='operator-action-life-select' aria-describedby='operator-action-help'>
+      <option value=''>Sélectionner une vie existante…</option>
+    </select>
+  </div>
+  <div class='operator-field operator-birth-field'>
+    <label for='operator-birth-name'>Nom exact à créer</label>
+    <input id='operator-birth-name' placeholder='Saisir le nom exact de la nouvelle vie' autocomplete='off'/>
+  </div>
+  <div class='operator-field operator-message-field'>
+    <label for='operator-action-message'>Message pour “Parler à une vie”</label>
+    <textarea id='operator-action-message' rows='2' placeholder='Écrire le message à envoyer à la vie sélectionnée…'></textarea>
+  </div>
+  <p id='operator-action-help' class='operator-action-help' role='status' aria-live='polite'>Sélectionnez une vie existante pour activer “Supprimer/archiver” et “Parler”.</p>
+</section>
 <div id='critical-action-result' class='critical-action-result' role='status' aria-live='polite'>Aucune action critique exécutée.</div>
 
 <div id='stale-data-banner' class='stale-banner panel-hidden' role='status' aria-live='polite'></div>
@@ -396,7 +413,7 @@
   <section id='actions'><h2>Actions rapides</h2><pre id='action-result'>Aucune exécution</pre>
     <div class='panel actions-panel'>
       <label>Jeton dashboard <input id='action-token' type='password' placeholder='optionnel'/></label>
-      <label>Nom de vie (créer/utiliser) <input id='action-life-name' placeholder='Nouvelle vie'/></label>
+      <label>Nom de vie (créer/utiliser) <input id='action-life-name' placeholder='Nom exact requis pour créer une vie'/></label>
       <label>Prompt de discussion <input id='action-prompt' placeholder='Prompt unique'/></label>
       <label>Budget boucle (s) <input id='action-budget' type='number' min='0.1' step='0.1' value='1.0'/></label>
       <div class='toolbar-wrap'>


### PR DESCRIPTION
### Motivation

- Rendre explicites les paramètres opérateur pour les actions critiques afin d’éviter l’envoi de payloads vides (sélection de vie, message de discussion, nom exact pour la création). 
- Empêcher visuellement et fonctionnellement l’exécution de `archive` / `talk` sans cible valide et forcer une confirmation claire lors de la création (`birth`).
- Garantir que l’interface se synchronize après une action en rafraîchissant les vues opérationnelles clés pour refléter l’état courant des vies.

### Description

- Ajout d’un mini-formulaire visible sous la barre d’actions critiques dans `src/singular/dashboard/templates/dashboard.html` contenant un sélecteur `#operator-action-life-select`, un champ `#operator-birth-name` et un message `#operator-action-message`, et d’une aide contextuelle.  
- Implémentation JS dans `src/singular/dashboard/static/actions.js` pour lire d’abord les nouveaux champs opérateur (`updateOperatorLifeOptions`, `selectedOperatorLife`, `operatorMessage`, `birthName`), construire les payloads depuis ces champs, valider les actions (`validateAction`), désactiver visuellement les boutons non applicables et exiger une confirmation explicite pour `birth`.  
- Raccord des chargeurs UI pour peupler le sélecteur opérateur depuis les sources existantes en appelant `updateOperatorLifeOptions` depuis `render-lives.js`, `render-conversations.js` et `render-cockpit.js`, et mise à jour du bootstrap pour explicitement rafraîchir `loadEco()`, `loadCockpit()`, `loadLivesBoard()` et `loadTimeline()` après actions réussies.  
- Ajout de styles réactifs et d’état visuel désactivé dans `src/singular/dashboard/static/dashboard.css`.  
- Backend: modification de la cible d’action `talk` dans `src/singular/dashboard/actions.py` pour accepter un paramètre `name` (résolution de la vie ciblée au lieu d’utiliser systématiquement la vie active). 

### Testing

- Vérifications syntaxiques JS et compilation Python exécutées avec `node --check` sur les fichiers modifiés et `python -m compileall -q src/singular/dashboard`, toutes réussies. 
- Tests unitaires ciblés lancés: `pytest tests/test_dashboard_static_smoke.py tests/test_dashboard.py::test_dashboard_actions_endpoint_and_ui_panel tests/test_dashboard.py::test_dashboard_actions_validation_robustness`, résultat: all tests passed (5 passed). 
- Linter/QA statique: `ruff check src/singular/dashboard/actions.py tests/test_dashboard.py tests/test_dashboard_static_smoke.py` exécuté et réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0301a15e40832a83c8286f83f482d5)