### PR TITLE
Document and smoke-test dashboard metrics

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,98 @@
+# Dashboard Singular
+
+Ce document décrit le tableau de bord web Singular : prérequis, lancement,
+endpoints principaux, flux de données et familles de métriques exposées.
+
+## Prérequis
+
+- Python 3.10 ou plus récent.
+- Installer le projet avec les dépendances dashboard :
+
+  ```bash
+  pip install -e .[dashboard]
+  ```
+
+- Avoir une vie Singular initialisée ou un `SINGULAR_HOME` pointant vers un home
+  contenant au minimum `mem/` et, idéalement, des logs dans `runs/*.jsonl` ou
+  `runs/*.jsonl.tmp`.
+- Pour les actions mutatives depuis l'interface, définir un jeton :
+
+  ```bash
+  export SINGULAR_DASHBOARD_ACTION_TOKEN='change-me'
+  ```
+
+  En développement local uniquement, il est possible d'autoriser les actions non
+  authentifiées avec `SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS=1`.
+
+## Commandes de lancement
+
+Point d'entrée CLI principal :
+
+```bash
+singular dashboard
+```
+
+Depuis un checkout source sans console script installé :
+
+```bash
+python scripts/run_dashboard.py --host 127.0.0.1 --port 8000
+```
+
+Le dashboard écoute par défaut sur `http://127.0.0.1:8000/`.
+
+## Endpoints principaux
+
+| Endpoint | Rôle |
+| --- | --- |
+| `GET /` | Page HTML du cockpit et des panneaux interactifs. |
+| `GET /dashboard/context` | Contexte registre/home actif, état d'onboarding, vies connues. |
+| `GET /api/cockpit` | Vue complète : santé, alertes, mémoire, ressources, performances, relations sociales, mutations et décisions. |
+| `GET /api/cockpit/essential` | Projection courte pour supervision rapide. |
+| `GET /runs/latest` | Dernier run et ses enregistrements JSONL. |
+| `GET /api/runs/{run_id}/timeline` | Timeline filtrable d'un run : mutations, refus, délais, décès, sandbox et décisions de gouvernance. |
+| `GET /api/runs/{run_id}/consciousness` | Journal de conscience compagnon quand il existe. |
+| `GET /api/runs/{run_id}/mutations/{index}` | Détail d'une mutation : décision, diff, métriques et contexte. |
+| `GET /mutations/top` | Mutations les plus bénéfiques, risquées et fréquentes. |
+| `GET /ecosystem` | Organismes/vies, énergie, ressources et contrat de compteurs. |
+| `GET /lives/comparison` | Comparaison multi-vies et métriques de vivacité. |
+| `GET /lives/genealogy` | Parentés, alliances, rivalités et conflits actifs. |
+| `GET /api/dashboard/work-items` | Objectifs, conversations et éléments de travail affichables. |
+| `POST /api/actions/{action}` | Exécution contrôlée d'actions (`birth`, `talk`, `loop`, `report`, `archive`, `memorial`, `clone`, `emergency_stop`). |
+| `GET /api/retention/status` | Statut de rétention et diagnostics de stockage. |
+
+## Données affichées
+
+Le cockpit agrège plusieurs familles de signaux :
+
+- **Mémoire** : signaux mémoire/reflection dans les runs, taille de la timeline
+  causale et dernier souvenir détecté (`memory_metrics`).
+- **Ressources** : énergie, ressources, organismes/vies vivantes et totales via
+  `vital_metrics.energy_resources` et `/ecosystem`.
+- **Performances** : volumes de records/mutations, acceptations/rejets, durées,
+  latences et delta moyen de score (`performance_metrics`).
+- **Relations sociales** : alliances, rivalités, interactions et échanges de
+  ressources (`social_relations`, `/lives/genealogy`).
+- **Mutations** : taux d'acceptation, dernière mutation notable, détails de diff
+  et classements `/mutations/top`.
+- **Décisions majeures** : mutations, refus, délais, décès, événements
+  orchestrateur et gouvernance/sandbox récents (`major_decisions`).
+- **Vie et santé** : score de santé, cycle circadien, objectifs actifs, risques,
+  génération de code, vivacité et trajectoire.
+- **Hôte** : CPU, RAM, température, disque et adaptations capteurs dans le
+  contexte retourné après les actions dashboard.
+
+## Flux de données
+
+```mermaid
+flowchart LR
+    A[Logs de run\n*.jsonl / *.jsonl.tmp] --> B[repositories\nRunRecordsRepository]
+    B --> C[services\ntrajectory, comparison, metrics contract]
+    C --> D[routes FastAPI\n/api/cockpit, /ecosystem, /timeline]
+    D --> E[templates\ndashboard.html]
+    D --> F[JS statique\napi.js, dashboard.js, render-*]
+    F --> E
+```
+
+Le dépôt `RunRecordsRepository` tolère les lignes JSON invalides et les fichiers
+temporaires en cours d'écriture. Les services transforment ensuite les records en
+contrats stables avant exposition par les routes FastAPI et rendu côté navigateur.

--- a/scripts/run_dashboard.py
+++ b/scripts/run_dashboard.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Launch the Singular dashboard from a source checkout.
+
+This helper mirrors `singular dashboard` for contributors who have not installed
+console scripts yet.  It intentionally keeps only host/port parsing here and
+reuses `singular.dashboard.run` for dependency checks and app creation.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from singular.dashboard import run
+
+
+def main() -> None:
+    """Parse dashboard launch options and start Uvicorn."""
+
+    parser = argparse.ArgumentParser(description="Run the Singular web dashboard")
+    parser.add_argument(
+        "--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)"
+    )
+    parser.add_argument(
+        "--port", default=8000, type=int, help="Bind port (default: 8000)"
+    )
+    args = parser.parse_args()
+    run(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -659,6 +659,157 @@ def create_app(
             "events": events[-10:],
         }
 
+    def _summarize_memory(records: list[dict[str, object]]) -> dict[str, object]:
+        """Build a compact memory summary for cockpit and smoke checks."""
+        memory_records = [
+            record
+            for record in records
+            if "memory" in record
+            or "memories" in record
+            or "reflection" in record
+            or str(record.get("event", "")).startswith("memory")
+        ]
+        latest_memory = None
+        for record in reversed(memory_records):
+            latest_memory = {
+                "timestamp": record.get("ts"),
+                "event": record.get("event", "memory"),
+                "summary": record.get(
+                    "summary", record.get("reflection", record.get("memory"))
+                ),
+                "life": _record_life(record),
+            }
+            break
+        causal_items = []
+        try:
+            causal_items = read_causal_timeline()
+        except Exception:
+            causal_items = []
+        causal_count = len(causal_items) if isinstance(causal_items, list) else 0
+        return {
+            "records_count": len(memory_records),
+            "causal_timeline_items": causal_count,
+            "latest_memory": latest_memory,
+            "has_memory_signal": bool(memory_records or causal_count),
+        }
+
+    def _summarize_performance(records: list[dict[str, object]]) -> dict[str, object]:
+        """Summarize runtime and score performance signals from run records."""
+        durations: list[float] = []
+        latencies_ms: list[float] = []
+        score_deltas: list[float] = []
+        accepted = 0
+        rejected = 0
+        for record in records:
+            for key in ("duration_seconds", "elapsed_seconds", "runtime_seconds"):
+                value = _as_float(record.get(key))
+                if value is not None:
+                    durations.append(value)
+                    break
+            latency = _as_float(record.get("latency_ms"))
+            if latency is not None:
+                latencies_ms.append(latency)
+            score_base = _as_float(record.get("score_base"))
+            score_new = _as_float(record.get("score_new"))
+            if score_base is not None and score_new is not None:
+                score_deltas.append(score_base - score_new)
+            accepted_value = record.get("accepted")
+            if not isinstance(accepted_value, bool):
+                accepted_value = record.get("ok")
+            if accepted_value is True:
+                accepted += 1
+            elif accepted_value is False:
+                rejected += 1
+
+        def _avg(values: list[float]) -> float | None:
+            return sum(values) / len(values) if values else None
+
+        return {
+            "records_count": len(records),
+            "mutation_count": sum(1 for record in records if _is_mutation_record(record)),
+            "accepted_count": accepted,
+            "rejected_count": rejected,
+            "avg_duration_seconds": _avg(durations),
+            "avg_latency_ms": _avg(latencies_ms),
+            "avg_score_delta": _avg(score_deltas),
+        }
+
+    def _summarize_social_relations(records: list[dict[str, object]]) -> dict[str, object]:
+        """Expose registry social links and recent social/resource interactions."""
+        registry = load_registry()
+        raw_lives = registry.get("lives")
+        lives = raw_lives if isinstance(raw_lives, dict) else {}
+        ally_edges: set[tuple[str, str]] = set()
+        rival_edges: set[tuple[str, str]] = set()
+        for slug, meta in lives.items():
+            if not isinstance(slug, str):
+                continue
+            allies = life_meta_get(meta, "allies", ())
+            rivals = life_meta_get(meta, "rivals", ())
+            if isinstance(allies, (list, tuple, set)):
+                for ally in allies:
+                    if isinstance(ally, str) and ally:
+                        ally_edges.add(tuple(sorted((slug, ally))))
+            if isinstance(rivals, (list, tuple, set)):
+                for rival in rivals:
+                    if isinstance(rival, str) and rival:
+                        rival_edges.add(tuple(sorted((slug, rival))))
+        social_events = [
+            record
+            for record in records
+            if record.get("event") == "interaction" or record.get("interaction") is not None
+        ]
+        resource_events = [
+            record
+            for record in social_events
+            if str(record.get("interaction", "")).startswith("resource")
+        ]
+        return {
+            "alliance_edges": len(ally_edges),
+            "rivalry_edges": len(rival_edges),
+            "interaction_events": len(social_events),
+            "resource_exchange_events": len(resource_events),
+            "recent_interactions": [
+                {
+                    "timestamp": item.get("ts"),
+                    "life": _record_life(item),
+                    "organism": item.get("organism"),
+                    "interaction": item.get("interaction"),
+                }
+                for item in social_events[-5:]
+            ],
+        }
+
+    def _summarize_major_decisions(records: list[dict[str, object]]) -> list[dict[str, object]]:
+        """Return recent high-level orchestration and mutation decisions."""
+        decisions: list[dict[str, object]] = []
+        for record in records:
+            event = _event_type(record) or str(record.get("event", ""))
+            if not (
+                event.startswith("orchestrator")
+                or event
+                in {"mutation", "refuse", "delay", "death", "sandbox_violation", "mutation_halted"}
+            ):
+                continue
+            accepted = record.get("accepted")
+            if not isinstance(accepted, bool):
+                accepted = record.get("ok")
+            decisions.append(
+                {
+                    "timestamp": record.get("ts"),
+                    "event": event,
+                    "life": _record_life(record),
+                    "decision": (
+                        "accepted"
+                        if accepted is True
+                        else "rejected" if accepted is False else record.get("decision")
+                    ),
+                    "reason": record.get("decision_reason", record.get("reason")),
+                    "operator": record.get("operator", record.get("op")),
+                }
+            )
+        return decisions[-10:]
+
     def _summarize_cockpit(current_life_only: bool = False) -> dict[str, object]:
         latest = _latest_run_file(current_life_only=current_life_only)
         if latest is None:
@@ -678,6 +829,30 @@ def create_app(
                 ],
                 "global_status": "unknown",
                 "autonomy_metrics": {},
+                "behavioral_regulation_metrics": {},
+                "memory_metrics": {
+                    "records_count": 0,
+                    "causal_timeline_items": 0,
+                    "latest_memory": None,
+                    "has_memory_signal": False,
+                },
+                "performance_metrics": {
+                    "records_count": 0,
+                    "mutation_count": 0,
+                    "accepted_count": 0,
+                    "rejected_count": 0,
+                    "avg_duration_seconds": None,
+                    "avg_latency_ms": None,
+                    "avg_score_delta": None,
+                },
+                "social_relations": {
+                    "alliance_edges": 0,
+                    "rivalry_edges": 0,
+                    "interaction_events": 0,
+                    "resource_exchange_events": 0,
+                    "recent_interactions": [],
+                },
+                "major_decisions": [],
                 "vital_metrics": {
                     "circadian_cycle": {"phase": "indéterminée", "hour_utc": None},
                     "active_objectives": {"count": 0, "items": []},
@@ -798,6 +973,10 @@ def create_app(
         autonomy_metrics = compute_autonomy_metrics(records)
         major_decisions = [e for e in records if str(e.get("event", "")).startswith("orchestrator") or str(e.get("event", ""))=="mutation"]
         behavioral_metrics = compute_behavioral_regulation_metrics(records, decision_events=major_decisions)
+        memory_metrics = _summarize_memory(records)
+        performance_metrics = _summarize_performance(records)
+        social_relations = _summarize_social_relations(records)
+        major_decision_items = _summarize_major_decisions(records)
         ecosystem = _compute_ecosystem(current_life_only=current_life_only)
         summary = ecosystem.get("summary", {}) if isinstance(ecosystem, dict) else {}
         metrics_contract = (
@@ -895,6 +1074,10 @@ def create_app(
             "global_status": global_status,
             "autonomy_metrics": autonomy_metrics,
             "behavioral_regulation_metrics": behavioral_metrics,
+            "memory_metrics": memory_metrics,
+            "performance_metrics": performance_metrics,
+            "social_relations": social_relations,
+            "major_decisions": major_decision_items,
             "vital_metrics": {
                 "circadian_cycle": {"phase": circadian_phase, "hour_utc": hour_utc},
                 "active_objectives": {

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -1,3 +1,9 @@
+"""Dashboard action orchestration.
+
+This module validates and dispatches mutative dashboard actions, captures their
+stdout, and returns a stable JSON payload for the FastAPI routes.
+"""
+
 from __future__ import annotations
 
 import io
@@ -17,6 +23,8 @@ from singular.dashboard.repositories.run_records import resolve_current_life_hom
 
 @dataclass(slots=True)
 class ActionResult:
+    """Normalized result returned by every dashboard action."""
+
     ok: bool
     action: str
     data: dict[str, Any]
@@ -24,6 +32,7 @@ class ActionResult:
     error: str | None = None
 
     def to_payload(self) -> dict[str, Any]:
+        """Serialize the result using the stable dashboard action schema."""
         return {
             "ok": self.ok,
             "action": self.action,
@@ -34,7 +43,11 @@ class ActionResult:
 
 
 class DashboardActionService:
-    """Execute controlled dashboard actions with strict validation."""
+    """Execute controlled dashboard actions with strict validation.
+
+    Handlers validate parameters, lazy-import domain operations, capture console
+    output, and attach refreshed vital/host context after execution.
+    """
 
     def __init__(self, *, root: Path | None = None, home: Path | None = None) -> None:
         self.root = Path(root) if root is not None else get_registry_root()
@@ -44,6 +57,7 @@ class DashboardActionService:
             self.home = Path(os.environ.get("SINGULAR_HOME", self.root))
 
     def _context_payload(self) -> dict[str, Any]:
+        """Return runtime context displayed next to action results."""
         current_home = resolve_current_life_home(load_registry, self.home)
         runs_dir = current_home / "runs"
         vital_metrics = self._consolidated_vital_metrics(runs_dir=runs_dir)
@@ -58,6 +72,7 @@ class DashboardActionService:
         }
 
     def _read_run_records(self, *, runs_dir: Path) -> list[dict[str, Any]]:
+        """Read valid JSON objects from run logs, skipping corrupt lines."""
         records: list[dict[str, Any]] = []
         if not runs_dir.exists():
             return records
@@ -77,6 +92,7 @@ class DashboardActionService:
         return records
 
     def _consolidated_vital_metrics(self, *, runs_dir: Path) -> dict[str, Any]:
+        """Summarize health, mutation acceptance, circadian phase, and risk."""
         if not runs_dir.exists():
             return {
                 "health_score": None,
@@ -289,6 +305,7 @@ class DashboardActionService:
         }
 
     def validate_token(self, token: str | None) -> None:
+        """Reject writes unless a token or local-dev override is configured."""
         expected = os.environ.get("SINGULAR_DASHBOARD_ACTION_TOKEN")
         allow_unauthenticated = (
             os.environ.get("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS") == "1"
@@ -306,6 +323,7 @@ class DashboardActionService:
         )
 
     def execute(self, action: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Dispatch an action name and always return JSON-safe data."""
         try:
             if action == "birth":
                 result = self._birth(params)

--- a/src/singular/dashboard/repositories/run_records.py
+++ b/src/singular/dashboard/repositories/run_records.py
@@ -1,3 +1,9 @@
+"""Repository helpers for dashboard run logs.
+
+Centralizes path discovery, tolerant JSONL parsing, `.jsonl.tmp` handling, and
+active-life resolution for dashboard routes and services.
+"""
+
 from __future__ import annotations
 
 import json
@@ -78,6 +84,7 @@ class RunRecordsRepository:
     registry_loader: Callable[[], dict[str, object]]
 
     def _registry_lives_paths(self) -> list[Path]:
+        """Return life home directories declared in the registry."""
         registry = self.registry_loader()
         raw_lives = registry.get("lives")
         if not isinstance(raw_lives, dict):
@@ -94,6 +101,7 @@ class RunRecordsRepository:
         return lives_paths
 
     def runs_dirs(self, current_life_only: bool = False) -> list[Path]:
+        """Return run directories for explicit, active-life, or registry-wide scope."""
         if self.runs_path is not None:
             return [self.runs_path]
         if current_life_only:
@@ -116,6 +124,7 @@ class RunRecordsRepository:
         return dirs
 
     def load_run_records(self, current_life_only: bool = False) -> list[dict[str, object]]:
+        """Load valid records and annotate each one with its logical run id."""
         records: list[dict[str, object]] = []
         for directory in self.runs_dirs(current_life_only=current_life_only):
             if not directory.exists():
@@ -139,6 +148,7 @@ class RunRecordsRepository:
         return records
 
     def iter_run_files(self, current_life_only: bool = False) -> list[Path]:
+        """List run JSONL files sorted by modification time then filename."""
         files: list[Path] = []
         for directory in self.runs_dirs(current_life_only=current_life_only):
             if not directory.exists():
@@ -152,6 +162,7 @@ class RunRecordsRepository:
         )
 
     def read_jsonl_records(self, file: Path) -> list[dict[str, object]]:
+        """Read JSON objects from one JSONL file while ignoring malformed lines."""
         records: list[dict[str, object]] = []
         for line in file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
@@ -166,6 +177,7 @@ class RunRecordsRepository:
         return records
 
     def latest_run_file(self, current_life_only: bool = False) -> Path | None:
+        """Return the most recent run file by mtime, record timestamp, and name."""
         files = self.iter_run_files(current_life_only=current_life_only)
         if not files:
             return None
@@ -184,6 +196,7 @@ class RunRecordsRepository:
         )
 
     def resolve_run_file(self, run_id: str, current_life_only: bool = False) -> Path | None:
+        """Resolve a logical run id to persisted or in-progress JSONL storage."""
         for directory in self.runs_dirs(current_life_only=current_life_only):
             for filename in (f"{run_id}.jsonl", f"{run_id}.jsonl.tmp"):
                 candidate = directory / filename
@@ -199,6 +212,7 @@ class RunRecordsRepository:
     def resolve_consciousness_path(
         self, run_id: str, current_life_only: bool = False
     ) -> Path | None:
+        """Resolve the companion consciousness log for a run id, if present."""
         raw_run_id = run_id
         if "-" in raw_run_id:
             candidate_id, suffix = raw_run_id.rsplit("-", 1)

--- a/src/singular/dashboard/services/metrics_contract.py
+++ b/src/singular/dashboard/services/metrics_contract.py
@@ -1,9 +1,15 @@
+"""Stable metrics contract shared by dashboard endpoints.
+
+Centralizes the life counter keys and labels rendered by ecosystem, cockpit, and
+comparison views.
+"""
+
 from __future__ import annotations
 
 from typing import Any
 
 
-METRICS_CONTRACT_LABELS = {
+METRICS_CONTRACT_LABELS: dict[str, str] = {
     "total_lives": "Vies totales",
     "alive_lives": "Vies vivantes",
     "dead_lives": "Vies mortes",
@@ -13,6 +19,7 @@ METRICS_CONTRACT_LABELS = {
 
 
 def build_life_counts(lives: dict[str, dict[str, Any]]) -> dict[str, int]:
+    """Compute life counters from aggregated comparison payloads."""
     total_lives = len(lives)
     selected_lives = 0
     recent_activity_lives = 0
@@ -41,6 +48,7 @@ def build_life_counts(lives: dict[str, dict[str, Any]]) -> dict[str, int]:
 
 
 def build_metrics_contract(lives: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Return counts plus human labels under the dashboard contract schema."""
     return {
         "counts": build_life_counts(lives),
         "labels": METRICS_CONTRACT_LABELS,

--- a/tests/test_dashboard_smoke_e2e.py
+++ b/tests/test_dashboard_smoke_e2e.py
@@ -217,6 +217,9 @@ def active_run_dashboard(
                         "objective": "stabiliser le cockpit",
                         "objective_status": "in_progress",
                         "objective_priority": "high",
+                        "duration_seconds": 1.5,
+                        "latency_ms": 120,
+                        "memory": "mutation acceptée et mémorisée",
                     }
                 ),
                 json.dumps(
@@ -232,6 +235,18 @@ def active_run_dashboard(
                         "score": 91,
                         "alive": True,
                         "accepted": True,
+                        "duration_seconds": 0.5,
+                        "latency_ms": 80,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-11T09:02:00+00:00",
+                        "run_id": "active-smoke",
+                        "life": "life-a",
+                        "event": "orchestrator.decision",
+                        "decision": "continue",
+                        "reason": "health stable and resources available",
                     }
                 ),
             ]
@@ -363,6 +378,13 @@ def test_active_tmp_run_feeds_dashboard_endpoints(
     assert cockpit["health_score"] == 84.0
     assert cockpit["accepted_mutation_rate"] == 1.0
     assert cockpit["next_action"]
+    assert cockpit["memory_metrics"]["has_memory_signal"] is True
+    assert cockpit["performance_metrics"]["avg_latency_ms"] == 100.0
+    assert cockpit["social_relations"]["alliance_edges"] >= 1
+    assert cockpit["social_relations"]["resource_exchange_events"] == 1
+    assert any(
+        item["event"] == "orchestrator.decision" for item in cockpit["major_decisions"]
+    )
     assert cockpit["vital_metrics"]["energy_resources"]["total_energy"] > 0
     assert cockpit["life_metrics_contract"]["counts"]["total_lives"] >= 2
 


### PR DESCRIPTION
### Motivation
- Provide documentation and a lightweight run script to make the web dashboard easier to run from source and understand.
- Improve observability by surfacing memory, performance, social relations and major decision signals in the cockpit payload.
- Cover those signals in smoke tests so the dashboard contract remains stable across refactors.

### Description
- Added `docs/dashboard.md` describing prerequisites, launch commands, main endpoints, displayed data families, and a simple Mermaid flow diagram linking run logs → repositories → services → routes → templates/JS. 
- Added `scripts/run_dashboard.py` as a small source-checkout launcher delegating to `singular.dashboard.run` and exposing `--host/--port` flags. 
- Documented code in `src/singular/dashboard/actions.py`, `src/singular/dashboard/repositories/run_records.py`, and `src/singular/dashboard/services/metrics_contract.py` with module and function docstrings and small clarifying type annotations. 
- Extended the cockpit response in `src/singular/dashboard/__init__.py` to include computed summaries: `memory_metrics`, `performance_metrics`, `social_relations`, and `major_decisions`, and wired helper summarizers that aggregate these from run records. 
- Updated smoke e2e test `tests/test_dashboard_smoke_e2e.py` to inject synthetic memory/performance/social/orchestrator decision records and assert the new fields are present and computed as expected.

### Testing
- Ran targeted test suites: `python -m pytest tests/test_dashboard_smoke_e2e.py tests/test_dashboard.py tests/test_dashboard_run_records_repository.py tests/test_dashboard_services.py -q`, all tests passed (56 passed, 2 expected warnings about test client collection). 
- Verified syntax by compiling modules and the launcher: `python -m py_compile scripts/run_dashboard.py src/singular/dashboard/__init__.py src/singular/dashboard/actions.py src/singular/dashboard/repositories/run_records.py src/singular/dashboard/services/metrics_contract.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c6cee0d0832aa99e22489d93eb2e)