### PR TITLE
Ajouter loader pour la configuration life_definition

### DIFF
--- a/configs/life_definition.yaml
+++ b/configs/life_definition.yaml
@@ -1,0 +1,22 @@
+schema_version: "1.0"
+
+criteria:
+  persistent_identity: true
+  generation_registry: true
+  stable_cycle: true
+  intrinsic_goals: true
+  reproduction_capability: true
+  narrative_continuity: true
+
+thresholds:
+  minimum_narrative_trajectory_days: 7
+  minimum_observed_cycles: 3
+  alive_minimum_score: 0.8
+  fragile_minimum_score: 0.5
+
+statuses:
+  not_alive_yet: not_alive_yet
+  fragile: fragile
+  alive: alive
+  dying: dying
+  extinct: extinct

--- a/src/singular/life/life_definition.py
+++ b/src/singular/life/life_definition.py
@@ -1,0 +1,143 @@
+"""Life definition configuration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from singular.orchestrator.lifecycle_clock import _load_simple_yaml
+
+DEFAULT_LIFECYCLE_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "lifecycle.yaml"
+DEFAULT_LIFE_DEFINITION_CONFIG_PATH = (
+    Path(__file__).resolve().parents[3] / "configs" / "life_definition.yaml"
+)
+AUTHORIZED_LIFE_STATUSES = ("not_alive_yet", "fragile", "alive", "dying", "extinct")
+
+
+@dataclass(frozen=True)
+class LifeCriteria:
+    """Criteria used to evaluate whether an organism should be considered alive."""
+
+    persistent_identity: bool = True
+    generation_registry: bool = True
+    stable_cycle: bool = True
+    intrinsic_goals: bool = True
+    reproduction_capability: bool = True
+    narrative_continuity: bool = True
+
+
+@dataclass(frozen=True)
+class LifeThresholds:
+    """Configurable thresholds for life status evaluation."""
+
+    minimum_narrative_trajectory_days: int = 7
+    minimum_observed_cycles: int = 3
+    alive_minimum_score: float = 0.8
+    fragile_minimum_score: float = 0.5
+
+
+@dataclass(frozen=True)
+class LifeDefinitionConfig:
+    """Complete definition of life used by Singular."""
+
+    schema_version: str = "1.0"
+    criteria: LifeCriteria = field(default_factory=LifeCriteria)
+    thresholds: LifeThresholds = field(default_factory=LifeThresholds)
+    statuses: dict[str, str] = field(
+        default_factory=lambda: {status: status for status in AUTHORIZED_LIFE_STATUSES}
+    )
+
+
+def _load_raw_life_definition(path: Path | None) -> dict[str, Any]:
+    if path is not None:
+        if not path.exists():
+            return {}
+        raw = _load_simple_yaml(path)
+        section = raw.get("life_definition")
+        return section if isinstance(section, dict) else raw
+
+    if DEFAULT_LIFE_DEFINITION_CONFIG_PATH.exists():
+        raw = _load_simple_yaml(DEFAULT_LIFE_DEFINITION_CONFIG_PATH)
+        section = raw.get("life_definition")
+        return section if isinstance(section, dict) else raw
+
+    if DEFAULT_LIFECYCLE_CONFIG_PATH.exists():
+        raw = _load_simple_yaml(DEFAULT_LIFECYCLE_CONFIG_PATH)
+        section = raw.get("life_definition")
+        return section if isinstance(section, dict) else {}
+
+    return {}
+
+
+def load_life_definition_config(path: Path | None = None) -> LifeDefinitionConfig:
+    """Load the life definition config, returning defaults when absent.
+
+    The loader accepts either a dedicated ``configs/life_definition.yaml`` file or a
+    ``life_definition`` section embedded in ``configs/lifecycle.yaml``. Missing files
+    and missing keys are intentionally backward-compatible with older deployments.
+    """
+
+    cfg = LifeDefinitionConfig()
+    raw = _load_raw_life_definition(path)
+    if not raw:
+        return cfg
+
+    criteria_raw = raw.get("criteria", {}) if isinstance(raw.get("criteria", {}), dict) else {}
+    thresholds_raw = raw.get("thresholds", {}) if isinstance(raw.get("thresholds", {}), dict) else {}
+    statuses_raw = raw.get("statuses", {}) if isinstance(raw.get("statuses", {}), dict) else {}
+
+    criteria = LifeCriteria(
+        persistent_identity=bool(criteria_raw.get("persistent_identity", cfg.criteria.persistent_identity)),
+        generation_registry=bool(criteria_raw.get("generation_registry", cfg.criteria.generation_registry)),
+        stable_cycle=bool(criteria_raw.get("stable_cycle", cfg.criteria.stable_cycle)),
+        intrinsic_goals=bool(criteria_raw.get("intrinsic_goals", cfg.criteria.intrinsic_goals)),
+        reproduction_capability=bool(
+            criteria_raw.get("reproduction_capability", cfg.criteria.reproduction_capability)
+        ),
+        narrative_continuity=bool(
+            criteria_raw.get("narrative_continuity", cfg.criteria.narrative_continuity)
+        ),
+    )
+    thresholds = LifeThresholds(
+        minimum_narrative_trajectory_days=int(
+            thresholds_raw.get(
+                "minimum_narrative_trajectory_days",
+                cfg.thresholds.minimum_narrative_trajectory_days,
+            )
+        ),
+        minimum_observed_cycles=int(
+            thresholds_raw.get("minimum_observed_cycles", cfg.thresholds.minimum_observed_cycles)
+        ),
+        alive_minimum_score=float(
+            thresholds_raw.get("alive_minimum_score", cfg.thresholds.alive_minimum_score)
+        ),
+        fragile_minimum_score=float(
+            thresholds_raw.get("fragile_minimum_score", cfg.thresholds.fragile_minimum_score)
+        ),
+    )
+    unknown = sorted(set(statuses_raw) - set(AUTHORIZED_LIFE_STATUSES))
+    if unknown:
+        raise ValueError(f"life statuses contain unauthorized keys: {', '.join(unknown)}")
+
+    statuses = dict(cfg.statuses)
+    for name in AUTHORIZED_LIFE_STATUSES:
+        value = statuses_raw.get(name, statuses[name])
+        statuses[name] = str(value)
+
+    missing = [status for status in AUTHORIZED_LIFE_STATUSES if status not in statuses]
+    if missing:
+        raise ValueError(f"life statuses missing required keys: {', '.join(missing)}")
+    if thresholds.minimum_narrative_trajectory_days < 0:
+        raise ValueError("minimum_narrative_trajectory_days must be >= 0")
+    if thresholds.minimum_observed_cycles < 0:
+        raise ValueError("minimum_observed_cycles must be >= 0")
+    if thresholds.alive_minimum_score < thresholds.fragile_minimum_score:
+        raise ValueError("alive_minimum_score must be >= fragile_minimum_score")
+
+    return LifeDefinitionConfig(
+        schema_version=str(raw.get("schema_version", cfg.schema_version)),
+        criteria=criteria,
+        thresholds=thresholds,
+        statuses=statuses,
+    )

--- a/tests/test_life_definition_config.py
+++ b/tests/test_life_definition_config.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+
+import pytest
+
+from singular.life.life_definition import load_life_definition_config
+
+
+def test_load_life_definition_defaults_when_file_missing(tmp_path: Path) -> None:
+    cfg = load_life_definition_config(tmp_path / "missing.yaml")
+
+    assert cfg.schema_version == "1.0"
+    assert cfg.criteria.persistent_identity is True
+    assert cfg.criteria.generation_registry is True
+    assert cfg.criteria.stable_cycle is True
+    assert cfg.criteria.intrinsic_goals is True
+    assert cfg.criteria.reproduction_capability is True
+    assert cfg.criteria.narrative_continuity is True
+    assert cfg.thresholds.minimum_narrative_trajectory_days == 7
+    assert cfg.thresholds.minimum_observed_cycles == 3
+    assert cfg.thresholds.alive_minimum_score == 0.8
+    assert cfg.thresholds.fragile_minimum_score == 0.5
+    assert set(cfg.statuses) == {"not_alive_yet", "fragile", "alive", "dying", "extinct"}
+
+
+def test_load_life_definition_from_dedicated_file(tmp_path: Path) -> None:
+    file_path = tmp_path / "life_definition.yaml"
+    file_path.write_text(
+        """
+schema_version: "1.1"
+criteria:
+  persistent_identity: false
+  generation_registry: true
+thresholds:
+  minimum_narrative_trajectory_days: 14
+  minimum_observed_cycles: 9
+  alive_minimum_score: 0.9
+  fragile_minimum_score: 0.4
+statuses:
+  not_alive_yet: not_alive_yet
+  fragile: fragile
+  alive: alive
+  dying: dying
+  extinct: extinct
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_life_definition_config(file_path)
+
+    assert cfg.schema_version == "1.1"
+    assert cfg.criteria.persistent_identity is False
+    assert cfg.criteria.stable_cycle is True
+    assert cfg.thresholds.minimum_narrative_trajectory_days == 14
+    assert cfg.thresholds.minimum_observed_cycles == 9
+    assert cfg.thresholds.alive_minimum_score == 0.9
+    assert cfg.thresholds.fragile_minimum_score == 0.4
+
+
+def test_load_life_definition_from_lifecycle_section(tmp_path: Path) -> None:
+    file_path = tmp_path / "lifecycle.yaml"
+    file_path.write_text(
+        """
+cycle:
+  veille_seconds: 2
+life_definition:
+  schema_version: "1.2"
+  thresholds:
+    minimum_observed_cycles: 5
+""".strip(),
+        encoding="utf-8",
+    )
+
+    cfg = load_life_definition_config(file_path)
+
+    assert cfg.schema_version == "1.2"
+    assert cfg.thresholds.minimum_observed_cycles == 5
+    assert cfg.thresholds.minimum_narrative_trajectory_days == 7
+
+
+def test_load_life_definition_rejects_invalid_threshold_order(tmp_path: Path) -> None:
+    file_path = tmp_path / "life_definition.yaml"
+    file_path.write_text(
+        """
+thresholds:
+  alive_minimum_score: 0.3
+  fragile_minimum_score: 0.5
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="alive_minimum_score"):
+        load_life_definition_config(file_path)


### PR DESCRIPTION
### Motivation
- Centraliser une définition configurable de « life » incluant schéma, critères et seuils pour évaluer le statut de vie d’un organisme.
- Permettre la configuration via un fichier dédié `configs/life_definition.yaml` ou via une section `life_definition` dans `configs/lifecycle.yaml` tout en restant backward-compatible.
- Exposer seuils et mapping de statuts configurables (`not_alive_yet`, `fragile`, `alive`, `dying`, `extinct`) pour rendre les règles de vivacité paramétrables.

### Description
- Ajout de `configs/life_definition.yaml` avec `schema_version`, `criteria`, `thresholds` et `statuses` par défaut. 
- Nouveau module `src/singular/life/life_definition.py` fournissant les dataclasses `LifeCriteria`, `LifeThresholds`, `LifeDefinitionConfig` et la fonction `load_life_definition_config` qui lit soit un fichier dédié soit une section embarquée en réutilisant `_load_simple_yaml`.
- Le loader applique des valeurs par défaut compatibles rétro-activement et effectue des validations pour les clés de statut non autorisées, les seuils négatifs et pour garantir `alive_minimum_score >= fragile_minimum_score`.
- Ajout de tests unitaires `tests/test_life_definition_config.py` couvrant valeurs par défaut, lecture depuis fichier dédié, lecture depuis section `lifecycle.yaml` et validation d’ordre des seuils.

### Testing
- Exécution ciblée des tests `python -m pytest tests/test_life_definition_config.py tests/test_lifecycle_clock_config.py` a réussi avec `8 passed`.
- Une exécution complète de `python -m pytest` a été tentée mais la suite globale a affiché échecs préexistants non liés à ce changement; les nouveaux tests unitaires ont néanmoins passé.
- Les nouveaux tests se trouvent dans `tests/test_life_definition_config.py` et couvrent les comportements documentés ci-dessus.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a352bd3bf5c832aa4e32d8ea435379e)