### PR TITLE
Use vital timeline in life status

### DIFF
--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -15,6 +15,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
+from singular.life.vital import compute_vital_timeline
+
 if TYPE_CHECKING:  # pragma: no cover - imported only for static typing.
     from singular.life.life_definition import LifeDefinitionConfig
 
@@ -201,6 +203,38 @@ def _cycle_count(rows: Sequence[Mapping[str, Any]]) -> int:
     return count
 
 
+def _health_score_from_payload(payload: Mapping[str, Any]) -> float | None:
+    health = payload.get("health")
+    if isinstance(health, Mapping) and isinstance(health.get("score"), (int, float)):
+        return float(health["score"])
+    global_health = payload.get("global_health")
+    if isinstance(global_health, Mapping) and isinstance(
+        global_health.get("score"), (int, float)
+    ):
+        return float(global_health["score"])
+    return None
+
+
+def _accepted_value(row: Mapping[str, Any]) -> bool | None:
+    accepted = row.get("accepted")
+    if not isinstance(accepted, bool):
+        accepted = row.get("ok")
+    return accepted if isinstance(accepted, bool) else None
+
+
+def _failure_streak(rows: Sequence[Mapping[str, Any]]) -> int:
+    current = 0
+    longest = 0
+    for row in rows:
+        accepted = _accepted_value(row)
+        if accepted is False:
+            current += 1
+            longest = max(longest, current)
+        elif accepted is True:
+            current = 0
+    return longest
+
+
 def _list_count(value: Any) -> int:
     return len(value) if isinstance(value, list) else 0
 
@@ -316,6 +350,22 @@ def compute_life_status(
     )
     reproduction_done = bool(children or reproduction_events)
 
+    world_state = _read_json(paths["world_state"])
+    mutation_rows = [row for row in run_rows if "score_new" in row]
+    success_records = [
+        row
+        for row in run_rows
+        if "score_new" in row or isinstance(_accepted_value(row), bool)
+    ]
+    ok_count = sum(1 for row in success_records if _accepted_value(row) is True)
+    health_scores = [
+        score
+        for score in (
+            _health_score_from_payload(row) for row in [*run_rows, world_state]
+        )
+        if score is not None
+    ]
+
     period_dates: list[Any] = [born_at]
     for period in (
         narrative.get("life_periods", [])
@@ -343,11 +393,23 @@ def compute_life_status(
         for row in run_rows
         if any(token in _event_text(row) for token in ("extinct", "death", "terminal"))
     ]
-    terminal = (
-        bool(autopsy)
-        or registry_status in {"extinct", "dead", "stopped", "terminal"}
-        or bool(extinction_events)
+    confirmed_extinction_events = [
+        row
+        for row in run_rows
+        if any(token in _event_text(row) for token in ("extinct", "death"))
+    ]
+    vital_timeline = compute_vital_timeline(
+        age=len(mutation_rows),
+        current_health=health_scores[-1] if health_scores else None,
+        failure_rate=(
+            (1 - (ok_count / len(success_records))) if success_records else None
+        ),
+        failure_streak=_failure_streak(success_records),
+        extinction_seen=bool(autopsy) or bool(confirmed_extinction_events),
+        registry_status=registry_status or None,
     )
+    vital_state = str(vital_timeline.get("state", ""))
+    terminal = vital_state in {"terminal", "extinct"}
 
     criteria = {
         "persistent_identity": (cfg.criteria.persistent_identity, persistent_identity),
@@ -356,7 +418,9 @@ def compute_life_status(
         "intrinsic_goals": (cfg.criteria.intrinsic_goals, intrinsic_goals),
         "reproduction_capability": (
             cfg.criteria.reproduction_capability,
-            reproduction_possible or reproduction_done,
+            reproduction_possible
+            or reproduction_done
+            or vital_timeline.get("reproduction_eligible") is True,
         ),
         "narrative_continuity": (
             cfg.criteria.narrative_continuity,
@@ -382,16 +446,17 @@ def compute_life_status(
     required_for_alive = [
         name
         for name, (configured, _) in criteria.items()
-        if configured and weighted_criteria.get(name) is not None and weighted_criteria[name].required_for_alive
+        if configured
+        and weighted_criteria.get(name) is not None
+        and weighted_criteria[name].required_for_alive
     ]
     required_for_alive_present = all(criteria[name][1] for name in required_for_alive)
-    if terminal:
-        score = min(score, 20.0 if registry_status == "extinct" or autopsy else 40.0)
-        status = (
-            LifeStatus.EXTINCT
-            if registry_status == "extinct" or autopsy
-            else LifeStatus.DYING
-        )
+    if vital_state == "extinct":
+        score = min(score, 20.0)
+        status = LifeStatus.EXTINCT
+    elif vital_state == "terminal":
+        score = min(score, 40.0)
+        status = LifeStatus.DYING
     elif not persistent_identity and not run_rows:
         status = LifeStatus.NOT_ALIVE_YET
     elif score >= alive_minimum_score and required_for_alive_present:
@@ -407,7 +472,12 @@ def compute_life_status(
     if negatives:
         explanation += " Manquants ou insuffisants: " + ", ".join(negatives) + "."
     if terminal:
-        explanation += " Un signal d'extinction ou d'état terminal domine l'évaluation."
+        explanation += (
+            f" Vital: état {vital_state}, risque {vital_timeline.get('risk_level')}."
+        )
+        causes = vital_timeline.get("causes")
+        if isinstance(causes, list) and causes:
+            explanation += " Causes: " + ", ".join(str(cause) for cause in causes) + "."
 
     signals = {
         "persistent_identity": persistent_identity,
@@ -419,10 +489,14 @@ def compute_life_status(
         "intrinsic_quest_count": intrinsic_quest_count,
         "reproduction_possible": reproduction_possible,
         "reproduction_done": reproduction_done,
+        "reproduction_capability": criteria["reproduction_capability"][1],
+        "reproduction_eligible": vital_timeline.get("reproduction_eligible") is True,
         "narrative_continuity": narrative_continuity,
         "narrative_age_days": age_days,
         "terminal": terminal,
         "extinction": status is LifeStatus.EXTINCT,
+        "vital_state": vital_state,
+        "vital_risk_level": vital_timeline.get("risk_level"),
     }
     evidence = {
         "files": {key: str(path) for key, path in paths.items() if path.exists()},
@@ -441,7 +515,9 @@ def compute_life_status(
         "runs_count": len(run_rows),
         "generations_count": len(generation_rows),
         "extinction_events_count": len(extinction_events),
+        "confirmed_extinction_events_count": len(confirmed_extinction_events),
         "reproduction_events_count": len(reproduction_events),
+        "vital_timeline": vital_timeline,
         "thresholds": {
             "minimum_narrative_trajectory_days": cfg.thresholds.minimum_narrative_trajectory_days,
             "minimum_observed_cycles": cfg.thresholds.minimum_observed_cycles,

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -112,3 +112,69 @@ def test_compute_life_status_terminal_signal_dominates(tmp_path) -> None:
 
     assert result.status == LifeStatus.EXTINCT
     assert result.signals["terminal"] is True
+
+
+def test_compute_life_status_uses_vital_terminal_without_extinction(tmp_path) -> None:
+    from singular.life.life_status import compute_life_status
+
+    life_home = tmp_path / "lives" / "alpha"
+    mem = life_home / "mem"
+    mem.mkdir(parents=True)
+    (mem / "world_state.json").write_text(
+        '{"global_health":{"score":90}}', encoding="utf-8"
+    )
+    (mem / "autopsy.json").write_text("{}", encoding="utf-8")
+    (mem / "self_narrative.json").write_text(
+        '{"identity":{"name":"Alpha","born_at":"2026-06-01T00:00:00+00:00"},"current_heading":"continuer"}',
+        encoding="utf-8",
+    )
+    (mem / "quests_state.json").write_text("{}", encoding="utf-8")
+    runs = [
+        {"event": "mutation", "score_new": index, "accepted": False}
+        for index in range(5)
+    ]
+
+    result = compute_life_status(
+        life_home,
+        registry_entry={"name": "Alpha", "slug": "alpha", "status": "active"},
+        runs=runs,
+    )
+
+    assert result.status == LifeStatus.DYING
+    assert result.signals["terminal"] is True
+    assert result.signals["extinction"] is False
+    assert result.evidence["vital_timeline"]["state"] == "terminal"
+    assert result.evidence["vital_timeline"]["risk_level"] == "high"
+    assert "failure_streak" in result.evidence["vital_timeline"]["causes"]
+    assert "failure_streak" in result.explanation
+
+
+def test_compute_life_status_uses_vital_reproduction_eligibility(tmp_path) -> None:
+    from singular.life.life_status import compute_life_status
+
+    life_home = tmp_path / "lives" / "alpha"
+    mem = life_home / "mem"
+    mem.mkdir(parents=True)
+    (mem / "world_state.json").write_text(
+        '{"global_health":{"score":90}}', encoding="utf-8"
+    )
+    (mem / "autopsy.json").write_text("{}", encoding="utf-8")
+    (mem / "self_narrative.json").write_text(
+        '{"identity":{"name":"Alpha","born_at":"2026-06-01T00:00:00+00:00"},"current_heading":"continuer"}',
+        encoding="utf-8",
+    )
+    (mem / "quests_state.json").write_text("{}", encoding="utf-8")
+    runs = [
+        {"event": "mutation", "score_new": index, "accepted": True}
+        for index in range(3)
+    ]
+
+    result = compute_life_status(
+        life_home,
+        registry_entry={"name": "Alpha", "slug": "alpha", "status": "active"},
+        runs=runs,
+    )
+
+    assert result.signals["reproduction_eligible"] is True
+    assert result.signals["reproduction_capability"] is True
+    assert result.evidence["vital_timeline"]["reproduction_eligible"] is True


### PR DESCRIPTION
### Motivation
- Centraliser les règles vitales en appelant `compute_vital_timeline()` afin d'éviter la duplication des seuils définis dans `src/singular/life/vital.py`.
- Faire remonter des preuves techniques (risque, causes, timeline) dans le verdict philosophique-opérationnel pour des explications et traces plus riches.
- Exposer l'information d'éligibilité à la reproduction déterminée par la timeline vitale comme signal utile pour les critères de vie.

### Description
- Import de `compute_vital_timeline` et appel depuis `compute_life_status()` en construisant les entrées observées (`age`, `current_health`, `failure_rate`, `failure_streak`, `extinction_seen`, `registry_status`).
- Ajout des helpers `_health_score_from_payload`, `_accepted_value` et `_failure_streak` pour normaliser extraction du score de santé, état d'acceptation et la plus longue série d'échecs.
- Mappage des sorties vitales vers le contrat de vie: `state == "extinct"` → `LifeStatus.EXTINCT` et `state == "terminal"` → `LifeStatus.DYING` (extinction confirmée uniquement si observée/autopsy/registre). 
- Surface `reproduction_eligible` du timeline vital dans le signal `reproduction_capability` et expose `reproduction_eligible`, `vital_state`, `vital_risk_level` et le `vital_timeline` complet dans `signals`/`evidence` et l'explication inclut `risk_level` et `causes`.
- Mise à jour des preuves retournées et du texte d'explication pour inclure les détails du timeline vital.
- Ajout de deux tests dans `tests/test_life_status.py` couvrant le basculement terminal sans extinction confirmée et l'éligibilité à la reproduction issue du timeline vital.

### Testing
- Exécuté `pytest -q tests/test_life_status.py` et obtenu `6 passed`.
- Le module a été compilé avec succès via la vérification automatique (formatage/compilation) pendant la validation des changements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d68e25e78832aa746516918911fb3)