### PR TITLE
Mapper les ancres historiques du dashboard vers les onglets

### DIFF
--- a/src/singular/dashboard/static/bootstrap.js
+++ b/src/singular/dashboard/static/bootstrap.js
@@ -248,6 +248,16 @@ const toggleEssentialMode=()=>{
 
 const DASHBOARD_TAB_KEY='singular.dashboard.lastTab';
 const DASHBOARD_TECHNICAL_DETAILS_KEY='singular.dashboard.technicalDetails';
+const DEFAULT_DASHBOARD_TAB='decider-maintenant';
+const LEGACY_DASHBOARD_ANCHORS={
+  'cockpit':'decider-maintenant',
+  'conversations-section':'decider-maintenant',
+  'timeline-section':'diagnostiquer',
+  'vies':'comparer-vies',
+  'parametres':'technique',
+  'logs-live':'technique',
+  'reflections-section':'technique',
+};
 
 const applyTechnicalDetailsVisibility=isEnabled=>{
   document.body.dataset.dashboardMode=isEnabled?'expert':'operator';
@@ -292,13 +302,23 @@ const activateDashboardTab=tabId=>{
   }
 };
 
+const normalizeDashboardTabHash=(hash,validTabs)=>{
+  const raw=(hash||'').replace(/^#/,'');
+  if(!raw){return '';}
+  const candidate=raw.startsWith('tab-')?raw.slice(4):LEGACY_DASHBOARD_ANCHORS[raw];
+  return candidate&&validTabs.has(candidate)?candidate:DEFAULT_DASHBOARD_TAB;
+};
+
 const bindTabNavigation=()=>{
   const triggers=document.querySelectorAll('.tab-trigger');
   if(!triggers.length){return;}
-  triggers.forEach(trigger=>{trigger.onclick=()=>activateDashboardTab(trigger.dataset.tab||'decider-maintenant');});
-  const fromHash=(window.location.hash||'').replace('#tab-','');
+  const validTabs=new Set(Array.from(triggers).map(trigger=>trigger.dataset.tab).filter(Boolean));
+  const activateFromHash=()=>activateDashboardTab(normalizeDashboardTabHash(window.location.hash,validTabs)||DEFAULT_DASHBOARD_TAB);
+  triggers.forEach(trigger=>{trigger.onclick=()=>activateDashboardTab(trigger.dataset.tab||DEFAULT_DASHBOARD_TAB);});
+  window.addEventListener('hashchange',activateFromHash);
+  const fromHash=normalizeDashboardTabHash(window.location.hash,validTabs);
   const fromStorage=localStorage.getItem(DASHBOARD_TAB_KEY)||'';
-  activateDashboardTab(fromHash||fromStorage||'decider-maintenant');
+  activateDashboardTab(fromHash||(validTabs.has(fromStorage)?fromStorage:'')||DEFAULT_DASHBOARD_TAB);
 };
 
 const bindCommonHandlers=()=>{

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -6,11 +6,10 @@
 <body>
 <h1>Tableau de bord Singular</h1>
 <nav aria-label='Navigation rapide'>
-  <a href='#cockpit'>#cockpit</a>
-  <a href='#timeline-section'>#timeline-section</a>
-  <a href='#vies'>#vies</a>
-  <a href='#logs-live'>#logs-live</a>
-  <a href='#parametres'>#parametres</a>
+  <a href='#tab-decider-maintenant'>Décider maintenant</a>
+  <a href='#tab-diagnostiquer'>Diagnostiquer</a>
+  <a href='#tab-comparer-vies'>Comparer les vies</a>
+  <a href='#tab-technique'>Technique</a>
 </nav>
 <nav>
   <strong>Vues :</strong>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -710,13 +710,12 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "Qu’est-ce que ce score ?" in body
     assert "Pourquoi cette alerte ?" in body
     assert "Navigation" in body
-    assert "#cockpit" in body
-    assert "#timeline-section" in body
+    assert "#tab-decider-maintenant" in body
+    assert "#tab-diagnostiquer" in body
     assert "Timeline des réflexions" in body
     assert "reflection-objective" in body
-    assert "#vies" in body
-    assert "#logs-live" in body
-    assert "#parametres" in body
+    assert "#tab-comparer-vies" in body
+    assert "#tab-technique" in body
     assert "Registre courant (SINGULAR_ROOT)" in body
     assert "Vie courante (SINGULAR_HOME)" in body
     assert "Nombre de vies détectées" in body

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -60,6 +60,34 @@ def test_dashboard_quests_websocket_targets_existing_raw_panel() -> None:
     assert "getElementById('quests-json-raw')" in bootstrap or "loadQuests()" in bootstrap
 
 
+def test_dashboard_tab_navigation_supports_legacy_hashes() -> None:
+    bootstrap = (DASHBOARD_STATIC / "bootstrap.js").read_text(encoding="utf-8")
+    template = DASHBOARD_TEMPLATE.read_text(encoding="utf-8")
+
+    for legacy_anchor, tab in {
+        "cockpit": "decider-maintenant",
+        "conversations-section": "decider-maintenant",
+        "timeline-section": "diagnostiquer",
+        "vies": "comparer-vies",
+        "parametres": "technique",
+        "logs-live": "technique",
+        "reflections-section": "technique",
+    }.items():
+        assert f"'{legacy_anchor}':'{tab}'" in bootstrap
+
+    assert "raw.startsWith('tab-')" in bootstrap
+    assert "DEFAULT_DASHBOARD_TAB='decider-maintenant'" in bootstrap
+    for current_tab in [
+        "#tab-decider-maintenant",
+        "#tab-diagnostiquer",
+        "#tab-comparer-vies",
+        "#tab-technique",
+    ]:
+        assert current_tab in template
+    for legacy_href in ["#cockpit", "#timeline-section", "#vies", "#logs-live", "#parametres"]:
+        assert f"href='{legacy_href}'" not in template
+
+
 def test_genealogy_renderer_escapes_malicious_life_names(tmp_path: Path) -> None:
     """Exercise the genealogy DOM renderer with a life name that looks like XSS."""
     script = tmp_path / "genealogy_escape_check.mjs"


### PR DESCRIPTION
### Motivation

- Préserver la compatibilité des liens historiques (`#cockpit`, `#timeline-section`, `#vies`, `#parametres`, etc.) avec la navigation par onglets actuelle qui utilise des `data-tab` et des ancres `#tab-*`. 

### Description

- Ajout d’une table de correspondance `LEGACY_DASHBOARD_ANCHORS` et d’une constante `DEFAULT_DASHBOARD_TAB` dans `src/singular/dashboard/static/bootstrap.js` pour résoudre les ancres legacy vers les `data-tab` actuels. 
- Implémentation de `normalizeDashboardTabHash` et modification de `bindTabNavigation()` pour normaliser `window.location.hash` (retirer `#`, gérer le préfixe `tab-`, rechercher dans la table legacy, valider auprès des onglets disponibles et fallback sur `decider-maintenant`) et écouter les changements de hash via `hashchange`. 
- Mise à jour des liens rapides dans `src/singular/dashboard/templates/dashboard.html` pour pointer vers les ancres `#tab-*` ou vers des liens activant explicitement les onglets. 
- Mise à jour/ajout de tests: adaptation d’assertions dans `tests/test_dashboard.py` et ajout de `test_dashboard_tab_navigation_supports_legacy_hashes` dans `tests/test_dashboard_static_smoke.py` pour vérifier la table de correspondance et les nouveaux liens. 

### Testing

- Exécution ciblée de `pytest tests/test_dashboard.py::test_dashboard_index_contains_cockpit_cards tests/test_dashboard_static_smoke.py` a réussi avec toutes les assertions vertes (`9 passed`).
- `git diff --check` a été exécuté et n’a retourné aucune erreur de style ou conflit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038a426e40832ab3b401d28853f971)