### PR TITLE
Add weighted life status scoring

### DIFF
--- a/configs/life_definition.yaml
+++ b/configs/life_definition.yaml
@@ -1,4 +1,4 @@
-schema_version: "1.0"
+schema_version: "1.1"
 
 criteria:
   persistent_identity: true
@@ -8,11 +8,50 @@ criteria:
   reproduction_capability: true
   narrative_continuity: true
 
+weighted_score:
+  total_points: 100
+  criteria:
+    persistent_identity:
+      points: 20
+      required_for_alive: true
+      description: "Identité persistante et vérifiable sur les artefacts de vie."
+    generation_registry:
+      points: 15
+      required_for_alive: true
+      description: "Présence dans le registre de générations ou filiation traçable."
+    stable_cycle:
+      points: 20
+      required_for_alive: true
+      description: "Cycle vital stable et observé sur un minimum de cycles."
+    continuous_intrinsic_goals:
+      points: 20
+      required_for_alive: true
+      description: "Objectifs intrinsèques continus, non réduits à une tâche ponctuelle."
+    reproduction_capability:
+      points: 10
+      required_for_alive: false
+      description: "Reproduction possible ou capacité déclarée compatible avec les règles vitales."
+    narrative_continuity:
+      points: 15
+      required_for_alive: true
+      minimum_days: 7
+      description: "Narration cohérente sur N jours."
+  terminal_signals:
+    autopsy_present: true
+    registry_extinct: true
+    death_event_confirmed: true
+  severe_degradation_signals:
+    terminal_lifecycle_state: true
+    critical_health_score: true
+    terminal_failure_streak: true
+    high_failure_rate: true
+
 thresholds:
   minimum_narrative_trajectory_days: 7
   minimum_observed_cycles: 3
-  alive_minimum_score: 0.8
-  fragile_minimum_score: 0.5
+  alive_minimum_score: 80
+  fragile_minimum_score: 50
+  dying_degradation_minimum_score: 40
 
 statuses:
   not_alive_yet: not_alive_yet
@@ -20,3 +59,10 @@ statuses:
   alive: alive
   dying: dying
   extinct: extinct
+
+status_rules:
+  not_alive_yet: "Score insuffisant ou signaux fondamentaux absents."
+  fragile: "Score intermédiaire mais continuité incomplète."
+  alive: "Score supérieur ou égal au seuil alive et aucun signal terminal."
+  dying: "Signal terminal ou dégradation forte détectés, sans extinction confirmée."
+  extinct: "Autopsy présente, registre extinct ou événement death confirmé."

--- a/docs/technical_life_status.md
+++ b/docs/technical_life_status.md
@@ -13,6 +13,49 @@ Valeurs supportées:
 
 Ce statut est porté par `LifeMetadata.status` dans `src/singular/lives.py`, persisté via `save_registry()`, et modifié via `set_life_status()`.
 
+## Barème pondéré de qualification vitale
+
+Le fichier versionné `configs/life_definition.yaml` définit un score vital sur **100 points**. Ce score ne remplace pas la source de vérité du registre pour l'extinction, mais il qualifie l'état fonctionnel observé d'une vie.
+
+Barème:
+
+- **Identité persistante**: 20 points.
+- **Registre de générations**: 15 points.
+- **Cycle stable**: 20 points.
+- **Objectifs intrinsèques continus**: 20 points.
+- **Reproduction possible**: 10 points.
+- **Narration cohérente sur N jours**: 15 points, avec `N = thresholds.minimum_narrative_trajectory_days`.
+
+Les critères fondamentaux pour atteindre `alive` sont:
+
+- identité persistante,
+- registre de générations,
+- cycle stable,
+- objectifs intrinsèques continus,
+- narration cohérente sur la durée minimale configurée.
+
+La reproduction possible contribue au score, mais n'est pas un critère bloquant pour `alive`.
+
+## Statuts qualifiés par score
+
+Les statuts métier exposés par `configs/life_definition.yaml` sont:
+
+- `not_alive_yet`: score insuffisant ou au moins un signal fondamental absent.
+- `fragile`: score intermédiaire mais continuité incomplète.
+- `alive`: score supérieur ou égal au seuil `alive_minimum_score`, critères fondamentaux présents et aucun signal terminal.
+- `dying`: signal terminal présumé ou dégradation forte, mais extinction non confirmée.
+- `extinct`: autopsy présente, registre `extinct` ou événement `death` confirmé.
+
+Ordre de priorité recommandé:
+
+1. `extinct` si une extinction est confirmée (`autopsy.json` présent, registre `extinct`, ou événement `death` confirmé).
+2. `dying` si une dégradation forte est détectée sans confirmation d'extinction.
+3. `alive` si le score atteint le seuil `alive_minimum_score`, les critères fondamentaux sont présents et aucun signal terminal n'est observé.
+4. `fragile` si le score atteint le seuil `fragile_minimum_score`, mais que la continuité reste incomplète.
+5. `not_alive_yet` sinon.
+
+Les signaux terminaux dominent toujours le score: un score élevé ne peut pas produire `alive` si un signal terminal confirmé existe.
+
 ## Distinction des notions
 
 Le dashboard distingue désormais:

--- a/docs/vital_lifecycle_rules.md
+++ b/docs/vital_lifecycle_rules.md
@@ -15,6 +15,9 @@ Cette spécification formalise des règles **déterministes** (seuils fixes) et 
 - `failure_streak`: plus longue série continue d’échecs.
 - `extinction_seen`: présence d’un événement `event == "death"` dans les runs.
 - `registry_status`: statut actuel du registre (`active` ou `extinct`).
+- `life_score`: score pondéré calculé depuis `configs/life_definition.yaml`.
+- `fundamental_signals_present`: présence des critères fondamentaux d'identité, génération, cycle, objectifs intrinsèques et narration minimale.
+- `autopsy_present`: présence d'un artefact `autopsy.json`.
 
 ## Seuils (version 1)
 
@@ -24,6 +27,45 @@ Cette spécification formalise des règles **déterministes** (seuils fixes) et 
 - `high_failure_rate = 0.60`
 - `terminal_failure_streak = 5`
 - `reproduction_age_window = [3, 80]`
+- `fragile_minimum_score = 50`
+- `alive_minimum_score = 80`
+
+## Barème vital pondéré
+
+Le barème de qualification vitale est défini dans `configs/life_definition.yaml` et totalise 100 points:
+
+- identité persistante: 20 points,
+- registre de générations: 15 points,
+- cycle stable: 20 points,
+- objectifs intrinsèques continus: 20 points,
+- reproduction possible: 10 points,
+- narration cohérente sur N jours: 15 points.
+
+`N` correspond à `thresholds.minimum_narrative_trajectory_days`. Les signaux fondamentaux sont tous les critères ci-dessus sauf la reproduction possible, qui reste contributive mais non bloquante pour l'état `alive`.
+
+## Statuts de qualification vitale
+
+La qualification vitale produit les statuts suivants:
+
+1. **Extinct** (`status=extinct`)
+   - si `autopsy_present == true`,
+   - ou `registry_status == "extinct"`,
+   - ou `extinction_seen == true`.
+2. **Dying** (`status=dying`)
+   - si un signal terminal ou une dégradation forte est détecté,
+   - et qu'aucune extinction confirmée n'est encore disponible.
+3. **Alive** (`status=alive`)
+   - si `life_score >= alive_minimum_score`,
+   - et `fundamental_signals_present == true`,
+   - et aucun signal terminal n'est présent.
+4. **Fragile** (`status=fragile`)
+   - si `life_score >= fragile_minimum_score`,
+   - mais que la continuité est incomplète ou qu'un critère fondamental reste partiel.
+5. **Not alive yet** (`status=not_alive_yet`)
+   - si le score est insuffisant,
+   - ou si des signaux fondamentaux sont absents.
+
+Priorité d'évaluation: `extinct` domine `dying`, qui domine `alive`, qui domine `fragile`, qui domine `not_alive_yet`. Cette priorité évite qu'un score élevé masque une extinction ou une trajectoire terminale.
 
 ## États et transitions
 

--- a/src/singular/life/life_definition.py
+++ b/src/singular/life/life_definition.py
@@ -37,6 +37,32 @@ class LifeThresholds:
     minimum_observed_cycles: int = 3
     alive_minimum_score: float = 0.8
     fragile_minimum_score: float = 0.5
+    dying_degradation_minimum_score: float = 0.4
+
+
+@dataclass(frozen=True)
+class WeightedCriterion:
+    """Weighted contribution to the life qualification score."""
+
+    points: float
+    required_for_alive: bool = True
+
+
+@dataclass(frozen=True)
+class LifeWeightedScore:
+    """Weighted scoring model for life status evaluation."""
+
+    total_points: float = 100.0
+    criteria: dict[str, WeightedCriterion] = field(
+        default_factory=lambda: {
+            "persistent_identity": WeightedCriterion(20.0, True),
+            "generation_registry": WeightedCriterion(15.0, True),
+            "stable_cycle": WeightedCriterion(20.0, True),
+            "intrinsic_goals": WeightedCriterion(20.0, True),
+            "reproduction_capability": WeightedCriterion(10.0, False),
+            "narrative_continuity": WeightedCriterion(15.0, True),
+        }
+    )
 
 
 @dataclass(frozen=True)
@@ -46,6 +72,7 @@ class LifeDefinitionConfig:
     schema_version: str = "1.0"
     criteria: LifeCriteria = field(default_factory=LifeCriteria)
     thresholds: LifeThresholds = field(default_factory=LifeThresholds)
+    weighted_score: LifeWeightedScore = field(default_factory=LifeWeightedScore)
     statuses: dict[str, str] = field(
         default_factory=lambda: {status: status for status in AUTHORIZED_LIFE_STATUSES}
     )
@@ -137,6 +164,44 @@ def load_life_definition_config(path: Path | None = None) -> LifeDefinitionConfi
                 "fragile_minimum_score", cfg.thresholds.fragile_minimum_score
             )
         ),
+        dying_degradation_minimum_score=float(
+            thresholds_raw.get(
+                "dying_degradation_minimum_score",
+                cfg.thresholds.dying_degradation_minimum_score,
+            )
+        ),
+    )
+    weighted_raw = (
+        raw.get("weighted_score", {})
+        if isinstance(raw.get("weighted_score", {}), dict)
+        else {}
+    )
+    weighted_criteria_raw = (
+        weighted_raw.get("criteria", {})
+        if isinstance(weighted_raw.get("criteria", {}), dict)
+        else {}
+    )
+    weighted_defaults = cfg.weighted_score.criteria
+    aliases = {"continuous_intrinsic_goals": "intrinsic_goals"}
+    weighted_criteria = dict(weighted_defaults)
+    for raw_name, value in weighted_criteria_raw.items():
+        name = aliases.get(str(raw_name), str(raw_name))
+        if name not in weighted_defaults or not isinstance(value, dict):
+            continue
+        weighted_criteria[name] = WeightedCriterion(
+            points=float(value.get("points", weighted_defaults[name].points)),
+            required_for_alive=bool(
+                value.get(
+                    "required_for_alive",
+                    weighted_defaults[name].required_for_alive,
+                )
+            ),
+        )
+    weighted_score = LifeWeightedScore(
+        total_points=float(
+            weighted_raw.get("total_points", cfg.weighted_score.total_points)
+        ),
+        criteria=weighted_criteria,
     )
     unknown = sorted(set(statuses_raw) - set(AUTHORIZED_LIFE_STATUSES))
     if unknown:
@@ -158,10 +223,13 @@ def load_life_definition_config(path: Path | None = None) -> LifeDefinitionConfi
         raise ValueError("minimum_observed_cycles must be >= 0")
     if thresholds.alive_minimum_score < thresholds.fragile_minimum_score:
         raise ValueError("alive_minimum_score must be >= fragile_minimum_score")
+    if weighted_score.total_points <= 0:
+        raise ValueError("weighted_score.total_points must be > 0")
 
     return LifeDefinitionConfig(
         schema_version=str(raw.get("schema_version", cfg.schema_version)),
         criteria=criteria,
         thresholds=thresholds,
+        weighted_score=weighted_score,
         statuses=statuses,
     )

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -233,7 +233,6 @@ def compute_life_status(
         "quests_state": mem / "quests_state.json",
         "generations": mem / "generations.jsonl",
     }
-    world_state = _read_json(paths["world_state"])
     autopsy = _read_json(paths["autopsy"])
     narrative = _read_json(paths["self_narrative"])
     goals = _read_json(paths["goals"])
@@ -367,11 +366,27 @@ def compute_life_status(
     enabled = [
         (name, value) for name, (required, value) in criteria.items() if required
     ]
-    score = (
-        0.0 if not enabled else sum(1.0 for _, value in enabled if value) / len(enabled)
+    weighted_criteria = cfg.weighted_score.criteria
+    score = sum(
+        weighted_criteria[name].points
+        for name, (_, value) in criteria.items()
+        if value and name in weighted_criteria
     )
+    total_points = cfg.weighted_score.total_points
+
+    def _score_threshold(value: float) -> float:
+        return value * total_points if 0.0 <= value <= 1.0 else value
+
+    alive_minimum_score = _score_threshold(cfg.thresholds.alive_minimum_score)
+    fragile_minimum_score = _score_threshold(cfg.thresholds.fragile_minimum_score)
+    required_for_alive = [
+        name
+        for name, (configured, _) in criteria.items()
+        if configured and weighted_criteria.get(name) is not None and weighted_criteria[name].required_for_alive
+    ]
+    required_for_alive_present = all(criteria[name][1] for name in required_for_alive)
     if terminal:
-        score = min(score, 0.2 if registry_status == "extinct" or autopsy else 0.4)
+        score = min(score, 20.0 if registry_status == "extinct" or autopsy else 40.0)
         status = (
             LifeStatus.EXTINCT
             if registry_status == "extinct" or autopsy
@@ -379,16 +394,16 @@ def compute_life_status(
         )
     elif not persistent_identity and not run_rows:
         status = LifeStatus.NOT_ALIVE_YET
-    elif score >= cfg.thresholds.alive_minimum_score:
+    elif score >= alive_minimum_score and required_for_alive_present:
         status = LifeStatus.ALIVE
-    elif score >= cfg.thresholds.fragile_minimum_score:
+    elif score >= fragile_minimum_score:
         status = LifeStatus.FRAGILE
     else:
         status = LifeStatus.NOT_ALIVE_YET
 
     positives = [name for name, value in enabled if value]
     negatives = [name for name, value in enabled if not value]
-    explanation = f"Statut {status.value}: {len(positives)}/{len(enabled)} sous-signaux configurés sont établis."
+    explanation = f"Statut {status.value}: {len(positives)}/{len(enabled)} sous-signaux configurés sont établis, score {score:g}/{total_points:g}."
     if negatives:
         explanation += " Manquants ou insuffisants: " + ", ".join(negatives) + "."
     if terminal:
@@ -432,6 +447,17 @@ def compute_life_status(
             "minimum_observed_cycles": cfg.thresholds.minimum_observed_cycles,
             "alive_minimum_score": cfg.thresholds.alive_minimum_score,
             "fragile_minimum_score": cfg.thresholds.fragile_minimum_score,
+            "dying_degradation_minimum_score": cfg.thresholds.dying_degradation_minimum_score,
+        },
+        "weighted_score": {
+            "total_points": total_points,
+            "criteria": {
+                name: {
+                    "points": criterion.points,
+                    "required_for_alive": criterion.required_for_alive,
+                }
+                for name, criterion in weighted_criteria.items()
+            },
         },
     }
     return LifeStatusResult(

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -82,7 +82,7 @@ def test_compute_life_status_aggregates_configured_signals(tmp_path) -> None:
     )
 
     assert result.status == LifeStatus.ALIVE
-    assert result.score == 1.0
+    assert result.score == 100.0
     assert result.signals["persistent_identity"] is True
     assert result.signals["stable_cycle"] is True
     assert result.signals["intrinsic_goals"] is True


### PR DESCRIPTION
### Motivation

- Introduce a configurable, weighted rubric to qualify a life on a 100-point scale so lifecycle evaluation can reflect differing importance of signals (identity, registry, cycle, goals, reproduction, narrative). 
- Surface terminal and severe-degradation signals as overrides so confirmed extinction/dying events dominate scoring.

### Description

- Add a `weighted_score` section to `configs/life_definition.yaml` with the requested weights (20/15/20/20/10/15), terminal/degradation signal keys, absolute thresholds and human-readable `status_rules`.
- Extend the config model in `src/singular/life/life_definition.py` with `WeightedCriterion` and `LifeWeightedScore`, parse `weighted_score` (including alias `continuous_intrinsic_goals`) and validate `total_points`.
- Update `compute_life_status` in `src/singular/life/life_status.py` to compute an absolute weighted score, accept legacy fractional thresholds (0..1) or absolute thresholds, require fundamental criteria to be present for `alive`, cap scores when terminal signals exist, and include `weighted_score` evidence in the returned payload.
- Document the rubric and evaluation priority in `docs/technical_life_status.md` and `docs/vital_lifecycle_rules.md`, and adjust the one test expectation that assumed the old 0..1 scale in `tests/test_life_status.py`.

### Testing

- Ran linter checks with `python -m ruff check src/singular/life/life_definition.py src/singular/life/life_status.py tests/test_life_status.py` which passed.
- Ran unit tests with `python -m pytest tests/test_life_definition_config.py tests/test_life_status.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d66667c1c832ab1cd68dac5067ce4)