### PR TITLE
Expose life status in status command

### DIFF
--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from ..lives import list_relations
 from ..life.health import detect_health_state
+from ..life.life_status import compute_life_status
 from ..life.vital import compute_vital_timeline
 from ..metrics.autonomy import compute_autonomy_metrics
 from ..psyche import Psyche
@@ -205,6 +206,13 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         "mutation_count": 0,
         "invalid_lines": 0,
         "health": None,
+        "life_status": {
+            "status": None,
+            "score": 0.0,
+            "explanation": "",
+            "signals": {},
+            "missing_signals": [],
+        },
         "alerts": [],
         "mood": None,
         "traits": {},
@@ -346,6 +354,16 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         quests=payload["quests"] if isinstance(payload["quests"], dict) else {},
     )
     payload["skills_lifecycle"] = _read_skill_lifecycle_status()
+    payload["life_status"] = {
+        key: value
+        for key, value in compute_life_status(
+            get_mem_dir().parent,
+            runs=all_records,
+        )
+        .to_payload()
+        .items()
+        if key in {"status", "score", "explanation", "signals", "missing_signals"}
+    }
     payload["traits"] = {
         "curiosity": round(psyche.curiosity, 2),
         "patience": round(psyche.patience, 2),
@@ -386,6 +404,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                     else "-"
                 ),
             ],
+            ["Verdict de vie", str((payload.get("life_status") or {}).get("status") or "-")],
+            ["Score de vie", _fmt_number((payload.get("life_status") or {}).get("score"))],
+            ["Explication", str((payload.get("life_status") or {}).get("explanation") or "-")],
             ["Taux d’initiatives proactives", _fmt_ratio(autonomy.get("proactive_initiative_rate"))],
             ["Stabilité long terme", _fmt_ratio(autonomy.get("long_term_stability"))],
             [
@@ -459,6 +480,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                 _print_table(["Level", "Message", "Action"], alert_rows)
             else:
                 print("Alerts: none")
+            missing = (payload.get("life_status") or {}).get("missing_signals")
+            if isinstance(missing, list) and missing:
+                print("Signaux de vie manquants: " + ", ".join(str(item) for item in missing))
         trait_rows = [[k, f"{v:.2f}"] for k, v in payload["traits"].items()]
         print("Traits")
         _print_table(["Trait", "Value"], trait_rows)
@@ -513,6 +537,15 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                     )
             else:
                 print("Alerts: none")
+
+    life_status = payload.get("life_status") if isinstance(payload.get("life_status"), dict) else {}
+    print(f"Verdict de vie: {life_status.get('status') or '-'}")
+    print(f"Score de vie: {_fmt_number(life_status.get('score'))}")
+    print(f"Explication: {life_status.get('explanation') or '-'}")
+    if verbose:
+        missing = life_status.get("missing_signals")
+        if isinstance(missing, list) and missing:
+            print("Signaux de vie manquants: " + ", ".join(str(item) for item in missing))
 
     print(f"Mood: {payload['mood']}")
     relationships = payload.get("relationships") if isinstance(payload.get("relationships"), dict) else {}

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -110,10 +110,51 @@ def test_status_filters_non_mutation_records_for_success_rate(
     assert payload["success_rate"] == 50.0
     assert payload["vital_timeline"]["age"] == 3
     assert payload["vital_timeline"]["state"] in {"mature", "declining", "terminal", "extinct"}
+    assert set(payload["life_status"]) == {
+        "status",
+        "score",
+        "explanation",
+        "signals",
+        "missing_signals",
+    }
+    assert isinstance(payload["life_status"]["signals"], dict)
+    assert isinstance(payload["life_status"]["missing_signals"], list)
     assert "autonomy_metrics" in payload
     assert "proactive_initiative_rate" in payload["autonomy_metrics"]
     assert "host_environment" in payload
     assert "impact" in payload["host_environment"]
+
+
+def test_status_renders_life_status_in_plain_and_table(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    class DummyPsyche:
+        last_mood = None
+        curiosity = 0.5
+        patience = 0.5
+        playfulness = 0.5
+        optimism = 0.5
+        resilience = 0.5
+
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod, "RUNS_DIR", tmp_path / "runs")
+    monkeypatch.setattr(
+        status_mod.Psyche, "load_state", staticmethod(lambda: DummyPsyche())
+    )
+
+    status_mod.status(verbose=True)
+    plain_out = capsys.readouterr().out
+    assert "Verdict de vie:" in plain_out
+    assert "Score de vie:" in plain_out
+    assert "Explication:" in plain_out
+    assert "Signaux de vie manquants:" in plain_out
+
+    status_mod.status(verbose=True, output_format="table")
+    table_out = capsys.readouterr().out
+    assert "Verdict de vie" in table_out
+    assert "Score de vie" in table_out
+    assert "Explication" in table_out
+    assert "Signaux de vie manquants:" in table_out
 
 
 def test_status_exposes_quest_counts(tmp_path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
### Motivation
- Surface the philosophical-operational life contract in the `status()` output so dashboards/CLI can consume a consistent `life_status` payload. 
- Reuse the canonical computation in `compute_life_status()` instead of duplicating signal logic in the status organism. 
- Make the life verdict visible in plain and table renderings and show missing signals in verbose mode for debugging.

### Description
- Import and use `compute_life_status()` from `singular.life.life_status` and add a `life_status` entry to the `status()` JSON payload containing only `status`, `score`, `explanation`, `signals`, and `missing_signals`.
- Compute `life_status` with `compute_life_status(get_mem_dir().parent, runs=all_records)` and store the trimmed result in `payload["life_status"]`.
- Render `Verdict de vie`, `Score de vie`, and `Explication` in both plain and `table` outputs, and print `Signaux de vie manquants` when `--verbose` is used.
- Add tests to assert the `life_status` JSON shape and to verify plain and table output rendering of the new fields.

### Testing
- Ran `pytest tests/test_status.py tests/test_life_status.py` and all tests passed (14 passed).
- New and existing assertions cover the JSON contract and plain/table rendering and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d6eef865c832abe4e3426b7c467b4)