### PR TITLE
Améliorer l’état des actions critiques quand le registre est vide

### DIFF
--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -34,6 +34,14 @@ const hasValidSelectedLife=()=>{
   return lives.size===0?false:lives.has(selected);
 };
 
+const operatorRegistryState=()=>{
+  const select=operatorLifeSelect();
+  if(!select){return 'loading';}
+  if(select.dataset.registryState!=='loaded'){return 'loading';}
+  if(validOperatorLives().size===0){return 'empty';}
+  return hasValidSelectedLife()?'valid':'invalid';
+};
+
 const updateCriticalTargetLabel=()=>{
   const target=document.getElementById('critical-current-life-target');
   if(!target){return;}
@@ -58,20 +66,32 @@ const setActionHelp=text=>{
 const requiresValidLife=action=>['archive','talk','emergency_stop','lives_use','memorial','clone'].includes(action);
 
 export const updateOperatorActionState=()=>{
-  const hasSelection=hasValidSelectedLife();
-  const select=operatorLifeSelect();
   syncOperatorSelectToShared();
+  const registryState=operatorRegistryState();
+  const hasSelection=registryState==='valid';
   const selected=selectedOperatorLife();
   const help=document.getElementById('operator-action-help');
-  const helpText=hasSelection
-    ? `Vie ciblée: ${selected}. “Supprimer/archiver” et “Parler” sont disponibles.`
-    : 'Sélectionnez une vie existante pour activer “Supprimer/archiver” et “Parler”.';
+  const helpMessages={
+    loading:'Les données de vies n’ont pas encore chargé',
+    empty:'Aucune vie détectée dans le registre',
+    invalid:'Sélectionnez une vie valide dans le registre pour activer “Supprimer/archiver” et “Parler”.',
+    valid:`Vie ciblée: ${selected}. “Supprimer/archiver” et “Parler” sont disponibles.`,
+  };
+  const helpText=helpMessages[registryState]||helpMessages.invalid;
   if(help){help.textContent=helpText;}
   updateCriticalTargetLabel();
-  ['critical-archive','critical-talk','critical-emergency-stop','act-archive','act-talk','act-lives-use','act-memorial','act-clone'].forEach(id=>{
+  ['critical-birth','act-birth'].forEach(id=>{
     const button=document.getElementById(id);
     if(!button){return;}
     button.disabled=false;
+    button.classList.remove('is-disabled');
+    button.setAttribute('aria-disabled','false');
+    button.title=birthName()?'Créer la vie nommée dans le champ “Nom exact à créer”':'Saisissez un nom dans “Nom exact à créer” pour créer une vie.';
+  });
+  ['critical-archive','critical-talk','critical-emergency-stop','act-archive','act-talk','act-lives-use','act-memorial','act-clone'].forEach(id=>{
+    const button=document.getElementById(id);
+    if(!button){return;}
+    button.disabled=!hasSelection;
     button.classList.toggle('is-disabled',!hasSelection);
     button.setAttribute('aria-disabled',hasSelection?'false':'true');
     button.title=hasSelection?'':helpText;
@@ -82,6 +102,7 @@ export const updateOperatorLifeOptions=(rows=[])=>{
   const select=operatorLifeSelect();
   if(!select){return;}
   const previous=select.value;
+  select.dataset.registryState='loaded';
   const names=[...new Set((rows||[]).map(row=>{
     if(typeof row==='string'){return row;}
     return row?.life||row?.slug||row?.name||'';

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -26,21 +26,25 @@
 
 <section class='critical-actions-bar' aria-label='Actions critiques'>
   <span id='critical-current-life-target' class='critical-target-badge' aria-live='polite'>Vie ciblée: aucune sélection</span>
-  <button id='critical-birth' type='button' class='critical-action-btn' data-dashboard-action='birth'>Créer une vie</button>
+  <button id='critical-birth' type='button' class='critical-action-btn' data-dashboard-action='birth' aria-disabled='false'>Créer une vie</button>
   <button
     id='critical-archive'
     type='button'
     class='critical-action-btn critical-action-warning'
+    disabled
+    aria-disabled='true'
     data-dashboard-action='archive'
     data-confirm="Confirmer la suppression/l’archivage ? Portée : la vie ciblée et ses données associées (historique, artefacts, contexte)."
   >
     Supprimer/archiver une vie
   </button>
-  <button id='critical-talk' type='button' class='critical-action-btn' data-dashboard-action='talk'>Parler à une vie</button>
+  <button id='critical-talk' type='button' class='critical-action-btn' data-dashboard-action='talk' disabled aria-disabled='true'>Parler à une vie</button>
   <button
     id='critical-emergency-stop'
     type='button'
     class='critical-action-btn critical-action-danger'
+    disabled
+    aria-disabled='true'
     data-dashboard-action='emergency_stop'
     data-confirm="ARRÊT D’URGENCE : cette action stoppe immédiatement les opérations en cours. Confirmez-vous ?"
     data-confirm-again="DOUBLE VALIDATION — Confirmez à nouveau l’arrêt d’urgence global."
@@ -51,8 +55,8 @@
 <section class='operator-action-form' aria-label='Paramètres opérateur des actions critiques'>
   <div class='operator-field'>
     <label for='operator-action-life-select'>Vie ciblée</label>
-    <select id='operator-action-life-select' aria-describedby='operator-action-help'>
-      <option value=''>Sélectionner une vie existante…</option>
+    <select id='operator-action-life-select' aria-describedby='operator-action-help' data-registry-state='loading'>
+      <option value=''>Chargement des vies…</option>
     </select>
   </div>
   <div class='operator-field operator-birth-field'>
@@ -63,7 +67,7 @@
     <label for='operator-action-message'>Message pour “Parler à une vie”</label>
     <textarea id='operator-action-message' rows='2' placeholder='Écrire le message à envoyer à la vie sélectionnée…'></textarea>
   </div>
-  <p id='operator-action-help' class='operator-action-help' role='status' aria-live='polite'>Sélectionnez une vie existante pour activer “Supprimer/archiver” et “Parler”.</p>
+  <p id='operator-action-help' class='operator-action-help' role='status' aria-live='polite'>Les données de vies n’ont pas encore chargé</p>
 </section>
 <div id='critical-action-result' class='critical-action-result' role='status' aria-live='polite'>Aucune action critique exécutée.</div>
 

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -471,3 +471,86 @@ if (!result.textContent.includes('Saisissez le nom exact')) {{ throw new Error(`
     )
 
     subprocess.run(["node", str(script)], check=True)
+
+
+def test_empty_lives_comparison_keeps_birth_action_enabled(tmp_path: Path) -> None:
+    """Critical birth action remains usable when /lives/comparison has no lives."""
+    script = tmp_path / "empty_lives_birth_action_check.mjs"
+    module_path = (Path.cwd() / DASHBOARD_STATIC / "actions.js").as_uri()
+    script.write_text(
+        f"""
+class ClassList {{
+  constructor() {{ this.values = new Set(); }}
+  add(...names) {{ names.forEach(name => this.values.add(name)); }}
+  remove(...names) {{ names.forEach(name => this.values.delete(name)); }}
+  toggle(name, force) {{
+    const shouldAdd = force === undefined ? !this.values.has(name) : Boolean(force);
+    if (shouldAdd) {{ this.values.add(name); }} else {{ this.values.delete(name); }}
+    return shouldAdd;
+  }}
+  contains(name) {{ return this.values.has(name); }}
+}}
+
+class Element {{
+  constructor(tagName, id = '') {{
+    this.tagName = tagName.toUpperCase();
+    this.id = id;
+    this.children = [];
+    this.dataset = {{}};
+    this.attributes = {{}};
+    this.classList = new ClassList();
+    this.value = '';
+    this.disabled = false;
+    this._textContent = '';
+    this._innerHTML = null;
+  }}
+  appendChild(child) {{ this.children.push(child); return child; }}
+  addEventListener() {{}}
+  setAttribute(name, value) {{ this.attributes[name] = String(value); }}
+  getAttribute(name) {{ return this.attributes[name] ?? null; }}
+  set textContent(value) {{ this._textContent = String(value ?? ''); this.children = []; this._innerHTML = null; }}
+  get textContent() {{ return this._textContent + this.children.map(child => child.textContent ?? '').join(''); }}
+  set innerHTML(value) {{ this._innerHTML = String(value ?? ''); this.children = []; this._textContent = ''; }}
+  get innerHTML() {{ return this._innerHTML ?? this.textContent; }}
+  set title(value) {{ this.attributes.title = String(value); }}
+  get title() {{ return this.attributes.title ?? ''; }}
+  get options() {{ return this.children.filter(child => child.tagName === 'OPTION'); }}
+}}
+
+const elements = new Map();
+const register = (tagName, id) => {{ const el = new Element(tagName, id); elements.set(id, el); return el; }};
+register('select', 'operator-action-life-select').dataset.registryState = 'loading';
+register('p', 'operator-action-help');
+register('span', 'critical-current-life-target');
+register('input', 'operator-birth-name').value = 'Nouvelle Vie';
+const birth = register('button', 'critical-birth');
+const archive = register('button', 'critical-archive');
+const talk = register('button', 'critical-talk');
+const emergency = register('button', 'critical-emergency-stop');
+register('div', 'critical-action-result');
+
+globalThis.document = {{
+  createElement: tagName => new Element(tagName),
+  getElementById: id => elements.get(id) ?? null,
+}};
+globalThis.window = {{ dispatchEvent() {{}} }};
+globalThis.CustomEvent = class CustomEvent {{ constructor(type, init) {{ this.type = type; this.detail = init?.detail; }} }};
+
+const {{ updateOperatorLifeOptions }} = await import('{module_path}');
+const emptyComparison = {{ table: [] }};
+updateOperatorLifeOptions(emptyComparison.table);
+
+const help = elements.get('operator-action-help').textContent;
+if (help !== 'Aucune vie détectée dans le registre') {{ throw new Error(`unexpected help message: ${{help}}`); }}
+if (birth.disabled) {{ throw new Error('Créer une vie was disabled for an empty /lives/comparison table'); }}
+if (birth.getAttribute('aria-disabled') !== 'false') {{ throw new Error('Créer une vie was not exposed as active'); }}
+if (birth.classList.contains('is-disabled')) {{ throw new Error('Créer une vie looked disabled'); }}
+for (const [label, button] of [['archive', archive], ['talk', talk], ['emergency_stop', emergency]]) {{
+  if (!button.disabled) {{ throw new Error(`${{label}} should be disabled without a valid life`); }}
+  if (button.getAttribute('aria-disabled') !== 'true') {{ throw new Error(`${{label}} aria-disabled missing`); }}
+}}
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(["node", str(script)], check=True)


### PR DESCRIPTION
### Motivation
- Clarifier l’état des actions critiques selon l’état du registre (chargement, registre vide, sélection invalide, sélection valide) pour éviter des actions dangereuses sans contexte valide.
- Permettre explicitement la création d’une vie (`birth`) même si le registre n’a pas encore rendu de vies.
- Fournir des messages d’aide concrets pour guider l’opérateur quand les données ne sont pas prêtes.

### Description
- Ajout de `operatorRegistryState()` et adaptation de `updateOperatorActionState()` dans `src/singular/dashboard/static/actions.js` pour distinguer `loading`, `empty`, `invalid` et `valid` et afficher les messages demandés dans `#operator-action-help`.
- Modification de la logique d’activation des boutons pour que `birth`/`act-birth` restent utilisables indépendamment du registre, et pour que `archive`, `talk`, `emergency_stop` (et actions dépendantes d’une vie) soient réellement désactivés (`button.disabled = true`) quand aucune vie valide n’est disponible.
- Initialisation HTML mise à jour dans `src/singular/dashboard/templates/dashboard.html` pour indiquer l’état de chargement du sélecteur (`data-registry-state='loading'`) et marquer par défaut les boutons critiques dépendants d’une vie comme désactivés.
- `updateOperatorLifeOptions()` met désormais `select.dataset.registryState='loaded'` lorsqu’un retour `/lives/comparison` est traité.
- Ajout d’un test UI/statique dans `tests/test_dashboard_static_smoke.py` qui simule une table vide retournée par `/lives/comparison` et vérifie que le message d’aide est `Aucune vie détectée dans le registre`, que `Créer une vie` reste actif, et que `archive`, `talk`, `emergency_stop` sont désactivés.

### Testing
- Exécution ciblée du test ajouté `test_empty_lives_comparison_keeps_birth_action_enabled` a réussi (`pytest -q tests/test_dashboard_static_smoke.py::test_empty_lives_comparison_keeps_birth_action_enabled`).
- Exécution complète de la suite statique UI `tests/test_dashboard_static_smoke.py` a réussi (`pytest -q tests/test_dashboard_static_smoke.py` → all tests passed: 7 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03859f6138832aae49d874b2e74234)