### PR TITLE
Instrument life loop phase profiling

### DIFF
--- a/scripts/profile_life_loop.py
+++ b/scripts/profile_life_loop.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Profile the Singular life loop on a temporary life for a fixed tick count."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import tempfile
+from pathlib import Path
+
+
+def _write_temporary_life(root: Path) -> tuple[Path, Path]:
+    skills_dir = root / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    (skills_dir / "toy_skill.py").write_text(
+        "def toy_skill(x=1):\n    return x + 1\n",
+        encoding="utf-8",
+    )
+    checkpoint = root / "life_checkpoint.json"
+    return skills_dir, checkpoint
+
+
+def _phase_records(runs_dir: Path, run_id: str) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for path in sorted(runs_dir.glob(f"{run_id}-*.jsonl")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict) and payload.get("event") == "life_loop_phase_metrics":
+                records.append(payload)
+    return records
+
+
+def _aggregate(records: list[dict[str, object]]) -> dict[str, object]:
+    phase_totals: dict[str, float] = {}
+    phase_calls: dict[str, int] = {}
+    cache_hits: dict[str, int] = {}
+    cache_misses: dict[str, int] = {}
+    candidates: list[dict[str, object]] = []
+    async_note = None
+    for record in records:
+        metrics = record.get("phase_metrics")
+        if not isinstance(metrics, dict):
+            continue
+        async_note = metrics.get("async_distribution_note") or async_note
+        if isinstance(metrics.get("cache_candidates"), list):
+            candidates = metrics["cache_candidates"]
+        phases = metrics.get("phases")
+        if not isinstance(phases, dict):
+            continue
+        for name, raw in phases.items():
+            if not isinstance(raw, dict):
+                continue
+            phase = str(name)
+            phase_totals[phase] = phase_totals.get(phase, 0.0) + float(raw.get("total_ms", 0.0) or 0.0)
+            phase_calls[phase] = phase_calls.get(phase, 0) + int(raw.get("calls", 0) or 0)
+            cache_hits[phase] = cache_hits.get(phase, 0) + int(raw.get("cache_hits", 0) or 0)
+            cache_misses[phase] = cache_misses.get(phase, 0) + int(raw.get("cache_misses", 0) or 0)
+    phases = {
+        phase: {
+            "total_ms": round(total, 3),
+            "calls": phase_calls.get(phase, 0),
+            "avg_ms": round(total / phase_calls[phase], 3) if phase_calls.get(phase) else 0.0,
+            "cache_hits": cache_hits.get(phase, 0),
+            "cache_misses": cache_misses.get(phase, 0),
+        }
+        for phase, total in sorted(phase_totals.items(), key=lambda item: item[1], reverse=True)
+    }
+    return {
+        "ticks_profiled": len(records),
+        "slowest_phase": next(iter(phases), None),
+        "phases": phases,
+        "cache_candidates": candidates,
+        "async_distribution_note": async_note
+        or "Étudier async/distribué uniquement après métriques fiables.",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Profile life loop phases on a temporary life")
+    parser.add_argument("--ticks", type=int, default=5, help="fixed number of life-loop ticks")
+    parser.add_argument("--run-id", default="profile-life-loop", help="run id used for JSONL logs")
+    parser.add_argument("--seed", type=int, default=7, help="deterministic random seed")
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory(prefix="singular-life-profile-") as tmp:
+        root = Path(tmp)
+        skills_dir, checkpoint = _write_temporary_life(root)
+        previous_home = os.environ.get("SINGULAR_HOME")
+        previous_cwd = Path.cwd()
+        os.environ["SINGULAR_HOME"] = str(root)
+        os.chdir(root)
+        try:
+            from singular.life.loop import run
+
+            run(
+                skills_dirs=skills_dir,
+                checkpoint_path=checkpoint,
+                budget_seconds=max(1.0, args.ticks * 0.5),
+                rng=random.Random(args.seed),
+                run_id=args.run_id,
+                max_iterations=max(1, args.ticks),
+            )
+            records = _phase_records(root / "runs", args.run_id)
+            print(json.dumps(_aggregate(records), ensure_ascii=False, indent=2))
+        finally:
+            os.chdir(previous_cwd)
+            if previous_home is None:
+                os.environ.pop("SINGULAR_HOME", None)
+            else:
+                os.environ["SINGULAR_HOME"] = previous_home
+
+
+if __name__ == "__main__":
+    main()

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -698,8 +698,34 @@ def create_app(
         durations: list[float] = []
         latencies_ms: list[float] = []
         score_deltas: list[float] = []
+        phase_totals: dict[str, float] = {}
+        phase_calls: dict[str, int] = {}
+        phase_cache_hits: dict[str, int] = {}
+        phase_cache_misses: dict[str, int] = {}
+        phase_records = 0
+        latest_phase_metrics: dict[str, object] | None = None
         accepted = 0
         rejected = 0
+        for record in records:
+            phase_metrics = record.get("phase_metrics")
+            if isinstance(phase_metrics, dict):
+                latest_phase_metrics = phase_metrics
+                phase_records += 1
+                phases = phase_metrics.get("phases")
+                if isinstance(phases, dict):
+                    for phase_name, raw_stats in phases.items():
+                        if not isinstance(raw_stats, dict):
+                            continue
+                        name = str(phase_name)
+                        total_ms = _as_float(raw_stats.get("total_ms")) or 0.0
+                        calls = int(_as_float(raw_stats.get("calls")) or 0)
+                        phase_totals[name] = phase_totals.get(name, 0.0) + total_ms
+                        phase_calls[name] = phase_calls.get(name, 0) + calls
+                        phase_cache_hits[name] = phase_cache_hits.get(name, 0) + int(_as_float(raw_stats.get("cache_hits")) or 0)
+                        phase_cache_misses[name] = phase_cache_misses.get(name, 0) + int(_as_float(raw_stats.get("cache_misses")) or 0)
+                total_ms = _as_float(phase_metrics.get("total_ms"))
+                if total_ms is not None:
+                    durations.append(total_ms / 1000.0)
         for record in records:
             for key in ("duration_seconds", "elapsed_seconds", "runtime_seconds"):
                 value = _as_float(record.get(key))
@@ -724,6 +750,21 @@ def create_app(
         def _avg(values: list[float]) -> float | None:
             return sum(values) / len(values) if values else None
 
+        phase_summary = {
+            name: {
+                "total_ms": round(total, 3),
+                "avg_ms": round(total / phase_calls[name], 3) if phase_calls.get(name) else 0.0,
+                "calls": phase_calls.get(name, 0),
+                "cache_hits": phase_cache_hits.get(name, 0),
+                "cache_misses": phase_cache_misses.get(name, 0),
+            }
+            for name, total in sorted(phase_totals.items(), key=lambda item: item[1], reverse=True)
+        }
+        slowest_phase = next(iter(phase_summary), None)
+        cache_candidates = []
+        if isinstance(latest_phase_metrics, dict) and isinstance(latest_phase_metrics.get("cache_candidates"), list):
+            cache_candidates = latest_phase_metrics.get("cache_candidates", [])
+
         return {
             "records_count": len(records),
             "mutation_count": sum(1 for record in records if _is_mutation_record(record)),
@@ -732,6 +773,15 @@ def create_app(
             "avg_duration_seconds": _avg(durations),
             "avg_latency_ms": _avg(latencies_ms),
             "avg_score_delta": _avg(score_deltas),
+            "phase_metrics_records": phase_records,
+            "phase_metrics": phase_summary,
+            "slowest_phase": slowest_phase,
+            "cache_candidates": cache_candidates,
+            "async_distribution_note": (
+                latest_phase_metrics.get("async_distribution_note")
+                if isinstance(latest_phase_metrics, dict)
+                else None
+            ),
         }
 
     def _summarize_social_relations(records: list[dict[str, object]]) -> dict[str, object]:
@@ -844,6 +894,11 @@ def create_app(
                     "avg_duration_seconds": None,
                     "avg_latency_ms": None,
                     "avg_score_delta": None,
+                    "phase_metrics_records": 0,
+                    "phase_metrics": {},
+                    "slowest_phase": None,
+                    "cache_candidates": [],
+                    "async_distribution_note": None,
                 },
                 "social_relations": {
                     "alliance_edges": 0,

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -526,6 +526,32 @@ export const loadCockpit=()=>Promise.allSettled([
   setText('kpi-behavior-trend',String(behavior.temporal_trend||na()));
   setText('kpi-behavior-correlation',`${behaviorCorr.major_decisions_count??0} décisions majeures`);
   if(behaviorAlerts.homeostasis_unstable||behaviorAlerts.robustness_low){setTone('kpi-behavior-homeostasis','bad');}
+  const perf=d.performance_metrics||{};
+  const phaseMetrics=perf.phase_metrics||{};
+  const phaseLabel=name=>{
+    const item=phaseMetrics[name]||{};
+    const total=Number(item.total_ms||0);
+    const calls=Number(item.calls||0);
+    const hits=Number(item.cache_hits||0);
+    const misses=Number(item.cache_misses||0);
+    const cache=(hits||misses)?` · cache ${hits}/${hits+misses}`:'';
+    return `${fmtNum(total,' ms')} · ${calls} appels${cache}`;
+  };
+  setText('kpi-phase-slowest',perf.slowest_phase?`${perf.slowest_phase} · ${phaseLabel(perf.slowest_phase)}`:na());
+  setText('kpi-phase-sandbox',phaseLabel('sandbox_scoring'));
+  setText('kpi-phase-tests',phaseLabel('test_runner'));
+  setText('kpi-phase-io',`${phaseLabel('checkpoint_write')} · logging ${phaseLabel('logging')}`);
+  const cacheList=clearElement('kpi-phase-cache-candidates');
+  if(cacheList){
+    const candidates=Array.isArray(perf.cache_candidates)?perf.cache_candidates:[];
+    for(const candidate of candidates){
+      const li=document.createElement('li');
+      li.textContent=`${candidate.phase||'phase'} · ${candidate.reason||'cache potentiel'} · hits=${candidate.current_cache_hits??0}, misses=${candidate.current_cache_misses??0}`;
+      cacheList.appendChild(li);
+    }
+    if(!candidates.length){const li=document.createElement('li');li.textContent='Aucune opportunité de cache répétitif détectée sur le dernier tick.';cacheList.appendChild(li);}
+  }
+  setText('kpi-phase-async-note',String(perf.async_distribution_note||'Étudier async/distribué uniquement après métriques fiables.'));
   const vital=d.vital_timeline||{};
   const skillLifecycle=d.skills_lifecycle||{};
   const vitalMetrics=d.vital_metrics||{};

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -208,6 +208,21 @@
       </ul>
     </div>
 
+    <div class='panel level-panel' data-essential-level='2'>
+      <h3 class='heading-reset-top'>Profilage boucle de vie</h3>
+      <p class='section-help'>Métriques par phase : mutation, sandbox, tests, co-évolution, Map-Elites, reproduction, checkpoint et logging.</p>
+      <div class='cards-grid'>
+        <div class='card'><div class='card-label'>Phase la plus coûteuse</div><div id='kpi-phase-slowest' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Sandbox scoring</div><div id='kpi-phase-sandbox' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Test runner</div><div id='kpi-phase-tests' class='card-value'>Chargement…</div></div>
+        <div class='card'><div class='card-label'>Checkpoint/logging</div><div id='kpi-phase-io' class='card-value'>Chargement…</div></div>
+      </div>
+      <ul id='kpi-phase-cache-candidates' class='list-tight-top'>
+        <li>Analyse des caches en attente…</li>
+      </ul>
+      <p id='kpi-phase-async-note' class='section-help'>Asynchrone/distribué à étudier après métriques fiables.</p>
+    </div>
+
     <details id='cockpit-followup' class='panel level-panel' data-essential-level='2' open>
       <summary>Contexte d’observation</summary>
       <div class='panel panel-compact panel-top-gap'>

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -78,6 +78,7 @@ from .reproduction_flow import (
 from .coevolution_flow import CoevolutionConfig, CoevolutionFlow, MapElites, LivingTestPool
 from .skill_genesis import create_skill
 from .social_decision import decide_social_actions
+from .profiling import LifeLoopProfiler
 
 # mypy: ignore-errors
 
@@ -212,6 +213,36 @@ ACTION_TYPE_FROM_LOOP_EVENT: dict[str, str] = {
 
 HEALTH_HISTORY_FINE_WINDOW = 500
 HEALTH_HISTORY_AGGREGATE_EVERY = 10
+
+_ECOSYSTEM_RULES_CONFIG_CACHE: dict[tuple[str, int], EcosystemRulesConfig] = {}
+
+
+def _load_ecosystem_rules_config_cached(
+    config_path: Path, profiler: LifeLoopProfiler | None = None
+) -> EcosystemRulesConfig | None:
+    """Load ecosystem rules config with a path+mtime cache for repeated runs."""
+
+    try:
+        stat = config_path.stat()
+    except OSError:
+        return None
+    cache_key = (str(config_path.resolve()), stat.st_mtime_ns)
+    cached = _ECOSYSTEM_RULES_CONFIG_CACHE.get(cache_key)
+    if profiler is not None:
+        profiler.record_cache("config_loading", hit=cached is not None)
+    if cached is not None:
+        return cached
+    if profiler is None:
+        config = EcosystemRulesConfig.from_file(config_path)
+    else:
+        with profiler.phase("config_loading"):
+            config = EcosystemRulesConfig.from_file(config_path)
+    # Drop stale entries for the same path so mtime changes refresh cleanly.
+    for key in list(_ECOSYSTEM_RULES_CONFIG_CACHE):
+        if key[0] == cache_key[0] and key != cache_key:
+            _ECOSYSTEM_RULES_CONFIG_CACHE.pop(key, None)
+    _ECOSYSTEM_RULES_CONFIG_CACHE[cache_key] = config
+    return config
 
 
 def _resolve_current_life_slug() -> str | None:
@@ -575,6 +606,18 @@ def _inactive_skill_keys(skills_state: Mapping[str, object]) -> set[str]:
     return inactive
 
 
+def _map_elites_accept(
+    map_elites: MapElites,
+    mutated: str,
+    mutated_score: float,
+    profiler: LifeLoopProfiler,
+) -> bool:
+    """Profile one MAP-Elites insertion decision."""
+
+    with profiler.phase("map_elites"):
+        return map_elites.add(mutated, mutated_score)
+
+
 def _first_sandbox_error_type(
     base_result: SandboxScore, mutated_result: SandboxScore
 ) -> str | None:
@@ -716,14 +759,15 @@ def run(
     state.health_history = _retain_health_history(state.health_history)
 
     organisms_input = _normalize_organism_inputs(skills_dirs)
+    setup_profiler = LifeLoopProfiler()
 
     world = world or WorldState()
     if ecosystem_rules is None:
         config_path = (
             Path(__file__).resolve().parents[3] / "configs" / "ecosystem" / f"{ecosystem_mode}.json"
         )
-        if config_path.exists():
-            config = EcosystemRulesConfig.from_file(config_path)
+        config = _load_ecosystem_rules_config_cached(config_path, setup_profiler)
+        if config is not None:
             ecosystem_rules = EcosystemRules(
                 resource_competition_unit=config.resource_competition_unit,
                 passive_energy_decay=config.passive_energy_decay,
@@ -789,6 +833,32 @@ def run(
             ),
         )
 
+    score_cache: dict[str, SandboxScore] = {}
+    current_tick_profiler: LifeLoopProfiler | None = None
+
+    def _profiled_score_code(code: str) -> SandboxScore:
+        code_hash = hashlib.sha256(code.encode("utf-8")).hexdigest()
+        cached = score_cache.get(code_hash)
+        if current_tick_profiler is not None:
+            current_tick_profiler.record_cache("sandbox_scoring", hit=cached is not None)
+        if cached is not None:
+            return cached
+        if current_tick_profiler is None:
+            result = score_code_with_error(code)
+        else:
+            with current_tick_profiler.phase("sandbox_scoring"):
+                result = score_code_with_error(code)
+        score_cache[code_hash] = result
+        return result
+
+    def _profiled_test_runner() -> int:
+        if test_runner is None:
+            return 0
+        if current_tick_profiler is None:
+            return test_runner()
+        with current_tick_profiler.phase("test_runner"):
+            return test_runner()
+
     with RunLogger(run_id, psyche=psyche) as logger:
         health_tracker = HealthTracker.from_state(state.health_counters)
         delayed: list[tuple[float, str, Path]] = []
@@ -825,6 +895,10 @@ def run(
             signals["skill_reputation"] = logger.skill_reputation()
             resource_manager.update_from_environment(temp)
             state.iteration += 1
+            tick_profiler = LifeLoopProfiler()
+            tick_profiler.merge(setup_profiler)
+            setup_profiler = LifeLoopProfiler()
+            current_tick_profiler = tick_profiler
 
             now = time.time()
             if delayed and delayed[0][0] <= now:
@@ -1197,15 +1271,16 @@ def run(
                 )
             # Graine constrains the operator family. Singular still materializes
             # the concrete source mutation, then sends it to sandbox/governance.
-            mutated = apply_mutation(original, eligible_operators[op_name], rng)
+            with tick_profiler.phase("mutation"):
+                mutated = apply_mutation(original, eligible_operators[op_name], rng)
             org = world.organisms[org_name]
 
             t0 = time.perf_counter()
-            base_score_result = score_code_with_error(original)
+            base_score_result = _profiled_score_code(original)
             base_score = base_score_result.score
             ms_base = (time.perf_counter() - t0) * 1000
             t0 = time.perf_counter()
-            mutated_score_result = score_code_with_error(mutated)
+            mutated_score_result = _profiled_score_code(mutated)
             mutated_score = mutated_score_result.score
             ms_new = (time.perf_counter() - t0) * 1000
 
@@ -1269,7 +1344,7 @@ def run(
                 False
                 if mutation_failed
                 else (
-                    map_elites.add(mutated, mutated_score)
+                    _map_elites_accept(map_elites, mutated, mutated_score, tick_profiler)
                     if map_elites
                     else mutated_score <= base_score
                 )
@@ -1304,14 +1379,15 @@ def run(
                         rejected_for_robustness=False,
                     )
                 else:
-                    coevo_decision = coevolution_flow.decide(
-                        base_code=original,
-                        mutated_code=mutated,
-                        base_score=base_score,
-                        mutated_score=mutated_score,
-                        initially_accepted=accepted,
-                        rng=rng,
-                    )
+                    with tick_profiler.phase("coevolution"):
+                        coevo_decision = coevolution_flow.decide(
+                            base_code=original,
+                            mutated_code=mutated,
+                            base_score=base_score,
+                            mutated_score=mutated_score,
+                            initially_accepted=accepted,
+                            rng=rng,
+                        )
                     accepted = coevo_decision.accepted
                     logger.log_test_coevolution(
                         skill=skill_path.stem,
@@ -1449,7 +1525,11 @@ def run(
 
             # Resource accounting
             cpu_ms = ms_base + ms_new
-            moods = manage_resources(resource_manager, cpu_ms / 1000.0, test_runner)
+            moods = manage_resources(
+                resource_manager,
+                cpu_ms / 1000.0,
+                _profiled_test_runner if test_runner is not None else None,
+            )
             can_mutate, state_flag = resource_manager.apply_capability_cost("mutation")
             if not can_mutate:
                 accepted = False
@@ -1960,6 +2040,7 @@ def run(
             except ValueError:
                 skill_relative_path = str(skill_path)
 
+            logging_phase_started = time.perf_counter()
             record_generation(
                 run_id=logger.run_id,
                 iteration=state.iteration,
@@ -1996,7 +2077,9 @@ def run(
                 mutation_error_type=mutated_score_result.error_type,
                 mutation_error_message=mutated_score_result.error_message,
             )
-
+            tick_profiler.record_duration(
+                "logging", (time.perf_counter() - logging_phase_started) * 1000.0
+            )
             if hasattr(psyche, "consume"):
                 psyche.consume()
             if hasattr(psyche, "save_state"):
@@ -2010,7 +2093,21 @@ def run(
                 effects_path=world_effects_path,
             )
             resource_manager.apply_world_state(updated_world_state)
-            save_checkpoint(checkpoint_path, state)
+            with tick_profiler.phase("checkpoint_write"):
+                save_checkpoint(checkpoint_path, state)
+            phase_summary = tick_profiler.summary()
+            logger.log_phase_metrics(
+                iteration=state.iteration,
+                phases=phase_summary["phases"],
+                total_ms=float(phase_summary["total_ms"]),
+                slowest_phase=(
+                    str(phase_summary["slowest_phase"])
+                    if phase_summary.get("slowest_phase") is not None
+                    else None
+                ),
+                cache_candidates=list(phase_summary.get("cache_candidates", [])),
+                async_distribution_note=str(phase_summary.get("async_distribution_note", "")),
+            )
 
             # DeathMonitor convention: ``action_succeeded=True`` means the
             # mutation outcome is accepted (not a failure signal).
@@ -2088,7 +2185,8 @@ def run(
                     },
                     payload_version=1,
                 )
-                save_checkpoint(checkpoint_path, state)
+                with tick_profiler.phase("checkpoint_write"):
+                    save_checkpoint(checkpoint_path, state)
                 tick_count += 1
                 break
 
@@ -2114,12 +2212,17 @@ def run(
                 and state.iteration % ecosystem_rules.crossover_interval == 0
                 and len(world.organisms) >= 2
             ):
+                reproduction_phase_started = time.perf_counter()
                 if any(organism.degraded_mode for organism in world.organisms.values()):
                     logger.log_interaction(
                         "reproduction_suspended_degraded_mode",
                         organism="ecosystem",
                         reason="sandbox_degraded_mode_active",
                         alive=True,
+                    )
+                    tick_profiler.record_duration(
+                        "reproduction",
+                        (time.perf_counter() - reproduction_phase_started) * 1000.0,
                     )
                     tick_count += 1
                     continue
@@ -2228,6 +2331,10 @@ def run(
                             child_skills_dir=str(child_dir),
                             alive=True,
                         )
+                tick_profiler.record_duration(
+                    "reproduction",
+                    (time.perf_counter() - reproduction_phase_started) * 1000.0,
+                )
             for name in list(world.reproduction_cooldowns):
                 remaining = int(world.reproduction_cooldowns[name]) - 1
                 if remaining <= 0:

--- a/src/singular/life/profiling.py
+++ b/src/singular/life/profiling.py
@@ -1,0 +1,137 @@
+"""Lightweight phase profiling helpers for the life loop."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from time import perf_counter
+from typing import Iterator, Mapping
+
+DEFAULT_LIFE_LOOP_PHASES: tuple[str, ...] = (
+    "mutation",
+    "sandbox_scoring",
+    "test_runner",
+    "coevolution",
+    "map_elites",
+    "reproduction",
+    "checkpoint_write",
+    "logging",
+)
+
+
+@dataclass
+class PhaseStats:
+    """Aggregated timing and cache counters for one named phase."""
+
+    calls: int = 0
+    total_ms: float = 0.0
+    max_ms: float = 0.0
+    cache_hits: int = 0
+    cache_misses: int = 0
+
+    def add_duration(self, duration_ms: float) -> None:
+        self.calls += 1
+        self.total_ms += max(0.0, float(duration_ms))
+        self.max_ms = max(self.max_ms, max(0.0, float(duration_ms)))
+
+    def add_cache(self, *, hit: bool) -> None:
+        if hit:
+            self.cache_hits += 1
+        else:
+            self.cache_misses += 1
+
+    def to_dict(self) -> dict[str, float | int]:
+        avg_ms = self.total_ms / self.calls if self.calls else 0.0
+        return {
+            "calls": self.calls,
+            "total_ms": round(self.total_ms, 3),
+            "avg_ms": round(avg_ms, 3),
+            "max_ms": round(self.max_ms, 3),
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+        }
+
+
+@dataclass
+class LifeLoopProfiler:
+    """Collect per-tick timings for repeatable life-loop phases."""
+
+    required_phases: tuple[str, ...] = DEFAULT_LIFE_LOOP_PHASES
+    stats: dict[str, PhaseStats] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for phase in self.required_phases:
+            self.stats.setdefault(phase, PhaseStats())
+
+    @contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        started = perf_counter()
+        try:
+            yield
+        finally:
+            self.record_duration(name, (perf_counter() - started) * 1000.0)
+
+    def record_duration(self, name: str, duration_ms: float) -> None:
+        self.stats.setdefault(name, PhaseStats()).add_duration(duration_ms)
+
+    def record_cache(self, name: str, *, hit: bool) -> None:
+        self.stats.setdefault(name, PhaseStats()).add_cache(hit=hit)
+
+    def merge(self, other: "LifeLoopProfiler") -> None:
+        for name, stats in other.stats.items():
+            target = self.stats.setdefault(name, PhaseStats())
+            target.calls += stats.calls
+            target.total_ms += stats.total_ms
+            target.max_ms = max(target.max_ms, stats.max_ms)
+            target.cache_hits += stats.cache_hits
+            target.cache_misses += stats.cache_misses
+
+    def summary(self) -> dict[str, object]:
+        phase_payload = {name: self.stats[name].to_dict() for name in sorted(self.stats)}
+        total_ms = sum(float(item["total_ms"]) for item in phase_payload.values())
+        slowest = None
+        if phase_payload:
+            slowest = max(
+                phase_payload,
+                key=lambda name: float(phase_payload[name].get("total_ms", 0.0)),
+            )
+        return {
+            "schema_version": 1,
+            "total_ms": round(total_ms, 3),
+            "slowest_phase": slowest,
+            "phases": phase_payload,
+            "cache_candidates": cache_candidates_from_phases(phase_payload),
+            "async_distribution_note": (
+                "Étudier l'exécution asynchrone/distribuée uniquement après "
+                "stabilisation de ces métriques de phase."
+            ),
+        }
+
+
+def cache_candidates_from_phases(
+    phases: Mapping[str, Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Identify repetitive phases where caching can reduce loop cost."""
+
+    candidates: list[dict[str, object]] = []
+    sandbox = phases.get("sandbox_scoring", {})
+    if int(sandbox.get("cache_hits", 0) or 0) or int(sandbox.get("cache_misses", 0) or 0):
+        candidates.append(
+            {
+                "phase": "sandbox_scoring",
+                "reason": "scoring de compétences inchangées réutilisable par empreinte SHA-256 du code",
+                "current_cache_hits": int(sandbox.get("cache_hits", 0) or 0),
+                "current_cache_misses": int(sandbox.get("cache_misses", 0) or 0),
+            }
+        )
+    config = phases.get("config_loading", {})
+    if int(config.get("calls", 0) or 0):
+        candidates.append(
+            {
+                "phase": "config_loading",
+                "reason": "chargement de configs répétitif réutilisable par chemin et mtime",
+                "current_cache_hits": int(config.get("cache_hits", 0) or 0),
+                "current_cache_misses": int(config.get("cache_misses", 0) or 0),
+            }
+        )
+    return candidates

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -359,6 +359,35 @@ class RunLogger:
         )
         add_procedural_memory(record)
 
+
+    def log_phase_metrics(
+        self,
+        *,
+        iteration: int | None,
+        phases: Mapping[str, object],
+        total_ms: float,
+        slowest_phase: str | None = None,
+        cache_candidates: list[dict[str, object]] | None = None,
+        async_distribution_note: str | None = None,
+    ) -> None:
+        """Record life-loop phase timings for profiling and dashboard views."""
+
+        record: dict[str, Any] = {
+            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "event": "life_loop_phase_metrics",
+            "iteration": iteration,
+            "phase_metrics": {
+                "schema_version": 1,
+                "total_ms": total_ms,
+                "slowest_phase": slowest_phase,
+                "phases": dict(phases),
+                "cache_candidates": cache_candidates or [],
+                "async_distribution_note": async_distribution_note,
+            },
+        }
+        self._write_record(record)
+        self._write_event("life_loop_phase_metrics", record, record["ts"])
+
     def log_death(self, reason: str, **info: Any) -> None:
         """Record a death event with optional additional information."""
 

--- a/tests/test_life_profiling.py
+++ b/tests/test_life_profiling.py
@@ -1,0 +1,28 @@
+from singular.life.profiling import LifeLoopProfiler, cache_candidates_from_phases
+
+
+def test_life_loop_profiler_records_required_phases_and_cache_candidates() -> None:
+    profiler = LifeLoopProfiler()
+    profiler.record_duration("mutation", 2.5)
+    profiler.record_cache("sandbox_scoring", hit=False)
+    profiler.record_cache("sandbox_scoring", hit=True)
+
+    summary = profiler.summary()
+
+    assert "mutation" in summary["phases"]
+    assert "checkpoint_write" in summary["phases"]
+    assert summary["phases"]["mutation"]["total_ms"] == 2.5
+    assert summary["phases"]["sandbox_scoring"]["cache_hits"] == 1
+    assert summary["cache_candidates"][0]["phase"] == "sandbox_scoring"
+    assert "asynchrone" in summary["async_distribution_note"]
+
+
+def test_cache_candidates_include_config_loading() -> None:
+    candidates = cache_candidates_from_phases(
+        {
+            "config_loading": {"calls": 1, "cache_hits": 2, "cache_misses": 1},
+            "sandbox_scoring": {"cache_hits": 0, "cache_misses": 0},
+        }
+    )
+
+    assert any(candidate["phase"] == "config_loading" for candidate in candidates)

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -178,3 +178,27 @@ def test_run_logger_aggregates_skill_reputation_from_usage_metrics(tmp_path: Pat
     assert 0.0 <= stats["success_rate"] <= 1.0
     assert stats["mean_cost"] > 0.0
     assert stats["recent_failures"] >= 1
+
+
+def test_log_phase_metrics(tmp_path: Path) -> None:
+    logger = RunLogger("profile", root=tmp_path)
+    logger.log_phase_metrics(
+        iteration=3,
+        phases={"sandbox_scoring": {"calls": 2, "total_ms": 10.0}},
+        total_ms=10.0,
+        slowest_phase="sandbox_scoring",
+        cache_candidates=[{"phase": "sandbox_scoring", "reason": "unchanged code"}],
+        async_distribution_note="measure first",
+    )
+    logger.close()
+
+    files = list(tmp_path.glob("profile-*.jsonl"))
+    assert len(files) == 1
+    record = json.loads(files[0].read_text(encoding="utf-8").splitlines()[0])
+    assert record["event"] == "life_loop_phase_metrics"
+    assert record["iteration"] == 3
+    assert record["phase_metrics"]["slowest_phase"] == "sandbox_scoring"
+    assert record["phase_metrics"]["cache_candidates"][0]["phase"] == "sandbox_scoring"
+
+    event = json.loads((tmp_path / "profile" / "events.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    assert event["event_type"] == "life_loop_phase_metrics"


### PR DESCRIPTION
### Motivation

- Collect reliable per-phase timing in the life loop to identify hotspots and repetitive phases that can be cached (e.g. sandbox scoring, config loading).  
- Expose these metrics in run logs and the dashboard so operators can validate optimisation opportunities before considering async/distributed execution.  
- Provide a small reproducible profiling workflow (temporary life + fixed ticks) to gather stable measurements. 

### Description

- Add a lightweight profiler `LifeLoopProfiler` in `src/singular/life/profiling.py` that records phase durations, cache hits/misses and emits a summary with cache-candidate heuristics.  
- Instrument the life loop (`src/singular/life/loop.py`) to measure phases: `mutation`, `sandbox_scoring`, `test_runner`, `coevolution`, `map_elites`, `reproduction`, `checkpoint_write`, and `logging`, and to record config-loading/cache signals; add a SHA-256 score-cache for repeated sandbox scoring.  
- Add `RunLogger.log_phase_metrics(...)` in `src/singular/runs/logger.py` to publish `life_loop_phase_metrics` JSONL events alongside existing run records.  
- Surface phase metrics in the dashboard: aggregate per-run phase metrics in `src/singular/dashboard/__init__.py`, add a cockpit UI panel in `src/singular/dashboard/templates/dashboard.html`, and render phase KPIs in `src/singular/dashboard/static/render-cockpit.js`.  
- Add `scripts/profile_life_loop.py` to run a temporary life for a fixed number of ticks and print aggregated phase metrics.  
- Tests: add `tests/test_life_profiling.py` for profiler behavior and extend `tests/test_runs_logger.py` with `test_log_phase_metrics` to validate logging of phase metrics.  

### Testing

- Compiled modified modules: `python3 -m py_compile src/singular/life/profiling.py src/singular/life/loop.py src/singular/runs/logger.py src/singular/dashboard/__init__.py scripts/profile_life_loop.py` (succeeded).  
- Unit tests: `PYTHONPATH=src pytest -q tests/test_life_profiling.py tests/test_runs_logger.py tests/test_dashboard.py::test_dashboard_endpoints` — all tests passed (`10 passed`, warnings about `datetime.utcnow()` noted).  
- Smoke profile run: `PYTHONPATH=src python3 scripts/profile_life_loop.py --ticks 1 --run-id profile-smoke` produced a profiling JSON summary showing measured phase totals and cache candidates (sandbox scoring reported as the slowest phase).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ccc3e3ac832aaf1da8b92e4151c0)