### PR TITLE
Keep lives comparison null values last when sorting

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -1595,14 +1595,21 @@ def create_app(
         }
         key_name = sort_key_map.get(sort_by, "current_health_score")
         reverse = sort_order != "asc"
-        lives_rows.sort(
-            key=lambda row: (
-                row.get(key_name) is None,
-                row.get(key_name),
-                str(row.get("life", "")),
-            ),
+
+        def _sort_value(row: dict[str, object]) -> object:
+            return row.get(key_name)
+
+        def _life_sort_value(row: dict[str, object]) -> str:
+            return str(row.get("life", ""))
+
+        non_null_rows = [row for row in lives_rows if _sort_value(row) is not None]
+        null_rows = [row for row in lives_rows if _sort_value(row) is None]
+        non_null_rows.sort(
+            key=lambda row: (_sort_value(row), _life_sort_value(row)),
             reverse=reverse,
         )
+        null_rows.sort(key=_life_sort_value)
+        lives_rows = non_null_rows + null_rows
         filter_steps.append(
             {
                 "step": "sorted",

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -9,6 +9,14 @@ const setTitle=(id,text)=>{const el=byId(id);if(el){el.title=text;}return el;};
 const badge=(label,tone)=>`<span class='badge ${tone}'>${label}</span>`;
 const safeText=value=>String(value??na());
 const escapeHtml=value=>safeText(value).replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;').replaceAll("'",'&#39;');
+const compareNullableNumberAsc=(left,right)=>{
+  const leftMissing=left===null||left===undefined;
+  const rightMissing=right===null||right===undefined;
+  if(leftMissing&&rightMissing){return 0;}
+  if(leftMissing){return 1;}
+  if(rightMissing){return -1;}
+  return Number(left)-Number(right);
+};
 
 const SORT_PRESETS={
   watch:{
@@ -20,7 +28,9 @@ const SORT_PRESETS={
       const trendA=a.trend==='dégradation'?0:(a.trend==='plateau'?1:2);
       const trendB=b.trend==='dégradation'?0:(b.trend==='plateau'?1:2);
       if(trendA!==trendB){return trendA-trendB;}
-      return Number(b.alerts_count||0)-Number(a.alerts_count||0);
+      const alertDiff=Number(b.alerts_count||0)-Number(a.alerts_count||0);
+      if(alertDiff!==0){return alertDiff;}
+      return compareNullableNumberAsc(a.current_health_score,b.current_health_score)||String(a.life||'').localeCompare(String(b.life||''));
     }),
   },
   active:{

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1330,6 +1330,66 @@ def test_lives_comparison_table_aggregation_filters_and_sorting(
     assert [row["life"] for row in by_life_asc] == ["life-a", "life-b", "life-c"]
 
 
+def test_lives_comparison_sorting_keeps_none_values_last(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    comparison = {
+        "alpha": {
+            "current_health_score": 10.0,
+            "last_activity": "2026-04-10T10:00:00+00:00",
+            "iterations": 2,
+            "life_liveness_index": 60.0,
+        },
+        "bravo": {
+            "current_health_score": None,
+            "last_activity": None,
+            "iterations": None,
+            "life_liveness_index": None,
+        },
+        "charlie": {
+            "current_health_score": 90.0,
+            "last_activity": "2026-04-12T10:00:00+00:00",
+            "iterations": 7,
+            "life_liveness_index": 20.0,
+        },
+        "delta": {
+            "current_health_score": 50.0,
+            "last_activity": "2026-04-11T10:00:00+00:00",
+            "iterations": 4,
+            "life_liveness_index": 80.0,
+        },
+    }
+
+    def fake_aggregate_lives_service(*args: object, **kwargs: object):
+        return comparison, {"records_count": 0, "runs_count": 0, "runs": []}
+
+    monkeypatch.setattr(
+        dashboard_module, "aggregate_lives_service", fake_aggregate_lives_service
+    )
+    monkeypatch.setattr(
+        dashboard_module,
+        "load_registry",
+        lambda: {"active": None, "lives": {}},
+    )
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    route = app._routes["/lives/comparison"]
+
+    expected = {
+        ("score", "asc"): ["alpha", "delta", "charlie", "bravo"],
+        ("score", "desc"): ["charlie", "delta", "alpha", "bravo"],
+        ("last_activity", "asc"): ["alpha", "delta", "charlie", "bravo"],
+        ("last_activity", "desc"): ["charlie", "delta", "alpha", "bravo"],
+        ("iterations", "asc"): ["alpha", "delta", "charlie", "bravo"],
+        ("iterations", "desc"): ["charlie", "delta", "alpha", "bravo"],
+        ("liveness", "asc"): ["charlie", "alpha", "delta", "bravo"],
+        ("liveness", "desc"): ["delta", "alpha", "charlie", "bravo"],
+    }
+    for (sort_by, sort_order), lives in expected.items():
+        payload = route(sort_by=sort_by, sort_order=sort_order)
+        assert [row["life"] for row in payload["table"]] == lives
+        assert payload["table"][-1]["life"] == "bravo"
+
+
 def test_lives_comparison_compare_lives_filter(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Ensure rows with `None` sort keys are always placed at the end of the `/lives/comparison` table regardless of `sort_order` to provide stable, predictable UI ordering.
- Apply ascending/descending direction only to non-null values to avoid flipping `None` entries to the front when sorting descending.
- Keep the client-side “À surveiller” preset ordering consistent with the new server-side null-last behavior.

### Description
- Update server sorting in `read_lives_comparison` to use helper functions ` _sort_value` and `_life_sort_value`, split `lives_rows` into `non_null_rows` and `null_rows`, sort `non_null_rows` with `reverse=reverse`, sort `null_rows` by life, and concatenate (`src/singular/dashboard/__init__.py`).
- Add a `compareNullableNumberAsc` helper and adjust the `watch` preset comparator to use a null-last numeric comparison with a final tie-break on `life` to match server-side ordering (`src/singular/dashboard/static/render-lives.js`).
- Add a regression test `test_lives_comparison_sorting_keeps_none_values_last` that verifies `score`, `last_activity`, `iterations`, and `liveness` sorting keep a row with `None` values last in both `asc` and `desc` (`tests/test_dashboard.py`).

### Testing
- Ran `pytest tests/test_dashboard.py -k "lives_comparison"` and all selected tests passed (8 passed, 32 deselected). 
- Ran `pytest tests/test_dashboard_static_smoke.py` and all tests passed (3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036fcf9050832a8053c064accdccc2)