### PR TITLE
Add life-creation tutorials (FR/EN) and governance `policy.yaml` guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ singular report --format plain
 singular dashboard
 ```
 
+## 📚 Tutoriels et gouvernance
+
+- [Tutoriel FR — créer une vie, ajouter une compétence, lancer un tick et lire les logs](docs/tutorial_create_life.fr.md)
+- [Tutorial EN — create a life, add a skill, run a tick and read logs](docs/tutorial_create_life.en.md)
+- [Guide de personnalisation de la gouvernance `policy.yaml`](docs/policy_customization.md)
+
 ## 🧭 Guide d’utilisation clair (pas à pas)
 
 Si vous débutez, suivez **exactement** ces étapes :

--- a/docs/policy_customization.md
+++ b/docs/policy_customization.md
@@ -1,0 +1,264 @@
+# Governance and `policy.yaml` customization guide
+
+Singular uses a strict, versioned governance policy to decide what an organism may read, mutate, create, expose, or do with other lives. The default root-level file is `policy.yaml`. If the file is missing, Singular can generate a default policy from the built-in schema.
+
+Although the repository file is named `policy.yaml`, its content may be YAML or JSON-compatible YAML. The current schema version is `1`, and unknown top-level or section keys are rejected by validation.
+
+## Where the active policy lives
+
+The active policy is resolved from the current registry root:
+
+```bash
+singular --root ./lab policy show --format table
+```
+
+Programmatically, the policy path is equivalent to:
+
+```text
+$SINGULAR_ROOT/policy.yaml
+```
+
+If `SINGULAR_ROOT` is unset, Singular falls back to its configured/default registry root. For repeatable experiments, pass `--root` explicitly.
+
+## Safe editing workflow
+
+1. Create an isolated root or a backup of the current file.
+2. Inspect the active values:
+   ```bash
+   singular --root ./lab policy show --format plain
+   ```
+3. Change one setting at a time. Prefer the CLI for supported scalar edits:
+   ```bash
+   singular --root ./lab policy set --key autonomy.safe_mode --value true
+   ```
+4. Re-run validation by showing the policy again:
+   ```bash
+   singular --root ./lab policy show --format table
+   ```
+5. Run a short loop and inspect `mem/policy_decisions.jsonl` for blocked or review-required decisions.
+
+If validation fails, Singular reports a `PolicySchemaError` and refuses to use malformed or unknown keys.
+
+## Policy structure
+
+### `version`
+
+Must match the supported policy schema version. Current value:
+
+```yaml
+version: 1
+```
+
+Do not increment this manually unless the code has been upgraded to support the new schema.
+
+### `memory`
+
+Controls destructive rewrites:
+
+```yaml
+memory:
+  preserve_threshold: 0.6
+```
+
+When memory preservation has sufficient value weight, an existing file rewrite is blocked if the new content appears to truncate too much of the previous content. Raise this for conservative preservation; lower it only when controlled compaction is expected.
+
+### `forgetting`
+
+Controls memory retention:
+
+```yaml
+forgetting:
+  enabled: true
+  max_episodic_entries: 5000
+```
+
+Use this to bound long-running organisms. Disabling forgetting may be useful for audit labs but increases storage growth.
+
+### `sensors`
+
+Controls host/environment signal exposure:
+
+```yaml
+sensors:
+  allowed: [host_metrics, artifact_scan, virtual_environment]
+  blocked: []
+  max_export_granularity: standard
+  anonymization:
+    enabled: true
+    block_sensitive_by_default: true
+    allow_sensitive_metrics_opt_in: false
+    redact_machine_user_info: true
+    sensitive_metric_keys_blocklist:
+      - hostname
+      - cwd
+      - username
+```
+
+Guidance:
+
+- keep anonymization enabled for shared logs;
+- add sensitive keys to the blocklist rather than post-processing logs later;
+- prefer `standard` granularity unless debugging a local-only sensor issue;
+- use `blocked` to deny a sensor even if it appears in `allowed`.
+
+### `permissions`
+
+Controls write zones:
+
+```yaml
+permissions:
+  modifiable_paths: [skills]
+  review_required_paths: [skills/experimental]
+  forbidden_paths: [src, .git, mem, runs, tests]
+  force_allow_paths: []
+```
+
+Meanings:
+
+- `modifiable_paths`: autonomous writes may proceed after simulation;
+- `review_required_paths`: writes are denied automatically and require human review;
+- `forbidden_paths`: writes are blocked and counted as governance violations;
+- `force_allow_paths`: emergency override that permits matching paths and journals a forced decision.
+
+Recommended practice:
+
+- keep autonomous writes limited to `skills/`;
+- never allow `.git`, `src`, `tests`, `mem`, or `runs` for ordinary autonomous mutation;
+- use `skills/experimental` for work that should be surfaced but not auto-applied;
+- treat `force_allow_paths` as temporary and document why it was used.
+
+### `autonomy`
+
+Controls mutation, runtime execution, rollback and circuit breakers:
+
+```yaml
+autonomy:
+  safe_mode: false
+  mutation_quota_per_window: 25
+  mutation_quota_window_seconds: 300.0
+  runtime_call_quota_per_hour: 240
+  runtime_blacklisted_capabilities: []
+  auto_rollback_failure_threshold: 5
+  auto_rollback_cost_threshold: 10.0
+  safe_mode_review_required_skill_families: [network, shell, filesystem]
+  circuit_breaker_threshold: 3
+  circuit_breaker_window_seconds: 180.0
+  circuit_breaker_cooldown_seconds: 300.0
+  skill_creation_quota_per_window: 3
+  skill_creation_quota_window_seconds: 900.0
+  file_creation_review_required: false
+  skill_circuit_breaker_failure_threshold: 3
+  skill_circuit_breaker_cost_threshold: 5.0
+  skill_circuit_breaker_cooldown_seconds: 600.0
+```
+
+Important knobs:
+
+- `safe_mode`: disables autonomous mutations and makes risky skill families require review;
+- `mutation_quota_per_window`: caps mutation frequency;
+- `runtime_call_quota_per_hour`: caps skill execution calls;
+- `runtime_blacklisted_capabilities`: blocks named runtime capabilities;
+- `auto_rollback_*`: thresholds for rollback-oriented failure handling;
+- `circuit_breaker_*`: opens a global cooldown after repeated governance violations;
+- `skill_creation_*`: limits automatic creation of new skill files;
+- `file_creation_review_required`: requires manual review for new skill files;
+- `skill_circuit_breaker_*`: isolates a repeatedly failing or expensive skill.
+
+Conservative profile for demos:
+
+```bash
+singular --root ./lab policy set --key autonomy.safe_mode --value true
+```
+
+Exploration profile for a local sandbox only:
+
+```yaml
+autonomy:
+  safe_mode: false
+  mutation_quota_per_window: 10
+  mutation_quota_window_seconds: 300.0
+  file_creation_review_required: true
+```
+
+Keep exploration roots disposable and inspect policy decisions after every run.
+
+### `social`
+
+Controls interactions between lives:
+
+```yaml
+social:
+  max_influence_per_life: 0.35
+  blocked_hostile_behaviors:
+    - threat.explicit
+    - harassment.explicit
+    - sabotage.explicit
+    - abuse.explicit
+  conflict_events:
+    - conflict.explicit
+    - betrayal
+    - resource_conflict
+  conflict_mediation_threshold: 3
+  conflict_window_seconds: 900.0
+  mediation_cooldown_seconds: 600.0
+  prudent_mode_on_mediation: true
+```
+
+These settings affect multi-agent help, competition, social updates and reproduction arbitration:
+
+- explicit hostile behaviors are blocked;
+- influence transfer above `max_influence_per_life` requires review;
+- repeated conflict events pause the pair via mediation cooldown;
+- `prudent_mode_on_mediation` can make the whole system more cautious after social escalation.
+
+## Reproduction governance
+
+Reproduction uses the same write policy as mutation. Before a child skill is written, Singular simulates and enforces the target path. This means:
+
+- output under an authorized child `skills/` directory is allowed;
+- output under `mem/`, `runs/`, `src/`, `tests/` or `.git/` is blocked;
+- review-required paths do not auto-write;
+- blocked attempts are journaled in `mem/policy_decisions.jsonl`.
+
+If you customize child output paths, keep the child root structured like:
+
+```text
+child/
+  skills/
+  mem/
+```
+
+## Equivalent governance files
+
+Some deployments may wrap or generate `policy.yaml` from an environment-specific governance file. The equivalent file must still produce the same runtime schema:
+
+- root keys: `version`, `memory`, `forgetting`, `sensors`, `permissions`, `autonomy`, `social`;
+- all required keys inside each section;
+- no unknown keys;
+- values with the expected types and minimums.
+
+A generator should write the resolved file to `$SINGULAR_ROOT/policy.yaml` before launching Singular, then verify with:
+
+```bash
+singular --root "$SINGULAR_ROOT" policy show --format json
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `unexpected root keys` | Extra section or typo | Remove the unknown key or update the code/schema together |
+| `missing keys` | Partial manual file | Start from `singular policy show` or the default file and edit incrementally |
+| Mutations never happen | `safe_mode` true or circuit breaker open | Check `policy show`, `status --verbose`, and `mem/policy_decisions.jsonl` |
+| Write blocked outside `skills/` | Path not in `modifiable_paths` | Keep autonomous writes under `skills/` or require review |
+| Social help is blocked | Influence cap, hostility block, or mediation cooldown | Reduce influence, reconcile lives, or wait for cooldown |
+| Child reproduction fails | Output path violates write policy or parent skills are incompatible | Use a child root with `skills/`; ensure parent skill signatures match |
+
+## Audit checklist before sharing a policy
+
+- [ ] `singular --root <root> policy show --format table` succeeds.
+- [ ] `permissions.forbidden_paths` still protects source, tests, memory, runs and VCS data.
+- [ ] Sensor anonymization is enabled unless logs are strictly local.
+- [ ] `safe_mode` can be switched on quickly for incident response.
+- [ ] Social conflict and mediation thresholds are documented.
+- [ ] Any `force_allow_paths` entry has an owner, reason and removal date.

--- a/docs/tutorial_create_life.en.md
+++ b/docs/tutorial_create_life.en.md
@@ -1,0 +1,235 @@
+# Tutorial — creating a Singular life
+
+This tutorial walks through a complete local path: create a life, add a skill, run an evolutionary tick, inspect memory and the checkpoint, then read the logs. The commands use an isolated lab root so experiments do not mix with your regular lives.
+
+## Prerequisites
+
+Install Singular from the repository root:
+
+```bash
+pip install -e .[yaml,dashboard,viz]
+```
+
+Create a reproducible workspace:
+
+```bash
+export SINGULAR_ROOT="$PWD/.singular-tutorial"
+rm -rf "$SINGULAR_ROOT"
+mkdir -p "$SINGULAR_ROOT"
+```
+
+> On Windows PowerShell, use `$env:SINGULAR_ROOT = "$PWD/.singular-tutorial"` instead.
+
+## 1. Create a life
+
+```bash
+singular --root "$SINGULAR_ROOT" lives create --name Lumen --curiosity 0.75 --patience 0.55
+singular --root "$SINGULAR_ROOT" lives list
+```
+
+The command creates a life directory under `lives/`, selects it in the registry, and initializes:
+
+- `skills/`: executable and mutable capabilities;
+- `mem/`: memory artifacts (`psyche.json`, `profile.json`, `values.yaml`, JSONL journals, and more);
+- `runs/`: traces for runs executed by this life.
+
+Check the active life:
+
+```bash
+singular --root "$SINGULAR_ROOT" status --format table
+```
+
+## 2. Add a simple skill
+
+Autonomous mutations normally write under `skills/`, but you can also add a starter skill manually. First resolve the life path:
+
+```bash
+LIFE_DIR=$(python - <<'PY'
+import json, os, pathlib
+root = pathlib.Path(os.environ["SINGULAR_ROOT"])
+registry = json.loads((root / "lives" / "registry.json").read_text())
+active = registry["active"]
+print(registry["lives"][active]["path"])
+PY
+)
+```
+
+Add a pure deterministic skill:
+
+```bash
+cat > "$LIFE_DIR/skills/greet.py" <<'PY'
+def greet(name="friend"):
+    """Return a deterministic greeting."""
+    return f"Hello {name}!"
+
+result = greet("Lumen")
+PY
+```
+
+Good practices for a first skill:
+
+- one short main function;
+- no network access;
+- no writes outside the organism directory;
+- a `result` variable that is useful if the loop evaluates it in the sandbox.
+
+## 3. Run an evolutionary tick
+
+The modern loop interface is time-based: `--budget-seconds` replaces the older tick-count interface.
+
+```bash
+singular --root "$SINGULAR_ROOT" --life lumen loop --budget-seconds 5 --run-id tutorial_tick
+```
+
+During this tick, Singular may select a skill, propose a mutation, evaluate it in the sandbox, score the result, apply write governance, and journal the verdict. A rejected mutation is normal: the log explains whether the rejection came from the sandbox, score, governance, or a quota.
+
+## 4. Inspect memory and checkpoint
+
+The life memory lives in `mem/`:
+
+```bash
+find "$LIFE_DIR/mem" -maxdepth 1 -type f | sort
+python -m json.tool "$LIFE_DIR/mem/psyche.json" | head -40
+```
+
+Useful files:
+
+- `mem/psyche.json`: traits, mood, fatigue, and possible social signals;
+- `mem/profile.json`: identity and birth metadata;
+- `mem/episodic.jsonl`: lived episodes, one JSON object per line;
+- `mem/procedural.jsonl`: learning and execution traces;
+- `mem/generations.jsonl`: mutation attempts and verdicts;
+- `mem/policy_decisions.jsonl`: blocked, forced, or review-required governance decisions.
+
+The default `loop` checkpoint is stored at the life root:
+
+```bash
+python -m json.tool "$LIFE_DIR/life_checkpoint.json" | head -80
+```
+
+It is used to resume loop state: current iteration, best known score, metadata, and persistent run state depending on the version.
+
+## 5. Interpret logs
+
+Display a human-readable summary:
+
+```bash
+singular --root "$SINGULAR_ROOT" --life lumen report --id tutorial_tick --format plain
+```
+
+Then inspect raw files when needed:
+
+```bash
+find "$LIFE_DIR/runs" -maxdepth 3 -type f | sort
+```
+
+Reading hints:
+
+- `accepted` or `improved` means a mutation was kept;
+- `rejected`, `sandbox_error`, `syntax_error`, or `missing_result` means a technical rejection;
+- `governance_violation` means a forbidden or unauthorized write;
+- `circuit_breaker_open` means too many violations in a short window;
+- `social_relation_update` appears in multi-life runs when the social graph changes.
+
+If the report is empty, verify the `run-id`, root, and active life:
+
+```bash
+singular --root "$SINGULAR_ROOT" lives list
+singular --root "$SINGULAR_ROOT" --life lumen status --verbose
+```
+
+## Reproduction tutorial — two parents and one child
+
+Reproduction crosses two organisms from their life directories. Create two parents:
+
+```bash
+singular --root "$SINGULAR_ROOT" lives create --name Alpha --curiosity 0.80 --resilience 0.70
+singular --root "$SINGULAR_ROOT" lives create --name Beta --curiosity 0.45 --resilience 0.90
+```
+
+Resolve their paths:
+
+```bash
+python - <<'PY'
+import json, os, pathlib
+root = pathlib.Path(os.environ["SINGULAR_ROOT"])
+registry = json.loads((root / "lives" / "registry.json").read_text())
+for slug in ("alpha", "beta"):
+    print(slug, registry["lives"][slug]["path"])
+PY
+```
+
+Select parents with auditable criteria:
+
+1. **Social compatibility**: a positive `SocialGraph` relation if the parents have interacted;
+2. **Skill complementarity**: different capabilities increase diversity;
+3. **Viability**: both parents have sufficient health;
+4. **Governance**: child writes must stay in an authorized zone.
+
+The direct command creates the child:
+
+```bash
+ALPHA_DIR=$(python - <<'PY'
+import json, os, pathlib
+root = pathlib.Path(os.environ["SINGULAR_ROOT"])
+registry = json.loads((root / "lives" / "registry.json").read_text())
+print(registry["lives"]["alpha"]["path"])
+PY
+)
+BETA_DIR=$(python - <<'PY'
+import json, os, pathlib
+root = pathlib.Path(os.environ["SINGULAR_ROOT"])
+registry = json.loads((root / "lives" / "registry.json").read_text())
+print(registry["lives"]["beta"]["path"])
+PY
+)
+singular --root "$SINGULAR_ROOT" spawn "$ALPHA_DIR" "$BETA_DIR" --out-dir "$SINGULAR_ROOT/children/alpha-beta-child"
+```
+
+What happens:
+
+- `crossover` picks one skill from each parent, checks that function signatures match, and produces a hybrid skill;
+- `inherit_psyche`, `inherit_values`, and `inherit_episodic_memory` combine non-code artifacts;
+- `authorize_reproduction_write` simulates and then applies `MutationGovernancePolicy.enforce_write` before writing the child skill;
+- if the output path is forbidden or unauthorized, reproduction fails before destructive modification.
+
+Inspect the child:
+
+```bash
+find "$SINGULAR_ROOT/children/alpha-beta-child" -maxdepth 3 -type f | sort
+python -m json.tool "$SINGULAR_ROOT/children/alpha-beta-child/mem/psyche.json" | head -60
+```
+
+## Multi-agent tutorial — help, response, and SocialGraph
+
+Ecosystem mode runs multiple lives in a shared loop. Lives can ask for help when their score is low, offer a skill when confidence is high, and update their relationships.
+
+Optionally prepare an initial relationship:
+
+```bash
+singular --root "$SINGULAR_ROOT" lives ally alpha beta
+singular --root "$SINGULAR_ROOT" lives relations --name alpha
+```
+
+Run a short multi-life loop:
+
+```bash
+singular --root "$SINGULAR_ROOT" ecosystem run --life alpha --life beta --budget-seconds 5 --run-id tutorial_ecosystem
+```
+
+Inside the loop:
+
+1. a struggling life emits a help request (`help.requested`);
+2. a confident life may respond with an offer (`help.offered`) or an answer;
+3. governance checks inter-life interactions, influence level, and conflicts;
+4. after successful assistance, `SocialGraph.update_relation` increases affinity and trust, and lowers rivalry;
+5. after a resource conflict, the relation can become more rivalrous and may trigger mediation when thresholds are exceeded.
+
+Inspect the persistent social graph:
+
+```bash
+python -m json.tool "$SINGULAR_ROOT/mem/social_graph.json" 2>/dev/null || true
+find "$SINGULAR_ROOT" -path '*social_graph.json' -print
+```
+
+Depending on the command and active `SINGULAR_HOME`, the graph can be written in root-level memory or active-life memory. Events to search for in logs include `help.requested`, `help.offered`, `help.completed`, `answer`, `social_relation_update`, `resource_conflict`, and `governance_violation`.

--- a/docs/tutorial_create_life.fr.md
+++ b/docs/tutorial_create_life.fr.md
@@ -1,0 +1,235 @@
+# Tutoriel — créer une vie Singular
+
+Ce tutoriel montre un parcours local complet : créer une vie, ajouter une compétence, lancer un tick d'évolution, inspecter la mémoire et le checkpoint, puis interpréter les logs. Les commandes utilisent un root de laboratoire isolé pour éviter de mélanger vos essais avec vos vies habituelles.
+
+## Pré-requis
+
+Installez Singular depuis la racine du dépôt :
+
+```bash
+pip install -e .[yaml,dashboard,viz]
+```
+
+Créez un espace de travail reproductible :
+
+```bash
+export SINGULAR_ROOT="$PWD/.singular-tutorial"
+rm -rf "$SINGULAR_ROOT"
+mkdir -p "$SINGULAR_ROOT"
+```
+
+> Sous Windows PowerShell, utilisez plutôt `$env:SINGULAR_ROOT = "$PWD/.singular-tutorial"`.
+
+## 1. Créer une vie
+
+```bash
+singular --root "$SINGULAR_ROOT" lives create --name Lumen --curiosity 0.75 --patience 0.55
+singular --root "$SINGULAR_ROOT" lives list
+```
+
+La commande crée un dossier de vie sous `lives/`, sélectionne cette vie dans le registre et initialise :
+
+- `skills/` : les compétences exécutables et mutables ;
+- `mem/` : les artefacts de mémoire (`psyche.json`, `profile.json`, `values.yaml`, journaux JSONL, etc.) ;
+- `runs/` : les traces des runs exécutés pour cette vie.
+
+Vérifiez la vie active :
+
+```bash
+singular --root "$SINGULAR_ROOT" status --format table
+```
+
+## 2. Ajouter une compétence simple
+
+Les mutations autonomes écrivent normalement dans `skills/`, mais vous pouvez aussi ajouter manuellement une compétence de départ. Identifiez d'abord le chemin de la vie :
+
+```bash
+LIFE_DIR=$(python - <<'PY'
+import json, os, pathlib
+root = pathlib.Path(os.environ["SINGULAR_ROOT"])
+registry = json.loads((root / "lives" / "registry.json").read_text())
+active = registry["active"]
+print(registry["lives"][active]["path"])
+PY
+)
+```
+
+Ajoutez une skill pure et déterministe :
+
+```bash
+cat > "$LIFE_DIR/skills/greet.py" <<'PY'
+def greet(name="ami"):
+    """Return a deterministic greeting."""
+    return f"Bonjour {name}!"
+
+result = greet("Lumen")
+PY
+```
+
+Bonnes pratiques pour une skill débutante :
+
+- une fonction principale courte ;
+- pas d'accès réseau ;
+- pas d'écriture hors du dossier de l'organisme ;
+- une variable `result` utile aux tests/sandbox si la boucle l'évalue.
+
+## 3. Lancer un tick d'évolution
+
+L'interface moderne de la boucle est temporelle : `--budget-seconds` remplace l'ancien pilotage par nombre de ticks.
+
+```bash
+singular --root "$SINGULAR_ROOT" --life lumen loop --budget-seconds 5 --run-id tutorial_tick
+```
+
+Pendant ce tick, Singular peut sélectionner une skill, proposer une mutation, l'évaluer en sandbox, scorer le résultat, appliquer la gouvernance d'écriture, puis journaliser le verdict. Une mutation rejetée est normale : le journal explique si le rejet vient du sandbox, du score, de la gouvernance ou d'un quota.
+
+## 4. Inspecter mémoire et checkpoint
+
+La mémoire de la vie est située dans `mem/` :
+
+```bash
+find "$LIFE_DIR/mem" -maxdepth 1 -type f | sort
+python -m json.tool "$LIFE_DIR/mem/psyche.json" | head -40
+```
+
+Points à regarder :
+
+- `mem/psyche.json` : traits, humeur, fatigue, signaux sociaux éventuels ;
+- `mem/profile.json` : identité et métadonnées de naissance ;
+- `mem/episodic.jsonl` : épisodes vécus, une entrée JSON par ligne ;
+- `mem/procedural.jsonl` : apprentissages et traces d'exécution ;
+- `mem/generations.jsonl` : tentatives de mutation et verdicts ;
+- `mem/policy_decisions.jsonl` : décisions de gouvernance bloquées, forcées ou en revue.
+
+Le checkpoint par défaut de `loop` est placé à la racine de la vie :
+
+```bash
+python -m json.tool "$LIFE_DIR/life_checkpoint.json" | head -80
+```
+
+Il sert à reprendre l'état de boucle : itération courante, meilleur score connu, méta-informations et état persistant du run selon la version.
+
+## 5. Interpréter les logs
+
+Affichez un résumé humain :
+
+```bash
+singular --root "$SINGULAR_ROOT" --life lumen report --id tutorial_tick --format plain
+```
+
+Puis inspectez les fichiers bruts si nécessaire :
+
+```bash
+find "$LIFE_DIR/runs" -maxdepth 3 -type f | sort
+```
+
+Repères de lecture :
+
+- `accepted` ou `improved` indique une mutation conservée ;
+- `rejected`, `sandbox_error`, `syntax_error` ou `missing_result` indiquent un rejet technique ;
+- `governance_violation` indique une écriture interdite ou une zone non autorisée ;
+- `circuit_breaker_open` signale trop de violations dans une fenêtre courte ;
+- `social_relation_update` apparaît dans les runs multi-vies quand le graphe social change.
+
+Si le rapport est vide, vérifiez le `run-id`, le root et la vie active :
+
+```bash
+singular --root "$SINGULAR_ROOT" lives list
+singular --root "$SINGULAR_ROOT" --life lumen status --verbose
+```
+
+## Tutoriel reproduction — deux parents et un enfant
+
+La reproduction croise deux organismes à partir de leurs dossiers de vie. Créez deux parents :
+
+```bash
+singular --root "$SINGULAR_ROOT" lives create --name Alpha --curiosity 0.80 --resilience 0.70
+singular --root "$SINGULAR_ROOT" lives create --name Beta --curiosity 0.45 --resilience 0.90
+```
+
+Récupérez leurs chemins :
+
+```bash
+python - <<'PY'
+import json, os, pathlib
+root = pathlib.Path(os.environ["SINGULAR_ROOT"])
+registry = json.loads((root / "lives" / "registry.json").read_text())
+for slug in ("alpha", "beta"):
+    print(slug, registry["lives"][slug]["path"])
+PY
+```
+
+Sélectionnez les parents en fonction de critères auditables :
+
+1. **Compatibilité sociale** : relation positive dans `SocialGraph` si les parents ont déjà interagi ;
+2. **Complémentarité des skills** : des compétences différentes augmentent la diversité ;
+3. **Viabilité** : santé suffisante des deux parents ;
+4. **Gouvernance** : l'écriture de l'enfant doit rester dans une zone autorisée.
+
+La commande directe crée l'enfant :
+
+```bash
+ALPHA_DIR=$(python - <<'PY'
+import json, os, pathlib
+root = pathlib.Path(os.environ["SINGULAR_ROOT"])
+registry = json.loads((root / "lives" / "registry.json").read_text())
+print(registry["lives"]["alpha"]["path"])
+PY
+)
+BETA_DIR=$(python - <<'PY'
+import json, os, pathlib
+root = pathlib.Path(os.environ["SINGULAR_ROOT"])
+registry = json.loads((root / "lives" / "registry.json").read_text())
+print(registry["lives"]["beta"]["path"])
+PY
+)
+singular --root "$SINGULAR_ROOT" spawn "$ALPHA_DIR" "$BETA_DIR" --out-dir "$SINGULAR_ROOT/children/alpha-beta-child"
+```
+
+Ce qui se passe :
+
+- `crossover` choisit une skill de chaque parent, vérifie que les signatures de fonctions correspondent et produit une skill hybride ;
+- `inherit_psyche`, `inherit_values` et `inherit_episodic_memory` combinent une partie des artefacts non-code ;
+- `authorize_reproduction_write` simule puis applique `MutationGovernancePolicy.enforce_write` avant d'écrire la skill enfant ;
+- si le chemin de sortie est interdit ou non autorisé, la reproduction échoue avant modification destructrice.
+
+Inspectez l'enfant :
+
+```bash
+find "$SINGULAR_ROOT/children/alpha-beta-child" -maxdepth 3 -type f | sort
+python -m json.tool "$SINGULAR_ROOT/children/alpha-beta-child/mem/psyche.json" | head -60
+```
+
+## Tutoriel multi-agent — aide, réponse et SocialGraph
+
+Le mode écosystème fait tourner plusieurs vies dans une boucle partagée. Les vies peuvent demander de l'aide si leur score est bas, offrir une compétence si leur confiance est haute, puis mettre à jour leurs relations.
+
+Préparez une relation initiale facultative :
+
+```bash
+singular --root "$SINGULAR_ROOT" lives ally alpha beta
+singular --root "$SINGULAR_ROOT" lives relations --name alpha
+```
+
+Lancez une courte boucle multi-vies :
+
+```bash
+singular --root "$SINGULAR_ROOT" ecosystem run --life alpha --life beta --budget-seconds 5 --run-id tutorial_ecosystem
+```
+
+Dans la boucle :
+
+1. une vie en difficulté émet une demande d'aide (`help.requested`) ;
+2. une vie confiante peut répondre par une offre (`help.offered`) ou une réponse ;
+3. la gouvernance vérifie les interactions inter-vies, le niveau d'influence et les conflits ;
+4. en cas d'entraide réussie, `SocialGraph.update_relation` augmente l'affinité et la confiance, et baisse la rivalité ;
+5. en cas de conflit de ressources, la relation peut devenir plus rivale et déclencher une médiation si les seuils sont dépassés.
+
+Inspectez le graphe social persistant :
+
+```bash
+python -m json.tool "$SINGULAR_ROOT/mem/social_graph.json" 2>/dev/null || true
+find "$SINGULAR_ROOT" -path '*social_graph.json' -print
+```
+
+Selon la commande et le `SINGULAR_HOME` actif, le graphe peut être écrit dans la mémoire globale du root ou dans la mémoire de la vie active. Les événements à chercher dans les logs sont `help.requested`, `help.offered`, `help.completed`, `answer`, `social_relation_update`, `resource_conflict` et `governance_violation`.


### PR DESCRIPTION
### Motivation

- Provide step-by-step onboarding to create a life, add a skill, run a tick, and read logs so new users can reproduce a basic lifecycle locally.  
- Document reproduction and multi-agent scenarios (parent selection, child generation, SocialGraph effects) to make coevolution workflows explicit and auditable.  
- Explain `policy.yaml` and runtime governance so operators can safely tune mutation/permission/social settings and understand why writes may be blocked.

### Description

- Added three new documentation pages: `docs/tutorial_create_life.fr.md`, `docs/tutorial_create_life.en.md`, and `docs/policy_customization.md` which cover life creation, adding skills, running `loop`, inspecting `mem/` and checkpoints, reproduction (`spawn`/`crossover`), multi-agent help flows, and governance details.  
- Linked the new docs from `README.md` under a new “Tutoriels et gouvernance” section.  
- The policy guide documents the runtime schema, explains `permissions`, `autonomy`, `sensors`, `social` and reproduction governance, and shows safe CLI/edit workflows (including `singular --root ./lab policy set --key autonomy.safe_mode --value true`).  
- Content is provided in both French and English tutorials and includes concrete shell snippets for reproducible local experiments (isolated `SINGULAR_ROOT`, `singular lives create`, `singular loop`, `singular spawn`, and `ecosystem run`).

### Testing

- Verified new files exist and are referenced in `README.md` with a scripted check using `python` (exists + README links); the check passed.  
- Verified Markdown code fence balance for the three docs with a scripted check counting backticks; the check passed.  
- Ran `git diff --check` to ensure no whitespace/format issues; it returned clean.  
- Commit created with message `Add life creation and policy tutorials` and changes staged/committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04cb4977cc832aadf9b9e4bcaf38e8)