### PR TITLE
Use POST with JSON bodies for dashboard actions

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -2103,27 +2103,93 @@ def create_app(
 
         app.post("/api/lives/{life}/chat")(chat_with_life_post)
 
-    @app.get("/api/actions/{action}")
-    def run_action(action: str, token: str | None = None, payload: str | None = None) -> dict[str, object]:
+    DESTRUCTIVE_GET_ACTIONS = {"archive", "emergency_stop", "clone"}
+
+    def _validate_action_token(token: str | None) -> None:
         try:
             actions.validate_token(token)
         except PermissionError as exc:
-            raise HTTPException(status_code=403, detail=str(exc)) from exc
+            raise HTTPException(
+                status_code=403,
+                detail="Jeton dashboard requis ou invalide pour exécuter cette action.",
+            ) from exc
 
-        params: dict[str, object] = {}
-        if payload:
-            try:
-                candidate = json.loads(payload)
-            except json.JSONDecodeError as exc:
-                raise HTTPException(status_code=400, detail="payload must be valid JSON") from exc
-            if not isinstance(candidate, dict):
-                raise HTTPException(status_code=400, detail="payload must be an object")
-            params = candidate
+    def _parse_action_payload(payload: str | None) -> dict[str, object]:
+        if not payload:
+            return {}
+        try:
+            candidate = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="Payload invalide: le corps JSON doit être un objet valide.",
+            ) from exc
+        if not isinstance(candidate, dict):
+            raise HTTPException(
+                status_code=400,
+                detail="Payload invalide: le corps JSON doit être un objet.",
+            )
+        return candidate
 
+    def _execute_dashboard_action(
+        action: str, params: dict[str, object], token: str | None = None
+    ) -> dict[str, object]:
+        _validate_action_token(token)
         result = actions.execute(action, params)
         if not result.get("ok"):
             raise HTTPException(status_code=400, detail=str(result.get("error") or "action failed"))
         return result
+
+    @app.get("/api/actions/{action}")
+    def run_action_get(
+        action: str, token: str | None = None, payload: str | None = None
+    ) -> dict[str, object]:
+        if action in DESTRUCTIVE_GET_ACTIONS:
+            raise HTTPException(
+                status_code=405,
+                detail=(
+                    "Méthode GET dépréciée et bloquée pour cette action destructive; "
+                    "utilisez POST avec un corps JSON."
+                ),
+            )
+        params = _parse_action_payload(payload)
+        result = _execute_dashboard_action(action, params, token=token)
+        result["deprecated"] = "GET /api/actions/{action} is deprecated; use POST with a JSON body."
+        return result
+
+    if hasattr(app, "post"):
+        async def run_action_post(
+            action: str, request: StarletteRequest, token: str | None = None
+        ) -> dict[str, object]:
+            try:
+                body = await request.body()
+            except AttributeError:
+                try:
+                    candidate = await request.json()
+                except Exception as exc:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Payload invalide: le corps JSON doit être un objet valide.",
+                    ) from exc
+                if not isinstance(candidate, dict):
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Payload invalide: le corps JSON doit être un objet.",
+                    )
+                return _execute_dashboard_action(action, candidate, token=token)
+            if not body:
+                return _execute_dashboard_action(action, {}, token=token)
+            try:
+                raw_payload = body.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Payload invalide: le corps JSON doit être encodé en UTF-8.",
+                ) from exc
+            params = _parse_action_payload(raw_payload)
+            return _execute_dashboard_action(action, params, token=token)
+
+        app.post("/api/actions/{action}")(run_action_post)
 
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:

--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -88,13 +88,49 @@ export const updateOperatorLifeOptions=(rows=[])=>{
   updateOperatorActionState();
 };
 
+const readActionError=async response=>{
+  let detail='';
+  try{
+    const data=await response.json();
+    detail=typeof data?.detail==='string'?data.detail:JSON.stringify(data?.detail||data);
+  }catch(_err){
+    detail=await response.text().catch(()=>'' );
+  }
+  if(response.status===403){
+    return detail||'Jeton dashboard requis ou invalide: renseignez le champ “Jeton dashboard”.';
+  }
+  if(response.status===400){
+    return detail||'Payload invalide: vérifiez les paramètres de l’action.';
+  }
+  if(response.status===405){
+    return detail||'Méthode non autorisée pour cette action: utilisez POST.';
+  }
+  return detail||`HTTP ${response.status}`;
+};
+
 export const runAction=(action,payload,{onAfterAction}={})=>{
   const token=document.getElementById('action-token')?.value||'';
+  const bodyPayload=payload??{};
+  if(typeof bodyPayload!=='object'||Array.isArray(bodyPayload)){
+    writeActionResult(`Erreur action ${action}: payload invalide, un objet JSON est attendu.`);
+    return Promise.resolve(false);
+  }
+  let body='{}';
+  try{
+    body=JSON.stringify(bodyPayload);
+  }catch(err){
+    writeActionResult(`Erreur action ${action}: payload invalide (${err.message}).`);
+    return Promise.resolve(false);
+  }
   const q=new URLSearchParams();
   if(token){q.set('token',token);}
-  if(payload){q.set('payload',JSON.stringify(payload));}
-  return fetch(`/api/actions/${action}?${q.toString()}`).then(async r=>{
-    if(!r.ok){throw new Error(`HTTP ${r.status}`);}
+  const suffix=q.toString()?`?${q.toString()}`:'';
+  return fetch(`/api/actions/${encodeURIComponent(action)}${suffix}`,{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body,
+  }).then(async r=>{
+    if(!r.ok){throw new Error(await readActionError(r));}
     return r.json();
   }).then(async data=>{
     writeActionResult(JSON.stringify(data,null,2));

--- a/tests/fastapi_stub/__init__.py
+++ b/tests/fastapi_stub/__init__.py
@@ -50,6 +50,7 @@ class FastAPI:
 
     def __init__(self) -> None:
         self._routes: Dict[str, Callable[[], Any]] = {}
+        self._post_routes: Dict[str, Callable[[], Any]] = {}
         self._ws_routes: Dict[str, Callable[[WebSocket], Any]] = {}
         self._mounts: Dict[str, Any] = {}
 
@@ -68,6 +69,17 @@ class FastAPI:
 
         return decorator
 
+
+    def post(
+        self, path: str, **_kwargs: Any
+    ) -> Callable[[Callable[[], Any]], Callable[[], Any]]:
+        """Register a POST handler for ``path``."""
+
+        def decorator(func: Callable[[], Any]) -> Callable[[], Any]:
+            self._post_routes[path] = func
+            return func
+
+        return decorator
 
     def mount(self, path: str, app: Any, name: str | None = None) -> None:
         self._mounts[path] = {"app": app, "name": name}

--- a/tests/fastapi_stub/testclient.py
+++ b/tests/fastapi_stub/testclient.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
 import asyncio
 import inspect
@@ -35,6 +36,38 @@ class TestClient:
             status = 200
         except HTTPException as exc:  # pragma: no cover - simple error path
             data = None
+            status = exc.status_code
+        return Response(status, data)
+
+    def post(self, path: str, json: Any = None) -> Response:
+        parsed = urlsplit(path)
+        handler = self.app._post_routes.get(parsed.path)
+        params = {key: values[-1] for key, values in parse_qs(parsed.query).items()}
+        if handler is None and parsed.path.startswith("/api/actions/"):
+            handler = self.app._post_routes["/api/actions/{action}"]
+            params["action"] = parsed.path.rsplit("/", 1)[-1]
+        if handler is None and parsed.path.endswith("/chat"):
+            handler = self.app._post_routes["/api/lives/{life}/chat"]
+            params["life"] = parsed.path.split("/")[3]
+
+        class Request:
+            async def body(self) -> bytes:
+                import json as json_module
+
+                if json is None:
+                    return b""
+                return json_module.dumps(json).encode("utf-8")
+
+            async def json(self) -> Any:
+                return json
+
+        try:
+            data = handler(request=Request(), **params)
+            if inspect.iscoroutine(data):
+                data = asyncio.run(data)
+            status = 200
+        except HTTPException as exc:  # pragma: no cover - simple error path
+            data = {"detail": exc.detail}
             status = exc.status_code
         return Response(status, data)
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1653,7 +1653,7 @@ def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: py
     assert "Mémorial" in body
     assert "Cloner" in body
 
-    ok = app._routes["/api/actions/{action}"]("lives_list", token="secret", payload="{}")
+    ok = client.post("/api/actions/lives_list?token=secret", json={}).json()
     assert ok["ok"] is True
     assert ok["action"] == "lives_list"
     assert "context" in ok
@@ -1678,7 +1678,12 @@ def test_dashboard_emergency_stop_action_writes_active_life_stop_signal(
     )
     route = app._routes["/api/actions/{action}"]
 
-    result = route("emergency_stop", payload=json.dumps({"scope": "active_life"}))
+    with pytest.raises(Exception):
+        route("emergency_stop", payload=json.dumps({"scope": "active_life"}))
+
+    result = TestClient(app).post(
+        "/api/actions/emergency_stop", json={"scope": "active_life"}
+    ).json()
 
     assert result["ok"] is True
     assert result["action"] == "emergency_stop"


### PR DESCRIPTION
### Motivation
- Move dashboard action invocation to `POST` with a JSON body to avoid sending structured payloads via the query string and to centralize token/payload validation and clearer user errors.
- Keep the legacy `GET` endpoint only as a deprecated fallback for non-destructive actions and explicitly block destructive actions over `GET` for safety.
- Improve the UI experience by sending JSON in the request body and surfacing more helpful, localized error messages when the token is missing/invalid or the payload is malformed.

### Description
- Add a `POST /api/actions/{action}` endpoint that reads and validates JSON bodies, centralizes token validation in `_validate_action_token`, parses payloads via `_parse_action_payload`, and executes via `_execute_dashboard_action` in `src/singular/dashboard/__init__.py`.
- Keep the existing `GET /api/actions/{action}` but mark it deprecated and return `405` for destructive actions in the set `{"archive","emergency_stop","clone"}` to block unsafe GET usage.
- Update the frontend `runAction()` in `src/singular/dashboard/static/actions.js` to send requests with `method: 'POST'`, `headers: {'Content-Type': 'application/json'}`, and `body: JSON.stringify(payload)`, plus client-side validation and clearer localized error text.
- Extend the test FastAPI stub to support `POST` routing and a `TestClient.post()` helper, and update `tests/test_dashboard.py` to exercise the new POST behaviour and validate GET blocking for destructive actions (files changed: `tests/fastapi_stub/__init__.py`, `tests/fastapi_stub/testclient.py`, `tests/test_dashboard.py`).

### Testing
- Ran the action-focused tests with `pytest tests/test_dashboard.py::test_dashboard_actions_endpoint_and_ui_panel tests/test_dashboard.py::test_dashboard_emergency_stop_action_writes_active_life_stop_signal tests/test_dashboard.py::test_dashboard_actions_validation_robustness -q`, and they all passed.
- Verified the modified module compiles with `python -m py_compile src/singular/dashboard/__init__.py` with no syntax errors.
- Ran the full dashboard test file with `pytest tests/test_dashboard.py -q`, which still reports unrelated failures in rendering/aggregation/genealogy tests not targeted by this change, while the action-related tests implemented here continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033a0d8b84832a9a8b19392c846f75)