### PR TITLE
Scope quest work item loading

### DIFF
--- a/src/singular/dashboard/static/bootstrap.js
+++ b/src/singular/dashboard/static/bootstrap.js
@@ -345,6 +345,7 @@ const bindCommonHandlers=()=>{
     scopeToggle.onchange=e=>{
       scopeState.currentLifeOnly=Boolean(e.target.checked);
       loadCockpit();
+      loadQuests();
       loadLivesBoard();
       loadTimeline();
       loadReflections();

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -421,7 +421,7 @@ export const loadEco=()=>Promise.all([fetchJson(withScope('/ecosystem')),fetchSh
 });
 
 export const loadQuests=()=>Promise.all([
-  fetchJson('/api/dashboard/work-items'),
+  fetchJson(withScope('/api/dashboard/work-items')),
   fetchSharedDashboardContext(),
   fetchSharedLivesComparison(),
 ]).then(([data,context,comparison])=>{


### PR DESCRIPTION
### Motivation
- Ensure the quests work-items request respects the current dashboard life scope and that quests are reloaded when the current-life scope toggle changes so the UI stays consistent with other scoped panels.

### Description
- Replace `fetchJson('/api/dashboard/work-items')` with `fetchJson(withScope('/api/dashboard/work-items'))` in `src/singular/dashboard/static/render-cockpit.js` so the request is scoped to the selected life.
- Call `loadQuests()` from the `#scope-current-life` change handler in `src/singular/dashboard/static/bootstrap.js` after updating `scopeState.currentLifeOnly` so quests are refreshed when the checkbox toggles.

### Testing
- Verified the edits with `rg` and inspected the updated lines showing `fetchJson(withScope('/api/dashboard/work-items'))` and the added `loadQuests()` invocation (succeeded).
- Ran `pytest` and observed a partial test run with many tests executed but the run was interrupted/contained unrelated failures; running `pytest tests/test_dashboard_static_smoke.py` produced one existing cockpit partial-failure test failure not caused by these small UI/JS changes.
- Attempted `pytest` with coverage flags used in CI (`--cov=...`) but the local environment rejected the coverage arguments due to missing `pytest-cov` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045214e81c832ab7237f799537b066)