### PR TITLE
Centralize lifecycle coevolution flow

### DIFF
--- a/configs/lifecycle.yaml
+++ b/configs/lifecycle.yaml
@@ -4,6 +4,12 @@ cycle:
   introspection_frequency_ticks: 1
   mutation_window_seconds: 0.2
 
+coevolution:
+  enabled: false
+  robustness_weight: 1.0
+  max_test_candidates: 3
+  ttl: 3
+
 phases:
   veille:
     cpu_budget_percent: 30

--- a/src/singular/life/coevolution_flow.py
+++ b/src/singular/life/coevolution_flow.py
@@ -1,6 +1,188 @@
+"""High-level co-evolution flow for mutations and living tests.
+
+This module centralizes the small primitives used by the life loop:
+:class:`MapElites`, :class:`LivingTestPool`, and candidate generation.  The
+``CoevolutionFlow`` interface keeps the mutation loop readable by grouping the
+steps that belong together: propose candidate tests, evaluate a mutation against
+living tests, compute robustness, expire/promote tests, and emit a single
+decision object that callers can log.
+"""
+
 from __future__ import annotations
 
-from .map_elites import MapElites
-from .test_coevolution import LivingTestPool, propose_test_candidates
+from dataclasses import dataclass, field
+import random
+from typing import Iterable
 
-__all__ = ["MapElites", "LivingTestPool", "propose_test_candidates"]
+from .map_elites import MapElites
+from .test_coevolution import LivingTestPool, TestCandidate, propose_test_candidates
+
+
+@dataclass(frozen=True)
+class CoevolutionConfig:
+    """Runtime knobs for mutation/test co-evolution."""
+
+    enabled: bool = False
+    robustness_weight: float = 1.0
+    max_test_candidates: int = 3
+    ttl: int = 3
+
+    def normalized(self) -> "CoevolutionConfig":
+        """Return a defensive, bounded copy suitable for execution."""
+
+        return CoevolutionConfig(
+            enabled=bool(self.enabled),
+            robustness_weight=max(0.0, float(self.robustness_weight)),
+            max_test_candidates=max(0, int(self.max_test_candidates)),
+            ttl=max(1, int(self.ttl)),
+        )
+
+
+@dataclass(frozen=True)
+class CandidateEvaluation:
+    """Evaluation outcome for one proposed test candidate."""
+
+    expr: str
+    origin: str
+    retained: bool
+
+
+@dataclass(frozen=True)
+class CoevolutionDecision:
+    """Decision summary returned to the mutation loop and logger."""
+
+    accepted: bool
+    rejected_for_robustness: bool
+    regression_detection_rate: float
+    robustness_score: float
+    score_combined_base: float
+    score_combined_new: float
+    proposed_tests: tuple[str, ...] = ()
+    retained_tests: tuple[str, ...] = ()
+    rejected_tests: tuple[str, ...] = ()
+    tests_added: int = 0
+    tests_removed: int = 0
+    pool_size: int = 0
+
+
+@dataclass
+class CoevolutionFlow:
+    """Coordinate living-test co-evolution for one mutation decision."""
+
+    pool: LivingTestPool = field(default_factory=LivingTestPool)
+    config: CoevolutionConfig = field(default_factory=CoevolutionConfig)
+
+    def __post_init__(self) -> None:
+        self.config = self.config.normalized()
+        self.pool.initial_ttl = self.config.ttl
+
+    def propose_candidates(
+        self,
+        mutated_code: str,
+        rng: random.Random,
+    ) -> list[TestCandidate]:
+        """Generate bounded candidate tests from mutated behavior."""
+
+        return propose_test_candidates(
+            mutated_code,
+            rng,
+            limit=self.config.max_test_candidates,
+        )
+
+    def evaluate_against_mutation(self, base_code: str, mutated_code: str) -> float:
+        """Return the living-test regression detection rate for a mutation."""
+
+        return self.pool.regression_detection_rate(base_code, mutated_code)
+
+    @staticmethod
+    def robustness_from_detection_rate(detection_rate: float) -> float:
+        """Convert regression detection pressure into a bounded robustness score."""
+
+        return max(0.0, min(1.0, 1.0 - detection_rate))
+
+    def expire_ttl(self, accepted_code: str) -> int:
+        """Expire stale living tests against the currently accepted code."""
+
+        before = len(self.pool.tests)
+        self.pool.evolve(accepted_code, [], random.Random(0))
+        return max(0, before - len(self.pool.tests))
+
+    def promote_or_reject(
+        self,
+        accepted_code: str,
+        candidates: Iterable[TestCandidate],
+        rng: random.Random,
+    ) -> tuple[dict[str, int], tuple[CandidateEvaluation, ...]]:
+        """Promote passing candidates into the pool and report rejected tests."""
+
+        candidate_list = list(candidates)
+        before_exprs = {test.expr for test in self.pool.tests}
+        delta = self.pool.evolve(accepted_code, candidate_list, rng)
+        after_exprs = {test.expr for test in self.pool.tests}
+        evaluations = tuple(
+            CandidateEvaluation(
+                expr=candidate.expr,
+                origin=candidate.origin,
+                retained=candidate.expr in after_exprs and candidate.expr not in before_exprs,
+            )
+            for candidate in candidate_list
+        )
+        return delta, evaluations
+
+    def decide(
+        self,
+        *,
+        base_code: str,
+        mutated_code: str,
+        base_score: float,
+        mutated_score: float,
+        initially_accepted: bool,
+        rng: random.Random,
+    ) -> CoevolutionDecision:
+        """Evaluate, possibly reject, and evolve tests for a mutation."""
+
+        detection_rate = self.evaluate_against_mutation(base_code, mutated_code)
+        robustness_score = self.robustness_from_detection_rate(detection_rate)
+        combined_base = base_score
+        combined_new = mutated_score + (self.config.robustness_weight * detection_rate)
+        accepted = initially_accepted and combined_new <= combined_base
+        rejected_for_robustness = initially_accepted and not accepted
+
+        proposed: list[TestCandidate] = []
+        retained: tuple[str, ...] = ()
+        rejected: tuple[str, ...] = ()
+        delta = {"added": 0, "removed": 0}
+        if accepted:
+            proposed = self.propose_candidates(mutated_code, rng)
+            delta, evaluations = self.promote_or_reject(mutated_code, proposed, rng)
+            retained = tuple(item.expr for item in evaluations if item.retained)
+            rejected = tuple(item.expr for item in evaluations if not item.retained)
+        else:
+            delta["removed"] = self.expire_ttl(base_code)
+
+        return CoevolutionDecision(
+            accepted=accepted,
+            rejected_for_robustness=rejected_for_robustness,
+            regression_detection_rate=detection_rate,
+            robustness_score=robustness_score,
+            score_combined_base=combined_base,
+            score_combined_new=combined_new,
+            proposed_tests=tuple(candidate.expr for candidate in proposed),
+            retained_tests=retained,
+            rejected_tests=rejected,
+            tests_added=delta["added"],
+            tests_removed=delta["removed"],
+            pool_size=len(self.pool.tests),
+        )
+
+
+__all__ = [
+    "CandidateEvaluation",
+    "CoevolutionConfig",
+    "CoevolutionDecision",
+    "CoevolutionFlow",
+    "MapElites",
+    "LivingTestPool",
+    "TestCandidate",
+    "propose_test_candidates",
+]

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -73,7 +73,7 @@ from .reproduction_flow import (
     decide_reproduction,
     _pick_crossover_parents,
 )
-from .coevolution_flow import MapElites, LivingTestPool, propose_test_candidates
+from .coevolution_flow import CoevolutionConfig, CoevolutionFlow, MapElites, LivingTestPool
 from .skill_genesis import create_skill
 
 # mypy: ignore-errors
@@ -684,6 +684,7 @@ def run(
     test_pool: LivingTestPool | None = None,
     robustness_weight: float = 1.0,
     max_test_candidates: int = 3,
+    test_ttl: int = 3,
     event_bus: EventBus | None = None,
     governance_policy: MutationGovernancePolicy | None = None,
     max_iterations: int | None = None,
@@ -768,8 +769,19 @@ def run(
     quarantined_skill_keys: set[str] = set()
     sleep_ticks_remaining = 0
     intrinsic_goals = IntrinsicGoals(value_weights=value_weights)
-    if coevolve_tests and test_pool is None:
-        test_pool = LivingTestPool()
+    coevolution_flow: CoevolutionFlow | None = None
+    if coevolve_tests:
+        if test_pool is None:
+            test_pool = LivingTestPool(initial_ttl=max(1, int(test_ttl)))
+        coevolution_flow = CoevolutionFlow(
+            pool=test_pool,
+            config=CoevolutionConfig(
+                enabled=True,
+                robustness_weight=robustness_weight,
+                max_test_candidates=max_test_candidates,
+                ttl=test_ttl,
+            ),
+        )
 
     with RunLogger(run_id, psyche=psyche) as logger:
         health_tracker = HealthTracker.from_state(state.health_counters)
@@ -1191,35 +1203,54 @@ def run(
                 "reason": "score_gate",
                 "corrective_action": None,
             }
-            detection_rate = 0.0
-            combined_base = base_score
-            combined_mutated = mutated_score
-            test_delta = {"added": 0, "removed": 0}
-            if coevolve_tests and test_pool is not None and not selected_org.degraded_mode:
+            if coevolution_flow is not None and not selected_org.degraded_mode:
                 can_run_coevo, coevo_state = resource_manager.apply_capability_cost("test_coevolution")
                 if not can_run_coevo:
-                    detection_rate = 0.0
                     accepted = accepted and coevo_state != CapabilityStatus.UNSTABLE
+                    logger.log_test_coevolution(
+                        skill=skill_path.stem,
+                        accepted=accepted,
+                        pool_size=len(coevolution_flow.pool.tests),
+                        added=0,
+                        removed=0,
+                        detection_rate=0.0,
+                        robustness_score=1.0,
+                        score_base=base_score,
+                        score_new=mutated_score,
+                        score_combined_base=base_score,
+                        score_combined_new=mutated_score,
+                        proposed_tests=[],
+                        retained_tests=[],
+                        rejected_tests=[],
+                        rejected_for_robustness=False,
+                    )
                 else:
-                    detection_rate = test_pool.regression_detection_rate(original, mutated)
-                    combined_mutated = mutated_score + (robustness_weight * detection_rate)
-                    combined_base = base_score
-                    accepted = combined_mutated <= combined_base
-                    if accepted:
-                        candidates = propose_test_candidates(mutated, rng, max_test_candidates)
-                        test_delta = test_pool.evolve(mutated, candidates, rng)
-                logger.log_test_coevolution(
-                    skill=skill_path.stem,
-                    accepted=accepted,
-                    pool_size=len(test_pool.tests),
-                    added=test_delta["added"],
-                    removed=test_delta["removed"],
-                    detection_rate=detection_rate,
-                    score_base=base_score,
-                    score_new=mutated_score,
-                    score_combined_base=combined_base,
-                    score_combined_new=combined_mutated,
-                )
+                    coevo_decision = coevolution_flow.decide(
+                        base_code=original,
+                        mutated_code=mutated,
+                        base_score=base_score,
+                        mutated_score=mutated_score,
+                        initially_accepted=accepted,
+                        rng=rng,
+                    )
+                    accepted = coevo_decision.accepted
+                    logger.log_test_coevolution(
+                        skill=skill_path.stem,
+                        accepted=accepted,
+                        pool_size=coevo_decision.pool_size,
+                        added=coevo_decision.tests_added,
+                        removed=coevo_decision.tests_removed,
+                        detection_rate=coevo_decision.regression_detection_rate,
+                        robustness_score=coevo_decision.robustness_score,
+                        score_base=base_score,
+                        score_new=mutated_score,
+                        score_combined_base=coevo_decision.score_combined_base,
+                        score_combined_new=coevo_decision.score_combined_new,
+                        proposed_tests=list(coevo_decision.proposed_tests),
+                        retained_tests=list(coevo_decision.retained_tests),
+                        rejected_tests=list(coevo_decision.rejected_tests),
+                        rejected_for_robustness=coevo_decision.rejected_for_robustness,
+                    )
             accepted = accepted and not mutation_failed
             org.last_score = mutated_score
             if accepted:
@@ -2036,6 +2067,7 @@ def run_tick(
     test_pool: LivingTestPool | None = None,
     robustness_weight: float = 1.0,
     max_test_candidates: int = 3,
+    test_ttl: int = 3,
     event_bus: EventBus | None = None,
     governance_policy: MutationGovernancePolicy | None = None,
     tick_budget_seconds: float = 0.2,
@@ -2059,6 +2091,7 @@ def run_tick(
         test_pool=test_pool,
         robustness_weight=robustness_weight,
         max_test_candidates=max_test_candidates,
+        test_ttl=test_ttl,
         event_bus=event_bus,
         governance_policy=governance_policy,
         max_iterations=1,

--- a/src/singular/orchestrator/lifecycle_clock.py
+++ b/src/singular/orchestrator/lifecycle_clock.py
@@ -30,10 +30,21 @@ class PhaseBehavior:
 
 
 @dataclass(frozen=True)
+class CoevolutionParameters:
+    """Configuration for living-test co-evolution during action ticks."""
+
+    enabled: bool = False
+    robustness_weight: float = 1.0
+    max_test_candidates: int = 3
+    ttl: int = 3
+
+
+@dataclass(frozen=True)
 class LifecycleClockConfig:
     """Complete lifecycle clock config with sane defaults."""
 
     cycle: CycleParameters = field(default_factory=CycleParameters)
+    coevolution: CoevolutionParameters = field(default_factory=CoevolutionParameters)
     phases: dict[str, PhaseBehavior] = field(
         default_factory=lambda: {
             "veille": PhaseBehavior(30.0, 1.1, ("perception", "resource_scan")),
@@ -51,6 +62,9 @@ def _parse_scalar(value: str) -> Any:
         if not inner:
             return []
         return [chunk.strip().strip('"').strip("'") for chunk in inner.split(",")]
+    lowered = text.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
     try:
         return int(text)
     except ValueError:
@@ -92,6 +106,7 @@ def load_lifecycle_clock_config(path: Path | None = None) -> LifecycleClockConfi
 
     raw = _load_simple_yaml(selected)
     cycle_raw = raw.get("cycle", {})
+    coevolution_raw = raw.get("coevolution", {})
     phases_raw = raw.get("phases", {})
 
     cycle = CycleParameters(
@@ -106,6 +121,25 @@ def load_lifecycle_clock_config(path: Path | None = None) -> LifecycleClockConfi
         mutation_window_seconds=float(
             cycle_raw.get("mutation_window_seconds", cfg.cycle.mutation_window_seconds)
         ),
+    )
+
+    coevolution = CoevolutionParameters(
+        enabled=bool(coevolution_raw.get("enabled", cfg.coevolution.enabled))
+        if isinstance(coevolution_raw, dict)
+        else cfg.coevolution.enabled,
+        robustness_weight=float(
+            coevolution_raw.get("robustness_weight", cfg.coevolution.robustness_weight)
+        )
+        if isinstance(coevolution_raw, dict)
+        else cfg.coevolution.robustness_weight,
+        max_test_candidates=int(
+            coevolution_raw.get("max_test_candidates", cfg.coevolution.max_test_candidates)
+        )
+        if isinstance(coevolution_raw, dict)
+        else cfg.coevolution.max_test_candidates,
+        ttl=int(coevolution_raw.get("ttl", cfg.coevolution.ttl))
+        if isinstance(coevolution_raw, dict)
+        else cfg.coevolution.ttl,
     )
 
     phases: dict[str, PhaseBehavior] = {}
@@ -124,5 +158,11 @@ def load_lifecycle_clock_config(path: Path | None = None) -> LifecycleClockConfi
         raise ValueError("introspection_frequency_ticks must be > 0")
     if cycle.mutation_window_seconds <= 0:
         raise ValueError("mutation_window_seconds must be > 0")
+    if coevolution.robustness_weight < 0:
+        raise ValueError("robustness_weight must be >= 0")
+    if coevolution.max_test_candidates < 0:
+        raise ValueError("max_test_candidates must be >= 0")
+    if coevolution.ttl <= 0:
+        raise ValueError("coevolution ttl must be > 0")
 
-    return LifecycleClockConfig(cycle=cycle, phases=phases)
+    return LifecycleClockConfig(cycle=cycle, coevolution=coevolution, phases=phases)

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -21,6 +21,7 @@ from singular.events import (
 )
 from singular.goals import IntrinsicGoals
 from singular.governance.policy import MutationGovernancePolicy
+from singular.life.coevolution_flow import LivingTestPool
 from singular.life.loop import WorldState, run_tick
 from singular.memory import (
     _atomic_write_text,
@@ -93,6 +94,10 @@ class OrchestratorConfig:
     tick_budget_seconds: float = 0.2
     introspection_frequency_ticks: int = 1
     mutation_window_seconds: float = 0.2
+    coevolution_enabled: bool = False
+    coevolution_robustness_weight: float = 1.0
+    coevolution_max_test_candidates: int = 3
+    coevolution_ttl: int = 3
     phase_behaviors: dict[str, dict[str, Any]] = field(default_factory=dict)
     dry_run: bool = False
     safe_mode: bool = False
@@ -132,6 +137,7 @@ class OrchestratorService:
         )
         self.governance_policy = MutationGovernancePolicy(safe_mode=self.config.safe_mode)
         self.world_state = WorldState()
+        self.test_pool = LivingTestPool(initial_ttl=max(1, int(self.config.coevolution_ttl)))
         self.routines = RoutinesOrchestrator(state_path=self.mem_dir / "routines_state.json")
         self.goals = IntrinsicGoals(path=self.mem_dir / "goals.json")
         self._running = False
@@ -488,6 +494,11 @@ class OrchestratorService:
                     tick_budget_seconds=tick_budget,
                     governance_policy=self.governance_policy,
                     world=self.world_state,
+                    coevolve_tests=self.config.coevolution_enabled,
+                    test_pool=self.test_pool,
+                    robustness_weight=self.config.coevolution_robustness_weight,
+                    max_test_candidates=self.config.coevolution_max_test_candidates,
+                    test_ttl=self.config.coevolution_ttl,
                 )
             host_metrics = self._latest_signals.get("host_metrics", {})
             world_health = self._latest_signals.get("world.global_health.score")
@@ -861,6 +872,10 @@ def run_orchestrator_daemon(
             tick_budget_seconds=resolved_tick_budget,
             introspection_frequency_ticks=lifecycle_clock.cycle.introspection_frequency_ticks,
             mutation_window_seconds=lifecycle_clock.cycle.mutation_window_seconds,
+            coevolution_enabled=lifecycle_clock.coevolution.enabled,
+            coevolution_robustness_weight=lifecycle_clock.coevolution.robustness_weight,
+            coevolution_max_test_candidates=lifecycle_clock.coevolution.max_test_candidates,
+            coevolution_ttl=lifecycle_clock.coevolution.ttl,
             phase_behaviors={
                 phase: {
                     "cpu_budget_percent": behavior.cpu_budget_percent,

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -448,6 +448,11 @@ class RunLogger:
         score_new: float,
         score_combined_base: float,
         score_combined_new: float,
+        robustness_score: float | None = None,
+        proposed_tests: list[str] | None = None,
+        retained_tests: list[str] | None = None,
+        rejected_tests: list[str] | None = None,
+        rejected_for_robustness: bool = False,
     ) -> None:
         """Record co-evolution decisions for the living test pool."""
 
@@ -464,6 +469,11 @@ class RunLogger:
             "score_new": score_new,
             "score_combined_base": score_combined_base,
             "score_combined_new": score_combined_new,
+            "robustness_score": robustness_score,
+            "tests_proposed": proposed_tests or [],
+            "tests_retained": retained_tests or [],
+            "tests_rejected": rejected_tests or [],
+            "mutation_rejected_for_robustness": rejected_for_robustness,
         }
         self._write_record(record)
         self._write_event("test_coevolution", record, record["ts"])

--- a/tests/test_lifecycle_clock_config.py
+++ b/tests/test_lifecycle_clock_config.py
@@ -57,3 +57,24 @@ cycle:
         assert "introspection_frequency_ticks" in str(err)
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_load_lifecycle_clock_parses_coevolution_values(tmp_path: Path) -> None:
+    file_path = tmp_path / "lifecycle.yaml"
+    file_path.write_text(
+        """
+coevolution:
+  enabled: true
+  robustness_weight: 2.5
+  max_test_candidates: 7
+  ttl: 5
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_lifecycle_clock_config(file_path)
+
+    assert cfg.coevolution.enabled is True
+    assert cfg.coevolution.robustness_weight == 2.5
+    assert cfg.coevolution.max_test_candidates == 7
+    assert cfg.coevolution.ttl == 5

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1402,7 +1402,7 @@ def test_coevolution_rejects_regression_on_combined_score(tmp_path: Path, monkey
         checkpoint,
         budget_seconds=0.05,
         rng=random.Random(0),
-        operators={"inc": _inc_operator},
+        operators={"dec": _dec_operator},
         coevolve_tests=True,
         test_pool=pool,
         robustness_weight=2.0,
@@ -1436,7 +1436,9 @@ def test_coevolution_logs_decisions(tmp_path: Path, monkeypatch):
 
     log_file = next((tmp_path / "logs").glob("loop-*.jsonl"))
     records = [json.loads(line) for line in log_file.read_text().splitlines()]
-    assert any(rec.get("event") == "test_coevolution" for rec in records)
+    coevo = next(rec for rec in records if rec.get("event") == "test_coevolution")
+    assert coevo["tests_proposed"]
+    assert coevo["tests_retained"]
 
 
 def test_governance_blocks_mutation_write(tmp_path: Path):
@@ -1458,3 +1460,39 @@ def test_governance_blocks_mutation_write(tmp_path: Path):
     )
 
     assert _read_result(skill) == 1
+
+
+def test_run_tick_with_coevolution_logs_candidates_and_rejections(tmp_path: Path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill = skills_dir / "foo.py"
+    skill.write_text("result = 1", encoding="utf-8")
+    checkpoint = tmp_path / "ckpt.json"
+
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(RL, root=tmp_path / "logs")
+    )
+
+    pool = LivingTestPool(tests=[TestCandidate("result == 1")], ttl={"result == 1": 2})
+    life_loop.run_tick(
+        skills_dir,
+        checkpoint,
+        rng=random.Random(0),
+        operators={"dec": _dec_operator},
+        coevolve_tests=True,
+        test_pool=pool,
+        robustness_weight=2.0,
+        max_test_candidates=2,
+        test_ttl=2,
+    )
+
+    assert skill.read_text(encoding="utf-8") == "result = 1"
+    log_file = next((tmp_path / "logs").glob("loop-*.jsonl"))
+    records = [json.loads(line) for line in log_file.read_text().splitlines()]
+    coevo = next(rec for rec in records if rec.get("event") == "test_coevolution")
+    assert coevo["mutation_rejected_for_robustness"] is True
+    assert coevo["tests_proposed"] == []
+    assert coevo["tests_retained"] == []
+    assert coevo["regression_detection_rate"] == 1.0

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -88,6 +88,9 @@ def test_log_test_coevolution(tmp_path: Path) -> None:
     record = json.loads(files[0].read_text(encoding="utf-8").splitlines()[0])
     assert record["event"] == "test_coevolution"
     assert record["regression_detection_rate"] == 0.5
+    assert record["tests_proposed"] == []
+    assert record["tests_retained"] == []
+    assert record["mutation_rejected_for_robustness"] is False
 
 
 def test_log_consciousness_file(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Reduce duplication and clarify the mutation↔test co‑evolution logic by centralizing MapElites/LivingTestPool/candidate generation into a single flow. 
- Provide a clear interface for proposing candidate tests, evaluating mutations against the living test pool, computing a robustness score, expiring TTL, and promoting/rejecting candidates. 
- Make co‑evolution runtime knobs configurable from the lifecycle config and surface co‑evolution decisions in the run logs for observability. 

### Description

- Add `src/singular/life/coevolution_flow.py` implementing `CoevolutionFlow`, `CoevolutionConfig`, `CoevolutionDecision` and helpers that wrap `MapElites`, `LivingTestPool` and `propose_test_candidates`. 
- Wire `CoevolutionFlow` into the mutation loop (`run` / `run_tick`) with a new `test_ttl` argument and use the flow to compute detection/robustness, promote/reject candidates and return a single decision used to accept/reject mutations. 
- Extend `RunLogger.log_test_coevolution` to include `robustness_score`, `tests_proposed`, `tests_retained`, `tests_rejected` and `mutation_rejected_for_robustness` and log the `CoevolutionDecision` payload. 
- Add `coevolution` section to `configs/lifecycle.yaml`, parse/validate it in `load_lifecycle_clock_config`, and propagate settings into the orchestrator and `run_tick`; persist a `LivingTestPool` in the orchestrator service. 
- Update and add integration tests touching `coevolve_tests=True` behavior and logger payloads (`tests/test_loop.py`, `tests/test_lifecycle_clock_config.py`, `tests/test_runs_logger.py`). 

### Testing

- Compiled updated modules with `python -m py_compile` to ensure syntax correctness and the compilation step succeeded. 
- Ran targeted pytest suites including `tests/test_coevolution.py`, `tests/test_lifecycle_clock_config.py`, `tests/test_runs_logger.py` and co‑evolution run tests in `tests/test_loop.py`, and all selected tests passed. 
- Exercised the orchestrator wiring with `tests/test_orchestrator_service.py` together with lifecycle parsing and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04af7c6e50832ab7bd3a72ac9e785f)