### PR TITLE
Handle partial cockpit dashboard failures

### DIFF
--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -63,6 +63,51 @@ const toneByRisk=(el,risk)=>{if(!el){return;}el.classList.remove('status-good','
 const extractHostMetrics=(record)=>{if(record&&typeof record.host_metrics==='object'&&record.host_metrics){return record.host_metrics;}if(record&&typeof record.signals==='object'&&record.signals&&typeof record.signals.host_metrics==='object'){return record.signals.host_metrics;}if(record&&typeof record.payload==='object'&&record.payload&&typeof record.payload.host_metrics==='object'){return record.payload.host_metrics;}return null;};
 
 const operatorSummaryState={context:null,lives:null,eco:null,cockpit:null,essential:null,workItems:null};
+const cockpitFallbackPayload={
+  global_status:'warning',
+  health_score:null,
+  trend:null,
+  accepted_mutation_rate:null,
+  critical_alerts:[],
+  life_liveness_index:null,
+  life_liveness_proofs:[],
+  autonomy_metrics:{decision_quality:{}},
+  behavioral_regulation_metrics:{alerts:{},decision_correlation:{}},
+  vital_timeline:{},
+  skills_lifecycle:{},
+  vital_metrics:{
+    active_objectives:{count:0,items:[]},
+    energy_resources:{},
+    code_generation:{},
+    risks:[],
+  },
+  trajectory:{objectives:{counts:{}},priority_changes:[],objective_narrative_links:[]},
+  daily_skills:{},
+  suggested_actions:[],
+};
+const endpointFallbacks={
+  context:{registry_lives_count:0,registry_state:{}},
+  comparison:{table:[],life_metrics_contract:{counts:{}}},
+  essential:{},
+  cockpit:cockpitFallbackPayload,
+};
+const settledValue=(result,key)=>result.status==='fulfilled'?result.value:endpointFallbacks[key];
+const endpointFailureMessage=result=>{
+  const reason=result.reason;
+  if(reason?.message){return reason.message;}
+  return String(reason||'erreur inconnue');
+};
+const showCockpitEndpointWarnings=failures=>{
+  const banner=byId('stale-data-banner');
+  if(!banner){return;}
+  if(!failures.length){
+    if(!staleTimeoutTasks.size){banner.classList.add('panel-hidden');banner.textContent='';}
+    return;
+  }
+  const labels=failures.map(([key,result])=>`${key}: ${endpointFailureMessage(result)}`).join(' · ');
+  banner.classList.remove('panel-hidden');
+  banner.textContent=`⚠️ Données cockpit partielles : ${labels}. Les données disponibles restent affichées.`;
+};
 
 const firstDefined=(...values)=>values.find(value=>value!==null&&value!==undefined&&value!=='');
 const formatOneDecimal=value=>value===null||value===undefined||Number.isNaN(Number(value))?na():Number(value).toFixed(1);
@@ -375,12 +420,20 @@ export const loadHostVitals=()=>fetchJson(withScope('/runs/latest')).then(data=>
   if(!hasData){setPanelState('host-vitals-panel','empty','Capteurs hôte non supportés ou données absentes.');}
 }).catch(error=>{renderHostMetrics([]);throw error;});
 
-export const loadCockpit=()=>Promise.all([
+export const loadCockpit=()=>Promise.allSettled([
   fetchSharedDashboardContext(),
   fetchSharedLivesComparison(),
   fetchSharedCockpitEssential(),
   fetchJson(withScope('/api/cockpit')),
-]).then(([ctx,lives,essential,d])=>{
+]).then(results=>{
+  const endpointKeys=['context','comparison','essential','cockpit'];
+  const failures=results.map((result,index)=>[endpointKeys[index],result]).filter(([,result])=>result.status==='rejected');
+  showCockpitEndpointWarnings(failures);
+  const [ctxResult,livesResult,essentialResult,cockpitResult]=results;
+  const ctx=settledValue(ctxResult,'context');
+  const lives=settledValue(livesResult,'comparison');
+  const essential=settledValue(essentialResult,'essential');
+  const d=settledValue(cockpitResult,'cockpit');
   if(!d||typeof d!=='object'){setPanelState('cockpit','empty','Aucune donnée cockpit disponible.');return;}
   const essentialPayload=(essential&&typeof essential==='object')?essential:{};
   operatorSummaryState.context=ctx||operatorSummaryState.context;
@@ -396,10 +449,10 @@ export const loadCockpit=()=>Promise.all([
 
   renderSandboxGovernance(d.sandbox_governance||{});
   renderGovernanceDiagnostics(d.governance_policy||{});
-  const healthValue=d.health_score===null?na():Number(d.health_score).toFixed(1);
+  const healthValue=d.health_score===null||d.health_score===undefined?na():Number(d.health_score).toFixed(1);
   const trend=d.trend||na();
-  const accepted=d.accepted_mutation_rate===null?na():`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
-  const alertsCount=Number(essentialPayload.critical_alerts_count??(d.critical_alerts||[]).length||0);
+  const accepted=d.accepted_mutation_rate===null||d.accepted_mutation_rate===undefined?na():`${(d.accepted_mutation_rate*100).toFixed(1)}%`;
+  const alertsCount=Number(essentialPayload.critical_alerts_count??((d.critical_alerts||[]).length||0));
   const livenessIndex=d.life_liveness_index===null||d.life_liveness_index===undefined?na():Number(d.life_liveness_index).toFixed(1);
   const livenessProofs=Array.isArray(d.life_liveness_proofs)?d.life_liveness_proofs:[];
   const autonomy=d.autonomy_metrics||{};

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -170,3 +170,123 @@ if (!optionsHtml.includes('Vie &lt;script&gt;alert(1)&lt;/script&gt;')) {{
     )
 
     subprocess.run(["node", str(script)], check=True)
+
+
+def test_cockpit_loader_keeps_available_data_when_cockpit_endpoint_fails(tmp_path: Path) -> None:
+    """Exercise the cockpit loader against a failed /api/cockpit response."""
+    script = tmp_path / "cockpit_partial_failure_check.mjs"
+    module_path = (Path.cwd() / DASHBOARD_STATIC / "render-cockpit.js").as_uri()
+    script.write_text(
+        f"""
+class ClassList {{
+  constructor() {{ this.values = new Set(); }}
+  add(...names) {{ for (const name of names) {{ this.values.add(name); }} }}
+  remove(...names) {{ for (const name of names) {{ this.values.delete(name); }} }}
+  toggle(name, force) {{
+    const shouldAdd = force === undefined ? !this.values.has(name) : Boolean(force);
+    if (shouldAdd) {{ this.values.add(name); }} else {{ this.values.delete(name); }}
+    return shouldAdd;
+  }}
+  contains(name) {{ return this.values.has(name); }}
+}}
+
+class Element {{
+  constructor(tagName) {{
+    this.tagName = tagName;
+    this.children = [];
+    this.dataset = {{}};
+    this.attributes = {{}};
+    this.classList = new ClassList();
+    this._textContent = '';
+    this._innerHTML = null;
+    this.value = '';
+    this.disabled = false;
+    this.eventListeners = {{}};
+  }}
+  appendChild(child) {{ this.children.push(child); this._innerHTML = null; return child; }}
+  insertBefore(child, before) {{
+    const index = this.children.indexOf(before);
+    if (index < 0) {{ this.children.unshift(child); }} else {{ this.children.splice(index, 0, child); }}
+    this._innerHTML = null;
+    return child;
+  }}
+  replaceChildren(...children) {{ this.children = []; this._textContent = ''; this._innerHTML = null; for (const child of children) {{ this.appendChild(child); }} }}
+  querySelector() {{ return this.children.find(child => child.className === 'state-layer') ?? null; }}
+  addEventListener(type, handler) {{ this.eventListeners[type] = handler; }}
+  setAttribute(name, value) {{ this.attributes[name] = String(value); }}
+  set textContent(value) {{ this._textContent = String(value ?? ''); this.children = []; this._innerHTML = null; }}
+  get textContent() {{ return this._textContent + this.children.map(child => child.textContent ?? '').join(''); }}
+  set innerHTML(value) {{ this._innerHTML = String(value ?? ''); this.children = []; this._textContent = ''; }}
+  get innerHTML() {{ return this._innerHTML !== null ? this._innerHTML : this.textContent; }}
+  set className(value) {{ this.attributes.class = String(value); if (value === 'state-layer') {{ this._className = value; }} }}
+  get className() {{ return this._className ?? this.attributes.class ?? ''; }}
+  set title(value) {{ this.attributes.title = String(value); }}
+  set colSpan(value) {{ this.attributes.colspan = String(value); }}
+  get firstChild() {{ return this.children[0] ?? null; }}
+  get options() {{ return this.children.filter(child => child.tagName === 'option'); }}
+}}
+
+const elements = new Map();
+const ids = [
+  'stale-data-banner','operator-lives-summary','operator-lives-total','operator-selected-life',
+  'operator-alive-lives','operator-risk-lives','operator-last-activity','operator-mood-energy',
+  'operator-trend','operator-liveness','digital-life-status','digital-life-health',
+  'digital-life-active-objectives','digital-life-last-message','digital-life-select',
+  'digital-life-safe-actions','operator-action-life-select','operator-action-help',
+  'critical-current-life-target','cockpit-status','kpi-health','kpi-trend','kpi-accepted',
+  'kpi-alerts','kpi-liveness-index','kpi-next-action','essential-selected-life',
+  'essential-active-incidents','raw-cockpit-json','kpi-actions','daily-skills-table-body',
+  'kpi-active-objectives-list','kpi-priority-changes-list','kpi-objective-links-list',
+  'kpi-liveness-proofs','sandbox-governance-empty','sandbox-breaker-status',
+  'sandbox-recent-violations','sandbox-last-skill','sandbox-cooldown-remaining',
+  'sandbox-corrective-action','governance-breaker-threshold','governance-breaker-window',
+  'governance-breaker-cooldown','governance-safe-mode','governance-mutation-quota',
+  'ctx-governance-diagnostics'
+];
+for (const id of ids) {{ elements.set(id, new Element(id.endsWith('select') ? 'select' : 'div')); }}
+
+globalThis.document = {{
+  createElement: tagName => new Element(tagName),
+  getElementById: id => elements.get(id) ?? null,
+}};
+globalThis.window = {{ location: {{ origin: 'http://localhost' }}, dispatchEvent() {{}} }};
+globalThis.CustomEvent = class CustomEvent {{ constructor(type, init) {{ this.type = type; this.detail = init?.detail; }} }};
+
+globalThis.fetch = async url => {{
+  const path = String(url);
+  if (path.startsWith('/dashboard/context')) {{
+    return {{ ok: true, json: async () => ({{registry_lives_count: 2, registry_state: {{active: 'alpha'}}}}) }};
+  }}
+  if (path.startsWith('/lives/comparison')) {{
+    return {{ ok: true, json: async () => ({{
+      table: [{{life: 'alpha', selected_life: true, current_health_score: 88.4, last_activity: '2026-05-12T10:00:00Z', life_status: 'active', life_liveness_index: 91.2}}],
+      life_metrics_contract: {{counts: {{total_lives: 2, alive_lives: 1, dead_lives: 1}}}},
+    }}) }};
+  }}
+  if (path.startsWith('/api/cockpit/essential')) {{
+    return {{ ok: true, json: async () => ({{global_status: 'stable', selected_life: 'alpha', next_action: 'observer'}}) }};
+  }}
+  if (path.startsWith('/api/cockpit')) {{
+    return {{ ok: false, status: 503, json: async () => ({{detail: 'boom'}}) }};
+  }}
+  throw new Error(`unexpected fetch ${{path}}`);
+}};
+
+const {{ loadCockpit }} = await import('{module_path}');
+await loadCockpit();
+
+const total = elements.get('operator-lives-total').textContent;
+const selected = elements.get('operator-selected-life').textContent;
+const health = elements.get('digital-life-health').textContent;
+const banner = elements.get('stale-data-banner').textContent;
+const raw = elements.get('raw-cockpit-json').textContent;
+if (total !== '2') {{ throw new Error(`available context was not rendered: ${{total}}`); }}
+if (!selected.includes('alpha')) {{ throw new Error(`available selected life was not rendered: ${{selected}}`); }}
+if (health === 'Chargement…' || health !== '88.4') {{ throw new Error(`available life metrics were not rendered: ${{health}}`); }}
+if (!banner.includes('Données cockpit partielles') || !banner.includes('cockpit: HTTP 503')) {{ throw new Error(`warning banner missing: ${{banner}}`); }}
+if (!raw.includes('"global_status": "warning"')) {{ throw new Error(`fallback cockpit payload missing: ${{raw}}`); }}
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(["node", str(script)], check=True)


### PR DESCRIPTION
### Motivation
- The cockpit loader used `Promise.all(...)` and would block rendering the entire dashboard when a single cockpit-related endpoint failed.
- The goal is to surface a non-blocking partial-data warning while preserving rendering of any data that successfully loaded (e.g. registry / lives metrics).

### Description
- Replaced `Promise.all([...])` with `Promise.allSettled([...])` in `loadCockpit()` inside `src/singular/dashboard/static/render-cockpit.js` and treat each settled result independently.
- Added typed fallback payloads for endpoints: `context`, `comparison` (lives), `essential`, and a minimal `cockpit` payload used when an endpoint rejects, and a `settledValue()` helper to pick fallback values when needed.
- Show a non-blocking warning in the `stale-data-banner` when one or more cockpit endpoints fail, and keep rendering available data (operator summary, lives, etc.) using the settled/fallback values.
- Hardened a few numeric/nullable expressions (e.g. `health_score`, `accepted_mutation_rate`, `alertsCount`) to avoid syntax/NaN issues when using fallback payloads.
- Added a static Node-backed smoke test `test_cockpit_loader_keeps_available_data_when_cockpit_endpoint_fails` in `tests/test_dashboard_static_smoke.py` that simulates `/api/cockpit` returning HTTP 503 and verifies other dashboard data still renders and a partial-data banner is shown.

### Testing
- Ran the new static smoke test: `pytest -q tests/test_dashboard_static_smoke.py`, which passed (all tests in that file passed).
- Ran targeted dashboard tests: `pytest -q tests/test_dashboard.py::test_dashboard_cockpit_endpoint_schema tests/test_dashboard.py::test_dashboard_index_contains_cockpit_cards`, which passed.
- Verified the new smoke test (`test_cockpit_loader_keeps_available_data_when_cockpit_endpoint_fails`) passes when executed with Node in the test harness (assertions in the test succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0381e73b14832aa776d9f4237f6dbc)