### PR TITLE
Normalize life statuses and disable operator actions for archived/dead/stopped lives

### DIFF
--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -70,6 +70,23 @@ def life_trend_rank(trend: str) -> int:
     return -1
 
 
+def normalize_life_status(value: object) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    normalized = value.strip().lower()
+    if normalized in {"active", "archived", "extinct", "dead", "stopped", "unknown"}:
+        return normalized
+    return "unknown"
+
+
+def _status_is_dead(status: str) -> bool:
+    return status in {"extinct", "dead"}
+
+
+def _status_is_terminated(status: str) -> bool:
+    return status in {"extinct", "dead", "stopped"}
+
+
 def _normalized_event(record: dict[str, object]) -> str:
     event = record.get("event")
     if isinstance(event, str):
@@ -346,21 +363,18 @@ def aggregate_lives(
         registry_status = "active"
         display_name = slug
         if isinstance(raw_meta, dict):
-            status_value = raw_meta.get("status")
-            if isinstance(status_value, str) and status_value in {"active", "extinct"}:
-                registry_status = status_value
+            registry_status = normalize_life_status(raw_meta.get("status", "active"))
             name_value = raw_meta.get("name")
             if isinstance(name_value, str) and name_value:
                 display_name = name_value
         else:
-            status_value = getattr(raw_meta, "status", None)
-            if isinstance(status_value, str) and status_value in {"active", "extinct"}:
-                registry_status = status_value
+            registry_status = normalize_life_status(getattr(raw_meta, "status", "active"))
             name_value = getattr(raw_meta, "name", None)
             if isinstance(name_value, str) and name_value:
                 display_name = name_value
         is_selected = isinstance(active_life, str) and active_life in {slug, display_name}
-        is_extinct = registry_status == "extinct"
+        is_extinct = _status_is_dead(registry_status)
+        is_terminated = _status_is_terminated(registry_status)
         comparison[slug] = {
             "health_score": None,
             "progression_slope": None,
@@ -380,7 +394,7 @@ def aggregate_lives(
             "is_registry_active_life": registry_status == "active",
             "has_recent_activity": False,
             "extinction_seen_in_runs": is_extinct,
-            "run_terminated": False,
+            "run_terminated": is_terminated,
             "registry_run_status_inconsistency": False,
             "status_reconciliation_suggestion": None,
             "vital_timeline": compute_vital_timeline(
@@ -478,16 +492,16 @@ def aggregate_lives(
         slug, raw_meta = registry_life_meta(life_name, registry_lives)
         registry_status = "active"
         if isinstance(raw_meta, dict):
-            status_value = raw_meta.get("status")
-            if isinstance(status_value, str) and status_value in {"active", "extinct"}:
-                registry_status = status_value
+            registry_status = normalize_life_status(raw_meta.get("status", "active"))
         elif slug is not None:
             registry_meta = registry_lives.get(slug)
-            status_value = getattr(registry_meta, "status", None)
-            if isinstance(status_value, str) and status_value in {"active", "extinct"}:
-                registry_status = status_value
+            registry_status = normalize_life_status(getattr(registry_meta, "status", "active"))
+        if registry_status == "unknown" and life_name in comparison:
+            registry_status = str(comparison[life_name].get("life_status", "unknown"))
+        extinction_seen = extinction_seen or _status_is_dead(registry_status)
+        run_terminated = run_terminated or _status_is_terminated(registry_status)
         registry_run_status_inconsistency = (
-            extinction_seen and slug is not None and registry_status != "extinct"
+            extinction_seen and slug is not None and not _status_is_dead(registry_status)
         )
         status_reconciliation_suggestion = (
             "mark_extinct" if registry_run_status_inconsistency else None

--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -20,6 +20,16 @@ const operatorLifeSelect=()=>document.getElementById('operator-action-life-selec
 const selectedOperatorLife=()=>getSelectedLife()||readValue('operator-action-life-select','action-life-name');
 const operatorMessage=()=>readValue('operator-action-message','action-prompt');
 const birthName=()=>readValue('operator-birth-name','action-life-name');
+const normalizeLifeStatus=value=>String(value||'').trim().toLowerCase();
+const blockedOperatorActionStatuses=new Set(['archived','dead','extinct','stopped']);
+const statusBlocksOperatorAction=status=>blockedOperatorActionStatuses.has(normalizeLifeStatus(status));
+const statusLabel=status=>{
+  const normalized=normalizeLifeStatus(status);
+  if(normalized==='archived'){return 'archivée';}
+  if(normalized==='dead'||normalized==='extinct'){return 'morte';}
+  if(normalized==='stopped'){return 'arrêtée';}
+  return normalized||'inconnue';
+};
 
 const validOperatorLives=()=>{
   const select=operatorLifeSelect();
@@ -64,18 +74,31 @@ const setActionHelp=text=>{
 };
 
 const requiresValidLife=action=>['archive','talk','emergency_stop','lives_use','memorial','clone'].includes(action);
+const requiresRunnableLife=action=>['archive','talk','emergency_stop'].includes(action);
+
+const selectedOperatorLifeStatus=()=>{
+  const select=operatorLifeSelect();
+  const selected=selectedOperatorLife();
+  if(!select||!selected){return '';}
+  const option=[...select.options].find(candidate=>candidate.value===selected);
+  return normalizeLifeStatus(option?.dataset?.lifeStatus);
+};
 
 export const updateOperatorActionState=()=>{
   syncOperatorSelectToShared();
   const registryState=operatorRegistryState();
   const hasSelection=registryState==='valid';
   const selected=selectedOperatorLife();
+  const selectedStatus=selectedOperatorLifeStatus();
+  const blocksOperatorActions=hasSelection&&statusBlocksOperatorAction(selectedStatus);
   const help=document.getElementById('operator-action-help');
   const helpMessages={
     loading:'Les données de vies n’ont pas encore chargé',
     empty:'Aucune vie détectée dans le registre',
     invalid:'Sélectionnez une vie valide dans le registre pour activer “Supprimer/archiver” et “Parler”.',
-    valid:`Vie ciblée: ${selected}. “Supprimer/archiver” et “Parler” sont disponibles.`,
+    valid:blocksOperatorActions
+      ?`Vie ciblée: ${selected}. Actions “Parler”, “Supprimer/archiver” et “Arrêt d’urgence” désactivées: vie ${statusLabel(selectedStatus)}.`
+      :`Vie ciblée: ${selected}. “Supprimer/archiver” et “Parler” sont disponibles.`,
   };
   const helpText=helpMessages[registryState]||helpMessages.invalid;
   if(help){help.textContent=helpText;}
@@ -88,13 +111,24 @@ export const updateOperatorActionState=()=>{
     button.setAttribute('aria-disabled','false');
     button.title=birthName()?'Créer la vie nommée dans le champ “Nom exact à créer”':'Saisissez un nom dans “Nom exact à créer” pour créer une vie.';
   });
-  ['critical-archive','critical-talk','critical-emergency-stop','act-archive','act-talk','act-lives-use','act-memorial','act-clone'].forEach(id=>{
+  [
+    ['critical-archive','archive'],
+    ['critical-talk','talk'],
+    ['critical-emergency-stop','emergency_stop'],
+    ['act-archive','archive'],
+    ['act-talk','talk'],
+    ['act-lives-use','lives_use'],
+    ['act-memorial','memorial'],
+    ['act-clone','clone'],
+  ].forEach(([id,action])=>{
     const button=document.getElementById(id);
     if(!button){return;}
-    button.disabled=!hasSelection;
-    button.classList.toggle('is-disabled',!hasSelection);
-    button.setAttribute('aria-disabled',hasSelection?'false':'true');
-    button.title=hasSelection?'':helpText;
+    const blockedByStatus=hasSelection&&requiresRunnableLife(action)&&blocksOperatorActions;
+    const disabled=!hasSelection||blockedByStatus;
+    button.disabled=disabled;
+    button.classList.toggle('is-disabled',disabled);
+    button.setAttribute('aria-disabled',disabled?'true':'false');
+    button.title=disabled?helpText:'';
   });
 };
 
@@ -146,10 +180,12 @@ export const updateOperatorLifeOptions=(rows=[])=>{
   if(!select){return;}
   const previous=select.value;
   select.dataset.registryState='loaded';
-  const names=[...new Set((rows||[]).map(row=>{
-    if(typeof row==='string'){return row;}
-    return row?.life||row?.slug||row?.name||'';
-  }).map(name=>String(name||'').trim()).filter(Boolean))].sort((a,b)=>a.localeCompare(b));
+  const rowByName=new Map();
+  for(const row of rows||[]){
+    const name=String(lifeRowName(row)||'').trim();
+    if(name&&!rowByName.has(name)){rowByName.set(name,row);}
+  }
+  const names=[...rowByName.keys()].sort((a,b)=>a.localeCompare(b));
   select.innerHTML='';
   const placeholder=document.createElement('option');
   placeholder.value='';
@@ -159,6 +195,8 @@ export const updateOperatorLifeOptions=(rows=[])=>{
     const option=document.createElement('option');
     option.value=name;
     option.textContent=name;
+    const row=rowByName.get(name);
+    option.dataset.lifeStatus=normalizeLifeStatus(row?.life_status||row?.registry_status||row?.status);
     select.appendChild(option);
   }
   const shared=getSelectedLife();
@@ -237,6 +275,10 @@ const actionPayload=(action,lifeName=selectedOperatorLife)=>{
 const validateAction=(action,payload)=>{
   if(requiresValidLife(action)&&!hasValidSelectedLife()){
     return 'Sélectionnez une vie valide dans le sélecteur opérateur avant de lancer cette action.';
+  }
+  const selectedStatus=selectedOperatorLifeStatus();
+  if(requiresRunnableLife(action)&&statusBlocksOperatorAction(selectedStatus)){
+    return `Action ${action} indisponible: la vie sélectionnée est ${statusLabel(selectedStatus)}.`;
   }
   if(action==='talk'&&!payload.prompt){
     return 'Écrivez un message dans le champ “Parler à une vie” avant d’envoyer.';

--- a/tests/test_dashboard_services.py
+++ b/tests/test_dashboard_services.py
@@ -162,6 +162,46 @@ def test_lives_comparison_default_rows_follow_active_and_dead_filters() -> None:
     assert [row["life"] for row in dead_only] == ["beta"]
 
 
+def test_lives_comparison_normalizes_registry_life_statuses() -> None:
+    comparison, _ = aggregate_lives(
+        [
+            {"life": "gamma", "event": "mutation", "ts": "2026-01-01T00:00:00Z"},
+        ],
+        registry={
+            "active": "alpha",
+            "lives": {
+                "alpha": {"name": "alpha", "status": "ACTIVE"},
+                "beta": {"name": "beta", "status": "archived"},
+                "gamma": {"name": "gamma", "status": "Dead"},
+                "delta": {"name": "delta", "status": "stopped"},
+                "epsilon": {"name": "epsilon", "status": "unknown"},
+                "zeta": {"name": "zeta", "status": "unexpected"},
+            },
+        },
+        compare_lives=None,
+        time_window="all",
+        record_life=lambda rec: str(rec.get("life", "unknown")),
+        record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
+        is_mutation_record=lambda rec: "score_base" in rec,
+        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        alerts_from_records=lambda _: [],
+        compute_vital_timeline=lambda **kwargs: {"registry_status": kwargs["registry_status"]},
+        registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
+    )
+
+    assert comparison["alpha"]["life_status"] == "active"
+    assert comparison["alpha"]["is_registry_active_life"] is True
+    assert comparison["beta"]["life_status"] == "archived"
+    assert comparison["beta"]["is_registry_active_life"] is False
+    assert comparison["gamma"]["life_status"] == "dead"
+    assert comparison["gamma"]["extinction_seen_in_runs"] is True
+    assert comparison["gamma"]["run_terminated"] is True
+    assert comparison["gamma"]["status_reconciliation_suggestion"] is None
+    assert comparison["delta"]["life_status"] == "stopped"
+    assert comparison["delta"]["run_terminated"] is True
+    assert comparison["epsilon"]["life_status"] == "unknown"
+    assert comparison["zeta"]["life_status"] == "unknown"
+
 def test_code_evolution_service_aggregates_by_life_and_metrics() -> None:
     payload = aggregate_code_evolution(
         [

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -582,3 +582,89 @@ for (const [label, button] of [['archive', archive], ['talk', talk], ['emergency
     )
 
     subprocess.run(["node", str(script)], check=True)
+
+
+def test_archived_dead_or_stopped_lives_disable_operator_actions(tmp_path: Path) -> None:
+    """Operator talk/archive/emergency stop are blocked for non-runnable life statuses."""
+    script = tmp_path / "blocked_life_action_check.mjs"
+    module_path = (Path.cwd() / DASHBOARD_STATIC / "actions.js").as_uri()
+    script.write_text(
+        f"""
+class ClassList {{
+  constructor() {{ this.values = new Set(); }}
+  add(...names) {{ names.forEach(name => this.values.add(name)); }}
+  remove(...names) {{ names.forEach(name => this.values.delete(name)); }}
+  toggle(name, force) {{
+    const shouldAdd = force === undefined ? !this.values.has(name) : Boolean(force);
+    if (shouldAdd) {{ this.values.add(name); }} else {{ this.values.delete(name); }}
+    return shouldAdd;
+  }}
+  contains(name) {{ return this.values.has(name); }}
+}}
+
+class Element {{
+  constructor(tagName, id = '') {{
+    this.tagName = tagName.toUpperCase();
+    this.id = id;
+    this.children = [];
+    this.dataset = {{}};
+    this.attributes = {{}};
+    this.classList = new ClassList();
+    this.value = '';
+    this.disabled = false;
+    this._textContent = '';
+    this._innerHTML = null;
+  }}
+  appendChild(child) {{ this.children.push(child); return child; }}
+  addEventListener() {{}}
+  setAttribute(name, value) {{ this.attributes[name] = String(value); }}
+  getAttribute(name) {{ return this.attributes[name] ?? null; }}
+  set textContent(value) {{ this._textContent = String(value ?? ''); this.children = []; this._innerHTML = null; }}
+  get textContent() {{ return this._textContent + this.children.map(child => child.textContent ?? '').join(''); }}
+  set innerHTML(value) {{ this._innerHTML = String(value ?? ''); this.children = []; this._textContent = ''; }}
+  get innerHTML() {{ return this._innerHTML ?? this.textContent; }}
+  set title(value) {{ this.attributes.title = String(value); }}
+  get title() {{ return this.attributes.title ?? ''; }}
+  get options() {{ return this.children.filter(child => child.tagName === 'OPTION'); }}
+}}
+
+const elements = new Map();
+const register = (tagName, id) => {{ const el = new Element(tagName, id); elements.set(id, el); return el; }};
+register('select', 'operator-action-life-select').dataset.registryState = 'loading';
+register('p', 'operator-action-help');
+register('span', 'critical-current-life-target');
+register('input', 'operator-birth-name').value = 'Nouvelle Vie';
+register('button', 'critical-birth');
+const criticalArchive = register('button', 'critical-archive');
+const criticalTalk = register('button', 'critical-talk');
+const criticalEmergency = register('button', 'critical-emergency-stop');
+const archive = register('button', 'act-archive');
+const talk = register('button', 'act-talk');
+const livesUse = register('button', 'act-lives-use');
+register('button', 'act-memorial');
+register('button', 'act-clone');
+register('div', 'critical-action-result');
+
+globalThis.document = {{
+  createElement: tagName => new Element(tagName),
+  getElementById: id => elements.get(id) ?? null,
+}};
+globalThis.window = {{ dispatchEvent() {{}} }};
+globalThis.CustomEvent = class CustomEvent {{ constructor(type, init) {{ this.type = type; this.detail = init?.detail; }} }};
+
+const {{ updateOperatorLifeOptions }} = await import('{module_path}');
+for (const [life, status, expectedLabel] of [['beta', 'archived', 'vie archivée'], ['gamma', 'dead', 'vie morte'], ['omega', 'extinct', 'vie morte'], ['delta', 'stopped', 'vie arrêtée']]) {{
+  updateOperatorLifeOptions([{{ life, life_status: status, selected_life: true }}]);
+  for (const [label, button] of [['critical archive', criticalArchive], ['critical talk', criticalTalk], ['critical emergency', criticalEmergency], ['archive', archive], ['talk', talk]]) {{
+    if (!button.disabled) {{ throw new Error(`${{label}} should be disabled for ${{status}} life`); }}
+    if (button.getAttribute('aria-disabled') !== 'true') {{ throw new Error(`${{label}} aria-disabled missing`); }}
+  }}
+  if (!livesUse || livesUse.disabled) {{ throw new Error('lives_use should remain available for a valid selected life'); }}
+  const help = elements.get('operator-action-help').textContent;
+  if (!help.includes(expectedLabel)) {{ throw new Error(`unexpected help message for ${{status}}: ${{help}}`); }}
+}}
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(["node", str(script)], check=True)


### PR DESCRIPTION
### Motivation

- Le traitement actuel des statuts de vie était limité à `active`/`extinct` et ne couvrait pas variantes comme `archived`, `dead`, `stopped` ou valeurs mal normalisées, ce qui provoquait des incohérences dans les champs exposés par l’agrégateur de vies et dans l’UI opérateur.

### Description

- Ajout de la fonction locale `normalize_life_status(value)` et des helpers `_status_is_dead` et `_status_is_terminated` dans `src/singular/dashboard/services/lives_comparison.py` pour normaliser les statuts (`active`, `archived`, `extinct`, `dead`, `stopped`, `unknown`).
- Remplacement des tests précédents `status_value in {"active","extinct"}` par la normalisation et application des valeurs normalisées aux champs exposés: `life_status`, `is_registry_active_life`, `extinction_seen_in_runs`, `run_terminated` et `status_reconciliation_suggestion`.
- Adaptation du calcul d’incohérence registre/runs pour tenir compte des nouveaux statuts et fusionner correctement les informations entre registre et runs lorsqu’un statut inconnu est rencontré.
- Mise à jour de l’UI opérateur dans `src/singular/dashboard/static/actions.js` pour stocker le statut normalisé dans les options du sélecteur, exposer une logique `statusBlocksOperatorAction` et désactiver/valider `talk`, `archive` et `emergency_stop` lorsque la vie est `archived`, `dead`/`extinct` ou `stopped`.
- Ajout/extension de tests JS/Python pour couvrir la normalisation et le blocage des actions opérateur (`tests/test_dashboard_services.py`, `tests/test_dashboard_static_smoke.py`).

### Testing

- Exécution ciblée de tests unitaires: `python -m pytest tests/test_dashboard_services.py::test_lives_comparison_normalizes_registry_life_statuses tests/test_dashboard_static_smoke.py::test_archived_dead_or_stopped_lives_disable_operator_actions tests/test_dashboard.py::test_lives_comparison_table_aggregation_filters_and_sorting` — tous les tests ciblés sont passés.
- Vérification de la compilation Python: `python -m py_compile src/singular/dashboard/services/lives_comparison.py` — réussite.
- Les checks JS/smoke intégrés aux tests Python (qui utilisent `node` pour exécuter les scénarios DOM simulés) ont également réussi dans le pipeline de tests ciblés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038e558df8832a984ec5e910c76360)