### PR TITLE
Normalize dashboard life metadata

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -54,6 +54,36 @@ from singular.dashboard.services.code_evolution import (
 )
 
 
+def life_meta_get(meta: object | None, key: str, default: object = None) -> object:
+    """Read a life metadata field from either a dict payload or an object."""
+    if isinstance(meta, dict):
+        return meta.get(key, default)
+    return getattr(meta, key, default)
+
+
+def _normalize_life_registry_entry(
+    slug: str, meta: object | None, *, active_slug: object | None = None
+) -> dict[str, object]:
+    """Return a dashboard-friendly payload for dict and object registries."""
+    raw_slug = life_meta_get(meta, "slug", slug)
+    normalized_slug = raw_slug if isinstance(raw_slug, str) and raw_slug else slug
+    name = life_meta_get(meta, "name", normalized_slug)
+    path = life_meta_get(meta, "path", "")
+    status = life_meta_get(meta, "status", "unknown")
+
+    payload: dict[str, object] = {
+        "slug": normalized_slug,
+        "name": str(name or normalized_slug),
+        "path": str(path or ""),
+        "status": str(status or "unknown"),
+        "active": normalized_slug == active_slug or slug == active_slug,
+    }
+    created_at = life_meta_get(meta, "created_at", None)
+    if created_at is not None:
+        payload["created_at"] = str(created_at)
+    return payload
+
+
 @dataclass
 class _LogCursor:
     inode: int | None
@@ -97,9 +127,11 @@ def create_app(
             return []
         lives_paths: list[Path] = []
         for meta in raw_lives.values():
-            path = getattr(meta, "path", None)
+            path = life_meta_get(meta, "path", None)
             if isinstance(path, Path):
                 lives_paths.append(path)
+            elif isinstance(path, str) and path:
+                lives_paths.append(Path(path))
         return lives_paths
 
     def _resolve_life_entry(life: str) -> tuple[str | None, object | None, Path | None]:
@@ -110,11 +142,8 @@ def create_app(
         for slug, meta in raw_lives.items():
             if not isinstance(slug, str):
                 continue
-            path_value = getattr(meta, "path", None)
-            display_name = getattr(meta, "name", None)
-            if isinstance(meta, dict):
-                path_value = meta.get("path", path_value)
-                display_name = meta.get("name", display_name)
+            path_value = life_meta_get(meta, "path", None)
+            display_name = life_meta_get(meta, "name", None)
             if isinstance(path_value, str):
                 path_value = Path(path_value)
             if not isinstance(path_value, Path):
@@ -128,9 +157,7 @@ def create_app(
         return path_value
 
     def _life_status(meta: object | None) -> str:
-        status = getattr(meta, "status", None)
-        if isinstance(meta, dict):
-            status = meta.get("status", status)
+        status = life_meta_get(meta, "status", None)
         return str(status or "unknown").strip().lower()
 
     def _active_run_locks(life_dir: Path) -> list[str]:
@@ -1282,13 +1309,9 @@ def create_app(
                 if not isinstance(slug, str):
                     continue
                 registry_lives.append(
-                    {
-                        "slug": slug,
-                        "name": str(getattr(meta, "name", slug)),
-                        "path": str(getattr(meta, "path", "")),
-                        "status": str(getattr(meta, "status", "unknown")),
-                        "active": slug == registry_state["active"],
-                    }
+                    _normalize_life_registry_entry(
+                        slug, meta, active_slug=registry_state["active"]
+                    )
                 )
         retention = retention_status_snapshot(base_dir=base_dir)
         return {
@@ -1404,18 +1427,11 @@ def create_app(
         for slug, raw_meta in lives_payload.items():
             if not isinstance(slug, str):
                 continue
-            if isinstance(raw_meta, dict):
-                candidate_name = raw_meta.get("name")
-                if life_name == slug or (
-                    isinstance(candidate_name, str) and candidate_name == life_name
-                ):
-                    return slug, raw_meta
-            else:
-                candidate_name = getattr(raw_meta, "name", None)
-                if life_name == slug or (
-                    isinstance(candidate_name, str) and candidate_name == life_name
-                ):
-                    return slug, None
+            candidate_name = life_meta_get(raw_meta, "name", None)
+            if life_name == slug or (
+                isinstance(candidate_name, str) and candidate_name == life_name
+            ):
+                return slug, _normalize_life_registry_entry(slug, raw_meta)
         return None, None
 
     def _aggregate_lives(
@@ -1741,14 +1757,14 @@ def create_app(
         statuses_by_slug: dict[str, str] = {}
         proximity_by_slug: dict[str, float] = {}
         for slug, meta in sorted(lives.items()):
-            name = getattr(meta, "name", slug)
-            status = getattr(meta, "status", "active")
-            parents = getattr(meta, "parents", ()) or ()
-            children = getattr(meta, "children", ()) or ()
-            allies = getattr(meta, "allies", ()) or ()
-            rivals = getattr(meta, "rivals", ()) or ()
-            proximity_score = getattr(meta, "proximity_score", 0.5)
-            lineage_depth = getattr(meta, "lineage_depth", 0)
+            name = life_meta_get(meta, "name", slug)
+            status = life_meta_get(meta, "status", "active")
+            parents = life_meta_get(meta, "parents", ()) or ()
+            children = life_meta_get(meta, "children", ()) or ()
+            allies = life_meta_get(meta, "allies", ()) or ()
+            rivals = life_meta_get(meta, "rivals", ()) or ()
+            proximity_score = life_meta_get(meta, "proximity_score", 0.5)
+            lineage_depth = life_meta_get(meta, "lineage_depth", 0)
             if not isinstance(parents, (tuple, list)):
                 parents = ()
             if not isinstance(children, (tuple, list)):

--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -362,7 +362,7 @@ def aggregate_lives(
                 display_name = name_value
         is_selected = isinstance(active_life, str) and active_life in {slug, display_name}
         is_extinct = registry_status == "extinct"
-        comparison[display_name] = {
+        comparison[slug] = {
             "health_score": None,
             "progression_slope": None,
             "failure_rate": None,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -5,8 +5,9 @@ from queue import Empty
 import pytest
 from fastapi_stub import TestClient
 
+import singular.dashboard as dashboard_module
 from singular.dashboard import create_app, run
-from singular.lives import create_life
+from singular.lives import LifeMetadata, create_life
 
 
 def _receive_with_timeout(ws: TestClient._WSConnection, timeout: float = 2.0) -> dict[str, object]:
@@ -46,6 +47,61 @@ def test_dashboard_endpoints(tmp_path: Path, monkeypatch) -> None:
     retention = client.get("/api/retention/status").json()
     assert "usage" in retention
     assert "last_purge" in retention
+
+
+def test_dashboard_context_normalizes_object_and_dict_life_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    object_life_dir = tmp_path / "object-life"
+    dict_life_dir = tmp_path / "dict-life"
+    object_life_dir.mkdir()
+    dict_life_dir.mkdir()
+
+    object_meta = LifeMetadata(
+        name="Object Life",
+        slug="object-life",
+        path=object_life_dir,
+        created_at="2026-05-12T08:00:00+00:00",
+        status="active",
+    )
+    dict_meta = {
+        "name": "Dict Life",
+        "slug": "dict-life",
+        "path": str(dict_life_dir),
+        "created_at": "2026-05-12T09:00:00+00:00",
+        "status": "extinct",
+    }
+
+    def fake_load_registry() -> dict[str, object]:
+        return {
+            "active": "object-life",
+            "lives": {"object-life": object_meta, "dict-life": dict_meta},
+        }
+
+    monkeypatch.setattr(dashboard_module, "load_registry", fake_load_registry)
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+
+    app = create_app(psyche_file=tmp_path / "psyche.json")
+    context = app._routes["/dashboard/context"]()
+
+    assert context["registry_lives"] == [
+        {
+            "slug": "dict-life",
+            "name": "Dict Life",
+            "path": str(dict_life_dir),
+            "status": "extinct",
+            "active": False,
+            "created_at": "2026-05-12T09:00:00+00:00",
+        },
+        {
+            "slug": "object-life",
+            "name": "Object Life",
+            "path": str(object_life_dir),
+            "status": "active",
+            "active": True,
+            "created_at": "2026-05-12T08:00:00+00:00",
+        },
+    ]
 
 
 def test_dashboard_starts_with_empty_registry_and_exposes_onboarding(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Unifier la lecture des métadonnées de vie pour supporter à la fois des entrées `dict` (payload registry) et des instances `LifeMetadata` afin d'éviter trois conventions différentes dans le dashboard. 
- S'assurer que le contexte exposé par `/dashboard/context` contient systématiquement `slug`, `name`, `path`, `status`, `active` et `created_at` quand disponible. 
- Simplifier l'intégration entre résolution de vie, affichage de la généalogie et l'agrégateur `aggregate_lives_service` pour réduire les divergences entre lignes issues du registre et celles issues des runs. 

### Description
- Ajouté le helper `life_meta_get(meta, key, default)` pour lire une clé depuis un `dict` ou un objet et la fonction `_normalize_life_registry_entry(slug, meta, active_slug=...)` pour produire une charge utile normalisée contenant `slug`, `name`, `path`, `status`, `active` et `created_at` si présent (fichier `src/singular/dashboard/__init__.py`).
- Remplacé les accès `getattr(meta, ...)` / `meta.get(...)` dispersés par des lectures via `life_meta_get` et produit des entrées normalisées dans `read_dashboard_context()` et `_registry_life_meta()` afin d'homogénéiser la sortie `registry_lives`.
- Adapté la résolution de chemins et le calcul de statut (`_registry_lives_paths`, `_resolve_life_entry`, `_life_status`, et usages associés) pour gérer correctement les `Path` stockés en tant qu'objets ou chaînes.
- Alignement avec le service d'agrégation : `aggregate_lives()` est maintenu/ajusté pour utiliser la convention par `slug` (modification légère du mapping dans `src/singular/dashboard/services/lives_comparison.py`) et la généalogie (`/lives/genealogy`) lit désormais les mêmes champs via `life_meta_get`.
- Ajout d'un test `test_dashboard_context_normalizes_object_and_dict_life_metadata` couvrant un registre mixte contenant une instance `LifeMetadata` et une entrée `dict` (fichier `tests/test_dashboard.py`).

### Testing
- Tests ciblés exécutés : `pytest -q tests/test_dashboard_services.py tests/test_dashboard.py::test_dashboard_context_normalizes_object_and_dict_life_metadata tests/test_dashboard.py::test_lives_comparison_table_aggregation_filters_and_sorting tests/test_dashboard.py::test_lives_genealogy_returns_normalized_relationships_and_conflicts tests/test_dashboard.py::test_lives_genealogy_life_filter_limits_active_relations` et la suite concernée s'est terminée avec succès (all tests passed).
- Commande `pytest -q tests/test_dashboard.py tests/test_dashboard_services.py` (exécutions interactives pendant le développement) a été utilisée pour itérer sur les corrections et les cas ont fini par passer.
- Vérification statique via `git diff --check` a été exécutée et n'a pas signalé d'erreurs de style/diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036803fbbc832aba3ff31c78dc397c)