### PR TITLE
Add dedicated life status contract model

### DIFF
--- a/src/singular/life/life_definition.py
+++ b/src/singular/life/life_definition.py
@@ -6,13 +6,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from singular.life.life_status import AUTHORIZED_LIFE_STATUSES
 from singular.orchestrator.lifecycle_clock import _load_simple_yaml
 
-DEFAULT_LIFECYCLE_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "lifecycle.yaml"
+DEFAULT_LIFECYCLE_CONFIG_PATH = (
+    Path(__file__).resolve().parents[3] / "configs" / "lifecycle.yaml"
+)
 DEFAULT_LIFE_DEFINITION_CONFIG_PATH = (
     Path(__file__).resolve().parents[3] / "configs" / "life_definition.yaml"
 )
-AUTHORIZED_LIFE_STATUSES = ("not_alive_yet", "fragile", "alive", "dying", "extinct")
 
 
 @dataclass(frozen=True)
@@ -83,17 +85,31 @@ def load_life_definition_config(path: Path | None = None) -> LifeDefinitionConfi
     if not raw:
         return cfg
 
-    criteria_raw = raw.get("criteria", {}) if isinstance(raw.get("criteria", {}), dict) else {}
-    thresholds_raw = raw.get("thresholds", {}) if isinstance(raw.get("thresholds", {}), dict) else {}
-    statuses_raw = raw.get("statuses", {}) if isinstance(raw.get("statuses", {}), dict) else {}
+    criteria_raw = (
+        raw.get("criteria", {}) if isinstance(raw.get("criteria", {}), dict) else {}
+    )
+    thresholds_raw = (
+        raw.get("thresholds", {}) if isinstance(raw.get("thresholds", {}), dict) else {}
+    )
+    statuses_raw = (
+        raw.get("statuses", {}) if isinstance(raw.get("statuses", {}), dict) else {}
+    )
 
     criteria = LifeCriteria(
-        persistent_identity=bool(criteria_raw.get("persistent_identity", cfg.criteria.persistent_identity)),
-        generation_registry=bool(criteria_raw.get("generation_registry", cfg.criteria.generation_registry)),
+        persistent_identity=bool(
+            criteria_raw.get("persistent_identity", cfg.criteria.persistent_identity)
+        ),
+        generation_registry=bool(
+            criteria_raw.get("generation_registry", cfg.criteria.generation_registry)
+        ),
         stable_cycle=bool(criteria_raw.get("stable_cycle", cfg.criteria.stable_cycle)),
-        intrinsic_goals=bool(criteria_raw.get("intrinsic_goals", cfg.criteria.intrinsic_goals)),
+        intrinsic_goals=bool(
+            criteria_raw.get("intrinsic_goals", cfg.criteria.intrinsic_goals)
+        ),
         reproduction_capability=bool(
-            criteria_raw.get("reproduction_capability", cfg.criteria.reproduction_capability)
+            criteria_raw.get(
+                "reproduction_capability", cfg.criteria.reproduction_capability
+            )
         ),
         narrative_continuity=bool(
             criteria_raw.get("narrative_continuity", cfg.criteria.narrative_continuity)
@@ -107,18 +123,26 @@ def load_life_definition_config(path: Path | None = None) -> LifeDefinitionConfi
             )
         ),
         minimum_observed_cycles=int(
-            thresholds_raw.get("minimum_observed_cycles", cfg.thresholds.minimum_observed_cycles)
+            thresholds_raw.get(
+                "minimum_observed_cycles", cfg.thresholds.minimum_observed_cycles
+            )
         ),
         alive_minimum_score=float(
-            thresholds_raw.get("alive_minimum_score", cfg.thresholds.alive_minimum_score)
+            thresholds_raw.get(
+                "alive_minimum_score", cfg.thresholds.alive_minimum_score
+            )
         ),
         fragile_minimum_score=float(
-            thresholds_raw.get("fragile_minimum_score", cfg.thresholds.fragile_minimum_score)
+            thresholds_raw.get(
+                "fragile_minimum_score", cfg.thresholds.fragile_minimum_score
+            )
         ),
     )
     unknown = sorted(set(statuses_raw) - set(AUTHORIZED_LIFE_STATUSES))
     if unknown:
-        raise ValueError(f"life statuses contain unauthorized keys: {', '.join(unknown)}")
+        raise ValueError(
+            f"life statuses contain unauthorized keys: {', '.join(unknown)}"
+        )
 
     statuses = dict(cfg.statuses)
     for name in AUTHORIZED_LIFE_STATUSES:

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -1,0 +1,63 @@
+"""Philosophical-operational life status contract.
+
+This module intentionally stays separate from :mod:`singular.life.vital`:
+``compute_vital_timeline()`` describes observable technical vital state, while
+``LifeStatusResult`` carries the life contract exposed to CLI, dashboards, and
+reports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+
+class LifeStatus(str, Enum):
+    """Authorized philosophical-operational life statuses."""
+
+    NOT_ALIVE_YET = "not_alive_yet"
+    FRAGILE = "fragile"
+    ALIVE = "alive"
+    DYING = "dying"
+    EXTINCT = "extinct"
+
+
+AUTHORIZED_LIFE_STATUSES: tuple[str, ...] = tuple(status.value for status in LifeStatus)
+
+
+def _status_value(status: LifeStatus | str) -> str:
+    return status.value if isinstance(status, LifeStatus) else str(status)
+
+
+def _computed_at_value(computed_at: datetime | str) -> str:
+    if isinstance(computed_at, datetime):
+        return computed_at.isoformat()
+    return str(computed_at)
+
+
+@dataclass(frozen=True)
+class LifeStatusResult:
+    """Portable result for the life contract shown by CLI, dashboards, and reports."""
+
+    status: LifeStatus | str
+    score: float
+    explanation: str
+    signals: Mapping[str, Any] = field(default_factory=dict)
+    missing_signals: Sequence[str] = field(default_factory=tuple)
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+    computed_at: datetime | str = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable payload for CLI, dashboard, and report use."""
+
+        return {
+            "status": _status_value(self.status),
+            "score": float(self.score),
+            "explanation": self.explanation,
+            "signals": dict(self.signals),
+            "missing_signals": list(self.missing_signals),
+            "evidence": dict(self.evidence),
+            "computed_at": _computed_at_value(self.computed_at),
+        }

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -1,0 +1,40 @@
+from datetime import UTC, datetime
+
+from singular.life.life_status import (
+    AUTHORIZED_LIFE_STATUSES,
+    LifeStatus,
+    LifeStatusResult,
+)
+
+
+def test_authorized_life_statuses_are_stable_contract() -> None:
+    assert AUTHORIZED_LIFE_STATUSES == (
+        "not_alive_yet",
+        "fragile",
+        "alive",
+        "dying",
+        "extinct",
+    )
+
+
+def test_life_status_result_to_payload_serializes_portable_contract() -> None:
+    computed_at = datetime(2026, 7, 7, 12, 30, tzinfo=UTC)
+    result = LifeStatusResult(
+        status=LifeStatus.ALIVE,
+        score=0.91,
+        explanation="Stable identity and cycle are observed.",
+        signals={"stable_cycle": True, "observed_cycles": 4},
+        missing_signals=("narrative_continuity",),
+        evidence={"source": "test"},
+        computed_at=computed_at,
+    )
+
+    assert result.to_payload() == {
+        "status": "alive",
+        "score": 0.91,
+        "explanation": "Stable identity and cycle are observed.",
+        "signals": {"stable_cycle": True, "observed_cycles": 4},
+        "missing_signals": ["narrative_continuity"],
+        "evidence": {"source": "test"},
+        "computed_at": "2026-07-07T12:30:00+00:00",
+    }


### PR DESCRIPTION
### Motivation
- Separate the philosophical/operational life contract from the technical vital timeline to avoid mixing domain contract concerns with deterministic observability logic.
- Provide a stable, centralized set of authorized life statuses to be reused across config and UI surfaces.

### Description
- Add new module `src/singular/life/life_status.py` that defines the `LifeStatus` enum and `AUTHORIZED_LIFE_STATUSES` tuple for `not_alive_yet`, `fragile`, `alive`, `dying`, and `extinct`.
- Implement `LifeStatusResult` dataclass with fields `status`, `score`, `explanation`, `signals`, `missing_signals`, `evidence`, and `computed_at`, and provide a JSON-serializable `to_payload()` method that returns portable payloads (ISO timestamps for `computed_at`).
- Update `src/singular/life/life_definition.py` to import and reuse `AUTHORIZED_LIFE_STATUSES` from the new module instead of duplicating the tuple.
- Add unit tests in `tests/test_life_status.py` that assert the stable status contract and verify `LifeStatusResult.to_payload()` serialization.

### Testing
- Ran `pytest tests/test_life_status.py tests/test_life_definition_config.py` and all tests passed (`6 passed`).
- The new module compiles and its tests exercise the payload serialization and the reused `AUTHORIZED_LIFE_STATUSES` contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d6422c7f0832abb3f6a0c0219358f)