### PR TITLE
Add multi-agent life loop orchestration

### DIFF
--- a/examples/multiagent_life_loop/demo.py
+++ b/examples/multiagent_life_loop/demo.py
@@ -1,0 +1,94 @@
+"""Executable demo: two lives exchange a skill and resolve an offer conflict.
+
+Run from the repository root:
+    PYTHONPATH=src python examples/multiagent_life_loop/demo.py
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from singular.governance.policy import MutationGovernancePolicy
+from singular.multiagent import (
+    CollectiveMemory,
+    InMemoryQueueTransport,
+    LifeTickContext,
+    MultiAgentPolicy,
+    MultiAgentRuntime,
+    TaskOffer,
+)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="singular-multiagent-demo-") as tmp:
+        root = Path(tmp)
+        alpha_skills = root / "alpha" / "skills"
+        beta_skills = root / "beta" / "skills"
+        alpha_skills.mkdir(parents=True)
+        beta_skills.mkdir(parents=True)
+        alpha_skill = alpha_skills / "rough_solver.py"
+        beta_skill = beta_skills / "expert_solver.py"
+        alpha_skill.write_text("result = 10\n", encoding="utf-8")
+        beta_skill.write_text("result = -3\n", encoding="utf-8")
+
+        transport = InMemoryQueueTransport()
+        runtime = MultiAgentRuntime(
+            transport=transport,
+            policy=MultiAgentPolicy(low_score_threshold=0.0, high_confidence_threshold=0.8),
+            governance_policy=MutationGovernancePolicy(
+                modifiable_paths=("skills",),
+                review_required_paths=(),
+                forbidden_paths=("src", ".git", "mem", "runs", "tests"),
+            ),
+            memory=CollectiveMemory(root / "collective", "demo"),
+        )
+
+        beta_context = LifeTickContext(
+            life_id="beta",
+            task="shared:solver",
+            skill_path=beta_skill,
+            skills_dir=beta_skills,
+            score=-3.0,
+            confidence=0.95,
+            governance_allowed=True,
+            peers=("alpha",),
+            iteration=1,
+        )
+        beta_decision = runtime.begin_tick(beta_context)
+        print("beta emitted:", [message.intent for message in beta_decision.emitted])
+
+        # A second, lower-priority offer creates a conflict. Alpha resolves the
+        # conflict by accepting beta's higher-priority/high-confidence offer.
+        runtime.emit(
+            TaskOffer(
+                helper_id="gamma",
+                receiver_id="alpha",
+                task="shared:solver",
+                skill="noisy_solver.py",
+                confidence=0.45,
+                priority=1,
+                evidence=["lower_priority_demo_offer"],
+            ).to_message()
+        )
+        alpha_context = LifeTickContext(
+            life_id="alpha",
+            task="shared:solver",
+            skill_path=alpha_skill,
+            skills_dir=alpha_skills,
+            score=5.0,
+            confidence=0.2,
+            governance_allowed=True,
+            peers=("beta",),
+            iteration=2,
+        )
+        alpha_decision = runtime.begin_tick(alpha_context)
+        print("alpha reasons:", alpha_decision.reasons)
+        print("accepted offer:", alpha_decision.accepted_offer.skill if alpha_decision.accepted_offer else None)
+
+        runtime.complete_tick(alpha_context, accepted=True, score_before=5.0, score_after=-3.0)
+        print("collective records:", len(runtime.memory.read()) if runtime.memory else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -55,6 +55,7 @@ from singular.life.metabolism.rewards import RewardContribution, apply_rewards
 from singular.lives import load_registry, set_life_status
 from singular.life.effectors import perform_action
 from singular.life.world_state import PersistentWorldState
+from singular.multiagent.runtime import LifeTickContext, MultiAgentRuntime
 from singular.life.ecosystem import ARCHETYPES, EcosystemRulesConfig, compute_population_metrics, draw_global_event
 
 from .death import DeathMonitor
@@ -687,6 +688,7 @@ def run(
     test_ttl: int = 3,
     event_bus: EventBus | None = None,
     governance_policy: MutationGovernancePolicy | None = None,
+    multiagent_runtime: MultiAgentRuntime | None = None,
     max_iterations: int | None = None,
     ecosystem_rules: EcosystemRules | None = None,
     ecosystem_mode: str = "production",
@@ -873,6 +875,59 @@ def run(
                 )
                 tick_count += 1
                 continue
+
+            # Multi-agent boundary: consult inbox and emit collaboration messages
+            # after skill selection, before mutation/action/reproduction decisions.
+            # At this moment the tick has concrete context but no filesystem write
+            # has been authorized yet, so help offers/refusals can safely gate it.
+            multiagent_context: LifeTickContext | None = None
+            multiagent_decision = None
+            if multiagent_runtime is not None:
+                peer_names = tuple(name for name in world.organisms if name != org_name)
+                reputation_entry = logger.skill_reputation().get(selected_skill_key, {})
+                confidence = float(reputation_entry.get("success_rate", 0.5))
+                if selected_org.last_score != float("-inf"):
+                    current_score = selected_org.last_score
+                elif state.health_history:
+                    current_score = float(state.health_history[-1].get("score", 0.0))
+                else:
+                    current_score = 0.0
+                rivalry_pressure = 1.0 if selected_org.degraded_mode else 0.0
+                if peer_names and selected_org.resources < 0.5:
+                    rivalry_pressure = max(rivalry_pressure, 0.8)
+                multiagent_context = LifeTickContext(
+                    life_id=org_name,
+                    task=selected_skill_key,
+                    skill_path=skill_path,
+                    skills_dir=selected_org.skills_dir,
+                    score=current_score,
+                    confidence=confidence,
+                    governance_allowed=governance_policy.mutations_enabled(),
+                    rivalry=rivalry_pressure,
+                    peers=peer_names,
+                    iteration=state.iteration,
+                )
+                multiagent_decision = multiagent_runtime.begin_tick(multiagent_context)
+                logger.log_interaction(
+                    "multiagent.tick",
+                    organism=org_name,
+                    skill=selected_skill_key,
+                    reasons=multiagent_decision.reasons,
+                    inbound=[message.to_dict() for message in multiagent_decision.inbound],
+                    emitted=[message.to_dict() for message in multiagent_decision.emitted],
+                    mutation_allowed=multiagent_decision.mutation_allowed,
+                    action_allowed=multiagent_decision.action_allowed,
+                    reproduction_allowed=multiagent_decision.reproduction_allowed,
+                    accepted_offer=(
+                        None
+                        if multiagent_decision.accepted_offer is None
+                        else multiagent_decision.accepted_offer.skill
+                    ),
+                    alive=True,
+                )
+                if not multiagent_decision.mutation_allowed:
+                    tick_count += 1
+                    continue
             for penalty in persistent_world_state.consume_due_penalties(state.iteration):
                 selected_org.energy += penalty.energy_delta
                 persistent_world_state.mortality_pressure = max(
@@ -1299,6 +1354,14 @@ def run(
                     org_name,
                     "steal",
                     {"moral_weights": ecosystem_rules.reputation_action_weights},
+                )
+
+            if multiagent_runtime is not None and multiagent_context is not None:
+                multiagent_runtime.complete_tick(
+                    multiagent_context,
+                    accepted=accepted,
+                    score_before=base_score,
+                    score_after=mutated_score,
                 )
 
             objective_weights = asdict(goal_weights)
@@ -1954,6 +2017,22 @@ def run(
                 target = child_skills_dir / "candidate_hybrid.py"
                 root = target.parent.parent if target.parent.name == "skills" else target.parent
                 simulated_governance = governance_policy.simulate_write(target, root=root)
+                reproduction_gate = None
+                if multiagent_runtime is not None:
+                    reproduction_gate = multiagent_runtime.gate_reproduction(
+                        parents=parent_names,
+                        governance_allowed=simulated_governance.allowed,
+                        rivalry=max(0.0, action_resolution.rivalry_penalty),
+                        task=f"reproduction:{state.iteration}",
+                    )
+                    logger.log_interaction(
+                        "multiagent.reproduction_gate",
+                        parents=parent_names,
+                        reasons=reproduction_gate.reasons,
+                        emitted=[message.to_dict() for message in reproduction_gate.emitted],
+                        reproduction_allowed=reproduction_gate.reproduction_allowed,
+                        alive=True,
+                    )
                 decision = decide_reproduction(
                     parent_a=parent_names[0],
                     parent_b=parent_names[1],
@@ -1964,6 +2043,13 @@ def run(
                     governance_allowed=simulated_governance.allowed,
                     policy=ecosystem_rules.reproduction_policy,
                 )
+                if reproduction_gate is not None and not reproduction_gate.reproduction_allowed:
+                    decision = decision.__class__(
+                        accepted=False,
+                        score=decision.score,
+                        reasons=["multiagent_gate"] + reproduction_gate.reasons + decision.reasons,
+                        components=decision.components,
+                    )
                 if cooldown_remaining > 0:
                     decision = decision.__class__(
                         accepted=False,
@@ -2070,6 +2156,7 @@ def run_tick(
     test_ttl: int = 3,
     event_bus: EventBus | None = None,
     governance_policy: MutationGovernancePolicy | None = None,
+    multiagent_runtime: MultiAgentRuntime | None = None,
     tick_budget_seconds: float = 0.2,
     ecosystem_rules: EcosystemRules | None = None,
 ) -> Checkpoint:
@@ -2094,6 +2181,7 @@ def run_tick(
         test_ttl=test_ttl,
         event_bus=event_bus,
         governance_policy=governance_policy,
+        multiagent_runtime=multiagent_runtime,
         max_iterations=1,
         ecosystem_rules=ecosystem_rules,
     )

--- a/src/singular/multiagent/__init__.py
+++ b/src/singular/multiagent/__init__.py
@@ -5,11 +5,19 @@ from .protocol import (
     CollectiveMemory,
     FileQueueTransport,
     HelpExchangeCoordinator,
+    HelpRequest,
     HelpTransferResult,
     InMemoryQueueTransport,
+    TaskOffer,
     OrchestrationScenario,
     resolve_conflicts,
     validate_message_schema,
+)
+from .runtime import (
+    LifeTickContext,
+    MultiAgentDecision,
+    MultiAgentPolicy,
+    MultiAgentRuntime,
 )
 
 __all__ = [
@@ -17,9 +25,15 @@ __all__ = [
     "CollectiveMemory",
     "FileQueueTransport",
     "HelpExchangeCoordinator",
+    "HelpRequest",
     "HelpTransferResult",
     "InMemoryQueueTransport",
+    "TaskOffer",
     "OrchestrationScenario",
     "resolve_conflicts",
     "validate_message_schema",
+    "LifeTickContext",
+    "MultiAgentDecision",
+    "MultiAgentPolicy",
+    "MultiAgentRuntime",
 ]

--- a/src/singular/multiagent/protocol.py
+++ b/src/singular/multiagent/protocol.py
@@ -56,6 +56,7 @@ class AgentMessage:
         "help.offered",
         "help.accepted",
         "help.completed",
+        "help.refused",
     ]
     task: str
     evidence: list[str]
@@ -106,6 +107,114 @@ class AgentMessage:
             payload=dict(payload.get("payload", {})),
         )
 
+
+
+@dataclass(slots=True)
+class HelpRequest:
+    """Typed request for assistance that can be serialized as AgentMessage."""
+
+    requester_id: str
+    task: str
+    skill: str
+    score: float
+    evidence: list[str] = field(default_factory=list)
+    priority: int = 5
+
+    @classmethod
+    def from_context(cls, context: Any) -> "HelpRequest":
+        return cls(
+            requester_id=str(context.life_id),
+            task=str(context.task),
+            skill=Path(context.skill_path).name,
+            score=float(context.score),
+            evidence=[f"score:{float(context.score):.6f}", "policy:low_score_help"],
+        )
+
+    def to_message(self) -> AgentMessage:
+        payload = build_help_event_payload(
+            requester_life=self.requester_id,
+            helper_life=None,
+            task=self.task,
+            attempts=0,
+            metadata={"skill": self.skill, "score": self.score},
+        )
+        return AgentMessage(
+            intent=HELP_REQUESTED,
+            task=self.task,
+            evidence=list(self.evidence),
+            confidence=1.0,
+            priority=self.priority,
+            agent_id=self.requester_id,
+            payload=payload,
+            version=2,
+        )
+
+
+@dataclass(slots=True)
+class TaskOffer:
+    """Typed skill/task offer exchanged between lives."""
+
+    helper_id: str
+    task: str
+    skill: str
+    confidence: float
+    receiver_id: str | None = None
+    evidence: list[str] = field(default_factory=list)
+    priority: int = 4
+
+    @classmethod
+    def from_context(cls, context: Any, receiver_id: str | None = None) -> "TaskOffer":
+        return cls(
+            helper_id=str(context.life_id),
+            receiver_id=receiver_id,
+            task=str(context.task),
+            skill=Path(context.skill_path).name,
+            confidence=float(context.confidence),
+            evidence=[
+                f"skill:{Path(context.skill_path).name}",
+                f"confidence:{float(context.confidence):.3f}",
+                "policy:high_confidence_offer",
+            ],
+        )
+
+    @classmethod
+    def from_message(cls, message: AgentMessage) -> "TaskOffer":
+        metadata = dict(message.payload.get("metadata", {}))
+        skill = str(metadata.get("skill") or message.payload.get("skill") or message.task)
+        return cls(
+            helper_id=str(message.agent_id or message.payload.get("helper_life") or "unknown"),
+            receiver_id=(
+                str(message.payload["receiver_id"])
+                if message.payload.get("receiver_id") is not None
+                else None
+            ),
+            task=message.task,
+            skill=skill,
+            confidence=message.confidence,
+            evidence=list(message.evidence),
+            priority=message.priority,
+        )
+
+    def to_message(self) -> AgentMessage:
+        payload = build_help_event_payload(
+            requester_life=self.receiver_id or "",
+            helper_life=self.helper_id,
+            task=self.task,
+            attempts=0,
+            metadata={"skill": self.skill, "confidence": self.confidence},
+        )
+        if self.receiver_id is not None:
+            payload["receiver_id"] = self.receiver_id
+        return AgentMessage(
+            intent=HELP_OFFERED,
+            task=self.task,
+            evidence=list(self.evidence),
+            confidence=max(0.0, min(1.0, self.confidence)),
+            priority=self.priority,
+            agent_id=self.helper_id,
+            payload=payload,
+            version=2,
+        )
 
 def _validate_payload_schema(
     payload: dict[str, Any],

--- a/src/singular/multiagent/runtime.py
+++ b/src/singular/multiagent/runtime.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Literal
+
+from singular.events import HELP_COMPLETED, HELP_OFFERED, HELP_REQUESTED, EventBus
+from singular.governance.policy import AUTH_BLOCKED, AUTH_REVIEW_REQUIRED, MutationGovernancePolicy
+from singular.multiagent.protocol import (
+    AgentMessage,
+    CollectiveMemory,
+    HelpRequest,
+    MessageTransport,
+    TaskOffer,
+    resolve_conflicts,
+)
+
+
+@dataclass(slots=True)
+class LifeTickContext:
+    """Multi-agent view of a life-loop tick.
+
+    The loop builds this context after selecting a skill and before choosing the
+    concrete mutation operator. This is the earliest point where the runtime
+    knows which life, task, and skill are involved, while still being early
+    enough to let messages block or bias mutation/action/reproduction choices.
+    """
+
+    life_id: str
+    task: str
+    skill_path: Path
+    skills_dir: Path
+    score: float
+    confidence: float
+    governance_allowed: bool
+    rivalry: float = 0.0
+    peers: tuple[str, ...] = ()
+    iteration: int = 0
+
+
+@dataclass(slots=True)
+class MultiAgentDecision:
+    """Decision returned to the life loop after inbox/outbox arbitration."""
+
+    mutation_allowed: bool = True
+    action_allowed: bool = True
+    reproduction_allowed: bool = True
+    accepted_offer: TaskOffer | None = None
+    conflict_winner: AgentMessage | None = None
+    reasons: list[str] = field(default_factory=list)
+    inbound: list[AgentMessage] = field(default_factory=list)
+    emitted: list[AgentMessage] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class MultiAgentPolicy:
+    """Thresholds for autonomous collaboration during a life tick."""
+
+    low_score_threshold: float = 0.0
+    high_confidence_threshold: float = 0.8
+    high_rivalry_threshold: float = 0.75
+    help_priority: int = 5
+    offer_priority: int = 4
+
+
+class MultiAgentRuntime:
+    """Coordinate inbox, outbox, conflict resolution, and help requests.
+
+    The runtime deliberately keeps filesystem writes and mutation materialization
+    in the life loop. It only exchanges protocol messages and returns gating
+    decisions that the loop applies to mutation acceptance, action execution,
+    and reproduction authorization.
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: MessageTransport,
+        policy: MultiAgentPolicy | None = None,
+        governance_policy: MutationGovernancePolicy | None = None,
+        bus: EventBus | None = None,
+        memory: CollectiveMemory | None = None,
+    ) -> None:
+        self.transport = transport
+        self.policy = policy or MultiAgentPolicy()
+        self.governance_policy = governance_policy
+        self.bus = bus
+        self.memory = memory
+        self.inbox: list[AgentMessage] = []
+        self.outbox: list[AgentMessage] = []
+
+    def drain_inbox(self) -> list[AgentMessage]:
+        messages = self.transport.receive()
+        self.inbox.extend(messages)
+        return messages
+
+    def emit(self, message: AgentMessage) -> AgentMessage:
+        self.transport.send(message)
+        self.outbox.append(message)
+        if self.memory is not None:
+            self.memory.append({"kind": "multiagent_message", "message": message.to_dict()})
+        if self.bus is not None and message.intent.startswith("help."):
+            self.bus.publish(message.intent, message.payload, payload_version=message.version)
+        return message
+
+    def begin_tick(self, context: LifeTickContext) -> MultiAgentDecision:
+        """Consult inbound messages and emit help/offer/refusal messages.
+
+        Policy:
+        * low score => request help;
+        * high confidence => offer the selected skill;
+        * blocked governance or high rivalry => refuse collaboration and gate
+          mutation/action/reproduction for this tick.
+        """
+
+        inbound = [msg for msg in self.drain_inbox() if self._matches_context(msg, context)]
+        winners = resolve_conflicts(inbound)
+        conflict_winner = winners.get(context.task)
+        emitted: list[AgentMessage] = []
+        reasons: list[str] = []
+
+        governance_allowed = context.governance_allowed and self._governance_allows(context)
+        rivalry_high = context.rivalry >= self.policy.high_rivalry_threshold
+        if not governance_allowed or rivalry_high:
+            reasons.append("governance_blocked" if not governance_allowed else "rivalry_high")
+            emitted.extend(self._refuse_inbound(context, inbound, reasons[-1]))
+            return MultiAgentDecision(
+                mutation_allowed=False,
+                action_allowed=False,
+                reproduction_allowed=False,
+                conflict_winner=conflict_winner,
+                reasons=reasons,
+                inbound=inbound,
+                emitted=emitted,
+            )
+
+        accepted_offer: TaskOffer | None = None
+        if conflict_winner and conflict_winner.intent == HELP_OFFERED:
+            accepted_offer = TaskOffer.from_message(conflict_winner)
+            reasons.append("accepted_best_offer")
+
+        if context.score <= self.policy.low_score_threshold:
+            emitted.append(self.emit(HelpRequest.from_context(context).to_message()))
+            reasons.append("requested_help_low_score")
+
+        if context.confidence >= self.policy.high_confidence_threshold:
+            for peer in context.peers or (None,):
+                emitted.append(self.emit(TaskOffer.from_context(context, receiver_id=peer).to_message()))
+            reasons.append("offered_skill_high_confidence")
+
+        return MultiAgentDecision(
+            accepted_offer=accepted_offer,
+            conflict_winner=conflict_winner,
+            reasons=reasons,
+            inbound=inbound,
+            emitted=emitted,
+        )
+
+    def complete_tick(
+        self,
+        context: LifeTickContext,
+        *,
+        accepted: bool,
+        score_before: float,
+        score_after: float,
+    ) -> AgentMessage:
+        intent: Literal["help.completed", "answer"] = HELP_COMPLETED if accepted else "answer"
+        message = AgentMessage(
+            intent=intent,
+            task=context.task,
+            evidence=[
+                f"skill:{context.skill_path.name}",
+                f"accepted:{accepted}",
+                f"score_before:{score_before:.6f}",
+                f"score_after:{score_after:.6f}",
+            ],
+            confidence=max(0.0, min(1.0, context.confidence)),
+            priority=1,
+            agent_id=context.life_id,
+            payload={
+                "iteration": context.iteration,
+                "skill_path": str(context.skill_path),
+                "accepted": accepted,
+                "score_before": score_before,
+                "score_after": score_after,
+            },
+            version=2,
+        )
+        return self.emit(message)
+
+    def gate_reproduction(
+        self,
+        *,
+        parents: Iterable[str],
+        governance_allowed: bool,
+        rivalry: float,
+        task: str,
+    ) -> MultiAgentDecision:
+        context = LifeTickContext(
+            life_id="ecosystem",
+            task=task,
+            skill_path=Path(task),
+            skills_dir=Path("."),
+            score=0.0,
+            confidence=0.0,
+            governance_allowed=governance_allowed,
+            rivalry=rivalry,
+            peers=tuple(parents),
+        )
+        if governance_allowed and rivalry < self.policy.high_rivalry_threshold:
+            return MultiAgentDecision(reasons=["reproduction_allowed"])
+        reason = "governance_blocked" if not governance_allowed else "rivalry_high"
+        message = AgentMessage(
+            intent="warning",
+            task=task,
+            evidence=[reason, *(f"parent:{parent}" for parent in parents)],
+            confidence=1.0,
+            priority=self.policy.help_priority,
+            agent_id="multiagent-runtime",
+            payload={"reason": reason, "rivalry": rivalry},
+            version=2,
+        )
+        return MultiAgentDecision(
+            mutation_allowed=False,
+            action_allowed=False,
+            reproduction_allowed=False,
+            reasons=[reason],
+            emitted=[self.emit(message)],
+        )
+
+    def _matches_context(self, message: AgentMessage, context: LifeTickContext) -> bool:
+        target = message.payload.get("receiver_id") or message.payload.get("requester_life") or None
+        return message.task == context.task and (target in {None, context.life_id})
+
+    def _governance_allows(self, context: LifeTickContext) -> bool:
+        if self.governance_policy is None:
+            return True
+        if not self.governance_policy.mutations_enabled():
+            return False
+        decision = self.governance_policy.simulate_write(
+            context.skill_path,
+            root=context.skills_dir.parent,
+        )
+        return decision.allowed and decision.level not in {AUTH_BLOCKED, AUTH_REVIEW_REQUIRED}
+
+    def _refuse_inbound(
+        self,
+        context: LifeTickContext,
+        inbound: list[AgentMessage],
+        reason: str,
+    ) -> list[AgentMessage]:
+        emitted: list[AgentMessage] = []
+        targets = [msg.agent_id for msg in inbound if msg.agent_id and msg.agent_id != context.life_id]
+        if not targets:
+            targets = [None]
+        for target in targets:
+            emitted.append(
+                self.emit(
+                    AgentMessage(
+                        intent="help.refused",
+                        task=context.task,
+                        evidence=[reason, f"skill:{context.skill_path.name}"],
+                        confidence=1.0,
+                        priority=self.policy.help_priority,
+                        agent_id=context.life_id,
+                        payload={"receiver_id": target, "reason": reason},
+                        version=2,
+                    )
+                )
+            )
+        return emitted

--- a/tests/test_multiagent_life_loop.py
+++ b/tests/test_multiagent_life_loop.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import ast
+import random
+from pathlib import Path
+
+from singular.governance.policy import MutationGovernancePolicy
+from singular.life.loop import EcosystemRules, WorldState, run_tick
+from singular.multiagent import (
+    InMemoryQueueTransport,
+    LifeTickContext,
+    MultiAgentPolicy,
+    MultiAgentRuntime,
+    TaskOffer,
+)
+
+
+def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            node.value -= 1
+            break
+    return tree
+
+
+def _governance_policy() -> MutationGovernancePolicy:
+    return MutationGovernancePolicy(
+        modifiable_paths=("skills",),
+        review_required_paths=(),
+        forbidden_paths=("src", ".git", "mem", "runs", "tests"),
+    )
+
+
+def test_runtime_requests_help_offers_skill_and_resolves_offer_conflict(tmp_path: Path) -> None:
+    transport = InMemoryQueueTransport()
+    runtime = MultiAgentRuntime(
+        transport=transport,
+        policy=MultiAgentPolicy(low_score_threshold=0.0, high_confidence_threshold=0.8),
+        governance_policy=_governance_policy(),
+    )
+    alpha_skills = tmp_path / "alpha" / "skills"
+    beta_skills = tmp_path / "beta" / "skills"
+    alpha_skills.mkdir(parents=True)
+    beta_skills.mkdir(parents=True)
+    alpha_skill = alpha_skills / "solver.py"
+    beta_skill = beta_skills / "expert.py"
+    alpha_skill.write_text("result = 4\n", encoding="utf-8")
+    beta_skill.write_text("result = -1\n", encoding="utf-8")
+
+    beta_decision = runtime.begin_tick(
+        LifeTickContext(
+            life_id="beta",
+            task="shared:solver",
+            skill_path=beta_skill,
+            skills_dir=beta_skills,
+            score=-1.0,
+            confidence=0.95,
+            governance_allowed=True,
+            peers=("alpha",),
+        )
+    )
+    assert [message.intent for message in beta_decision.emitted] == ["help.requested", "help.offered"]
+
+    runtime.emit(
+        TaskOffer(
+            helper_id="gamma",
+            receiver_id="alpha",
+            task="shared:solver",
+            skill="weaker.py",
+            confidence=0.2,
+            priority=1,
+        ).to_message()
+    )
+    alpha_decision = runtime.begin_tick(
+        LifeTickContext(
+            life_id="alpha",
+            task="shared:solver",
+            skill_path=alpha_skill,
+            skills_dir=alpha_skills,
+            score=3.0,
+            confidence=0.1,
+            governance_allowed=True,
+            peers=("beta",),
+        )
+    )
+
+    assert alpha_decision.accepted_offer is not None
+    assert alpha_decision.accepted_offer.helper_id == "beta"
+    assert alpha_decision.accepted_offer.skill == "expert.py"
+    assert "accepted_best_offer" in alpha_decision.reasons
+
+
+def test_runtime_refuses_and_gates_when_governance_or_rivalry_is_high(tmp_path: Path) -> None:
+    transport = InMemoryQueueTransport()
+    runtime = MultiAgentRuntime(transport=transport)
+    skills_dir = tmp_path / "alpha" / "skills"
+    skills_dir.mkdir(parents=True)
+    skill = skills_dir / "solver.py"
+    skill.write_text("result = 1\n", encoding="utf-8")
+
+    decision = runtime.begin_tick(
+        LifeTickContext(
+            life_id="alpha",
+            task="blocked:solver",
+            skill_path=skill,
+            skills_dir=skills_dir,
+            score=1.0,
+            confidence=0.9,
+            governance_allowed=False,
+            rivalry=0.9,
+        )
+    )
+
+    assert decision.mutation_allowed is False
+    assert decision.action_allowed is False
+    assert decision.reproduction_allowed is False
+    assert [message.intent for message in decision.emitted] == ["help.refused"]
+
+
+def test_life_loop_consults_multiagent_runtime_during_tick(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    alpha_skills = tmp_path / "alpha" / "skills"
+    beta_skills = tmp_path / "beta" / "skills"
+    alpha_skills.mkdir(parents=True)
+    beta_skills.mkdir(parents=True)
+    (alpha_skills / "solver.py").write_text("result = 2\n", encoding="utf-8")
+    (beta_skills / "helper.py").write_text("result = -2\n", encoding="utf-8")
+
+    transport = InMemoryQueueTransport()
+    runtime = MultiAgentRuntime(
+        transport=transport,
+        policy=MultiAgentPolicy(low_score_threshold=1.0, high_confidence_threshold=0.99),
+        governance_policy=_governance_policy(),
+    )
+    world = WorldState()
+
+    state = run_tick(
+        {"alpha": alpha_skills, "beta": beta_skills},
+        tmp_path / "checkpoint.json",
+        rng=random.Random(0),
+        operators={"dec": _dec_operator},
+        world=world,
+        governance_policy=_governance_policy(),
+        multiagent_runtime=runtime,
+        ecosystem_rules=EcosystemRules(crossover_interval=0),
+        tick_budget_seconds=0.05,
+    )
+
+    assert state.iteration == 1
+    intents = [message.intent for message in runtime.outbox]
+    assert "help.requested" in intents
+    assert any(intent in {"help.completed", "answer"} for intent in intents)


### PR DESCRIPTION
### Motivation
- Introduce a lightweight multi-agent orchestration layer so lives can exchange help/offers, resolve conflicts, and gate mutations/reproduction at the appropriate point in a tick. 
- Place the multi-agent decision boundary after skill selection and before any filesystem writes or mutation materialization so collaboration can safely influence mutation/action/reproduction decisions.

### Description
- Add a runtime coordinator `src/singular/multiagent/runtime.py` implementing `LifeTickContext`, `MultiAgentPolicy`, `MultiAgentDecision` and `MultiAgentRuntime` to handle inbox/outbox, conflict resolution, help requests, skill offers, refusals and reproduction gating. 
- Extend protocol in `src/singular/multiagent/protocol.py` with typed adapters `HelpRequest`, `TaskOffer` and a new `help.refused` intent to serialize common multi-agent interactions. 
- Export runtime and new protocol types from `src/singular/multiagent/__init__.py`.
- Integrate the runtime into the life loop in `src/singular/life/loop.py` at the selected-skill / pre-mutation boundary by: constructing a `LifeTickContext`, calling `MultiAgentRuntime.begin_tick()` to consult inbox and optionally emit messages, gating mutation/action when `mutation_allowed` is false, emitting `complete_tick()` messages after mutation outcome, and calling `gate_reproduction()` before crossover to allow multi-agent reproduction gating. 
- Add an executable demo `examples/multiagent_life_loop/demo.py` that runs two lives exchanging a skill and resolving an offer conflict. 
- Add integration tests `tests/test_multiagent_life_loop.py` covering help requests, offers, conflict resolution, governance/rivalry refusal, and verifying the life loop consults the runtime during a tick.

### Testing
- Ran unit/integration tests: `pytest -q tests/test_import_packages.py tests/test_multiagent_protocol.py tests/test_multi_life_help_integration.py tests/test_multiagent_life_loop.py` ; all tests passed (`16 passed`).
- Exercised the demo with `PYTHONPATH=src python examples/multiagent_life_loop/demo.py`; demo ran and printed expected message flow.
- Performed static compile checks with `python -m py_compile src/singular/multiagent/protocol.py src/singular/multiagent/runtime.py src/singular/life/loop.py examples/multiagent_life_loop/demo.py`; compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b5f15598832a88157a41f1a283a1)