### PR TITLE
Add sandbox scoring results to starter skills

### DIFF
--- a/configs/starter_skills.yaml
+++ b/configs/starter_skills.yaml
@@ -1,6 +1,10 @@
 {
   "profiles": {
-    "minimal": ["addition", "subtraction", "multiplication"],
+    "minimal": [
+      "addition",
+      "subtraction",
+      "multiplication"
+    ],
     "assistant": [
       "addition",
       "subtraction",
@@ -19,6 +23,14 @@
       "summary",
       "intent_classification"
     ],
-    "creative": ["summary", "entity_extraction", "planning", "addition"]
+    "creative": [
+      "summary",
+      "entity_extraction",
+      "planning",
+      "addition"
+    ]
+  },
+  "scoring_contract": {
+    "result": "Every generated starter skill must assign a finite numeric sandbox result."
   }
 }

--- a/skills/addition.py
+++ b/skills/addition.py
@@ -4,3 +4,5 @@
 def add(a: float, b: float) -> float:
     """Return the sum of ``a`` and ``b``."""
     return a + b
+
+result = add(1, 2)

--- a/skills/multiplication.py
+++ b/skills/multiplication.py
@@ -4,3 +4,5 @@
 def multiply(a: float, b: float) -> float:
     """Return the product of ``a`` and ``b``."""
     return a * b
+
+result = multiply(2, 3)

--- a/skills/subtraction.py
+++ b/skills/subtraction.py
@@ -4,3 +4,5 @@
 def subtract(a: float, b: float) -> float:
     """Return the difference of ``a`` and ``b``."""
     return a - b
+
+result = subtract(3, 1)

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -20,12 +20,13 @@ from ..memory import ensure_memory_structure, update_score, write_profile
 from ..psyche import Psyche
 from ..life.skill_catalog import refresh_skill_catalog
 
-
 _PSYCHE_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
 _PSYCHE_DEFAULTS = {trait: 0.5 for trait in _PSYCHE_TRAITS}
 _DEFAULT_STARTER_PROFILE = "minimal"
 _BIRTH_SCHEMA_VERSION = 1
-_STARTER_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "starter_skills.yaml"
+_STARTER_CONFIG_PATH = (
+    Path(__file__).resolve().parents[3] / "configs" / "starter_skills.yaml"
+)
 _DEFAULT_STARTER_PROFILES: dict[str, list[str]] = {
     "minimal": ["addition", "subtraction", "multiplication"],
 }
@@ -34,32 +35,37 @@ _SKILL_TEMPLATES: dict[str, str] = {
         '"""Simple addition skill."""\n\n'
         "def add(a: float, b: float) -> float:\n"
         '    """Return the sum of ``a`` and ``b``."""\n'
-        "    return a + b\n"
+        "    return a + b\n\n"
+        "result = add(1, 2)\n"
     ),
     "subtraction": (
         '"""Simple subtraction skill."""\n\n'
         "def subtract(a: float, b: float) -> float:\n"
         '    """Return the difference of ``a`` and ``b``."""\n'
-        "    return a - b\n"
+        "    return a - b\n\n"
+        "result = subtract(3, 1)\n"
     ),
     "multiplication": (
         '"""Simple multiplication skill."""\n\n'
         "def multiply(a: float, b: float) -> float:\n"
         '    """Return the product of ``a`` and ``b``."""\n'
-        "    return a * b\n"
+        "    return a * b\n\n"
+        "result = multiply(2, 3)\n"
     ),
     "validation": (
         '"""Validation helpers for basic input checks."""\n\n'
         "def validate_non_empty_text(text: str) -> bool:\n"
         '    """Return ``True`` when ``text`` contains non-whitespace characters."""\n'
-        "    return bool(text.strip())\n"
+        '    return text.strip() != ""\n\n'
+        'result = 1.0 if validate_non_empty_text("ready") else 0.0\n'
     ),
     "summary": (
         '"""Summary helpers for short text snippets."""\n\n'
         "def summarize_preview(text: str, max_words: int = 12) -> str:\n"
         '    """Return the first ``max_words`` words from ``text`` for quick previews."""\n'
         "    words = text.split()\n"
-        "    return \" \".join(words[:max_words])\n"
+        '    return " ".join(words[:max_words])\n\n'
+        'result = len(summarize_preview("one two three").split())\n'
     ),
     "intent_classification": (
         '"""Intent classification helper using simple keyword heuristics."""\n\n'
@@ -68,25 +74,27 @@ _SKILL_TEMPLATES: dict[str, str] = {
         "    lowered = message.strip().lower()\n"
         "    if not lowered:\n"
         '        return "statement"\n'
-        "    if lowered.endswith(\"?\"):\n"
+        '    if lowered.endswith("?"):\n'
         '        return "question"\n'
-        "    request_markers = (\"please\", \"peux-tu\", \"merci de\", \"fais\")\n"
+        '    request_markers = ("please", "peux-tu", "merci de", "fais")\n'
         "    if any(marker in lowered for marker in request_markers):\n"
         '        return "request"\n'
-        '    return "statement"\n'
+        '    return "statement"\n\n'
+        'result = 1.0 if classify_intent("please help") == "request" else 0.0\n'
     ),
     "entity_extraction": (
         '"""Entity extraction helper for lightweight token detection."""\n\n'
         "def extract_capitalized_entities(text: str) -> list[str]:\n"
         '    """Return unique capitalized tokens found in ``text`` preserving order."""\n'
         "    entities: list[str] = []\n"
-        "    seen: set[str] = set()\n"
+        "    seen: list[str] = []\n"
         "    for token in text.split():\n"
-        "        cleaned = token.strip(\".,;:!?()[]{}\\\"'\")\n"
+        '        cleaned = token.strip(".,;:!?()[]{}\\"\'")\n'
         "        if cleaned and cleaned[0].isupper() and cleaned not in seen:\n"
         "            entities.append(cleaned)\n"
-        "            seen.add(cleaned)\n"
-        "    return entities\n"
+        "            seen.append(cleaned)\n"
+        "    return entities\n\n"
+        'result = len(extract_capitalized_entities("Ada Lovelace wrote Notes"))\n'
     ),
     "planning": (
         '"""Planning helper to build a simple ordered checklist."""\n\n'
@@ -97,7 +105,8 @@ _SKILL_TEMPLATES: dict[str, str] = {
         '        "goal": goal.strip(),\n'
         '        "steps": cleaned_steps,\n'
         '        "total_steps": len(cleaned_steps),\n'
-        "    }\n"
+        "    }\n\n"
+        'result = build_plan("learn", ["read", "practice"])["total_steps"]\n'
     ),
     "metrics": (
         '"""Metrics helper to compute simple completion ratios."""\n\n'
@@ -106,7 +115,8 @@ _SKILL_TEMPLATES: dict[str, str] = {
         "    if total <= 0:\n"
         "        return 0.0\n"
         "    ratio = completed / total\n"
-        "    return max(0.0, min(1.0, ratio))\n"
+        "    return max(0.0, min(1.0, ratio))\n\n"
+        "result = completion_ratio(1, 2)\n"
     ),
 }
 
@@ -126,14 +136,18 @@ def _resolve_psyche_overrides(
         try:
             value = float(raw_value)
         except (TypeError, ValueError) as exc:
-            raise ValueError(f"invalid psyche trait override for {key}: {raw_value!r}") from exc
+            raise ValueError(
+                f"invalid psyche trait override for {key}: {raw_value!r}"
+            ) from exc
         if not isfinite(value) or value < 0.0 or value > 1.0:
             raise ValueError(f"psyche trait override out of range for {key}: {value!r}")
         normalized[key] = value
     return normalized
 
 
-def _load_starter_profiles(config_path: Path = _STARTER_CONFIG_PATH) -> dict[str, list[str]]:
+def _load_starter_profiles(
+    config_path: Path = _STARTER_CONFIG_PATH,
+) -> dict[str, list[str]]:
     """Load starter skill profiles from configuration with a safe default fallback."""
 
     if not config_path.exists():
@@ -223,7 +237,9 @@ def _build_birth_snapshot(
         "goals": goals_payload,
         "world": world_payload,
     }
-    canonical = json.dumps(initial_state, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    canonical = json.dumps(
+        initial_state, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
     checksum = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     snapshot = {
         "schema_version": _BIRTH_SCHEMA_VERSION,
@@ -312,11 +328,15 @@ def birth(
     goals_init = GoalState().to_dict()
     world_init = default_world_state()
     save_world_state(world_init, path=mem_dir / "world_state.json")
-    _atomic_write_json(mem_dir / "world_effects.json", {"schema_version": 1, "events": []})
+    _atomic_write_json(
+        mem_dir / "world_effects.json", {"schema_version": 1, "events": []}
+    )
 
     snapshot_payload, initial_checksum = _build_birth_snapshot(
         identity_payload=identity.__dict__,
-        psyche_payload=json.loads((mem_dir / "psyche.json").read_text(encoding="utf-8")),
+        psyche_payload=json.loads(
+            (mem_dir / "psyche.json").read_text(encoding="utf-8")
+        ),
         values_payload={"values": values_defaults},
         goals_payload={"schema_version": 1, **goals_init},
         world_payload={"schema_version": 1, **world_init},
@@ -331,7 +351,11 @@ def birth(
         "schema_version": _BIRTH_SCHEMA_VERSION,
         "event_type": "birth_certificate",
         "issued_at": birth_time,
-        "identity": {"id": identity.id, "name": identity.name, "soulseed": identity.soulseed},
+        "identity": {
+            "id": identity.id,
+            "name": identity.name,
+            "soulseed": identity.soulseed,
+        },
         "artifacts": {
             "initial_snapshot": "mem/initial_snapshot.json",
             "psyche_state": "mem/psyche.json",

--- a/tests/test_birth_starter_profiles.py
+++ b/tests/test_birth_starter_profiles.py
@@ -1,4 +1,5 @@
-from singular.organisms.birth import _resolve_starter_skills
+from singular.life.loop import score_code_with_error
+from singular.organisms.birth import _SKILL_TEMPLATES, _resolve_starter_skills
 
 
 def test_resolve_starter_skills_falls_back_to_minimal_profile() -> None:
@@ -10,3 +11,12 @@ def test_resolve_starter_skills_falls_back_to_minimal_profile() -> None:
     resolved = _resolve_starter_skills("does-not-exist", ["summary"], profiles=profiles)
 
     assert resolved == ["addition", "subtraction", "multiplication", "summary"]
+
+
+def test_starter_skill_templates_satisfy_sandbox_scoring_contract() -> None:
+    for skill_name, source in _SKILL_TEMPLATES.items():
+        score = score_code_with_error(source)
+
+        assert (
+            score.ok is True
+        ), f"{skill_name}: {score.error_type} {score.error_message}"

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -23,6 +23,13 @@ from singular.life.reproduction import ReproductionDecisionPolicy  # noqa: E402
 from singular.events import EventBus  # noqa: E402
 
 
+def test_repository_addition_skill_satisfies_sandbox_scoring_contract():
+    assert (
+        life_loop.score_code_with_error(Path("skills/addition.py").read_text()).ok
+        is True
+    )
+
+
 def test_score_code_with_error_returns_structured_sandbox_score():
     ok = life_loop.score_code_with_error("result = 3")
     assert ok == life_loop.SandboxScore(score=3.0)
@@ -279,7 +286,10 @@ def test_reproduction_decision_is_logged_with_cooldown(tmp_path: Path, monkeypat
     )
 
     events_path = tmp_path / "logs" / "repro-loop" / "events.jsonl"
-    events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+    events = [
+        json.loads(line)
+        for line in events_path.read_text(encoding="utf-8").splitlines()
+    ]
     decisions = [
         e["payload"]
         for e in events
@@ -419,7 +429,9 @@ def _stable_psyche(monkeypatch):
         def feel(self, mood):
             pass
 
-    monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: StablePsyche()))
+    monkeypatch.setattr(
+        life_loop.Psyche, "load_state", staticmethod(lambda: StablePsyche())
+    )
 
 
 def _run_sandbox_case(
@@ -468,7 +480,9 @@ def _run_sandbox_case(
 
 
 def _event_payloads(events: list[dict], event_type: str) -> list[dict]:
-    return [event["payload"] for event in events if event.get("event_type") == event_type]
+    return [
+        event["payload"] for event in events if event.get("event_type") == event_type
+    ]
 
 
 def _sandbox_diagnostics(events: list[dict]) -> list[dict]:
@@ -538,7 +552,9 @@ def test_base_failure_remains_critical_violation(tmp_path: Path, monkeypatch):
     assert breaker["severity"] == "critical"
 
 
-def test_dangerous_mutation_failure_can_escalate_to_critical(tmp_path: Path, monkeypatch):
+def test_dangerous_mutation_failure_can_escalate_to_critical(
+    tmp_path: Path, monkeypatch
+):
     policy = MutationGovernancePolicy(circuit_breaker_threshold=1)
     _state, events = _run_sandbox_case(
         tmp_path,
@@ -896,7 +912,9 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
         def feel(self, mood):
             pass
 
-    monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: StablePsyche()))
+    monkeypatch.setattr(
+        life_loop.Psyche, "load_state", staticmethod(lambda: StablePsyche())
+    )
 
     events: list[dict] = []
     bus = EventBus()
@@ -942,7 +960,10 @@ def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extincti
 
     assert state.iteration >= life_loop.SANDBOX_DEGRADED_MODE_THRESHOLD
     assert events
-    assert events[0]["sandbox_violation_streak"] >= life_loop.SANDBOX_DEGRADED_MODE_THRESHOLD
+    assert (
+        events[0]["sandbox_violation_streak"]
+        >= life_loop.SANDBOX_DEGRADED_MODE_THRESHOLD
+    )
 
     events_path = tmp_path / "logs" / "loop" / "events.jsonl"
     run_events = [
@@ -1037,7 +1058,9 @@ def test_prolonged_sandbox_violation_persistence_triggers_controlled_extinction(
         def feel(self, mood):
             pass
 
-    monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: StablePsyche()))
+    monkeypatch.setattr(
+        life_loop.Psyche, "load_state", staticmethod(lambda: StablePsyche())
+    )
 
     class FailureOnlyMonitor:
         def __init__(self, max_failures: int):


### PR DESCRIPTION
### Motivation
- Ensure starter skills produced by the repository and by bootstrap generate a finite numeric `result` so they score correctly in the sandbox scoring system.
- Make starter skill templates robust to the sandbox's restricted builtins (avoid relying on names not present in the sandbox) so newly bootstrapped lives do not produce sandbox failures.

### Description
- Append explicit numeric `result = ...` assignments to `skills/addition.py`, `skills/subtraction.py` and `skills/multiplication.py` so the repository skills set a sandbox-visible numeric result.
- Update `_SKILL_TEMPLATES` in `src/singular/organisms/birth.py` so generated starter skill files include matching `result` assignments and avoid use of builtins not available in the sandbox (e.g., replace `bool(...)` and `set()` usages with sandbox-safe equivalents).
- Add a `scoring_contract` entry to `configs/starter_skills.yaml` documenting the requirement that starter skills assign a finite numeric `result`.
- Add tests: `test_repository_addition_skill_satisfies_sandbox_scoring_contract` in `tests/test_loop.py` and `test_starter_skill_templates_satisfy_sandbox_scoring_contract` in `tests/test_birth_starter_profiles.py` to assert the sandbox scoring contract for both repo skills and templates.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_loop.py::test_repository_addition_skill_satisfies_sandbox_scoring_contract tests/test_birth_starter_profiles.py` and the tests passed (`3 passed`).
- Ran targeted checks of `score_code_with_error` against the three repository arithmetic skill files and the starter templates during development to verify `ok is True` for each generated/source skill (observed success in the session).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037b21139c832aa0d414ea431b29c4)