### PR TITLE
Resolve current-life via registry for dashboard run records and actions

### DIFF
--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -9,9 +9,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
-from singular.lives import get_registry_root
+from singular.lives import get_registry_root, load_registry
 from singular.sensors import load_host_sensor_thresholds
 from singular.skills_daily import build_daily_skills_snapshot
+from singular.dashboard.repositories.run_records import resolve_current_life_home
 
 
 @dataclass(slots=True)
@@ -43,7 +44,7 @@ class DashboardActionService:
             self.home = Path(os.environ.get("SINGULAR_HOME", self.root))
 
     def _context_payload(self) -> dict[str, Any]:
-        current_home = Path(os.environ.get("SINGULAR_HOME", str(self.home)))
+        current_home = resolve_current_life_home(load_registry, self.home)
         runs_dir = current_home / "runs"
         vital_metrics = self._consolidated_vital_metrics(runs_dir=runs_dir)
         host_metrics = self._consolidated_host_metrics(runs_dir=runs_dir)

--- a/src/singular/dashboard/repositories/run_records.py
+++ b/src/singular/dashboard/repositories/run_records.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -39,6 +40,35 @@ def logical_run_file_stem(path: Path) -> str:
     return normalized
 
 
+def resolve_current_life_home(
+    registry_loader: Callable[[], dict[str, object]],
+    fallback_base_dir: Path,
+) -> Path:
+    """Resolve the active life directory from the registry, with a stable fallback."""
+
+    fallback_home = Path(os.environ.get("SINGULAR_HOME", str(fallback_base_dir)))
+    try:
+        registry = registry_loader()
+    except Exception:
+        return fallback_home
+
+    active = registry.get("active")
+    raw_lives = registry.get("lives")
+    if not isinstance(active, str) or not isinstance(raw_lives, dict):
+        return fallback_home
+
+    active_meta = raw_lives.get(active)
+    path_value = getattr(active_meta, "path", None)
+    if isinstance(active_meta, dict):
+        path_value = active_meta.get("path", path_value)
+    if isinstance(path_value, str):
+        path_value = Path(path_value)
+    if isinstance(path_value, Path):
+        return path_value
+
+    return fallback_home
+
+
 @dataclass
 class RunRecordsRepository:
     """Read dashboard run records from one or many life run directories."""
@@ -67,7 +97,11 @@ class RunRecordsRepository:
         if self.runs_path is not None:
             return [self.runs_path]
         if current_life_only:
-            return [self.base_dir / "runs"]
+            current_life_home = resolve_current_life_home(
+                self.registry_loader,
+                self.base_dir,
+            )
+            return [current_life_home / "runs"]
         dirs: list[Path] = []
         seen: set[str] = set()
         for life_dir in self._registry_lives_paths():

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -88,6 +88,42 @@ def test_dashboard_starts_with_empty_registry_and_exposes_onboarding(tmp_path: P
     }
 
 
+def test_lives_comparison_current_life_only_uses_registry_after_life_creation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry_root = tmp_path / "registry-root"
+    registry_root.mkdir()
+    monkeypatch.setenv("SINGULAR_ROOT", str(registry_root))
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    app = create_app()
+
+    life = create_life("active-life")
+    runs_dir = life.path / "runs"
+    runs_dir.mkdir(parents=True)
+    (runs_dir / "active-run.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-05-12T10:00:00+00:00",
+                "life": life.slug,
+                "accepted": True,
+                "score_base": 10.0,
+                "score_new": 8.0,
+                "health": {"score": 91.0, "sandbox_stability": 0.98},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    # Equivalent to GET /lives/comparison?current_life_only=true; the test
+    # FastAPI stub dispatches query parameters via direct route kwargs.
+    payload = app._routes["/lives/comparison"](current_life_only=True)
+    assert set(payload["lives"]) == {life.slug}
+    assert payload["lives"][life.slug]["health_score"] == 91.0
+    assert payload["table"][0]["life"] == life.slug
+
+
 def test_dashboard_quests_endpoint(tmp_path: Path, monkeypatch) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Faire en sorte que la résolution de la "vie courante" soit lue depuis le registre à chaque appel quand `current_life_only=True`, afin de détecter une vie créée après démarrage même si `SINGULAR_HOME` n’est pas défini.
- Unifier la logique de résolution de la vie active entre la lecture des fichiers de run et le contexte d’actions du dashboard pour éviter deux définitions concurrentes de la "vie courante".
- Fournir un fallback stable vers `Path(os.environ.get("SINGULAR_HOME", base_dir))` lorsque le registre est vide, incohérent ou non lisible.

### Description
- Ajout de `resolve_current_life_home(registry_loader, fallback_base_dir)` dans `src/singular/dashboard/repositories/run_records.py` pour encapsuler la résolution de la vie active depuis le registre avec fallback vers `SINGULAR_HOME`/base dir.
- Modification de `RunRecordsRepository.runs_dirs(current_life_only=True)` pour utiliser `resolve_current_life_home(...)` et retourner `[current_life_home / "runs"]` au lieu de s’appuyer seulement sur `self.base_dir`.
- Harmonisation de `DashboardActionService._context_payload()` dans `src/singular/dashboard/actions.py` pour réutiliser `resolve_current_life_home(load_registry, self.home)` et ainsi centraliser la même définition de la vie active.
- Ajout d’un test `test_lives_comparison_current_life_only_uses_registry_after_life_creation` dans `tests/test_dashboard.py` qui démarre le dashboard sans `SINGULAR_HOME`, crée une vie, écrit un run et vérifie l’équivalent de `GET /lives/comparison?current_life_only=true` retourne la vie créée.

### Testing
- Exécution ciblée du nouveau test avec `pytest -q tests/test_dashboard.py::test_lives_comparison_current_life_only_uses_registry_after_life_creation`, qui a réussi.
- Compilation des modules modifiés avec `python -m py_compile src/singular/dashboard/repositories/run_records.py src/singular/dashboard/actions.py`, qui a réussi.
- Exécution plus large `pytest -q tests/test_dashboard.py tests/test_dashboard_services.py` a été lancée et a montré 5 échecs existants et non liés directement à la résolution actuelle (échecs dans rendu d’index, ordering de lives comparison et attentes de genealogy), 37 tests ont réussi, 5 ont échoué.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034d9bfa60832ab378802a214c3fb6)