### PR TITLE
Synchronize selected life across dashboard actions

### DIFF
--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -1,3 +1,4 @@
+import {getSelectedLife,SELECTED_LIFE_CHANGED_EVENT,setSelectedLife} from './state.js';
 const actionResultTargets=()=>[
   document.getElementById('action-result'),
   document.getElementById('critical-action-result'),
@@ -16,7 +17,7 @@ const readValue=(...ids)=>{
 };
 
 const operatorLifeSelect=()=>document.getElementById('operator-action-life-select');
-const selectedOperatorLife=()=>readValue('operator-action-life-select','action-life-name');
+const selectedOperatorLife=()=>getSelectedLife()||readValue('operator-action-life-select','action-life-name');
 const operatorMessage=()=>readValue('operator-action-message','action-prompt');
 const birthName=()=>readValue('operator-birth-name','action-life-name');
 
@@ -27,10 +28,25 @@ const validOperatorLives=()=>{
 };
 
 const hasValidSelectedLife=()=>{
-  const selected=operatorLifeSelect()?.value?.trim()||'';
+  const selected=selectedOperatorLife();
   if(!selected){return false;}
   const lives=validOperatorLives();
   return lives.size===0?false:lives.has(selected);
+};
+
+const updateCriticalTargetLabel=()=>{
+  const target=document.getElementById('critical-current-life-target');
+  if(!target){return;}
+  const selected=selectedOperatorLife();
+  target.textContent=selected?`Vie ciblée: ${selected}`:'Vie ciblée: aucune sélection';
+  target.classList.toggle('target-missing',!selected);
+};
+
+const syncOperatorSelectToShared=()=>{
+  const select=operatorLifeSelect();
+  const selected=getSelectedLife();
+  if(select&&selected&&[...select.options].some(option=>option.value===selected)){select.value=selected;}
+  updateCriticalTargetLabel();
 };
 
 const setActionHelp=text=>{
@@ -39,18 +55,20 @@ const setActionHelp=text=>{
   if(text){writeActionResult(text);}
 };
 
-const requiresValidLife=action=>['archive','talk'].includes(action);
+const requiresValidLife=action=>['archive','talk','emergency_stop','lives_use','memorial','clone'].includes(action);
 
 export const updateOperatorActionState=()=>{
   const hasSelection=hasValidSelectedLife();
   const select=operatorLifeSelect();
-  const selected=select?.value?.trim()||'';
+  syncOperatorSelectToShared();
+  const selected=selectedOperatorLife();
   const help=document.getElementById('operator-action-help');
   const helpText=hasSelection
     ? `Vie ciblée: ${selected}. “Supprimer/archiver” et “Parler” sont disponibles.`
     : 'Sélectionnez une vie existante pour activer “Supprimer/archiver” et “Parler”.';
   if(help){help.textContent=helpText;}
-  ['critical-archive','critical-talk','act-archive','act-talk'].forEach(id=>{
+  updateCriticalTargetLabel();
+  ['critical-archive','critical-talk','critical-emergency-stop','act-archive','act-talk','act-lives-use','act-memorial','act-clone'].forEach(id=>{
     const button=document.getElementById(id);
     if(!button){return;}
     button.disabled=false;
@@ -79,12 +97,16 @@ export const updateOperatorLifeOptions=(rows=[])=>{
     option.textContent=name;
     select.appendChild(option);
   }
-  if(previous&&names.includes(previous)){select.value=previous;}
+  const shared=getSelectedLife();
+  if(shared&&names.includes(shared)){select.value=shared;}
+  else if(previous&&names.includes(previous)){select.value=previous;}
   else{
     const selectedRow=(rows||[]).find(row=>row?.selected_life===true||row?.active===true||row?.is_registry_active_life===true);
     const selectedName=selectedRow?.life||selectedRow?.slug||selectedRow?.name||'';
     if(selectedName&&names.includes(selectedName)){select.value=selectedName;}
   }
+  if(select.value){setSelectedLife(select.value,{source:'operator-options'});}
+  else{setSelectedLife(null,{source:'operator-options'});}
   updateOperatorActionState();
 };
 
@@ -144,7 +166,7 @@ const actionPayload=(action,lifeName=selectedOperatorLife)=>{
   if(action==='birth'){return {name:birthName()};}
   if(action==='talk'){return {name:lifeName(),prompt:operatorMessage()};}
   if(action==='archive'){return {name:lifeName()};}
-  if(action==='emergency_stop'){return {scope:'active_life'};}
+  if(action==='emergency_stop'){return {scope:'active_life',name:lifeName(),target_life:lifeName()};}
   return {};
 };
 
@@ -163,11 +185,12 @@ const validateAction=(action,payload)=>{
 
 const confirmBirth=payload=>window.confirm(`Créer la vie nommée exactement “${payload.name}” ?`);
 
-const confirmCriticalAction=button=>{
+const confirmCriticalAction=(button,payload={})=>{
+  const target=payload.name||payload.target_life||selectedOperatorLife()||'aucune sélection';
   const message=button.dataset.confirm;
-  if(message&&!window.confirm(message)){return false;}
+  if(message&&!window.confirm(`${message}\n\nVie actuellement ciblée: ${target}`)){return false;}
   const secondMessage=button.dataset.confirmAgain;
-  if(secondMessage&&!window.confirm(secondMessage)){return false;}
+  if(secondMessage&&!window.confirm(`${secondMessage}\n\nVie actuellement ciblée: ${target}`)){return false;}
   return true;
 };
 
@@ -175,7 +198,7 @@ const runValidatedAction=(action,payload,handlers,button=null)=>{
   const help=validateAction(action,payload);
   if(help){setActionHelp(help);updateOperatorActionState();return false;}
   if(action==='birth'&&!confirmBirth(payload)){return false;}
-  if(button&&!confirmCriticalAction(button)){return false;}
+  if(button&&!confirmCriticalAction(button,payload)){return false;}
   return runAction(action,payload,handlers);
 };
 
@@ -183,7 +206,10 @@ export const bindCriticalActionHandlers=(handlers)=>{
   const select=operatorLifeSelect();
   if(select&&select.dataset.bound!=='true'){
     select.dataset.bound='true';
-    select.addEventListener('change',updateOperatorActionState);
+    select.addEventListener('change',()=>{
+      setSelectedLife(select.value,{source:'operator-select'});
+      updateOperatorActionState();
+    });
   }
   ['operator-action-message','operator-birth-name','action-life-name','action-prompt'].forEach(id=>{
     const el=document.getElementById(id);
@@ -192,6 +218,10 @@ export const bindCriticalActionHandlers=(handlers)=>{
       el.addEventListener('input',updateOperatorActionState);
     }
   });
+  if(typeof window!=='undefined'&&window.__singularSelectedLifeActionBinding!=='true'){
+    window.__singularSelectedLifeActionBinding='true';
+    window.addEventListener(SELECTED_LIFE_CHANGED_EVENT,()=>updateOperatorActionState());
+  }
   updateOperatorActionState();
   document.querySelectorAll('.critical-actions-bar [data-dashboard-action]').forEach(button=>{
     if(button.offsetParent===null){return;}
@@ -216,9 +246,9 @@ export const bindActionHandlers=(handlers)=>{
   bind('act-loop',()=>runAction('loop',{budget_seconds:budget()},handlers));
   bind('act-report',()=>runAction('report',{},handlers));
   bind('act-lives-list',()=>runAction('lives_list',{},handlers));
-  bind('act-lives-use',()=>runAction('lives_use',{name:lifeName()},handlers));
+  bind('act-lives-use',()=>runValidatedAction('lives_use',{name:lifeName()},handlers));
   bind('act-archive',()=>runValidatedAction('archive',{name:lifeName()},handlers));
-  bind('act-memorial',()=>runAction('memorial',{name:lifeName(),message:'Merci pour ce cycle de vie.'},handlers));
-  bind('act-clone',()=>runAction('clone',{name:lifeName(),new_name:`${lifeName()||'Vie'} clone`},handlers));
+  bind('act-memorial',()=>runValidatedAction('memorial',{name:lifeName(),message:'Merci pour ce cycle de vie.'},handlers));
+  bind('act-clone',()=>runValidatedAction('clone',{name:lifeName(),new_name:`${lifeName()||'Vie'} clone`},handlers));
   bindCriticalActionHandlers(handlers);
 };

--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -389,6 +389,22 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
 
 
 
+.critical-target-badge {
+  align-self: center;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 191, 83, 0.65);
+  border-radius: 999px;
+  background: rgba(255, 191, 83, 0.12);
+  color: var(--warn);
+  font-weight: 700;
+}
+
+.critical-target-badge.target-missing {
+  border-color: rgba(255, 107, 141, 0.7);
+  background: rgba(255, 107, 141, 0.14);
+  color: var(--bad);
+}
+
 .operator-action-form {
   display: grid;
   grid-template-columns: minmax(180px, 1fr) minmax(180px, 1fr) minmax(240px, 2fr);
@@ -433,7 +449,23 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
 }
 
 @media (max-width: 820px) {
-  .operator-action-form {
+  .critical-target-badge {
+  align-self: center;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 191, 83, 0.65);
+  border-radius: 999px;
+  background: rgba(255, 191, 83, 0.12);
+  color: var(--warn);
+  font-weight: 700;
+}
+
+.critical-target-badge.target-missing {
+  border-color: rgba(255, 107, 141, 0.7);
+  background: rgba(255, 107, 141, 0.14);
+  color: var(--bad);
+}
+
+.operator-action-form {
     grid-template-columns: 1fr;
   }
 }

--- a/src/singular/dashboard/static/render-conversations.js
+++ b/src/singular/dashboard/static/render-conversations.js
@@ -1,5 +1,6 @@
 import {updateOperatorLifeOptions} from './actions.js';
 import {normalizeItem} from './render-quests.js';
+import {getSelectedLife,SELECTED_LIFE_CHANGED_EVENT,setSelectedLife} from './state.js';
 
 const conversationState={
   selectedLife:'',
@@ -40,6 +41,29 @@ const escapeHtml=value=>String(value??'').replace(/[&<>'"]/g,char=>({
   "'":'&#39;',
   '"':'&quot;',
 }[char]));
+
+const highlightConversationLife=(life)=>{
+  document.querySelectorAll('#conversation-life-list [data-life]').forEach(node=>{
+    const active=node.dataset.life===life;
+    node.classList.toggle('active',active);
+    node.setAttribute('aria-pressed',active?'true':'false');
+  });
+};
+
+const syncConversationSelection=(life)=>{
+  conversationState.selectedLife=life||'';
+  highlightConversationLife(conversationState.selectedLife);
+  renderMeta(conversationState.selectedLife);
+};
+
+let selectedLifeListenerBound=false;
+const bindSelectedLifeListener=()=>{
+  if(selectedLifeListenerBound||typeof window==='undefined'){return;}
+  selectedLifeListenerBound=true;
+  window.addEventListener(SELECTED_LIFE_CHANGED_EVENT,event=>{
+    syncConversationSelection(event.detail?.name||'');
+  });
+};
 
 const setFlowState=(flow)=>{
   conversationState.flow=flow;
@@ -181,19 +205,22 @@ export const renderConversationsSection=payload=>{
       const flow=inferFlow(meta);
       li.innerHTML=`<button type='button' class='filter-chip' data-life='${escapeHtml(life)}'>${escapeHtml(life)}</button> <span class='summary-pill ${FLOW_STYLES[flow]||'summary-muted'}'>${escapeHtml(flow)}</span>`;
       li.querySelector('button').addEventListener('click',()=>{
-        conversationState.selectedLife=life;
-        renderMeta(life);
+        setSelectedLife(life,{source:'conversation-list',metadata:meta});
       });
       list.appendChild(li);
     }
   }
 
+  const sharedLife=getSelectedLife();
+  if(sharedLife&&lives.has(sharedLife)){conversationState.selectedLife=sharedLife;}
   if(!conversationState.selectedLife&&lives.size){
     const selected=[...lives.entries()].find(([,meta])=>meta.active||meta.selected_life);
     conversationState.selectedLife=selected?.[0]||[...lives.keys()][0];
+    setSelectedLife(conversationState.selectedLife,{source:'conversation-default',metadata:lives.get(conversationState.selectedLife)||{}});
   }
+  bindSelectedLifeListener();
   updateOperatorLifeOptions([...lives.entries()].map(([life,meta])=>({life,...meta})));
-  renderMeta(conversationState.selectedLife);
+  syncConversationSelection(conversationState.selectedLife);
   bindSend();
 
   const raw=document.getElementById('conversations-json-raw');

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -1,6 +1,6 @@
 import {fetchJson} from './api.js';
 import {updateOperatorLifeOptions} from './actions.js';
-import {BADGE_TONE,liveState,livesTableState,na,scopeState,setPanelState} from './state.js';
+import {BADGE_TONE,liveState,livesTableState,na,scopeState,setPanelState,setSelectedLife} from './state.js';
 
 const byId=id=>document.getElementById(id);
 const setText=(id,text)=>{const el=byId(id);if(el){el.textContent=text;}return el;};
@@ -200,10 +200,12 @@ const showLifeDetails=lifeName=>{
     content.textContent='Aucune vie sélectionnée.';
     if(proofs){proofs.innerHTML='<li>Aucune vie sélectionnée.</li>';}
     livesUiState.selectedLife=null;
+    setSelectedLife(null,{source:'lives-detail'});
     return;
   }
   panel.classList.remove('panel-hidden');
   livesUiState.selectedLife=lifeName;
+  setSelectedLife(lifeName,{source:'lives-detail',metadata:row});
   const operatorMetadata=[
     ['Vie',row.life],
     ['Statut registre',row.life_status],

--- a/src/singular/dashboard/static/state.js
+++ b/src/singular/dashboard/static/state.js
@@ -10,6 +10,26 @@ export const MISSING_TEXT={notAvailable:'Non disponible',notMeasured:'Pas encore
 export const na=()=>MISSING_TEXT.notAvailable;
 export const nm=()=>MISSING_TEXT.notMeasured;
 
+
+export const SELECTED_LIFE_CHANGED_EVENT='singular:selected-life-changed';
+export const selectedLifeState={name:null,source:null,metadata:{}};
+
+export const setSelectedLife=(name,{source='unknown',metadata={}}={})=>{
+  const normalized=String(name||'').trim()||null;
+  const previous=selectedLifeState.name;
+  selectedLifeState.name=normalized;
+  selectedLifeState.source=source;
+  selectedLifeState.metadata=metadata&&typeof metadata==='object'?metadata:{};
+  if(typeof window!=='undefined'){
+    window.dispatchEvent(new CustomEvent(SELECTED_LIFE_CHANGED_EVENT,{
+      detail:{name:normalized,previous,source,metadata:selectedLifeState.metadata},
+    }));
+  }
+  return normalized;
+};
+
+export const getSelectedLife=()=>selectedLifeState.name;
+
 export const livesTableState={sortBy:'score',sortOrder:'desc'};
 export const liveState={paused:false,autoScroll:true,events:[]};
 export const scopeState={currentLifeOnly:false};

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -18,6 +18,7 @@
 </nav>
 
 <section class='critical-actions-bar' aria-label='Actions critiques'>
+  <span id='critical-current-life-target' class='critical-target-badge' aria-live='polite'>Vie ciblée: aucune sélection</span>
   <button id='critical-birth' type='button' class='critical-action-btn' data-dashboard-action='birth'>Créer une vie</button>
   <button
     id='critical-archive'


### PR DESCRIPTION
### Motivation
- Garantir une sélection de « vie » cohérente entre les panneaux (table des vies, conversation, et actions) afin d’éviter des actions ciblant une vie différente de celle affichée. 
- Afficher explicitement la cible avant toute action destructive pour réduire les risques d’erreur humaine lors d’archivage/arrêt/clonage.

### Description
- Ajout d’un état partagé `selectedLifeState` et des helpers `setSelectedLife` / `getSelectedLife` avec l’événement DOM `singular:selected-life-changed` dans `src/singular/dashboard/static/state.js` pour publier les changements de sélection. 
- Publication de la sélection depuis la vue détail des vies (`showLifeDetails`) et injection de la sélection par défaut lors du rendu des conversations (`renderConversationsSection`).
- Synchronisation du sélecteur opérateur et lecture centrale de la sélection depuis `src/singular/dashboard/static/actions.js`, avec mise à jour des boutons critiques (activation/désactivation, label de cible) et inclusion du nom cible dans les dialogues de confirmation; adaptation des payloads pour `emergency_stop` et autres actions secondaires. 
- Écoute côté conversations dans `src/singular/dashboard/static/render-conversations.js` pour mettre à jour la liste conversationnelle, les métadonnées et l’état visuel quand la sélection change. 
- Ajout d’un badge visible dans la barre critique et des styles (`dashboard.html`, `dashboard.css`) pour afficher la vie ciblée et signaler l’absence de sélection.

### Testing
- `node --check` sur les fichiers JS modifiés (`state.js`, `actions.js`, `render-lives.js`, `render-conversations.js`) a réussi. 
- `pytest -q --maxfail=1` a été exécuté; le run a échoué avec 1 test (`tests/test_cli_config.py::test_config_openai_windows_writes_hkcu_environment`) tandis que 75 tests ont réussi et 1 a été ignoré, et l’échec est dû à l’instanciation de `pathlib.WindowsPath` dans un environnement Linux et est indépendant des changements JS du dashboard.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034b009814832aa7c15904d7240bd6)