### PR TITLE
Harden dashboard renderers to avoid injecting unescaped API data

### DIFF
--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -10,6 +10,8 @@ const setText=(id,text)=>{const el=byId(id);if(el){el.textContent=text;}return e
 const setTitle=(id,text)=>{const el=byId(id);if(el){el.title=text;}return el;};
 const clearElement=id=>{const el=byId(id);if(el){el.innerHTML='';}return el;};
 const setTone=(id,tone)=>{const el=byId(id);if(el){setStatusTone(el,tone);}return el;};
+const appendCell=(row,value)=>{const cell=document.createElement('td');cell.textContent=String(value??na());row.appendChild(cell);return cell;};
+const appendEmptyRow=(tbody,colspan,message)=>{const tr=document.createElement('tr');const td=document.createElement('td');td.colSpan=colspan;td.textContent=message;tr.appendChild(td);tbody.appendChild(tr);return tr;};
 
 const renderDailySkills=(dailySkills)=>{
   const frequency=dailySkills?.frequency_totals||{};
@@ -26,10 +28,15 @@ const renderDailySkills=(dailySkills)=>{
     const successRate=item.success_rate===null||item.success_rate===undefined?na():`${(Number(item.success_rate)*100).toFixed(1)}%`;
     const frequencyCell=`${item.frequency?.uses_24h||0}/${item.frequency?.uses_7d||0}`;
     const tasks=(item.associated_tasks||[]).join(', ')||na();
-    tr.innerHTML=`<td>${item.skill||na()}</td><td>${frequencyCell}</td><td>${successRate}</td><td>${item.last_used_at||na()}</td><td>${tasks}</td><td>${item.trend||'stable'}</td>`;
+    appendCell(tr,item.skill||na());
+    appendCell(tr,frequencyCell);
+    appendCell(tr,successRate);
+    appendCell(tr,item.last_used_at||na());
+    appendCell(tr,tasks);
+    appendCell(tr,item.trend||'stable');
     body.appendChild(tr);
   }
-  if(!topSkills.length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='6'>Aucune compétence quotidienne détectée.</td>";body.appendChild(tr);} 
+  if(!topSkills.length){appendEmptyRow(body,6,'Aucune compétence quotidienne détectée.');} 
 };
 
 const hostRisk=(name,value)=>{

--- a/src/singular/dashboard/static/render-conversations.js
+++ b/src/singular/dashboard/static/render-conversations.js
@@ -33,6 +33,7 @@ const STATUS_LABELS={
 };
 
 const setText=(id,text)=>{const el=document.getElementById(id);if(el){el.textContent=text;}return el;};
+const clearChildren=element=>{if(element){element.replaceChildren();}return element;};
 
 const escapeHtml=value=>String(value??'').replace(/[&<>'"]/g,char=>({
   '&':'&amp;',
@@ -198,13 +199,28 @@ export const renderConversationsSection=payload=>{
 
   const list=document.getElementById('conversation-life-list');
   if(list){
-    list.innerHTML='';
-    if(!lives.size){list.innerHTML="<li class='empty-state'>Aucune vie détectée.</li>";}
+    clearChildren(list);
+    if(!lives.size){
+      const li=document.createElement('li');
+      li.className='empty-state';
+      li.textContent='Aucune vie détectée.';
+      list.appendChild(li);
+    }
     for(const [life,meta] of lives.entries()){
       const li=document.createElement('li');
       const flow=inferFlow(meta);
-      li.innerHTML=`<button type='button' class='filter-chip' data-life='${escapeHtml(life)}'>${escapeHtml(life)}</button> <span class='summary-pill ${FLOW_STYLES[flow]||'summary-muted'}'>${escapeHtml(flow)}</span>`;
-      li.querySelector('button').addEventListener('click',()=>{
+      const button=document.createElement('button');
+      button.type='button';
+      button.className='filter-chip';
+      button.dataset.life=life;
+      button.textContent=life;
+      const pill=document.createElement('span');
+      pill.className=`summary-pill ${FLOW_STYLES[flow]||'summary-muted'}`;
+      pill.textContent=flow;
+      li.appendChild(button);
+      li.appendChild(document.createTextNode(' '));
+      li.appendChild(pill);
+      button.addEventListener('click',()=>{
         setSelectedLife(life,{source:'conversation-list',metadata:meta});
       });
       list.appendChild(li);

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -6,9 +6,22 @@ const byId=id=>document.getElementById(id);
 const setText=(id,text)=>{const el=byId(id);if(el){el.textContent=text;}return el;};
 const setTitle=(id,text)=>{const el=byId(id);if(el){el.title=text;}return el;};
 
-const badge=(label,tone)=>`<span class='badge ${tone}'>${label}</span>`;
 const safeText=value=>String(value??na());
 const escapeHtml=value=>safeText(value).replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;').replaceAll("'",'&#39;');
+const badge=(label,tone)=>`<span class='badge ${tone}'>${escapeHtml(label)}</span>`;
+
+const clearChildren=element=>{if(element){element.replaceChildren();}return element;};
+const appendCell=(row,value,tag='td')=>{const cell=document.createElement(tag);cell.textContent=safeText(value);row.appendChild(cell);return cell;};
+const appendEmptyRow=(tbody,colspan,message)=>{
+  const tr=document.createElement('tr');
+  const td=document.createElement('td');
+  td.colSpan=colspan;
+  td.textContent=message;
+  tr.appendChild(td);
+  tbody.appendChild(tr);
+  return tr;
+};
+
 const compareNullableNumberAsc=(left,right)=>{
   const leftMissing=left===null||left===undefined;
   const rightMissing=right===null||right===undefined;
@@ -177,7 +190,25 @@ const renderLivesTable=(rows)=>{
     const risk=rowRiskSummary(row);
     const activity=rowActivitySummary(row);
     const codeEvolutionEndpoint=row.code_evolution_endpoint||`/api/lives/${encodeURIComponent(row.life||'')}/code-evolution`;
-    tr.innerHTML=`<td>${escapeHtml(row.life||na())}<br/><a href='${escapeHtml(codeEvolutionEndpoint)}' target='_blank' rel='noopener noreferrer'>audit code</a></td><td>${score}</td><td>${escapeHtml(lastActivity)}</td><td>${liveness}</td><td><span class='summary-pill ${state.tone}'>${state.label}</span></td><td><span class='summary-pill ${risk.tone}'>${risk.label}</span></td><td><span class='summary-pill ${activity.tone}'>${activity.label}</span></td>`;
+    const lifeCell=appendCell(tr,row.life||na());
+    lifeCell.appendChild(document.createElement('br'));
+    const auditLink=document.createElement('a');
+    auditLink.href=codeEvolutionEndpoint;
+    auditLink.target='_blank';
+    auditLink.rel='noopener noreferrer';
+    auditLink.textContent='audit code';
+    lifeCell.appendChild(auditLink);
+    appendCell(tr,score);
+    appendCell(tr,lastActivity);
+    appendCell(tr,liveness);
+    for(const summary of [state,risk,activity]){
+      const cell=document.createElement('td');
+      const pill=document.createElement('span');
+      pill.className=`summary-pill ${summary.tone}`;
+      pill.textContent=summary.label;
+      cell.appendChild(pill);
+      tr.appendChild(cell);
+    }
     tr.onclick=()=>showLifeDetails(row.life||'');
     tr.onkeydown=event=>{
       if(event.key==='Enter'||event.key===' '){
@@ -187,7 +218,7 @@ const renderLivesTable=(rows)=>{
     };
     body.appendChild(tr);
   }
-  if(!(rows||[]).length){const tr=document.createElement('tr');tr.innerHTML="<td colspan='7'>Aucune vie ne correspond aux filtres.</td>";body.appendChild(tr);}
+  if(!(rows||[]).length){appendEmptyRow(body,7,'Aucune vie ne correspond aux filtres.');}
 };
 
 const renderEssentialLivesSummary=rows=>{
@@ -344,7 +375,7 @@ export const renderGenealogyTree=(payload)=>{
     if(treeEl){treeEl.textContent='Aucune lignée enregistrée.';}
     if(socialEl){socialEl.textContent='Aucun réseau social.';}
     if(conflictsEl){conflictsEl.textContent='Aucun conflit.';}
-    if(relationsBody){relationsBody.innerHTML=\"<tr><td colspan='6'>Aucune relation active.</td></tr>\";}
+    if(relationsBody){clearChildren(relationsBody);appendEmptyRow(relationsBody,6,'Aucune relation active.');}
     return;
   }
   const bySlug=new Map(nodes.map(node=>[node.slug,node]));
@@ -368,14 +399,24 @@ export const renderGenealogyTree=(payload)=>{
   const conflicts=payload?.active_conflicts||[];
   if(conflictsEl){conflictsEl.textContent=conflicts.length?conflicts.map(c=>`${c.life_a} ⚔ ${c.life_b} | sévérité=${c.severity??'-'} | MAJ=${c.updated_at||'n/a'}`).join('\n'):'Aucun conflit actif.';}
   if(relationsBody){
-    if(!relationRows.length){relationsBody.innerHTML=\"<tr><td colspan='6'>Aucune relation active pour ce filtre.</td></tr>\";}
+    clearChildren(relationsBody);
+    if(!relationRows.length){appendEmptyRow(relationsBody,6,'Aucune relation active pour ce filtre.');}
     else{
-      relationsBody.innerHTML=relationRows.map(row=>`<tr><td>${row.type||'unknown'}</td><td>${row.source||'-'}</td><td>${row.target||'-'}</td><td>${row.status||'unknown'}</td><td>${row.severity??'-'}</td><td>${row.updated_at||'n/a'}</td></tr>`).join('');
+      for(const row of relationRows){
+        const tr=document.createElement('tr');
+        appendCell(tr,row.type||'unknown');
+        appendCell(tr,row.source||'-');
+        appendCell(tr,row.target||'-');
+        appendCell(tr,row.status||'unknown');
+        appendCell(tr,row.severity??'-');
+        appendCell(tr,row.updated_at||'n/a');
+        relationsBody.appendChild(tr);
+      }
     }
   }
   if(lifeFilterEl){
     const currentValue=(payload?.filters?.life)||'all';
-    const options=['<option value=\"all\">Toutes les vies</option>',...nodes.map(node=>`<option value=\"${node.slug}\">${node.name} (${node.slug})</option>`)];
+    const options=['<option value="all">Toutes les vies</option>',...nodes.map(node=>`<option value="${escapeHtml(node.slug)}">${escapeHtml(node.name)} (${escapeHtml(node.slug)})</option>`)];
     lifeFilterEl.innerHTML=options.join('');
     lifeFilterEl.value=currentValue;
     lifeFilterEl.onchange=()=>{

--- a/src/singular/dashboard/static/render-objectives.js
+++ b/src/singular/dashboard/static/render-objectives.js
@@ -1,4 +1,7 @@
+import {na} from './state.js';
 import {normalizeItem} from './render-quests.js';
+
+const appendCell=(row,value)=>{const cell=document.createElement('td');cell.textContent=String(value??na());row.appendChild(cell);return cell;};
 
 export const renderObjectivesSection=payload=>{
   const rows=(Array.isArray(payload?.items)?payload.items:[]).map(item=>normalizeItem(item,'objectif'));
@@ -8,12 +11,20 @@ export const renderObjectivesSection=payload=>{
   if(!rows.length){
     const tr=document.createElement('tr');
     tr.className='table-state-empty';
-    tr.innerHTML="<td colspan='6'>Aucun objectif disponible.</td>";
+    const td=document.createElement('td');
+    td.colSpan=6;
+    td.textContent='Aucun objectif disponible.';
+    tr.appendChild(td);
     tbody.appendChild(tr);
   }else{
     for(const row of rows){
       const tr=document.createElement('tr');
-      tr.innerHTML=`<td>${row.title} · ${row.next_step}</td><td>${row.status}</td><td>${row.priority}</td><td>${row.owner}</td><td>${row.last_update}</td><td>${row.blockage}</td>`;
+      appendCell(tr,`${row.title} · ${row.next_step}`);
+      appendCell(tr,row.status);
+      appendCell(tr,row.priority);
+      appendCell(tr,row.owner);
+      appendCell(tr,row.last_update);
+      appendCell(tr,row.blockage);
       tbody.appendChild(tr);
     }
   }

--- a/src/singular/dashboard/static/render-quests.js
+++ b/src/singular/dashboard/static/render-quests.js
@@ -16,6 +16,8 @@ const normalizeItem=(item,fallbackTitle='quête')=>({
   blockage: requiredField(item,'blockage',String(item?.blocked_by||item?.blocker||'aucun')),
 });
 
+const appendCell=(row,value)=>{const cell=document.createElement('td');cell.textContent=String(value??na());row.appendChild(cell);return cell;};
+
 const renderRows=(rows,tbodyId)=>{
   const tbody=document.getElementById(tbodyId);
   if(!tbody){return;}
@@ -23,13 +25,21 @@ const renderRows=(rows,tbodyId)=>{
   if(!rows.length){
     const tr=document.createElement('tr');
     tr.className='table-state-empty';
-    tr.innerHTML="<td colspan='6'>Aucun élément disponible.</td>";
+    const td=document.createElement('td');
+    td.colSpan=6;
+    td.textContent='Aucun élément disponible.';
+    tr.appendChild(td);
     tbody.appendChild(tr);
     return;
   }
   for(const row of rows){
     const tr=document.createElement('tr');
-    tr.innerHTML=`<td>${row.title} · ${row.next_step}</td><td>${row.status}</td><td>${row.priority}</td><td>${row.owner}</td><td>${row.last_update}</td><td>${row.blockage}</td>`;
+    appendCell(tr,`${row.title} · ${row.next_step}`);
+    appendCell(tr,row.status);
+    appendCell(tr,row.priority);
+    appendCell(tr,row.owner);
+    appendCell(tr,row.last_update);
+    appendCell(tr,row.blockage);
     tbody.appendChild(tr);
   }
 };

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 DASHBOARD_STATIC = Path("src/singular/dashboard/static")
@@ -57,3 +58,115 @@ def test_dashboard_quests_websocket_targets_existing_raw_panel() -> None:
     bootstrap = (DASHBOARD_STATIC / "bootstrap.js").read_text(encoding="utf-8")
     assert "getElementById('quests')" not in bootstrap
     assert "getElementById('quests-json-raw')" in bootstrap or "loadQuests()" in bootstrap
+
+
+def test_genealogy_renderer_escapes_malicious_life_names(tmp_path: Path) -> None:
+    """Exercise the genealogy DOM renderer with a life name that looks like XSS."""
+    script = tmp_path / "genealogy_escape_check.mjs"
+    module_path = (Path.cwd() / DASHBOARD_STATIC / "render-lives.js").as_uri()
+    script.write_text(
+        f"""
+const encode = value => String(value ?? '')
+  .replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;')
+  .replaceAll('>', '&gt;')
+  .replaceAll('"', '&quot;')
+  .replaceAll("'", '&#39;');
+
+class Element {{
+  constructor(tagName) {{
+    this.tagName = tagName;
+    this.children = [];
+    this.attributes = {{}};
+    this.dataset = {{}};
+    this._textContent = '';
+    this._innerHTML = null;
+    this.value = '';
+    this.onchange = null;
+  }}
+  appendChild(child) {{
+    this.children.push(child);
+    this._innerHTML = null;
+    return child;
+  }}
+  replaceChildren(...children) {{
+    this.children = [];
+    this._textContent = '';
+    this._innerHTML = null;
+    for (const child of children) {{ this.appendChild(child); }}
+  }}
+  set textContent(value) {{
+    this._textContent = String(value ?? '');
+    this.children = [];
+    this._innerHTML = null;
+  }}
+  get textContent() {{
+    return this._textContent + this.children.map(child => child.textContent ?? '').join('');
+  }}
+  set innerHTML(value) {{
+    this._innerHTML = String(value ?? '');
+    this.children = [];
+    this._textContent = '';
+  }}
+  get innerHTML() {{
+    if (this._innerHTML !== null) {{ return this._innerHTML; }}
+    return encode(this._textContent) + this.children.map(child => child.outerHTML ?? encode(child.textContent ?? '')).join('');
+  }}
+  set colSpan(value) {{ this.attributes.colspan = String(value); }}
+  set className(value) {{ this.attributes.class = String(value); }}
+  set href(value) {{ this.attributes.href = String(value); }}
+  set target(value) {{ this.attributes.target = String(value); }}
+  set rel(value) {{ this.attributes.rel = String(value); }}
+  get outerHTML() {{
+    const attrs = Object.entries(this.attributes).map(([key, value]) => ` ${{key}}="${{encode(value)}}"`).join('');
+    return `<${{this.tagName}}${{attrs}}>${{this.innerHTML}}</${{this.tagName}}>`;
+  }}
+}}
+
+const elements = new Map();
+globalThis.document = {{
+  createElement: tagName => new Element(tagName),
+  getElementById: id => {{
+    if (!elements.has(id)) {{ elements.set(id, new Element('div')); }}
+    return elements.get(id);
+  }},
+}};
+globalThis.window = {{ location: {{ origin: 'http://localhost' }}, dispatchEvent() {{}} }};
+globalThis.CustomEvent = class CustomEvent {{ constructor(type, init) {{ this.type = type; this.detail = init?.detail; }} }};
+
+const {{ renderGenealogyTree }} = await import('{module_path}');
+const maliciousName = 'Vie <script>alert(1)</script>';
+const maliciousSlug = 'life-<img src=x onerror=alert(1)>';
+renderGenealogyTree({{
+  nodes: [{{ slug: maliciousSlug, name: maliciousName, status: 'active', active: true, parents: [] }}],
+  relationships: [],
+  active_relations: [{{
+    type: '<img src=x onerror=alert(2)>',
+    source: maliciousSlug,
+    target: maliciousName,
+    status: '<script>alert(3)</script>',
+    severity: '<img src=x onerror=alert(4)>',
+    updated_at: '<script>alert(5)</script>',
+  }}],
+  filters: {{ life: maliciousSlug }},
+}});
+
+const relationsHtml = elements.get('active-relations-table-body').innerHTML;
+const optionsHtml = elements.get('genealogy-relations-life-filter').innerHTML;
+if (relationsHtml.includes('<script>') || relationsHtml.includes('<img')) {{
+  throw new Error(`relations HTML was not escaped: ${{relationsHtml}}`);
+}}
+if (optionsHtml.includes('<script>') || optionsHtml.includes('<img')) {{
+  throw new Error(`option HTML was not escaped: ${{optionsHtml}}`);
+}}
+if (!relationsHtml.includes('&lt;script&gt;alert(3)&lt;/script&gt;')) {{
+  throw new Error(`escaped relation script fixture missing: ${{relationsHtml}}`);
+}}
+if (!optionsHtml.includes('Vie &lt;script&gt;alert(1)&lt;/script&gt;')) {{
+  throw new Error(`escaped option fixture missing: ${{optionsHtml}}`);
+}}
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(["node", str(script)], check=True)


### PR DESCRIPTION
### Motivation
- Prevent reflected XSS by avoiding string interpolation of API-provided fields into `innerHTML` in dashboard renderers. 
- Ensure that all life/relationship labels and option values are escaped before being rendered into the DOM. 
- Prefer DOM construction APIs (`createElement`, `textContent`) for table/list rows to make intent explicit and safe. 

### Description
- Reused the existing `escapeHtml()`/safe text helpers and centralized badge escaping, and added small DOM helpers (`appendCell`, `appendEmptyRow`, `clearChildren`) to consistently build table rows without `innerHTML` in `render-lives.js`.
- Replaced vulnerable interpolations in the genealogy relations rendering with explicit DOM creation and `textContent`, and escaped `node.slug` / `node.name` when generating `<option>` elements for `#genealogy-relations-life-filter`.
- Updated other dashboard renderers to avoid unsafe `innerHTML` usage: replaced row/list `innerHTML` with `createElement` + `textContent` in `render-cockpit.js`, `render-conversations.js`, `render-quests.js`, and `render-objectives.js`.
- Added a Node-backed smoke test that mounts a minimal fake `document` and exercises `renderGenealogyTree()` with malicious fixtures containing `<script>` and `<img onerror=...>` to assert the output is escaped (new test in `tests/test_dashboard_static_smoke.py`).

### Testing
- Ran the new smoke test: `pytest -q tests/test_dashboard_static_smoke.py` — passed.
- Performed Node syntax checks: `node --check` on the modified JS files — passed.
- Ran a focused combined test run: `pytest -q tests/test_dashboard.py tests/test_dashboard_static_smoke.py` — two unrelated assertions in `tests/test_dashboard.py` failed (existing template/content expectations), not caused by the JS escaping changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03724b963c832a8466fb1a4be1505d)