### PR TITLE
Avoid silent life status reconciliation

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -31,7 +31,6 @@ except Exception:  # pragma: no cover - fastapi test stub does not expose Starle
 from singular.schedulers.reevaluation import alerts_from_records
 from singular.dashboard.repositories.run_records import (
     RunRecordsRepository,
-    is_run_jsonl_file,
     logical_run_file_stem,
 )
 from singular.dashboard.services.trajectory import (
@@ -1020,13 +1019,6 @@ def create_app(
     def read_dashboard_work_items(current_life_only: bool = False) -> dict[str, object]:
         quests = read_quests()
         active = quests.get("active") if isinstance(quests.get("active"), list) else []
-        completed = quests.get("completed") if isinstance(quests.get("completed"), list) else []
-
-        quests_items = [
-            _normalize_work_item(item, fallback_title="quête", default_owner="système")
-            for item in [*active, *completed]
-            if isinstance(item, dict)
-        ]
         objectives_items = [
             _normalize_work_item(item, fallback_title="objectif", default_owner="système")
             for item in active
@@ -1451,7 +1443,6 @@ def create_app(
             as_float=_as_float,
             alerts_from_records=alerts_from_records,
             compute_vital_timeline=compute_vital_timeline,
-            set_life_status=set_life_status,
             registry_life_meta=_registry_life_meta,
         )
 
@@ -1622,11 +1613,22 @@ def create_app(
         )
 
         registry_state = _registry_overview()
+        status_reconciliation = [
+            {
+                "life": name,
+                "registry_status": payload.get("life_status"),
+                "extinction_seen_in_runs": payload.get("extinction_seen_in_runs"),
+                "suggestion": payload.get("status_reconciliation_suggestion"),
+            }
+            for name, payload in sorted(comparison.items())
+            if payload.get("status_reconciliation_suggestion") is not None
+        ]
         return {
             "lives": comparison,
             "table": lives_rows,
             "life_metrics_contract": metrics_contract,
             "unattached_runs": unattached,
+            "status_reconciliation": status_reconciliation,
             "onboarding": {
                 "required": bool(registry_state["is_empty"]),
                 "message": registry_state["onboarding_message"],
@@ -1644,6 +1646,41 @@ def create_app(
                 "before_filter_count": len(base_rows),
                 "steps": filter_steps,
             },
+        }
+
+
+    @app.post("/api/lives/reconcile-status")
+    async def reconcile_lives_status(request: StarletteRequest) -> dict[str, object]:
+        comparison, _ = _aggregate_lives(current_life_only=False)
+        applied: list[dict[str, object]] = []
+        skipped: list[dict[str, object]] = []
+        for life_name, payload in sorted(comparison.items()):
+            suggestion = payload.get("status_reconciliation_suggestion")
+            if suggestion == "mark_extinct":
+                slug, _ = _registry_life_meta(life_name, load_registry().get("lives", {}))
+                if slug is None:
+                    skipped.append(
+                        {
+                            "life": life_name,
+                            "suggestion": suggestion,
+                            "reason": "life_not_found_in_registry",
+                        }
+                    )
+                    continue
+                set_life_status(slug, "extinct")
+                applied.append(
+                    {
+                        "life": life_name,
+                        "slug": slug,
+                        "from_status": payload.get("life_status"),
+                        "to_status": "extinct",
+                        "suggestion": suggestion,
+                    }
+                )
+        return {
+            "applied_count": len(applied),
+            "applied": applied,
+            "skipped": skipped,
         }
 
     @app.get("/lives/genealogy")

--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -316,7 +316,6 @@ def aggregate_lives(
     as_float: Callable[[object], float | None],
     alerts_from_records: Callable[[list[dict[str, object]]], list[dict[str, object]]],
     compute_vital_timeline: Callable[..., dict[str, object]],
-    set_life_status: Callable[[str, str], object],
     registry_life_meta: Callable[[str, dict[str, object]], tuple[str | None, dict[str, object] | None]],
 ) -> tuple[dict[str, dict[str, object]], dict[str, object]]:
     active_life = registry.get("active")
@@ -382,6 +381,8 @@ def aggregate_lives(
             "has_recent_activity": False,
             "extinction_seen_in_runs": is_extinct,
             "run_terminated": False,
+            "registry_run_status_inconsistency": False,
+            "status_reconciliation_suggestion": None,
             "vital_timeline": compute_vital_timeline(
                 age=0,
                 current_health=None,
@@ -485,9 +486,12 @@ def aggregate_lives(
             status_value = getattr(registry_meta, "status", None)
             if isinstance(status_value, str) and status_value in {"active", "extinct"}:
                 registry_status = status_value
-        if extinction_seen and slug is not None and registry_status != "extinct":
-            set_life_status(slug, "extinct")
-            registry_status = "extinct"
+        registry_run_status_inconsistency = (
+            extinction_seen and slug is not None and registry_status != "extinct"
+        )
+        status_reconciliation_suggestion = (
+            "mark_extinct" if registry_run_status_inconsistency else None
+        )
         is_selected = isinstance(active_life, str) and active_life in {life_name, slug}
         trend = life_trend_label(health_score_points)
         alerts = alerts_from_records(mutation_records) if mutation_records else []
@@ -521,6 +525,8 @@ def aggregate_lives(
             "has_recent_activity": last_timestamp is not None,
             "extinction_seen_in_runs": extinction_seen,
             "run_terminated": run_terminated,
+            "registry_run_status_inconsistency": registry_run_status_inconsistency,
+            "status_reconciliation_suggestion": status_reconciliation_suggestion,
             "vital_timeline": compute_vital_timeline(
                 age=len(mutation_records),
                 current_health=current_health_score,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1922,3 +1922,125 @@ def test_dashboard_registry_scope_aggregates_multiple_lives_and_can_filter_curre
     timeline_current = app._routes["/timeline"](current_life_only=True)
     assert timeline_current["count"] == 1
     assert timeline_current["items"][0]["life"] == "alpha"
+
+
+def test_lives_comparison_get_does_not_reconcile_registry_silently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    registry_dir = tmp_path / "lives"
+    registry_dir.mkdir(parents=True)
+    registry_file = registry_dir / "registry.json"
+    registry_payload = {
+        "active": "alpha",
+        "lives": {
+            "alpha": {
+                "name": "alpha",
+                "slug": "alpha",
+                "path": str(tmp_path / "alpha"),
+                "created_at": "2026-05-12T00:00:00+00:00",
+                "status": "active",
+            }
+        },
+    }
+    registry_file.write_text(json.dumps(registry_payload, indent=2), encoding="utf-8")
+
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "run-death.jsonl").write_text(
+        json.dumps(
+            {
+                "life": "alpha",
+                "ts": "2026-05-12T01:00:00+00:00",
+                "event": "death",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+
+    before = registry_file.read_text(encoding="utf-8")
+    first_payload = client.get("/lives/comparison").json()
+    between = registry_file.read_text(encoding="utf-8")
+    second_payload = client.get("/lives/comparison").json()
+    after = registry_file.read_text(encoding="utf-8")
+
+    assert before == between == after
+    assert json.loads(after)["lives"]["alpha"]["status"] == "active"
+    assert first_payload["lives"]["alpha"]["life_status"] == "active"
+    assert first_payload["lives"]["alpha"]["extinction_seen_in_runs"] is True
+    assert first_payload["lives"]["alpha"]["registry_run_status_inconsistency"] is True
+    assert first_payload["lives"]["alpha"]["status_reconciliation_suggestion"] == "mark_extinct"
+    assert first_payload["status_reconciliation"] == second_payload["status_reconciliation"] == [
+        {
+            "life": "alpha",
+            "registry_status": "active",
+            "extinction_seen_in_runs": True,
+            "suggestion": "mark_extinct",
+        }
+    ]
+
+
+def test_lives_status_reconciliation_action_marks_suggested_extinctions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+
+    registry_dir = tmp_path / "lives"
+    registry_dir.mkdir(parents=True)
+    registry_file = registry_dir / "registry.json"
+    registry_file.write_text(
+        json.dumps(
+            {
+                "active": "alpha",
+                "lives": {
+                    "alpha": {
+                        "name": "alpha",
+                        "slug": "alpha",
+                        "path": str(tmp_path / "alpha"),
+                        "created_at": "2026-05-12T00:00:00+00:00",
+                        "status": "active",
+                    }
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "run-death.jsonl").write_text(
+        json.dumps(
+            {
+                "life": "alpha",
+                "ts": "2026-05-12T01:00:00+00:00",
+                "event": "death",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+
+    response = client.post("/api/lives/reconcile-status")
+
+    assert response.status_code == 200
+    assert response.json()["applied"] == [
+        {
+            "life": "alpha",
+            "slug": "alpha",
+            "from_status": "active",
+            "to_status": "extinct",
+            "suggestion": "mark_extinct",
+        }
+    ]
+    assert json.loads(registry_file.read_text(encoding="utf-8"))["lives"]["alpha"]["status"] == "extinct"

--- a/tests/test_dashboard_services.py
+++ b/tests/test_dashboard_services.py
@@ -62,7 +62,6 @@ def test_lives_comparison_service_aggregates_metrics() -> None:
         as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
-        set_life_status=lambda *_: None,
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
     )
 
@@ -98,7 +97,6 @@ def test_lives_comparison_includes_registry_life_without_records_in_table() -> N
         as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
-        set_life_status=lambda *_: None,
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
     )
 
@@ -128,7 +126,6 @@ def test_lives_comparison_marks_selected_active_life_without_records() -> None:
         as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
-        set_life_status=lambda *_: None,
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
     )
 
@@ -154,7 +151,6 @@ def test_lives_comparison_default_rows_follow_active_and_dead_filters() -> None:
         as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
-        set_life_status=lambda *_: None,
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
     )
 

--- a/tests/test_liveness_index.py
+++ b/tests/test_liveness_index.py
@@ -109,7 +109,6 @@ def test_lives_comparison_exposes_liveness_fields() -> None:
         as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
-        set_life_status=lambda *_: None,
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
     )
 


### PR DESCRIPTION
### Motivation
- Prevent `aggregate_lives()` from mutating the lives registry as a side-effect when run data indicates a death, and instead surface diagnostics so operators can reconcile explicitly.
- Provide an explicit, auditable maintenance action to apply reconciliations rather than silently changing registry state during read-only endpoints.

### Description
- Removed the direct call to `set_life_status()` from `aggregate_lives()` and dropped it from the function signature so the service is side-effect-free (`src/singular/dashboard/services/lives_comparison.py`).
- Added diagnostic fields to the lives comparison payload: `registry_run_status_inconsistency` and `status_reconciliation_suggestion` (e.g. `"mark_extinct"`) for runs/registry mismatches (`src/singular/dashboard/services/lives_comparison.py`).
- Exposed reconciliation diagnostics in the `/lives/comparison` response as a top-level `status_reconciliation` list (`src/singular/dashboard/__init__.py`).
- Added an explicit maintenance endpoint `POST /api/lives/reconcile-status` that applies suggested reconciliations by calling `set_life_status()` only when invoked (`src/singular/dashboard/__init__.py`).
- Updated unit tests to reflect the new side-effect-free behavior and added two regression tests: one ensuring two successive `GET /lives/comparison` calls do not modify the registry, and one testing the explicit reconciliation action (`tests/test_dashboard.py`, plus small adjustments in `tests/test_dashboard_services.py` and `tests/test_liveness_index.py`).
- Minor cleanup/lint fixes to remove unused imports/variables in dashboard module.

### Testing
- Ran targeted unit tests and they passed: `pytest -q tests/test_dashboard.py::test_lives_comparison_get_does_not_reconcile_registry_silently tests/test_dashboard.py::test_lives_status_reconciliation_action_marks_suggested_extinctions tests/test_dashboard_services.py tests/test_liveness_index.py` (all passed).
- Ran a broader dashboard test run (`pytest -q tests/test_dashboard.py`) which surfaced pre-existing template-related assertions unrelated to this change (two failures in dashboard index rendering), so full dashboard smoke still fails on unrelated expectations.
- Performed linters/formatting checks during development: `ruff` and `black` were exercised and files were reformatted as needed; final code adjustments removed lint warnings reported during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036b6f1ec4832a890cafd03aa3f65c)