### PR TITLE
Add cockpit "Verdict de vie" card with score, explanation and signal details

### DIFF
--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -507,3 +507,28 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
 .conversation-composer { display:flex; flex-direction:column; gap:8px; margin-top:8px; }
 .conversation-composer textarea { width:100%; }
 .conversation-meta { display:flex; flex-direction:column; gap:6px; margin-bottom:8px; }
+
+.life-verdict-card {
+  grid-column: span 2;
+  border-color: rgba(152, 170, 215, 0.35);
+}
+.life-verdict-neutral { background: linear-gradient(160deg, rgba(19, 33, 81, 0.78), rgba(13, 22, 55, 0.88)); }
+.life-verdict-warning { border-color: rgba(255, 191, 83, 0.72); box-shadow: 0 0 0 1px rgba(255, 191, 83, 0.18), var(--shadow); }
+.life-verdict-success { border-color: rgba(55, 245, 162, 0.72); box-shadow: 0 0 0 1px rgba(55, 245, 162, 0.18), var(--shadow); }
+.life-verdict-danger { border-color: rgba(255, 107, 141, 0.78); box-shadow: 0 0 0 1px rgba(255, 107, 141, 0.2), var(--shadow); }
+.life-verdict-terminal { border-color: rgba(255, 107, 141, 0.9); background: linear-gradient(160deg, rgba(60, 19, 38, 0.82), rgba(30, 25, 42, 0.92)); }
+.life-verdict-score-row { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; margin-top: 10px; }
+.life-verdict-score { font-size: 1.8rem; color: #f2f6ff; }
+.life-verdict-meter { width: 100%; height: 12px; margin-top: 6px; accent-color: var(--accent); }
+.life-verdict-success .life-verdict-meter { accent-color: var(--ok); }
+.life-verdict-warning .life-verdict-meter { accent-color: var(--warn); }
+.life-verdict-danger .life-verdict-meter,
+.life-verdict-terminal .life-verdict-meter { accent-color: var(--bad); }
+.life-verdict-explanation { color: var(--text-secondary); margin: 10px 0; }
+.life-verdict-details { border-top: 1px solid var(--table-border); padding-top: 8px; }
+.life-verdict-details summary { cursor: pointer; color: #dbe6ff; font-weight: 700; }
+.life-verdict-signals-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-top: 8px; }
+
+@media (max-width: 720px) {
+  .life-verdict-card { grid-column: span 1; }
+}

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -62,6 +62,62 @@ const sparkline=(values)=>{
 const toneByRisk=(el,risk)=>{if(!el){return;}el.classList.remove('status-good','status-warn','status-bad','status-muted');if(risk==='ok'){el.classList.add('status-good');return;}if(risk==='warn'){el.classList.add('status-warn');return;}if(risk==='critical'){el.classList.add('status-bad');return;}el.classList.add('status-muted');};
 const extractHostMetrics=(record)=>{if(record&&typeof record.host_metrics==='object'&&record.host_metrics){return record.host_metrics;}if(record&&typeof record.signals==='object'&&record.signals&&typeof record.signals.host_metrics==='object'){return record.signals.host_metrics;}if(record&&typeof record.payload==='object'&&record.payload&&typeof record.payload.host_metrics==='object'){return record.payload.host_metrics;}return null;};
 
+
+const LIFE_VERDICT_STYLE={
+  not_alive_yet:{tone:'neutral',label:'Pas encore vivante'},
+  fragile:{tone:'warning',label:'Fragile'},
+  alive:{tone:'success',label:'Vivante'},
+  dying:{tone:'danger',label:'En train de mourir'},
+  extinct:{tone:'terminal',label:'Éteinte'},
+};
+const lifeVerdictStyle=status=>LIFE_VERDICT_STYLE[String(status||'not_alive_yet')]||LIFE_VERDICT_STYLE.not_alive_yet;
+const signalLabel=signal=>String(signal||'signal').replaceAll('_',' ');
+const signalIsValidated=value=>{
+  if(value===true){return true;}
+  if(value===false||value===null||value===undefined){return false;}
+  if(typeof value==='number'){return Number.isFinite(value)&&value>0;}
+  if(typeof value==='string'){return value.trim().length>0&&!['false','missing','absent','0'].includes(value.trim().toLowerCase());}
+  if(Array.isArray(value)){return value.length>0;}
+  if(typeof value==='object'){
+    if(Object.prototype.hasOwnProperty.call(value,'valid')){return value.valid===true;}
+    if(Object.prototype.hasOwnProperty.call(value,'present')){return value.present===true;}
+    if(Object.prototype.hasOwnProperty.call(value,'ok')){return value.ok===true;}
+    if(Object.prototype.hasOwnProperty.call(value,'score')){return Number(value.score)>0;}
+    return Object.keys(value).length>0;
+  }
+  return Boolean(value);
+};
+const renderSignalList=(id,items,emptyText)=>{
+  const list=clearElement(id);
+  if(!list){return;}
+  if(!items.length){const li=document.createElement('li');li.textContent=emptyText;list.appendChild(li);return;}
+  for(const item of items){const li=document.createElement('li');li.textContent=item;list.appendChild(li);}
+};
+const renderLifeVerdict=payload=>{
+  const status=String(payload.life_status||'not_alive_yet');
+  const style=lifeVerdictStyle(status);
+  const card=byId('life-verdict-card');
+  if(card){
+    card.classList.remove('life-verdict-neutral','life-verdict-warning','life-verdict-success','life-verdict-danger','life-verdict-terminal');
+    card.classList.add(`life-verdict-${style.tone}`);
+  }
+  setText('life-verdict-status',`${style.label} (${status})`);
+  const score=Number(payload.life_status_score||0);
+  const normalizedScore=Number.isFinite(score)?Math.max(0,Math.min(100,score)):0;
+  setText('life-verdict-score',normalizedScore.toFixed(1));
+  const meter=byId('life-verdict-score-meter');
+  if(meter){meter.value=normalizedScore;meter.textContent=normalizedScore.toFixed(1);}
+  setText('life-verdict-explanation',payload.life_status_explanation||'Aucune explication fournie.');
+  const missingSignals=Array.isArray(payload.life_status_missing_signals)?payload.life_status_missing_signals.map(signalLabel):[];
+  const missingSet=new Set(missingSignals.map(item=>item.toLowerCase()));
+  const signalEntries=Object.entries(payload.life_status_signals||{});
+  const validSignals=signalEntries
+    .filter(([key,value])=>signalIsValidated(value)&&!missingSet.has(signalLabel(key).toLowerCase()))
+    .map(([key])=>signalLabel(key));
+  renderSignalList('life-verdict-valid-signals',validSignals,'Aucun signal validé.');
+  renderSignalList('life-verdict-missing-signals',missingSignals,'Aucun signal manquant.');
+};
+
 const operatorSummaryState={context:null,lives:null,eco:null,cockpit:null,essential:null,workItems:null};
 let lastCockpitPayload=null;
 const cockpitFallbackPayload={
@@ -482,6 +538,7 @@ export const loadCockpit=()=>Promise.allSettled([
     else if(globalStatus==='critical'){setStatusTone(statusBox,'bad');applyStatusIndicator(statusBox,'bad');}
   }
 
+  renderLifeVerdict(d);
   renderSandboxGovernance(d.sandbox_governance||{});
   renderGovernanceDiagnostics(d.governance_policy||{});
   const healthValue=d.health_score===null||d.health_score===undefined?na():Number(d.health_score).toFixed(1);

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -159,6 +159,29 @@
       <p class='section-help'>Taux d’initiatives proactives · Qu’est-ce que ce score ? · Pourquoi cette alerte ? · source /api/cockpit</p>
       <div id='cockpit-status' class='card card-value'>Statut global: Non disponible</div>
       <div class='cards-grid'>
+        <div id='life-verdict-card' class='card life-verdict-card life-verdict-neutral'>
+          <div class='card-label kpi-label' title='Verdict calculé à partir des signaux de vie validés et manquants'>Verdict de vie</div>
+          <div id='life-verdict-status' class='card-value'>Non disponible</div>
+          <div class='life-verdict-score-row'>
+            <span class='card-label'>Score</span>
+            <strong id='life-verdict-score' class='life-verdict-score'>0.0</strong>
+          </div>
+          <meter id='life-verdict-score-meter' class='life-verdict-meter' min='0' max='100' value='0'>0</meter>
+          <p id='life-verdict-explanation' class='life-verdict-explanation'>Explication indisponible.</p>
+          <details class='life-verdict-details'>
+            <summary>Détail des signaux</summary>
+            <div class='life-verdict-signals-grid'>
+              <div>
+                <strong>Validés</strong>
+                <ul id='life-verdict-valid-signals' class='list-tight-top'><li>Aucun signal validé.</li></ul>
+              </div>
+              <div>
+                <strong>Manquants</strong>
+                <ul id='life-verdict-missing-signals' class='list-tight-top'><li>Aucun signal manquant.</li></ul>
+              </div>
+            </div>
+          </details>
+        </div>
         <div class='card'><div class='card-label kpi-label' title='Capacité observée du système à fonctionner sans assistance'>Niveau d’autonomie</div><div id='kpi-health' class='card-value'>Pas encore mesuré</div></div>
         <div class='card'><div class='card-label kpi-label' title='Cohérence observée entre les vies actives'>Stabilité collective</div><div id='kpi-active-lives' class='card-value'>0</div></div>
         <div class='card'><div class='card-label kpi-label' title='Nombre d’incidents critiques en cours'>Incidents critiques</div><div id='kpi-alerts' class='card-value'>0</div></div>


### PR DESCRIPTION
### Motivation
- Provide a concise, visible verdict for a selected digital life in the cockpit so operators can quickly assess life status and evidence.  
- Surface a numeric score, short explanation and the validated vs missing signals to accelerate diagnosis and triage.  
- Map life status semantics to clear visual tones to align the cockpit UI with backend life-status payloads.

### Description
- Add a new cockpit card UI in `src/singular/dashboard/templates/dashboard.html` containing status, numeric `Score`, a `meter` gauge, an `Explication` paragraph and a collapsible detail listing validated and missing signals.  
- Implement rendering logic in `src/singular/dashboard/static/render-cockpit.js`: introduce `renderLifeVerdict`, `signalIsValidated`, `renderSignalList`, and `LIFE_VERDICT_STYLE`, and plug `renderLifeVerdict(d)` into the cockpit load flow to consume `/api/cockpit` payload fields (`life_status`, `life_status_score`, `life_status_explanation`, `life_status_signals`, `life_status_missing_signals`).  
- Map backend statuses to visual tones: `not_alive_yet` → neutral, `fragile` → warning, `alive` → success, `dying` → danger, `extinct` → terminal.  
- Add responsive styling and tone-specific rules in `src/singular/dashboard/static/dashboard.css` for card layout, meter accents, and the validated/missing signal lists.

### Testing
- Ran a JavaScript syntax check with `node --check src/singular/dashboard/static/render-cockpit.js`, which succeeded.  
- Exercised relevant Python tests with `python -m pytest tests/test_dashboard_services.py tests/test_liveness_index.py -q`, which passed (`11 passed`).  
- Attempted a full test run (`python -m pytest tests -q`) in this environment but it did not complete cleanly and showed multiple unrelated failures from the existing test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d7476fd74832a91c13faee9feaf63)