### PR TITLE
Expose life status in cockpit APIs

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -14,6 +14,7 @@ from urllib.parse import quote
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 from singular.lives import get_registry_root, load_registry, set_life_status
+from singular.life.life_status import compute_life_status
 from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
 from singular.metrics.behavioral_regulation import compute_behavioral_regulation_metrics
@@ -860,6 +861,64 @@ def create_app(
             )
         return decisions[-10:]
 
+    def _default_cockpit_life_status(
+        explanation: str = "Aucune vie active ou mémoire disponible.",
+    ) -> dict[str, object]:
+        return {
+            "status": "not_alive_yet",
+            "score": 0.0,
+            "explanation": explanation,
+            "signals": {},
+            "missing_signals": ["active_life", "memory"],
+        }
+
+    def _active_life_entry() -> tuple[str | None, object | None, Path | None]:
+        registry = load_registry()
+        active = registry.get("active")
+        lives = registry.get("lives")
+        if not isinstance(active, str) or not isinstance(lives, dict):
+            return None, None, None
+        meta = lives.get(active)
+        path_value = life_meta_get(meta, "path", None)
+        if isinstance(path_value, str):
+            path_value = Path(path_value)
+        return active, meta, path_value if isinstance(path_value, Path) else None
+
+    def _resolve_cockpit_life_entry(
+        selected_life: object | None,
+    ) -> tuple[str | None, object | None, Path | None]:
+        if isinstance(selected_life, str) and selected_life:
+            slug, meta, life_dir = _resolve_life_entry(selected_life)
+            if life_dir is not None:
+                return slug, meta, life_dir
+        return _active_life_entry()
+
+    def _cockpit_life_status_payload(
+        *, records: list[dict[str, object]], selected_life: object | None = None
+    ) -> dict[str, object]:
+        slug, meta, life_dir = _resolve_cockpit_life_entry(selected_life)
+        if life_dir is None:
+            return _default_cockpit_life_status()
+        if not (life_dir / "mem").exists():
+            life_name = slug or selected_life or "active"
+            return _default_cockpit_life_status(
+                f"Statut not_alive_yet: la vie {life_name} n'a pas encore de mémoire."
+            )
+        filtered_records = [
+            record for record in records if slug and _record_life(record) == slug
+        ]
+        try:
+            return compute_life_status(
+                life_dir,
+                registry_entry=meta,
+                runs=filtered_records if filtered_records else records,
+            ).to_payload()
+        except Exception:
+            life_name = slug or selected_life or "la vie active"
+            return _default_cockpit_life_status(
+                f"Statut not_alive_yet: impossible de calculer le statut de vie pour {life_name}."
+            )
+
     def _summarize_cockpit(current_life_only: bool = False) -> dict[str, object]:
         latest = _latest_run_file(current_life_only=current_life_only)
         if latest is None:
@@ -942,6 +1001,16 @@ def create_app(
                 "life_liveness_proofs": [],
                 "life_liveness_life": None,
             }
+            life_status_payload = _cockpit_life_status_payload(records=[])
+            empty.update(
+                {
+                    "life_status": life_status_payload.get("status", "not_alive_yet"),
+                    "life_status_score": life_status_payload.get("score", 0.0),
+                    "life_status_explanation": life_status_payload.get("explanation", ""),
+                    "life_status_signals": life_status_payload.get("signals", {}),
+                    "life_status_missing_signals": life_status_payload.get("missing_signals", []),
+                }
+            )
             return empty
 
         records = _read_jsonl_records(latest)
@@ -1114,6 +1183,10 @@ def create_app(
             if records
             else {"index": 0.0, "components": {}, "proofs": []}
         )
+        life_status_payload = _cockpit_life_status_payload(
+            records=records,
+            selected_life=selected_life,
+        )
 
         return {
             "run": _run_file_id(latest),
@@ -1169,6 +1242,11 @@ def create_app(
             "life_liveness_components": liveness_payload.get("components", {}),
             "life_liveness_proofs": liveness_payload.get("proofs", []),
             "life_liveness_life": selected_life,
+            "life_status": life_status_payload.get("status", "not_alive_yet"),
+            "life_status_score": life_status_payload.get("score", 0.0),
+            "life_status_explanation": life_status_payload.get("explanation", ""),
+            "life_status_signals": life_status_payload.get("signals", {}),
+            "life_status_missing_signals": life_status_payload.get("missing_signals", []),
         }
 
     def _summarize_cockpit_essential(current_life_only: bool = False) -> dict[str, object]:
@@ -1193,6 +1271,9 @@ def create_app(
             "next_action": cockpit.get("next_action") or "Aucune action immédiate",
             "selected_life": selected_life,
             "active_incidents_count": incidents_count,
+            "life_status": cockpit.get("life_status", "not_alive_yet"),
+            "life_status_score": cockpit.get("life_status_score", 0.0),
+            "life_status_summary": cockpit.get("life_status_explanation", ""),
         }
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -532,6 +532,11 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert "objectives" in payload["trajectory"]
     assert "priority_changes" in payload["trajectory"]
     assert "objective_narrative_links" in payload["trajectory"]
+    assert payload["life_status"] == "not_alive_yet"
+    assert payload["life_status_score"] == 0.0
+    assert isinstance(payload["life_status_explanation"], str)
+    assert isinstance(payload["life_status_signals"], dict)
+    assert isinstance(payload["life_status_missing_signals"], list)
 
 
 def test_dashboard_cockpit_sandbox_governance_summary(tmp_path: Path) -> None:
@@ -670,12 +675,18 @@ def test_dashboard_cockpit_essential_projection_schema(tmp_path: Path) -> None:
         "next_action": payload["next_action"],
         "selected_life": payload["selected_life"],
         "active_incidents_count": payload["active_incidents_count"],
+        "life_status": payload["life_status"],
+        "life_status_score": payload["life_status_score"],
+        "life_status_summary": payload["life_status_summary"],
     }
     assert payload["global_status"] in {"critical", "warning", "stable", "unknown"}
     assert isinstance(payload["critical_alerts_count"], int)
     assert isinstance(payload["next_action"], str)
     assert isinstance(payload["selected_life"], str)
     assert isinstance(payload["active_incidents_count"], int)
+    assert payload["life_status"] == "not_alive_yet"
+    assert payload["life_status_score"] == 0.0
+    assert isinstance(payload["life_status_summary"], str)
 
 
 def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Surface a computed life status for the selected or active life in cockpit summaries and provide a safe fallback to avoid errors when no active life or memory is available.
- Provide both a full detailed payload for `/api/cockpit` and a compact projection for `/api/cockpit/essential` so UIs can show concise status information.

### Description
- Import and use `compute_life_status()` and add helpers `_default_cockpit_life_status`, `_active_life_entry`, `_resolve_cockpit_life_entry`, and `_cockpit_life_status_payload` to resolve selected/active life and compute status safely.
- Add detailed fields to the cockpit payload: `life_status`, `life_status_score`, `life_status_explanation`, `life_status_signals`, and `life_status_missing_signals` (present on both empty and non-empty responses).
- Add compact projection fields to the essential endpoint: `life_status`, `life_status_score`, and `life_status_summary`.
- Ensure missing life or missing memory returns a `not_alive_yet` status instead of raising an error; computation is wrapped in a try/except fallback.
- Update `tests/test_dashboard.py` to assert the new fields in the cockpit and essential endpoint schemas.

### Testing
- Ran `python -m py_compile src/singular/dashboard/__init__.py` which succeeded.
- Ran targeted tests `python -m pytest tests/test_dashboard.py -k 'cockpit_endpoint_schema or cockpit_essential_projection_schema'` and both selected tests passed (2 passed, 41 deselected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d7337e944832abdad9e26e91e56ef)