### PR TITLE
Add targeted lifecycle, orchestrator and memory-layer tests; harden LocalJsonMemoryBackend

### DIFF
--- a/src/singular/memory_layers/local_json.py
+++ b/src/singular/memory_layers/local_json.py
@@ -4,7 +4,9 @@ from collections import Counter
 from pathlib import Path
 import json
 import math
+import os
 import re
+import tempfile
 
 from .base import MemoryBackend, MemoryRecord
 
@@ -31,7 +33,12 @@ class LocalJsonMemoryBackend(MemoryBackend):
                 line = line.strip()
                 if not line:
                     continue
-                payload = json.loads(line)
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(payload, dict):
+                    continue
                 records.append(
                     MemoryRecord(
                         id=str(payload.get("id", "")),
@@ -44,14 +51,26 @@ class LocalJsonMemoryBackend(MemoryBackend):
     def _write_layer(self, layer: str, records: list[MemoryRecord]) -> None:
         path = self._layer_path(layer)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w", encoding="utf-8") as handle:
-            for rec in records:
-                handle.write(
-                    json.dumps(
-                        {"id": rec.id, "text": rec.text, "metadata": rec.metadata}
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                for rec in records:
+                    handle.write(
+                        json.dumps(
+                            {"id": rec.id, "text": rec.text, "metadata": rec.metadata},
+                            ensure_ascii=False,
+                        )
+                        + "\n"
                     )
-                    + "\n"
-                )
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_path, path)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
 
     def put(self, layer: str, record: MemoryRecord) -> None:
         records = [r for r in self._read_layer(layer) if r.id != record.id]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,3 +25,61 @@ sys.modules.setdefault("fastapi", fastapi_stub)
 sys.modules.setdefault("fastapi.responses", fastapi_stub.responses)
 sys.modules.setdefault("fastapi.testclient", fastapi_stub.testclient)
 sys.modules.setdefault("fastapi.staticfiles", fastapi_stub.staticfiles)
+
+import pytest  # noqa: E402
+
+from singular.life.checkpointing import Checkpoint, save_checkpoint  # noqa: E402
+from singular.memory_layers.local_json import LocalJsonMemoryBackend  # noqa: E402
+from singular.memory_layers.service import MemoryLayerService  # noqa: E402
+
+
+@pytest.fixture
+def isolated_singular_home(tmp_path, monkeypatch):
+    """Create an isolated SINGULAR_HOME with lightweight life directories."""
+
+    root = tmp_path / "life"
+    (root / "skills").mkdir(parents=True)
+    (root / "mem").mkdir()
+    (root / "runs").mkdir()
+    monkeypatch.setenv("SINGULAR_HOME", str(root))
+    return root
+
+
+@pytest.fixture
+def temp_skills_dir(isolated_singular_home):
+    """Return a small skills/ directory containing one mutable Python skill."""
+
+    skills_dir = isolated_singular_home / "skills"
+    (skills_dir / "skill.py").write_text("result = 2\n", encoding="utf-8")
+    return skills_dir
+
+
+@pytest.fixture
+def temp_checkpoint(isolated_singular_home):
+    """Create and return a checkpoint path for lifecycle tests."""
+
+    checkpoint_path = isolated_singular_home / "life_checkpoint.json"
+    save_checkpoint(checkpoint_path, Checkpoint())
+    return checkpoint_path
+
+
+@pytest.fixture
+def isolated_memory(isolated_singular_home):
+    """Return an isolated memory-layer service and backend pair."""
+
+    memory_dir = isolated_singular_home / "mem" / "layers"
+    backend = LocalJsonMemoryBackend(memory_dir)
+    service = MemoryLayerService(backend, short_term_window=5, consolidate_every=2)
+    return service, backend, memory_dir
+
+
+@pytest.fixture
+def temp_life(isolated_singular_home, temp_skills_dir, temp_checkpoint):
+    """Return lightweight paths for a temporary life."""
+
+    return {
+        "root": isolated_singular_home,
+        "skills_dir": temp_skills_dir,
+        "checkpoint_path": temp_checkpoint,
+        "mem_dir": isolated_singular_home / "mem",
+    }

--- a/tests/test_life_loop_targeted.py
+++ b/tests/test_life_loop_targeted.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import ast
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from singular.cognition.reflect import ActionHypothesis, reflect_action
+from singular.life import loop
+from singular.life.coevolution_flow import CoevolutionConfig, CoevolutionFlow, LivingTestPool, TestCandidate
+from singular.life.loop import EcosystemRules, Organism, WorldState, run_tick
+from singular.life.mutation_flow import select_operator
+from singular.life.reproduction_flow import ReproductionDecisionPolicy, decide_reproduction
+from singular.life.sandbox_scoring import score_code_with_error
+from singular.resource_manager import ResourceManager
+
+
+def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            node.value -= 1
+            break
+    return tree
+
+
+def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, int):
+            node.value += 1
+            break
+    return tree
+
+
+def test_reflection_prefers_long_term_low_risk_action() -> None:
+    decision = reflect_action(
+        [
+            ActionHypothesis("risky", long_term=0.9, sandbox_risk=0.9, resource_cost=0.7),
+            ActionHypothesis("steady", long_term=0.75, sandbox_risk=0.05, resource_cost=0.05),
+        ]
+    )
+
+    assert decision.action == "steady"
+    assert decision.ranked_actions[0] == "steady"
+    assert decision.assessments[0].action_recommended == "execute"
+
+
+def test_operator_selection_uses_analyze_and_objective_bias() -> None:
+    operators = {"low_count": _dec_operator, "rewarded": _inc_operator}
+    stats = {"low_count": {"count": 0, "reward": 0.0}, "rewarded": {"count": 3, "reward": 1.0}}
+
+    assert select_operator(operators, stats, "analyze", random.Random(0)) == "low_count"
+
+    stats["low_count"]["count"] = 3
+    assert (
+        select_operator(
+            operators,
+            stats,
+            "exploit",
+            random.Random(0),
+            objective_bias={"low_count": 2.0},
+        )
+        == "low_count"
+    )
+
+
+def test_sandbox_scoring_reports_success_and_failure() -> None:
+    ok = score_code_with_error("result = 1\n")
+    bad = score_code_with_error("raise RuntimeError('boom')\n")
+
+    assert ok.ok is True
+    assert ok.score == 1.0
+    assert bad.ok is False
+    assert bad.score == float("-inf")
+    assert bad.error_type is not None
+
+
+def test_run_tick_manages_resources_and_mutates_skill(temp_life) -> None:
+    resources = ResourceManager(path=temp_life["root"] / "resources.json")
+    before_energy = resources.energy
+
+    state = run_tick(
+        temp_life["skills_dir"],
+        temp_life["checkpoint_path"],
+        rng=random.Random(0),
+        operators={"dec": _dec_operator},
+        resource_manager=resources,
+        ecosystem_rules=EcosystemRules(crossover_interval=0),
+        tick_budget_seconds=0.05,
+    )
+
+    assert state.iteration == 1
+    assert (temp_life["skills_dir"] / "skill.py").read_text(encoding="utf-8").strip() == "result = 1"
+    assert resources.energy != before_energy
+
+
+@dataclass
+class _SleepyPsyche:
+    energy: float = 1.0
+    sleeping: bool = False
+    mutation_rate: float = 1.0
+    sleep_ticks: int = 0
+
+    def sleep_tick(self) -> None:
+        self.sleep_ticks += 1
+        self.energy += 1.0
+
+    def save_state(self) -> None:  # pragma: no cover - no-op test double
+        return None
+
+
+def test_run_tick_sleeps_without_mutating_when_energy_is_low(temp_life, monkeypatch: pytest.MonkeyPatch) -> None:
+    sleepy = _SleepyPsyche()
+    monkeypatch.setattr(loop.Psyche, "load_state", staticmethod(lambda: sleepy))
+
+    state = run_tick(
+        temp_life["skills_dir"],
+        temp_life["checkpoint_path"],
+        rng=random.Random(0),
+        operators={"dec": _dec_operator},
+        tick_budget_seconds=0.05,
+    )
+
+    assert state.iteration == 0
+    assert sleepy.sleeping is True
+    assert sleepy.sleep_ticks == 1
+    assert (temp_life["skills_dir"] / "skill.py").read_text(encoding="utf-8") == "result = 2\n"
+
+
+def test_reproduction_decision_accepts_healthy_governed_parents(temp_life) -> None:
+    parent_a = temp_life["root"] / "a" / "skills"
+    parent_b = temp_life["root"] / "b" / "skills"
+    parent_a.mkdir(parents=True)
+    parent_b.mkdir(parents=True)
+    (parent_a / "a.py").write_text("result = 1\n", encoding="utf-8")
+    (parent_b / "b.py").write_text("result = 1\n", encoding="utf-8")
+
+    decision = decide_reproduction(
+        parent_a="a",
+        parent_b="b",
+        parent_a_skills=parent_a,
+        parent_b_skills=parent_b,
+        parent_a_health=1.0,
+        parent_b_health=1.0,
+        governance_allowed=True,
+        policy=ReproductionDecisionPolicy(min_parent_health=0.1, compatibility_threshold=0.1),
+    )
+
+    assert decision.accepted is True
+    assert decision.score >= 0.1
+
+
+def test_coevolution_rejects_regression_detected_by_living_test() -> None:
+    flow = CoevolutionFlow(
+        pool=LivingTestPool(tests=[TestCandidate("result == 1")], ttl={"result == 1": 3}),
+        config=CoevolutionConfig(enabled=True, robustness_weight=1.0),
+    )
+
+    decision = flow.decide(
+        base_code="result = 1",
+        mutated_code="result = 2",
+        base_score=1.0,
+        mutated_score=1.0,
+        initially_accepted=True,
+        rng=random.Random(0),
+    )
+
+    assert decision.accepted is False
+    assert decision.rejected_for_robustness is True
+    assert decision.regression_detection_rate == 1.0
+
+
+def test_cycle_complet_creation_tick_mutation_learning_reproduction_and_stop(temp_life) -> None:
+    world = WorldState(
+        organisms={
+            "alpha": Organism(temp_life["skills_dir"], energy=5.0, resources=5.0),
+            "beta": Organism(temp_life["root"] / "beta" / "skills", energy=5.0, resources=5.0),
+        }
+    )
+    (temp_life["skills_dir"] / "skill.py").write_text("result = 2\ndef solve():\n    return 2\n", encoding="utf-8")
+    beta_skill = world.organisms["beta"].skills_dir
+    beta_skill.mkdir(parents=True)
+    (beta_skill / "skill.py").write_text("result = 3\ndef solve():\n    return 3\n", encoding="utf-8")
+
+    state = run_tick(
+        {name: org.skills_dir for name, org in world.organisms.items()},
+        temp_life["checkpoint_path"],
+        rng=random.Random(1),
+        operators={"dec": _dec_operator},
+        world=world,
+        ecosystem_rules=EcosystemRules(
+            crossover_interval=1,
+            reproduction_policy=ReproductionDecisionPolicy(min_parent_health=0.1, compatibility_threshold=0.1, cooldown_ticks=1),
+        ),
+        tick_budget_seconds=0.05,
+    )
+
+    assert state.iteration == 1
+    assert state.stats["dec"]["count"] == 1
+    assert list(Path("runs").glob("**/*.jsonl"))
+    assert any(path.name.startswith("child_") for path in temp_life["root"].iterdir()) or world.reproduction_cooldowns
+
+    stopped = loop.run(
+        temp_life["skills_dir"],
+        temp_life["checkpoint_path"],
+        budget_seconds=0.0,
+        rng=random.Random(2),
+        operators={"dec": _dec_operator},
+        max_iterations=0,
+    )
+    assert stopped.iteration == state.iteration

--- a/tests/test_memory_layers_service_targeted.py
+++ b/tests/test_memory_layers_service_targeted.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from singular.memory_layers.base import MemoryRecord
+from singular.memory_layers.local_json import LocalJsonMemoryBackend
+from singular.memory_layers.service import MemoryLayerService
+
+
+def _read_jsonl(path):
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_memory_backend_put_is_atomic_and_recovers_after_replace_error(isolated_memory, monkeypatch) -> None:
+    _service, backend, memory_dir = isolated_memory
+    backend.put("short_term", MemoryRecord(id="existing", text="old"))
+    before = (memory_dir / "short_term.jsonl").read_text(encoding="utf-8")
+
+    def fail_replace(src, dst):
+        raise OSError("simulated atomic replace failure")
+
+    monkeypatch.setattr("singular.memory_layers.local_json.os.replace", fail_replace)
+
+    with pytest.raises(OSError):
+        backend.put("short_term", MemoryRecord(id="new", text="new"))
+
+    assert (memory_dir / "short_term.jsonl").read_text(encoding="utf-8") == before
+    assert not list(memory_dir.glob("*.tmp"))
+
+
+def test_service_consolidates_short_term_into_long_term(isolated_memory) -> None:
+    service, _backend, memory_dir = isolated_memory
+
+    service.ingest_episode({"event": "first", "summary": "alpha"})
+    service.ingest_episode({"event": "second", "summary": "beta"})
+
+    long_term_rows = _read_jsonl(memory_dir / "long_term.jsonl")
+    assert len(long_term_rows) == 2
+    assert all(row["metadata"]["consolidated"] is True for row in long_term_rows)
+
+
+def test_backend_skips_corrupt_jsonl_lines_and_keeps_valid_records(tmp_path) -> None:
+    backend = LocalJsonMemoryBackend(tmp_path)
+    (tmp_path / "short_term.jsonl").write_text(
+        json.dumps({"id": "ok", "text": "alpha", "metadata": {}}) + "\n{bad json\n",
+        encoding="utf-8",
+    )
+
+    records = backend.search("short_term", "alpha", limit=10)
+
+    assert [record.id for record in records] == ["ok"]
+
+
+def test_backend_deduplicates_records_by_id(isolated_memory) -> None:
+    _service, backend, memory_dir = isolated_memory
+
+    backend.put("semantic", MemoryRecord(id="same", text="old", metadata={"v": 1}))
+    backend.put("semantic", MemoryRecord(id="same", text="new", metadata={"v": 2}))
+
+    rows = _read_jsonl(memory_dir / "semantic.jsonl")
+    assert len(rows) == 1
+    assert rows[0]["text"] == "new"
+    assert rows[0]["metadata"]["v"] == 2
+
+
+def test_service_recovers_after_backend_error_on_next_ingest(tmp_path, monkeypatch) -> None:
+    backend = LocalJsonMemoryBackend(tmp_path)
+    service = MemoryLayerService(backend, short_term_window=5, consolidate_every=10)
+    calls = {"count": 0}
+    original_write = backend._write_layer
+
+    def flaky_write(layer, records):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise OSError("disk busy")
+        return original_write(layer, records)
+
+    monkeypatch.setattr(backend, "_write_layer", flaky_write)
+
+    with pytest.raises(OSError):
+        service.ingest_episode({"summary": "lost once"})
+    service.ingest_episode({"summary": "recovered"})
+
+    rows = _read_jsonl(tmp_path / "short_term.jsonl")
+    assert len(rows) == 1
+    assert rows[0]["text"] == "recovered"
+
+
+def test_service_extracts_semantic_facts_and_enforces_short_term_window(isolated_memory) -> None:
+    service, _backend, memory_dir = isolated_memory
+    service.short_term_window = 2
+
+    service.ingest_episode({"summary": "one", "preference": "tea"})
+    service.ingest_episode({"summary": "two"})
+    service.ingest_episode({"summary": "three"})
+
+    short_term_rows = _read_jsonl(memory_dir / "short_term.jsonl")
+    semantic_rows = _read_jsonl(memory_dir / "semantic.jsonl")
+
+    assert [row["text"] for row in short_term_rows] == ["two", "three"]
+    assert semantic_rows[0]["text"] == "tea"

--- a/tests/test_orchestrator_service_targeted.py
+++ b/tests/test_orchestrator_service_targeted.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from singular.events import EventBus, HELP_REQUESTED
+from singular.orchestrator import service as orchestrator_service
+from singular.orchestrator.service import LifecyclePhase, OrchestratorConfig, OrchestratorService, SchedulerConfig
+from singular.skills.runtime import SkillExecutionResult
+
+
+def _service(root, *, bus=None, dry_run=True, **config_kwargs) -> OrchestratorService:
+    return OrchestratorService(
+        config=OrchestratorConfig(
+            scheduler=SchedulerConfig(veille_seconds=0.01, action_seconds=0.01, introspection_seconds=0.01, sommeil_seconds=0.01),
+            poll_interval_seconds=0.01,
+            tick_budget_seconds=0.05,
+            mutation_window_seconds=0.05,
+            dry_run=dry_run,
+            **config_kwargs,
+        ),
+        bus=bus or EventBus(),
+        base_dir=root,
+    )
+
+
+def test_runtime_adaptation_prudent_mode_and_skip_action(temp_life) -> None:
+    service = _service(temp_life["root"])
+    service._latest_signals = {
+        "host_metrics": {
+            "cpu_percent": 99.0,
+            "ram_used_percent": 99.0,
+            "host_temperature_c": 999.0,
+        }
+    }
+
+    adaptation = service._compute_runtime_adaptation()
+
+    assert adaptation["enforce_prudent_mode"] is True
+    assert adaptation["skip_action_tick"] is True
+    assert "cpu_high_critical" in adaptation["rule_triggers"]
+    assert "thermal_critical_sleep" in adaptation["rule_triggers"]
+
+
+def test_startup_stop_signal_is_honored_without_tick(temp_life, monkeypatch) -> None:
+    service = _service(temp_life["root"])
+    service.stop_signal_path.write_text(
+        json.dumps({"reason": "test", "requested_at": datetime.now(timezone.utc).isoformat()}),
+        encoding="utf-8",
+    )
+    called = {"tick": 0}
+    monkeypatch.setattr(service, "tick", lambda: called.__setitem__("tick", called["tick"] + 1))
+
+    service.run_forever()
+
+    assert called["tick"] == 0
+    assert service._running is False
+
+
+def test_transient_tick_errors_backoff_then_continue(temp_life, monkeypatch) -> None:
+    service = _service(temp_life["root"], max_consecutive_tick_failures=3, tick_failure_backoff_seconds=0.01)
+    calls = {"tick": 0, "sleep": 0}
+
+    def flaky_tick():
+        calls["tick"] += 1
+        if calls["tick"] == 1:
+            raise TimeoutError("temporary lock")
+        service._running = False
+        return LifecyclePhase.ACTION
+
+    monkeypatch.setattr(service, "tick", flaky_tick)
+    monkeypatch.setattr(orchestrator_service.time, "sleep", lambda _seconds: calls.__setitem__("sleep", calls["sleep"] + 1))
+
+    service.run_forever()
+
+    assert calls["tick"] == 2
+    assert calls["sleep"] >= 1
+
+
+def test_veille_phase_triggers_quests(temp_life, monkeypatch) -> None:
+    service = _service(temp_life["root"])
+    monkeypatch.setattr(orchestrator_service, "capture_signals", lambda bus=None: {"novelty": 1.0})
+    triggered: list[dict[str, object]] = []
+
+    def fake_evaluate(signals):
+        triggered.append(dict(signals))
+        return [{"quest_id": "q1", "status": "started"}]
+
+    service.quest_runtime.evaluate_triggers = fake_evaluate
+
+    service._run_phase(LifecyclePhase.VEILLE)
+
+    assert triggered == [{"novelty": 1.0}]
+    assert service.state.last_events[-1]["details"]["quests_triggered"][0]["quest_id"] == "q1"
+
+
+@dataclass
+class _RoutineSpec:
+    id: str
+    prompt: str
+    priority: int
+
+
+def test_action_phase_orchestrates_skill_routines_and_life_tick(temp_life, monkeypatch) -> None:
+    service = _service(temp_life["root"], dry_run=False)
+    service._latest_signals = {"host_metrics": {"cpu_percent": 10.0, "ram_used_percent": 10.0, "host_temperature_c": 20.0}}
+    service.routines.specs = [_RoutineSpec("routine", "do", 1)]
+    service.goals.derive_execution_strategy = lambda signals: {"mode": "explore"}
+    service.goals.adjust_routine_priorities = lambda specs, perception_signals: specs
+    service.skill_runtime.execute_best_skill = lambda task, context: SkillExecutionResult("skill", "succeeded", score=1.0)
+    service.routines.execute_with_runtime = lambda skill_runtime, base_context, priority_overrides: [{"id": "routine", "status": "done"}]
+    service.quest_runtime.settle_active = lambda **kwargs: [{"quest_id": "q1", "status": "settled"}]
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(orchestrator_service, "run_tick", lambda **kwargs: calls.append(kwargs))
+
+    service._run_phase(LifecyclePhase.ACTION)
+
+    assert calls
+    assert calls[0]["skills_dirs"] == temp_life["skills_dir"]
+    details = service.state.last_events[-1]["details"]
+    assert details["skill_execution"]["status"] == "succeeded"
+    assert details["routines"] == [{"id": "routine", "status": "done"}]
+    assert details["quests"] == [{"quest_id": "q1", "status": "settled"}]
+
+
+def test_repeated_action_failures_publish_help_request(temp_life) -> None:
+    bus = EventBus()
+    events = []
+    bus.subscribe(HELP_REQUESTED, lambda event: events.append(event))
+    service = _service(temp_life["root"], bus=bus, help_request_failure_threshold=2)
+    failed = SkillExecutionResult(skill="missing", status="failed", reason="no_compatible_skill")
+
+    service._track_action_failure_and_request_help(task_name="orchestrator.action", skill_execution=failed)
+    service._track_action_failure_and_request_help(task_name="orchestrator.action", skill_execution=failed)
+
+    assert len(events) == 1
+    assert events[0].payload["task"] == "orchestrator.action"
+    assert events[0].payload["attempts"] == 2


### PR DESCRIPTION
### Motivation

- Improve unit/integration coverage for the evolutionary life loop, orchestrator daemon, and memory layers with focused assertions around reflection, operator selection, sandbox scoring, resource/accounting, sleep/reproduction, co-evolution and end-to-end cycle behavior. 
- Add light, reusable fixtures to create an isolated temporary life environment (skills, mem, checkpoint) so tests are hermetic and cheap to run. 
- Make the local JSON memory backend more robust to partial/corrupt JSONL and atomic write failures to avoid flakiness during tests and runtime.

### Description

- Added lightweight pytest fixtures and test helpers to `tests/conftest.py` to create an isolated `SINGULAR_HOME`, `skills/`, checkpoint and memory-layer backend. 
- Added focused life-loop tests in `tests/test_life_loop_targeted.py` covering `reflect_action`, operator selection, `score_code_with_error`, resource accounting, sleep gating, reproduction decision, co-evolution rejection and a full cycle (creation → tick → mutation → learning → reproduction → stop). 
- Added orchestrator service tests in `tests/test_orchestrator_service_targeted.py` covering runtime adaptation rules, honoring start/stop signals, transient tick errors/backoff, quest triggering, orchestrated action/routine execution and help-request emission. 
- Added memory-layer tests in `tests/test_memory_layers_service_targeted.py` for atomic writes, consolidation to long-term layer, skipping corrupt JSONL lines, deduplication by id and recovery after backend write errors. 
- Hardened `src/singular/memory_layers/local_json.py` to skip malformed or non-object JSONL lines on read and to write via an fsynced temp-file followed by an atomic `os.replace`, cleaning up temp files on failure.
- No Hypothesis property-based tests were added because Hypothesis is not present in the project dependencies or optional test stack.

### Testing

- Ran the new targeted suites with `pytest -q tests/test_memory_layers_service_targeted.py tests/test_orchestrator_service_targeted.py tests/test_life_loop_targeted.py`, and all tests passed (`20 passed`, with warnings only). 
- Ran `pytest -q tests/test_memory_layers_service_targeted.py` in isolation, and it passed (`6 passed`). 
- Performed a quick bytecode check with `python -m compileall -q` on modified files and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c95aa86c832ab9a793222dafa3ef)