### PR TITLE
Require dashboard action token by default

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -2192,7 +2192,13 @@ def create_app(
         except PermissionError as exc:
             raise HTTPException(
                 status_code=403,
-                detail="Jeton dashboard requis ou invalide pour exécuter cette action.",
+                detail=(
+                    "Jeton dashboard requis ou invalide pour exécuter cette action: "
+                    "définissez SINGULAR_DASHBOARD_ACTION_TOKEN et fournissez-le avec la requête. "
+                    "Pour du développement local uniquement, "
+                    "SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS=1 "
+                    "autorise les actions sans jeton."
+                ),
             ) from exc
 
     def _parse_action_payload(payload: str | None) -> dict[str, object]:

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -290,8 +290,20 @@ class DashboardActionService:
 
     def validate_token(self, token: str | None) -> None:
         expected = os.environ.get("SINGULAR_DASHBOARD_ACTION_TOKEN")
-        if expected and token != expected:
-            raise PermissionError("invalid action token")
+        allow_unauthenticated = (
+            os.environ.get("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS") == "1"
+        )
+        if expected:
+            if token != expected:
+                raise PermissionError("invalid action token")
+            return
+        if allow_unauthenticated:
+            return
+        raise PermissionError(
+            "dashboard action token required: set SINGULAR_DASHBOARD_ACTION_TOKEN "
+            "for mutative or destructive dashboard actions, or set "
+            "SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS=1 only for local development"
+        )
 
     def execute(self, action: str, params: dict[str, Any]) -> dict[str, Any]:
         try:

--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -221,7 +221,7 @@ const readActionError=async response=>{
     detail=await response.text().catch(()=>'' );
   }
   if(response.status===403){
-    return detail||'Jeton dashboard requis ou invalide: renseignez le champ “Jeton dashboard”.';
+    return detail||'Jeton dashboard requis ou invalide: renseignez le champ “Jeton dashboard” pour les actions sensibles.';
   }
   if(response.status===400){
     return detail||'Payload invalide: vérifiez les paramètres de l’action.';

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -442,7 +442,7 @@
 
   <section id="actions"><h2>Actions rapides</h2><pre id='action-result'>Aucune exécution</pre>
     <div class='panel actions-panel'>
-      <label>Jeton dashboard <input id='action-token' type='password' placeholder='optionnel'/></label>
+      <label>Jeton dashboard <input id='action-token' type='password' placeholder='requis pour actions sensibles'/></label>
       <label>Nom de vie (créer/utiliser) <input id='action-life-name' placeholder='Nom exact requis pour créer une vie'/></label>
       <label>Prompt de discussion <input id='action-prompt' placeholder='Prompt unique'/></label>
       <label>Budget boucle (s) <input id='action-budget' type='number' min='0.1' step='0.1' value='1.0'/></label>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1834,6 +1834,27 @@ def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: py
         app._routes["/api/actions/{action}"]("lives_list", token="wrong", payload="{}")
 
 
+def test_dashboard_actions_require_token_unless_local_dev_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SINGULAR_DASHBOARD_ACTION_TOKEN", raising=False)
+    monkeypatch.delenv("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS", raising=False)
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+
+    missing_token = client.post("/api/actions/lives_list", json={})
+
+    assert missing_token.status_code == 403
+    assert "SINGULAR_DASHBOARD_ACTION_TOKEN" in missing_token.json()["detail"]
+    assert "SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS=1" in missing_token.json()["detail"]
+
+    monkeypatch.setenv("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS", "1")
+    allowed = client.post("/api/actions/lives_list", json={}).json()
+
+    assert allowed["ok"] is True
+    assert allowed["action"] == "lives_list"
+
+
 def test_dashboard_emergency_stop_action_writes_active_life_stop_signal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1841,6 +1862,7 @@ def test_dashboard_emergency_stop_action_writes_active_life_stop_signal(
     root.mkdir()
     monkeypatch.setenv("SINGULAR_ROOT", str(root))
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.setenv("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS", "1")
     meta = create_life("Urgence")
 
     app = create_app(


### PR DESCRIPTION
### Motivation
- Ensure destructive or mutative dashboard actions require an explicit dashboard token in non-development environments. 
- Provide a safe, explicit override for local development to avoid accidental unauthenticated changes.
- Clarify UI and API messages so the token is not presented as optional for sensitive operations.

### Description
- Change `DashboardActionService.validate_token()` in `src/singular/dashboard/actions.py` to require `SINGULAR_DASHBOARD_ACTION_TOKEN` by default and allow unauthenticated actions only when `SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS=1` is set for local development.
- Update `_validate_action_token()` in `src/singular/dashboard/__init__.py` to return a more informative 403 `detail` explaining the required `SINGULAR_DASHBOARD_ACTION_TOKEN` and the local-dev override `SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS=1`.
- Update frontend messaging in `src/singular/dashboard/static/actions.js` and the placeholder in `src/singular/dashboard/templates/dashboard.html` so the dashboard token is described as required for sensitive actions instead of "optionnel".
- Add test coverage in `tests/test_dashboard.py` for the default-deny behavior and the explicit local-development override, and adjust the emergency-stop test to opt into the dev override where needed.

### Testing
- Ran `pytest tests/test_dashboard.py -q` which passed (`43 passed, 1 warning`).
- Ran a focused subset `pytest tests/test_dashboard.py::test_dashboard_actions_endpoint_and_ui_panel tests/test_dashboard.py::test_dashboard_actions_require_token_unless_local_dev_override tests/test_dashboard.py::test_dashboard_emergency_stop_action_writes_active_life_stop_signal -q`, which passed (`3 passed`).
- Running the full test suite (`pytest -q -x`) surfaced an unrelated, pre-existing platform-specific failure in `tests/test_cli_config.py::test_config_openai_windows_writes_hkcu_environment` when `os.name` is monkeypatched to `nt` on this POSIX runner; this failure is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043cc1c310832ab239a7c88fca9dfe)