### PR TITLE
Add life verdict to run reports

### DIFF
--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -10,6 +10,7 @@ from typing import Any
 from .logger import RUNS_DIR
 from ..governance.policy import load_runtime_policy
 from ..life.health import detect_health_state
+from ..life.life_status import compute_life_status
 from ..memory import read_skills, get_skills_file
 from ..sensors import compute_host_metrics_aggregates, summarize_environmental_impact
 
@@ -61,9 +62,7 @@ def _build_report_payload(
 ) -> dict[str, Any]:
     """Build a stable export payload for a run."""
 
-    mutations = [
-        r for r in records if r.get("_event_type") == "mutation" or "op" in r
-    ]
+    mutations = [r for r in records if r.get("_event_type") == "mutation" or "op" in r]
     if not mutations:
         raise ValueError("no_mutations")
 
@@ -116,7 +115,9 @@ def _build_report_payload(
 
     health_payload: dict[str, Any] | None = None
     if health_scores:
-        health_state = detect_health_state(health_scores, short_window=10, long_window=50)
+        health_state = detect_health_state(
+            health_scores, short_window=10, long_window=50
+        )
         health_payload = {
             "score": round(health_scores[-1], 2),
             "trend": health_state,
@@ -134,6 +135,16 @@ def _build_report_payload(
     policy = load_runtime_policy()
     host_aggregates = compute_host_metrics_aggregates()
     host_impact = summarize_environmental_impact(host_aggregates)
+    life_verdict = {
+        key: value
+        for key, value in compute_life_status(
+            Path.cwd(),
+            runs=records,
+        )
+        .to_payload()
+        .items()
+        if key in {"status", "score", "explanation", "signals", "missing_signals"}
+    }
 
     return {
         "schema_version": 1,
@@ -156,6 +167,7 @@ def _build_report_payload(
         "health": health_payload,
         "alerts": alerts,
         "verdict": final_verdict,
+        "life_verdict": life_verdict,
         "skills": read_skills(path=skills_path),
         "policy": {
             "active": policy.to_payload(),
@@ -166,6 +178,34 @@ def _build_report_payload(
             "impact": host_impact,
         },
     }
+
+
+def _format_signal_value(value: Any) -> str:
+    """Format a life signal value for human report renderers."""
+
+    if isinstance(value, bool):
+        return "oui" if value else "non"
+    if isinstance(value, (int, float, str)) or value is None:
+        return str(value)
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _signal_lines(signals: dict[str, Any]) -> list[str]:
+    """Return compact human-readable lines for the most useful life signals."""
+
+    if not signals:
+        return ["- aucun"]
+    scalar_signals = {
+        key: value
+        for key, value in signals.items()
+        if key != "structured" and not isinstance(value, (dict, list, tuple, set))
+    }
+    if not scalar_signals:
+        return ["- aucun"]
+    return [
+        f"- {key}: {_format_signal_value(value)}"
+        for key, value in sorted(scalar_signals.items())
+    ]
 
 
 def _render_markdown(payload: dict[str, Any]) -> str:
@@ -188,12 +228,38 @@ def _render_markdown(payload: dict[str, Any]) -> str:
         f"- Meilleur score: {summary['best_score']}",
         f"- Améliorations: {summary['improvements']}",
         f"- Dégradations: {summary['degradations']}",
-        f"- Verdict final: **{payload['verdict']}**",
+        f"- Verdict mutation/performance: **{payload['verdict']}**",
         "",
-        "## Timeline des mutations",
-        "| # | ts | op | base | new | Δ | verdict |",
-        "|---|----|----|------|-----|---|---------|",
+        "## Verdict de vie",
     ]
+    life_verdict = (
+        payload.get("life_verdict")
+        if isinstance(payload.get("life_verdict"), dict)
+        else {}
+    )
+    lines.extend(
+        [
+            f"- Statut: {life_verdict.get('status', '-')}",
+            f"- Score: {life_verdict.get('score', '-')}",
+            f"- Explication: {life_verdict.get('explanation', '-')}",
+            "- Signaux clés:",
+        ]
+    )
+    lines.extend(f"  {line}" for line in _signal_lines(life_verdict.get("signals", {})))
+    missing_signals = life_verdict.get("missing_signals") or []
+    lines.append("- Signaux manquants:")
+    if missing_signals:
+        lines.extend(f"  - {signal}" for signal in missing_signals)
+    else:
+        lines.append("  - aucun")
+    lines.extend(
+        [
+            "",
+            "## Timeline des mutations",
+            "| # | ts | op | base | new | Δ | verdict |",
+            "|---|----|----|------|-----|---|---------|",
+        ]
+    )
     for item in payload["timeline"]:
         lines.append(
             "| {index} | {timestamp} | {operator} | {score_base} | {score_new} | {delta} | {verdict} |".format(
@@ -263,7 +329,8 @@ def report(
         export_path.parent.mkdir(parents=True, exist_ok=True)
         if export_path.suffix.lower() == ".json":
             export_path.write_text(
-                json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+                + "\n",
                 encoding="utf-8",
             )
         else:
@@ -280,6 +347,8 @@ def report(
     print(f"Generations: {summary['generations']}")
     print(f"Final score: {summary['final_score']}")
     print(f"Best score: {summary['best_score']}")
+    print(f"Verdict mutation/performance: {payload['verdict']}")
+    _print_life_verdict(payload.get("life_verdict", {}))
 
     if payload["health"]:
         print(
@@ -304,9 +373,7 @@ def report(
         for op, count in counter.items():
             print(f"  {op}: {count}")
 
-    mutations = [
-        r for r in records if r.get("_event_type") == "mutation" or "op" in r
-    ]
+    mutations = [r for r in records if r.get("_event_type") == "mutation" or "op" in r]
     _print_loop_modifications(mutations)
 
     skills = payload.get("skills", {})
@@ -325,6 +392,24 @@ def report(
             print(line)
     else:
         print("No skills recorded.")
+
+
+def _print_life_verdict(life_verdict: dict[str, Any]) -> None:
+    """Print the Singular life verdict separately from mutation performance."""
+
+    print(f"Verdict de vie: {life_verdict.get('status') or '-'}")
+    print(f"Score de vie: {life_verdict.get('score', '-')}")
+    print(f"Explication de vie: {life_verdict.get('explanation') or '-'}")
+    print("Signaux clés de vie:")
+    for line in _signal_lines(life_verdict.get("signals", {})):
+        print(f"  {line[2:] if line.startswith('- ') else line}")
+    missing_signals = life_verdict.get("missing_signals") or []
+    print("Signaux manquants de vie:")
+    if missing_signals:
+        for signal in missing_signals:
+            print(f"  {signal}")
+    else:
+        print("  aucun")
 
 
 def _print_loop_modifications(mutations: list[dict[str, Any]]) -> None:
@@ -377,7 +462,9 @@ def _print_loop_modifications(mutations: list[dict[str, Any]]) -> None:
 
     frequency = Counter(entry["op"] for entry in entries)
     print("  Plus fréquent:")
-    for op, count in sorted(frequency.items(), key=lambda item: (-item[1], item[0]))[:3]:
+    for op, count in sorted(frequency.items(), key=lambda item: (-item[1], item[0]))[
+        :3
+    ]:
         print(f"    {op}: {count}")
 
     profitable = sorted(entries, key=lambda e: e["profit"], reverse=True)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -65,6 +65,10 @@ def test_report_cli(monkeypatch, tmp_path, capsys):
     assert "Run run1" in out
     assert "Generations: 2" in out
     assert "Best score: 1.0" in out
+    assert "Verdict mutation/performance:" in out
+    assert "Verdict de vie:" in out
+    assert "Signaux clés de vie:" in out
+    assert "Signaux manquants de vie:" in out
     assert "skillA" in out
     assert "Modifications de boucle:" in out
 
@@ -243,6 +247,15 @@ def test_report_export_json_schema(monkeypatch, tmp_path):
     assert payload["timeline"][0]["operator"] == "mutate"
     assert payload["timeline"][0]["verdict"] == "improvement"
     assert payload["verdict"] == "improvement"
+    assert set(payload["life_verdict"]) == {
+        "status",
+        "score",
+        "explanation",
+        "signals",
+        "missing_signals",
+    }
+    assert isinstance(payload["life_verdict"]["signals"], dict)
+    assert isinstance(payload["life_verdict"]["missing_signals"], list)
     assert isinstance(payload["alerts"], list)
     assert payload["policy"]["active"]["version"] == 1
     assert isinstance(payload["policy"]["impact"], list)
@@ -334,6 +347,12 @@ def test_report_export_markdown_stdout(monkeypatch, tmp_path, capsys):
     main(["report", "--id", "run6", "--export", "markdown"])
     out = capsys.readouterr().out
     assert "# Run report `run6`" in out
+    assert "## Verdict de vie" in out
+    assert "- Statut:" in out
+    assert "- Score:" in out
+    assert "- Explication:" in out
+    assert "- Signaux clés:" in out
+    assert "- Signaux manquants:" in out
     assert "## Timeline des mutations" in out
 
 


### PR DESCRIPTION
### Motivation
- Exposer le verdict de vie calculé par `compute_life_status()` dans les exports de rapport afin de distinguer clairement le verdict de mutation/performance existant du verdict philosophico-opérationnel « vie » de Singular.

### Description
- Intègre `compute_life_status()` dans `_build_report_payload()` et ajoute la clé `life_verdict` contenant `status`, `score`, `explanation`, `signals` et `missing_signals` dans le payload de sortie (modifié `src/singular/runs/report.py`).
- Ajoute un rendu markdown dédié `## Verdict de vie` affichant `Statut`, `Score`, `Explication`, `Signaux clés` et `Signaux manquants`, et renomme l’étiquette du verdict de performance en `Verdict mutation/performance` dans le rapport markdown.
- Ajoute des helpers d’affichage (`_format_signal_value`, `_signal_lines`) et `_print_life_verdict()` pour séparer proprement l’affichage plain/table du verdict de mutation et du verdict de vie.
- Met à jour les tests pour vérifier la présence et le schéma de `life_verdict` en JSON, le rendu markdown et l’affichage plain (modifié `tests/test_report.py`).

### Testing
- Executed `pytest -q tests/test_report.py` and all tests passed (`8 passed`).
- Ran lint/format checks with `python -m ruff check src/singular/runs/report.py tests/test_report.py` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d7c1b7714832a979295d0baced129)