### PR TITLE
Add psyche-driven action decisions

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -32,7 +32,7 @@ from singular.memory import (
     temporarily_disable_skill,
     update_score,
 )
-from singular.psyche import Psyche, Mood
+from singular.psyche import Psyche, Mood, choose_action_from_psyche
 from singular.runs.logger import RunLogger
 from singular.runs.explain import summarize_mutation
 from singular.runs.generations import record_generation
@@ -1643,15 +1643,43 @@ def run(
                     )
                 )
 
-            action_name = "simulated_world_task" if accepted else "structured_user_interaction"
+            fallback_action_name = "simulated_world_task" if accepted else "structured_user_interaction"
             if action_resolution.granted:
-                action_name = "resource_management"
+                fallback_action_name = "resource_management"
+            psyche_decision = choose_action_from_psyche(
+                psyche,
+                {
+                    "risk": persistent_world_state.risks,
+                    "rarity_pressure": persistent_world_state.rarity,
+                    "competition_pressure": getattr(persistent_world_state, "competition", 0.5),
+                    "opportunity": persistent_world_state.opportunities,
+                    "resource_energy": resource_manager.energy,
+                    "success_bias": 0.2 if accepted else -0.2,
+                    "fallback_action": fallback_action_name,
+                },
+            )
+            action_name = psyche_decision.action
+            logger.log_interaction(
+                "psyche_action_decision",
+                action=action_name,
+                fallback_action=fallback_action_name,
+                reason=psyche_decision.reason,
+                mood=mood_value,
+                energy=float(getattr(psyche, "energy", resource_manager.energy)),
+                resource_energy=float(resource_manager.energy),
+                scores={
+                    name: round(score, 6)
+                    for name, score in sorted(psyche_decision.scores.items())
+                },
+            )
             effect_result = perform_action(
                 action_name,
                 {
                     "risk": persistent_world_state.risks,
                     "rarity_pressure": persistent_world_state.rarity,
+                    "competition_pressure": getattr(persistent_world_state, "competition", 0.5),
                     "success_bias": 0.2 if accepted else -0.2,
+                    "psyche_decision_reason": psyche_decision.reason,
                 },
             )
             selected_org.energy += effect_result.energy_delta

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Any, ClassVar
+from typing import Dict, Any, ClassVar, Mapping, Sequence
 from pathlib import Path
 import random
 from enum import Enum
@@ -67,6 +67,151 @@ def derive_mood(record: dict) -> Mood:
             return Mood.FRUSTRATED
 
     return Mood.ANXIOUS
+
+
+@dataclass(frozen=True, slots=True)
+class PsycheActionDecision:
+    """Action selected from psyche, resource, social, and environment signals."""
+
+    action: str
+    reason: str
+    scores: dict[str, float] = field(default_factory=dict)
+
+
+def _numeric_signal(signals: Mapping[str, Any], key: str, default: float = 0.0) -> float:
+    """Return ``key`` from ``signals`` as a float, falling back on ``default``."""
+    try:
+        return float(signals.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _social_loneliness_signal(social_states: Mapping[str, Mapping[str, float]]) -> float:
+    """Estimate social isolation from low loyalty/gratitude and high resentment."""
+    if not social_states:
+        return 0.5
+    signals: list[float] = []
+    for state in social_states.values():
+        if not isinstance(state, Mapping):
+            continue
+        gratitude = _clamp(float(state.get("gratitude", 0.5)))
+        loyalty = _clamp(float(state.get("loyalty", 0.5)))
+        resentment = _clamp(float(state.get("resentment", 0.5)))
+        signals.append(_clamp(1.0 - ((gratitude + loyalty) / 2.0) + (resentment * 0.25)))
+    if not signals:
+        return 1.0
+    return _clamp(sum(signals) / len(signals))
+
+
+def _objective_pressure(psyche: "Psyche") -> tuple[float, float, float]:
+    """Return exploration, safety, and resource pressure from objectives."""
+    axes = getattr(psyche, "weighted_objective_axes", lambda: {"long_term": 0.33, "sandbox": 0.33, "resource": 0.34})()
+    exploration = _clamp(float(axes.get("long_term", 0.33)))
+    safety = _clamp(float(axes.get("sandbox", 0.33)))
+    resources = _clamp(float(axes.get("resource", 0.34)))
+    return exploration, safety, resources
+
+
+def choose_action_from_psyche(
+    psyche: "Psyche",
+    environment_signals: Mapping[str, Any] | None = None,
+    *,
+    available_actions: Sequence[str] | None = None,
+) -> PsycheActionDecision:
+    """Choose a concrete world action from psyche and environment signals.
+
+    Explicit policy rules make the decision observable and testable:
+
+    * fatigue or low energy favours ``rest``;
+    * curiosity favours exploration via ``move`` or ``forage``;
+    * anger favours controlled competition via ``compete``;
+    * loneliness favours cooperation via ``cooperate`` or ``share_resource``.
+    """
+    signals = dict(environment_signals or {})
+    allowed = set(
+        available_actions
+        or (
+            "rest",
+            "move",
+            "forage",
+            "cooperate",
+            "share_resource",
+            "compete",
+            "avoid_threat",
+            "resource_management",
+            "structured_user_interaction",
+            "simulated_world_task",
+        )
+    )
+    if not allowed:
+        allowed = {"simulated_world_task"}
+
+    mood = getattr(psyche, "last_mood", None) or Mood.NEUTRAL
+    energy = float(getattr(psyche, "energy", 100.0))
+    resource_energy = _numeric_signal(signals, "resource_energy", energy)
+    effective_energy = min(energy, resource_energy)
+    risk = _clamp(_numeric_signal(signals, "risk", 0.0))
+    rarity = _clamp(_numeric_signal(signals, "rarity_pressure", 0.0))
+    competition = _clamp(_numeric_signal(signals, "competition_pressure", 0.0))
+    opportunity = _clamp(_numeric_signal(signals, "opportunity", 0.5))
+    fallback_action = signals.get("fallback_action")
+    exploration_pressure, safety_pressure, resource_pressure = _objective_pressure(psyche)
+    loneliness = max(
+        _social_loneliness_signal(getattr(psyche, "social_states", {})),
+        _clamp(_numeric_signal(signals, "social_isolation", 0.0)),
+    )
+
+    scores = {action: 0.0 for action in allowed}
+
+    def add(action: str, value: float) -> None:
+        if action in scores:
+            scores[action] += value
+
+    if isinstance(fallback_action, str):
+        add(fallback_action, 1.0)
+    add("move", 0.35 * exploration_pressure + 0.20 * opportunity)
+    add("forage", 0.30 * resource_pressure + 0.25 * rarity)
+    add("rest", 0.20 * safety_pressure + max(0.0, 40.0 - effective_energy) / 40.0)
+    add("avoid_threat", 0.35 * risk + 0.20 * safety_pressure)
+    add("cooperate", 0.30 * loneliness + max(0.0, 0.5 - competition) * 0.15)
+    add("share_resource", 0.20 * loneliness + 0.15 * resource_pressure)
+    add("compete", 0.25 * competition + 0.10 * resource_pressure)
+    add("resource_management", 0.20 * resource_pressure + 0.10 * rarity)
+    add("structured_user_interaction", 0.15 * loneliness + 0.10 * safety_pressure)
+    add("simulated_world_task", 0.10 * exploration_pressure + 0.10 * opportunity)
+
+    reason_parts: list[str] = []
+    if mood == Mood.FATIGUE or effective_energy < 25.0:
+        add("rest", 3.0)
+        reason_parts.append(
+            f"fatigue_or_low_energy(mood={mood.value}, energy={effective_energy:.1f}) favors rest"
+        )
+    if mood == Mood.CURIOUS or getattr(psyche, "curiosity", 0.0) >= 0.7:
+        add("move", 2.2)
+        add("forage", 1.0)
+        reason_parts.append("curiosity favors exploration")
+    if mood == Mood.ANGER:
+        add("compete", 2.4)
+        add("avoid_threat", 0.5)
+        reason_parts.append("anger favors controlled competition")
+    if mood == Mood.LONELY or loneliness >= 0.65:
+        add("cooperate", 2.5)
+        add("share_resource", 1.2)
+        reason_parts.append("loneliness favors cooperation")
+    if risk >= 0.75:
+        add("avoid_threat", 2.0)
+        reason_parts.append(f"high environmental risk({risk:.2f}) favors avoiding threat")
+    if rarity >= 0.70 and effective_energy >= 35.0:
+        add("forage", 1.3)
+        reason_parts.append(f"scarcity({rarity:.2f}) favors foraging")
+
+    action = max(sorted(scores), key=lambda candidate: scores[candidate])
+    if not reason_parts:
+        reason_parts.append(
+            "balanced objective/environment scoring selected the highest-scoring action"
+        )
+    reason = "; ".join(reason_parts) + f"; selected={action}; score={scores[action]:.3f}"
+    return PsycheActionDecision(action=action, reason=reason, scores=scores)
 
 
 @dataclass

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1496,3 +1496,57 @@ def test_run_tick_with_coevolution_logs_candidates_and_rejections(tmp_path: Path
     assert coevo["tests_proposed"] == []
     assert coevo["tests_retained"] == []
     assert coevo["regression_detection_rate"] == 1.0
+
+
+def test_loop_logs_psyche_action_decision_before_effector(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setattr(life_loop, "propose_mutations", lambda *_a, **_k: [])
+    monkeypatch.setattr(life_loop, "SKILL_GENESIS_TECH_DEBT_THRESHOLD", 10_000)
+    monkeypatch.setattr(life_loop, "SKILL_GENESIS_FAILURE_STREAK_THRESHOLD", 10_000)
+    monkeypatch.setattr(life_loop, "SKILL_GENESIS_COVERAGE_GAP_THRESHOLD", 10_000.0)
+
+    from singular.runs.logger import RunLogger as RL
+
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(RL, root=tmp_path / "logs")
+    )
+    performed: list[tuple[str, dict[str, object]]] = []
+    original_perform_action = life_loop.perform_action
+
+    def capture_perform_action(action, context=None):
+        performed.append((action, dict(context or {})))
+        return original_perform_action(action, context)
+
+    monkeypatch.setattr(life_loop, "perform_action", capture_perform_action)
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "foo.py").write_text("result = 1", encoding="utf-8")
+
+    run(
+        skills_dir,
+        tmp_path / "ckpt.json",
+        budget_seconds=10.0,
+        max_iterations=1,
+        rng=random.Random(0),
+        operators={"dec": _dec_operator},
+    )
+
+    assert performed
+    action, context = performed[0]
+    assert action == "move"
+    assert "psyche_decision_reason" in context
+
+    records = [
+        json.loads(line)
+        for line in (tmp_path / "logs" / "loop" / "events.jsonl").read_text().splitlines()
+    ]
+    decision_events = [
+        record["payload"]
+        for record in records
+        if record.get("event_type") == "interaction"
+        and record.get("payload", {}).get("interaction") == "psyche_action_decision"
+    ]
+    assert decision_events
+    assert decision_events[0]["action"] == action
+    assert "curiosity favors exploration" in decision_events[0]["reason"]

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from singular.psyche import Psyche, Mood
+import pytest
+
+from singular.psyche import Psyche, Mood, choose_action_from_psyche
 from singular.resource_manager import ResourceManager
 from singular.motivation import GoalPolicy, Objective
 
@@ -178,3 +180,63 @@ def test_social_state_bounds_are_stable() -> None:
         assert 0.0 <= psyche.cooperation_score(target) <= 1.0
         assert 0.0 <= psyche.reproduction_arbitration_score(0.9, target) <= 1.0
         assert 0.0 <= psyche.relational_risk_tolerance(target) <= 1.0
+
+
+@pytest.mark.parametrize(
+    ("mood", "energy", "signals", "social_states", "expected_action", "reason_text"),
+    [
+        (Mood.FATIGUE, 12.0, {"resource_energy": 12.0}, {}, "rest", "fatigue_or_low_energy"),
+        (Mood.CURIOUS, 80.0, {"opportunity": 0.9}, {}, "move", "curiosity"),
+        (Mood.ANGER, 70.0, {"competition_pressure": 0.8}, {}, "compete", "anger"),
+        (
+            Mood.LONELY,
+            65.0,
+            {"competition_pressure": 0.1},
+            {"peer": {"gratitude": 0.1, "loyalty": 0.1, "resentment": 0.8}},
+            "cooperate",
+            "loneliness",
+        ),
+    ],
+)
+def test_choose_action_from_psyche_parametrized_rules(
+    mood: Mood,
+    energy: float,
+    signals: dict[str, float],
+    social_states: dict[str, dict[str, float]],
+    expected_action: str,
+    reason_text: str,
+) -> None:
+    psyche = Psyche(energy=energy, social_states=social_states)
+    psyche.feel(mood)
+
+    decision = choose_action_from_psyche(psyche, signals)
+
+    assert decision.action == expected_action
+    assert reason_text in decision.reason
+    assert decision.scores[expected_action] == max(decision.scores.values())
+
+
+def test_choose_action_from_psyche_uses_objectives_and_environment() -> None:
+    psyche = Psyche(
+        energy=90.0,
+        objectives={
+            "resources": Objective(
+                "resources",
+                weight=1.0,
+                policy=GoalPolicy(
+                    besoin=1.0,
+                    priorite=0.2,
+                    urgence=0.1,
+                    alignement_valeurs=0.4,
+                ),
+            )
+        },
+    )
+
+    decision = choose_action_from_psyche(
+        psyche,
+        {"rarity_pressure": 0.95, "resource_energy": 90.0},
+    )
+
+    assert decision.action == "forage"
+    assert "scarcity" in decision.reason


### PR DESCRIPTION
### Motivation
- Provide a single, observable decision point to pick world actions from internal psyche state and environment signals to make behaviour explainable and testable. 
- Make the life loop choose and log higher-level actions informed by `Psyche` axes rather than only falling back to hardcoded effector selection.

### Description
- Add `PsycheActionDecision` and `choose_action_from_psyche` in `src/singular/psyche.py` to score candidate actions using `last_mood`, `energy`, `objectives` (weighted axes), `social_states` and environment signals (risk, rarity, competition, opportunity, resource energy). 
- Implement explicit rules: fatigue/low energy favors `rest`, curiosity favors exploration (`move`/`forage`), anger favors controlled `compete`, and loneliness favors `cooperate`/`share_resource`, and assemble a textual `reason` for observability. 
- Wire the decision into the life loop in `src/singular/life/loop.py` before calling `perform_action`, passing environment signals and a `fallback_action` and logging the chosen action, scores and reason (`psyche_action_decision` interaction). 
- Add unit and integration tests: parameterized rules for several moods/energy levels in `tests/test_psyche.py` and a loop integration test `test_loop_logs_psyche_action_decision_before_effector` that captures the effector call context and recorded decision in logs.

### Testing
- Ran `pytest -q tests/test_psyche.py` to exercise the new decision function and psyche behaviour, and all tests passed.  
- Ran `pytest -q tests/test_loop.py::test_loop_logs_psyche_action_decision_before_effector` to validate the decision is logged and forwarded to the effector, and it passed.  
- Verified modules compile with `python -m py_compile src/singular/psyche.py src/singular/life/loop.py` (success).  
- Tests completed with existing deprecation warnings (UTC `datetime.utcnow()`), but no failures related to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04bad6ecdc832a906bea5d32b17757)