### PR TITLE
Make life chat GET status-only

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -2142,15 +2142,35 @@ def create_app(
     def chat_with_life_get(
         life: str, token: str | None = None, payload: str | None = None
     ) -> dict[str, object]:
-        body: object = {}
-        if payload:
-            try:
-                candidate = json.loads(payload)
-                if isinstance(candidate, dict):
-                    body = candidate
-            except json.JSONDecodeError:
-                body = {}
-        return _run_life_chat(life, body, token=token)
+        _ = (token, payload)
+        slug, meta, life_dir = _resolve_life_entry(life)
+        target = slug or life
+        life_status = _life_status(meta)
+        available = life_dir is not None and life_dir.exists()
+        status = "ready" if available else "life_unavailable"
+        details: dict[str, object] = {}
+
+        if available and life_status in {"archived", "extinct", "dead", "stopped"}:
+            available = False
+            status = "life_archived"
+        elif available and life_dir is not None:
+            locks = _active_run_locks(life_dir)
+            if locks:
+                available = False
+                status = "run_in_progress"
+                details["active_run_locks"] = locks
+
+        payload_status: dict[str, object] = {
+            "life": target,
+            "available": available,
+            "life_status": life_status,
+            "status": status,
+            "message": "Utilisez POST avec un corps JSON pour envoyer un message.",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        if details:
+            payload_status["details"] = details
+        return payload_status
 
     if hasattr(app, "post"):
         async def chat_with_life_post(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2122,3 +2122,70 @@ def test_lives_status_reconciliation_action_marks_suggested_extinctions(
         }
     ]
     assert json.loads(registry_file.read_text(encoding="utf-8"))["lives"]["alpha"]["status"] == "extinct"
+
+
+def test_chat_get_reports_status_without_running_chat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    life_dir = tmp_path / "alpha"
+    life_dir.mkdir()
+
+    def fake_load_registry() -> dict[str, object]:
+        return {
+            "active": "alpha",
+            "lives": {
+                "alpha": {
+                    "name": "Alpha",
+                    "slug": "alpha",
+                    "path": str(life_dir),
+                    "created_at": "2026-05-12T00:00:00+00:00",
+                    "status": "active",
+                }
+            },
+        }
+
+    monkeypatch.setattr(dashboard_module, "load_registry", fake_load_registry)
+    monkeypatch.setenv("SINGULAR_DASHBOARD_ACTION_TOKEN", "secret")
+
+    app = create_app(psyche_file=tmp_path / "psyche.json")
+    response = app._routes["/api/lives/{life}/chat"](
+        life="alpha",
+        payload=json.dumps({"message": "ne doit pas etre envoye"}),
+    )
+
+    assert response["life"] == "alpha"
+    assert response["available"] is True
+    assert response["life_status"] == "active"
+    assert response["status"] == "ready"
+    assert response["message"] == "Utilisez POST avec un corps JSON pour envoyer un message."
+
+
+def test_chat_post_remains_the_message_execution_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    life_dir = tmp_path / "alpha"
+    life_dir.mkdir()
+
+    def fake_load_registry() -> dict[str, object]:
+        return {
+            "active": "alpha",
+            "lives": {
+                "alpha": {
+                    "name": "Alpha",
+                    "slug": "alpha",
+                    "path": str(life_dir),
+                    "created_at": "2026-05-12T00:00:00+00:00",
+                    "status": "active",
+                }
+            },
+        }
+
+    monkeypatch.setattr(dashboard_module, "load_registry", fake_load_registry)
+
+    app = create_app(psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+    response = client.post("/api/lives/alpha/chat", json={"message": ""})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "message_missing"
+    assert response.json()["response"] == "Message vide: saisissez un contenu à envoyer."


### PR DESCRIPTION
### Motivation
- Faire de la route GET de conversation une vérification de statut sans effet de bord pour éviter d'exécuter une conversation depuis une requête GET et encourager l'utilisation de POST pour l'envoi de messages.
- Préserver le chemin d'exécution unique pour l'envoi de messages afin de conserver la sécurité et la validation des jetons via `chat_with_life_post()` et `_run_life_chat()`.

### Description
- Modifié `chat_with_life_get` dans `src/singular/dashboard/__init__.py` pour qu'il résolve la vie, calcule `available` et `life_status`, signale les cas `life_archived` et `run_in_progress`, et retourne un payload de statut sans appeler `_run_life_chat()`.
- Le message de guidance retourné par GET est désormais `"Utilisez POST avec un corps JSON pour envoyer un message."` et la réponse inclut un `timestamp` et éventuellement `details` (ex. verrous de run actifs).
- Conservé le comportement existant de `chat_with_life_post` qui lit le JSON de la requête et appelle `_run_life_chat()` (chemin d'exécution pour l'envoi).
- Ajout de deux tests dans `tests/test_dashboard.py`: `test_chat_get_reports_status_without_running_chat` qui vérifie le comportement status-only de GET, et `test_chat_post_remains_the_message_execution_path` qui vérifie que POST déclenche toujours la logique de message.

### Testing
- Exécution ciblée de `pytest -q tests/test_dashboard.py::test_chat_get_reports_status_without_running_chat tests/test_dashboard.py::test_chat_post_remains_the_message_execution_path` qui a réussi (2 passed).
- Exécution complète de `pytest -q tests/test_dashboard.py` montrant que la suite concernée passe (42 passed), avec une erreur finale d'arrêt d'interpréteur liée à un thread daemon du harnais de test signalée en sortie mais n'ayant pas fait échouer les assertions des tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03932243c0832abd2aad20dabb3777)