### PR TITLE
Encode life code evolution links

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta, timezone
 import os
 import sys
 from pathlib import Path
+from urllib.parse import quote
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 from singular.lives import get_registry_root, load_registry, set_life_status
@@ -1534,7 +1535,7 @@ def create_app(
         base_rows = [
             {
                 "life": name,
-                "code_evolution_endpoint": f"/api/lives/{name}/code-evolution",
+                "code_evolution_endpoint": f"/api/lives/{quote(name, safe='')}/code-evolution",
                 **payload,
             }
             for name, payload in comparison.items()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -993,6 +993,18 @@ def test_dashboard_code_evolution_endpoint_and_comparison_link(tmp_path: Path) -
                         "trace_id": "trace-ko",
                     }
                 ),
+                json.dumps(
+                    {
+                        "ts": "2026-04-12T12:12:00Z",
+                        "life": "life explicit/with spaces",
+                        "file": "skills/safe.py",
+                        "change_type": "safety_fix",
+                        "score_base": 5.0,
+                        "score_new": 4.0,
+                        "accepted": True,
+                        "trace_id": "trace-special",
+                    }
+                ),
             ]
         )
         + "\n",
@@ -1005,6 +1017,13 @@ def test_dashboard_code_evolution_endpoint_and_comparison_link(tmp_path: Path) -
     comparison_payload = client.get("/lives/comparison").json()
     life_row = next(row for row in comparison_payload["table"] if row["life"] == "life-explicit")
     assert life_row["code_evolution_endpoint"] == "/api/lives/life-explicit/code-evolution"
+    special_life_row = next(
+        row for row in comparison_payload["table"] if row["life"] == "life explicit/with spaces"
+    )
+    assert (
+        special_life_row["code_evolution_endpoint"]
+        == "/api/lives/life%20explicit%2Fwith%20spaces/code-evolution"
+    )
 
     endpoint_payload = app._routes["/api/lives/{life}/code-evolution"](life="life-explicit")
     assert endpoint_payload["life"] == "life-explicit"


### PR DESCRIPTION
### Motivation
- Les noms de vie peuvent contenir des caractères spéciaux (espaces, `/`, etc.) qui doivent être correctement encodés lorsqu'ils sont insérés dans des URLs d'API pour éviter des liens invalides ou des failles.

### Description
- Import de `quote` depuis `urllib.parse` et utilisation de `quote(name, safe='')` pour construire `code_evolution_endpoint` dans la réponse de `GET /lives/comparison` dans `src/singular/dashboard/__init__.py`.
- Mise à jour de `tests/test_dashboard.py` pour ajouter un cas de test couvrant un nom de vie contenant des espaces et un slash et vérifier que l'endpoint est encodé comme attendu.
- Vérification des usages front-end existants autour de `/api/lives/{life}/causal-timeline`, `/api/lives/{life}/chat` et des liens de détail montrant qu'ils utilisent déjà `encodeURIComponent` côté client dans les fichiers statiques.

### Testing
- Exécution de `pytest tests/test_dashboard.py::test_dashboard_code_evolution_endpoint_and_comparison_link -q` qui a réussi (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03900141bc832a9344215aa54a6897)