### PR TITLE
Fusionner les vies du registre avec les métriques de comparaison pour les options opérateur

### DIFF
--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -98,6 +98,49 @@ export const updateOperatorActionState=()=>{
   });
 };
 
+
+const lifeRowName=row=>{
+  if(typeof row==='string'){return row;}
+  return row?.life||row?.slug||row?.name||'';
+};
+
+const mergeDefined=(base,extra)=>{
+  const merged={...base};
+  for(const [key,value] of Object.entries(extra||{})){
+    if(value!==undefined&&value!==null){merged[key]=value;}
+  }
+  return merged;
+};
+
+export const mergeLifeRows=(context={},comparison={})=>{
+  const rowsByLife=new Map();
+  const pushRow=(life,row)=>{
+    const key=String(life||'').trim();
+    if(!key){return;}
+    rowsByLife.set(key,mergeDefined(rowsByLife.get(key)||{},row));
+  };
+  const registryLives=Array.isArray(context?.registry_lives)?context.registry_lives:[];
+  for(const item of registryLives){
+    const slug=String(item?.slug||'').trim();
+    const name=String(item?.name||'').trim();
+    const life=slug||name;
+    pushRow(life,{
+      life,
+      slug,
+      name,
+      status:item?.status,
+      active:item?.active,
+    });
+  }
+  const comparisonRows=Array.isArray(comparison?.table)?comparison.table:[];
+  for(const row of comparisonRows){
+    const candidates=[row?.life,row?.slug,row?.name].map(value=>String(value||'').trim()).filter(Boolean);
+    const life=candidates.find(candidate=>rowsByLife.has(candidate))||candidates[0]||lifeRowName(row);
+    pushRow(life,row);
+  }
+  return [...rowsByLife.values()];
+};
+
 export const updateOperatorLifeOptions=(rows=[])=>{
   const select=operatorLifeSelect();
   if(!select){return;}

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -1,6 +1,6 @@
 import {fetchJson,withScope} from './api.js';
 import {fetchSharedDashboardContext,fetchSharedLivesComparison,fetchSharedCockpitEssential} from './dashboard-data.js';
-import {updateOperatorLifeOptions} from './actions.js';
+import {mergeLifeRows,updateOperatorLifeOptions} from './actions.js';
 import {HOST_SENSORS_THRESHOLD,na,setPanelState,setStatusTone,applyStatusIndicator,getSelectedLife,setSelectedLife,staleTimeoutTasks} from './state.js';
 import {renderQuestsSection} from './render-quests.js';
 import {renderObjectivesSection} from './render-objectives.js';
@@ -390,7 +390,7 @@ export const loadRetentionStatus=()=>fetchJson('/api/retention/status').then(pay
   setText('kpi-retention-thresholds',exceeded.length?`${thresholdLabel} · dépassement: ${exceeded.join(', ')}`:thresholdLabel);
 });
 
-export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchSharedLivesComparison()]).then(([eco,lives])=>{
+export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchSharedDashboardContext(),fetchSharedLivesComparison()]).then(([eco,context,lives])=>{
   const contract=eco.life_metrics_contract||lives.life_metrics_contract||{};
   const counts=contract.counts||{};
   const labels=contract.labels||{};
@@ -401,8 +401,9 @@ export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchSh
   setText('eco-alive-lives',String(alive));
   setText('eco-dead-lives',String(dead));
   operatorSummaryState.eco=eco;
+  operatorSummaryState.context=context;
   operatorSummaryState.lives=lives;
-  updateOperatorLifeOptions(lives.table||[]);
+  updateOperatorLifeOptions(mergeLifeRows(context,lives));
   renderOperatorSummary();
   const rows=lives.table||[];
   const selected=rows.find(row=>row.selected_life===true);
@@ -496,10 +497,8 @@ export const loadCockpit=()=>Promise.allSettled([
 
   operatorSummaryState.cockpit={trend,liveness_index:livenessIndex,life_liveness_index:d.life_liveness_index,health_score:d.health_score,selected_life:essentialPayload.selected_life};
   const comparisonAvailable=livesResult.status==='fulfilled'&&isComparisonPayload(livesResult.value);
-  if(comparisonAvailable){
-    operatorSummaryState.lives=lives;
-    updateOperatorLifeOptions(lives.table||[]);
-  }
+  if(comparisonAvailable){operatorSummaryState.lives=lives;}
+  updateOperatorLifeOptions(mergeLifeRows(ctx,comparisonAvailable?lives:{}));
   renderOperatorSummary();
   setText('kpi-health',healthValue);
   setText('kpi-trend',trend);

--- a/src/singular/dashboard/static/render-conversations.js
+++ b/src/singular/dashboard/static/render-conversations.js
@@ -1,4 +1,4 @@
-import {updateOperatorLifeOptions} from './actions.js';
+import {mergeLifeRows,updateOperatorLifeOptions} from './actions.js';
 import {normalizeItem} from './render-quests.js';
 import {getSelectedLife,SELECTED_LIFE_CHANGED_EVENT,setSelectedLife} from './state.js';
 
@@ -235,7 +235,7 @@ export const renderConversationsSection=payload=>{
     setSelectedLife(conversationState.selectedLife,{source:'conversation-default',metadata:lives.get(conversationState.selectedLife)||{}});
   }
   bindSelectedLifeListener();
-  updateOperatorLifeOptions([...lives.entries()].map(([life,meta])=>({life,...meta})));
+  updateOperatorLifeOptions(mergeLifeRows(payload?.context,payload?.comparison));
   syncConversationSelection(conversationState.selectedLife);
   bindSend();
 


### PR DESCRIPTION
### Motivation
- Garantir que le sélecteur opérateur est initialisé d’abord avec les vies du registre (`context.registry_lives`) et que ces vies ne sont pas perdues si les métriques de `/lives/comparison` sont absentes.
- Unifier la source des « rows » utilisées par `updateOperatorLifeOptions()` pour éviter des sélections invalides ou la suppression de vies uniquement présentes dans le registre.

### Description
- Ajout de la fonction utilitaire front `mergeLifeRows(context, comparison)` dans `src/singular/dashboard/static/actions.js` qui initialise les lignes depuis `context.registry_lives` (avec `slug`, `name`, `status`, `active`) puis fusionne les champs disponibles de `comparison.table` sans écraser les valeurs `null`/`undefined` et sans supprimer les vies du registre.
- Adaptation de la logique de rapprochement pour associer intelligemment les lignes de `comparison.table` aux entrées du registre via une liste de candidats (`life`, `slug`, `name`) afin de privilégier les entrées du registre lors de la fusion.
- Mise à jour des appels pour passer les lignes fusionnées à `updateOperatorLifeOptions()` : `loadEco()` (maintenant charge aussi `fetchSharedDashboardContext()`), `loadCockpit()` (utilise `mergeLifeRows(ctx, livesOrEmpty)` même si la comparaison est absente) et `renderConversationsSection()` (utilise `mergeLifeRows(payload?.context, payload?.comparison)`).

### Testing
- `node --check` sur les fichiers JS modifiés a réussi sans erreurs.
- Vérification smoke en Node de `mergeLifeRows()` (import/usage minimal) exécutée et validée avec succès.
- Exécution des tests JS/Python de type smoke (`pytest tests/test_dashboard_static_smoke.py`) a montré un échec sur `test_cockpit_loader_keeps_available_data_when_cockpit_endpoint_fails` où la charge simulée de `/api/cockpit` retourne HTTP 503 et la routine lève `cockpit_partial_failure` (comportement observé pendant la validation).
- Exécution complète des tests Python (`pytest -q`) révèle également un échec existant non lié à ce changement (`tests/test_cli_config.py::test_config_openai_windows_writes_hkcu_environment`) dû à une émulation Windows dans l’environnement de test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038d264870832a9e60dec2953ab02d)