### PR TITLE
Add cockpit life-status assertions and essential projection tests

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -633,6 +633,132 @@ def test_dashboard_cockpit_sandbox_governance_empty_state(tmp_path: Path) -> Non
     assert governance["empty_state"] == "aucune violation sandbox récente"
 
 
+def test_dashboard_cockpit_life_status_defaults_without_memory_or_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "orphan.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-05-12T10:00:00+00:00",
+                "life": "orphan",
+                "accepted": True,
+                "health": {"score": 95.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(dashboard_module, "load_registry", lambda: {"active": None, "lives": {}})
+    client = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+
+    payload = client.get("/api/cockpit").json()
+    assert payload["life_status"] == "not_alive_yet"
+    assert payload["life_status_score"] == 0.0
+    assert "active_life" in payload["life_status_missing_signals"]
+    assert "memory" in payload["life_status_missing_signals"]
+
+    essential_payload = client.get("/api/cockpit/essential").json()
+    assert essential_payload["life_status"] == "not_alive_yet"
+    assert essential_payload["life_status_score"] == 0.0
+    assert isinstance(essential_payload["life_status_summary"], str)
+
+
+def test_dashboard_cockpit_life_status_defaults_when_active_life_has_no_memory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    life_dir = tmp_path / "life-no-memory"
+    life_dir.mkdir()
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "no-memory.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-05-12T10:00:00+00:00",
+                "life": "life-no-memory",
+                "accepted": True,
+                "health": {"score": 95.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        dashboard_module,
+        "load_registry",
+        lambda: {
+            "active": "life-no-memory",
+            "lives": {
+                "life-no-memory": LifeMetadata(
+                    name="Life No Memory",
+                    slug="life-no-memory",
+                    path=life_dir,
+                    created_at="2026-05-12T08:00:00+00:00",
+                    status="active",
+                )
+            },
+        },
+    )
+    client = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+
+    payload = client.get("/api/cockpit").json()
+    assert payload["life_status"] == "not_alive_yet"
+    assert payload["life_status_score"] == 0.0
+    assert "n'a pas encore de mémoire" in payload["life_status_explanation"]
+
+
+def test_dashboard_cockpit_life_status_uses_extinct_registry_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    life_dir = tmp_path / "extinct-life"
+    (life_dir / "mem").mkdir(parents=True)
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "extinct.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-05-12T10:00:00+00:00",
+                "life": "extinct-life",
+                "event": "mutation",
+                "accepted": False,
+                "health": {"score": 0.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        dashboard_module,
+        "load_registry",
+        lambda: {
+            "active": "extinct-life",
+            "lives": {
+                "extinct-life": LifeMetadata(
+                    name="Extinct Life",
+                    slug="extinct-life",
+                    path=life_dir,
+                    created_at="2026-05-12T08:00:00+00:00",
+                    status="extinct",
+                )
+            },
+        },
+    )
+    client = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+
+    payload = client.get("/api/cockpit").json()
+    assert payload["life_status"] == "extinct"
+    assert isinstance(payload["life_status_score"], float)
+    assert payload["life_status_signals"].get("extinction") is True
+
+    essential_payload = client.get("/api/cockpit/essential").json()
+    assert essential_payload["life_status"] == "extinct"
+    assert essential_payload["life_status_score"] == payload["life_status_score"]
+
+
 def test_dashboard_cockpit_essential_projection_schema(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()

--- a/tests/test_dashboard_smoke_e2e.py
+++ b/tests/test_dashboard_smoke_e2e.py
@@ -158,6 +158,15 @@ def test_smoke_dashboard_e2e_capacites_critiques(
     cockpit_payload = cockpit.json()
     assert str(cockpit_payload["run"]).startswith(run_id)
     assert "accepted_mutation_rate" in cockpit_payload
+    assert cockpit_payload["life_status"] in {
+        "not_alive_yet",
+        "fragile",
+        "alive",
+        "dying",
+        "extinct",
+    }
+    assert isinstance(cockpit_payload["life_status_score"], float)
+    assert isinstance(cockpit_payload["life_status_explanation"], str)
 
     genealogy = client.get("/lives/genealogy")
     assert genealogy.status_code == 200
@@ -185,6 +194,9 @@ def test_smoke_dashboard_e2e_capacites_critiques(
     essential_payload = essential.json()
     assert essential_payload["schema_version"] == "2026-04-15"
     assert "global_status" in essential_payload
+    assert essential_payload["life_status"] == cockpit_payload["life_status"]
+    assert essential_payload["life_status_score"] == cockpit_payload["life_status_score"]
+    assert "life_status_summary" in essential_payload
 
 
 @pytest.fixture
@@ -387,6 +399,15 @@ def test_active_tmp_run_feeds_dashboard_endpoints(
     )
     assert cockpit["vital_metrics"]["energy_resources"]["total_energy"] > 0
     assert cockpit["life_metrics_contract"]["counts"]["total_lives"] >= 2
+    assert cockpit["life_status"] in {
+        "not_alive_yet",
+        "fragile",
+        "alive",
+        "dying",
+        "extinct",
+    }
+    assert isinstance(cockpit["life_status_score"], float)
+    assert isinstance(cockpit["life_status_explanation"], str)
 
     context_response = client.get("/dashboard/context")
     assert context_response.status_code == 200


### PR DESCRIPTION
### Motivation
- Ensure the dashboard cockpit APIs surface life verdict information consistently so monitoring and UIs can rely on `life_status` signals.
- Verify the compact essential projection (`/api/cockpit/essential`) mirrors the full cockpit for life verdict data.
- Validate edge cases where registry or memory is missing return `not_alive_yet` and a registry-marked extinct life reports `extinct`.

### Description
- Added new tests in `tests/test_dashboard.py` to assert `life_status`, `life_status_score`, `life_status_explanation`, `life_status_signals`, and `life_status_missing_signals` are present and have expected fallback behaviors.
- Added tests that simulate an empty registry or an active life directory without `mem` to assert the cockpit returns `not_alive_yet` with explanatory messages.
- Added a test that an active registry entry with status `extinct` yields an `extinct` life verdict exposed by both `/api/cockpit` and `/api/cockpit/essential`.
- Extended the smoke E2E tests (`tests/test_dashboard_smoke_e2e.py`) to treat life verdict fields as critical capabilities and assert the essential projection matches the full cockpit values.

### Testing
- Ran `pytest -q tests/test_dashboard.py tests/test_dashboard_smoke_e2e.py` and all tests passed: `49 passed, 2 warnings`.
- Also exercised focused test runs during development for the new cases with `pytest -q tests/test_dashboard.py::test_dashboard_cockpit_life_status_uses_extinct_registry_status` and related tests which passed after fixes.
- No changes to production code logic were made; this PR only adds test coverage for existing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d809e0938832ab9b59f95335cc0d5)