### PR TITLE
Distinguish self-generated intrinsic goals

### DIFF
--- a/mem/goals.json
+++ b/mem/goals.json
@@ -1,0 +1,1 @@
+{"tick":0,"catalogue":["coherence","robustesse","efficacite","exploration"],"source":"intrinsic","origin":"self_generated","kind":"intrinsic_goal","status":"active","weights":{"coherence":0.25,"robustesse":0.25,"efficacite":0.25,"exploration":0.25},"history":[]}

--- a/mem/quests_state.json
+++ b/mem/quests_state.json
@@ -1,0 +1,1 @@
+{"active":[],"paused":[],"completed":[],"cooldowns":{}}

--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -12,6 +12,10 @@ from singular.goals.perception_rules import apply_perception_rules
 
 OBJECTIVE_CATALOGUE = ("coherence", "robustesse", "efficacite", "exploration")
 INTRINSIC_MODULATION_VERSION = "intrinsic-mod-v2"
+INTRINSIC_GOAL_SOURCE = "intrinsic"
+INTRINSIC_GOAL_ORIGIN = "self_generated"
+INTRINSIC_GOAL_KIND = "intrinsic_goal"
+ACTIVE_INTRINSIC_GOAL_STATUS = "active"
 
 
 def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
@@ -82,6 +86,10 @@ class GoalState:
         return {
             "tick": self.tick,
             "catalogue": list(OBJECTIVE_CATALOGUE),
+            "source": INTRINSIC_GOAL_SOURCE,
+            "origin": INTRINSIC_GOAL_ORIGIN,
+            "kind": INTRINSIC_GOAL_KIND,
+            "status": ACTIVE_INTRINSIC_GOAL_STATUS,
             "weights": asdict(self.weights),
             "history": self.history,
         }
@@ -315,6 +323,10 @@ class IntrinsicGoals:
             {
                 "tick": int(tick),
                 "weights": asdict(weights),
+                "source": INTRINSIC_GOAL_SOURCE,
+                "origin": INTRINSIC_GOAL_ORIGIN,
+                "kind": INTRINSIC_GOAL_KIND,
+                "status": "renewed",
                 "signals": {
                     "health": health_norm,
                     "resource_stability": resource_stability,

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -327,12 +327,34 @@ def _extract_narrative_continuity_signal(
     )
 
 
+def _is_self_generated_intrinsic_goal(item: Mapping[str, object]) -> bool:
+    return (
+        item.get("source") == "intrinsic"
+        or item.get("origin") in {"intrinsic", "self_generated"}
+        or item.get("kind") == "intrinsic_goal"
+    )
+
+
+def _is_active_intrinsic_goal(item: Mapping[str, object]) -> bool:
+    if not _is_self_generated_intrinsic_goal(item):
+        return False
+    status = str(item.get("status") or item.get("state") or "active").lower()
+    return status in {"active", "maintained", "renewed", "resumed"}
+
+
 def _extract_goal_signal(goals: dict, quests: dict, runs: list[dict]) -> dict:
     weights = goals.get("weights") if isinstance(goals.get("weights"), Mapping) else {}
     active_goal_count = sum(
         1
         for value in weights.values()
         if isinstance(value, (int, float)) and float(value) > 0
+    )
+    intrinsic_goal_weight_count = active_goal_count if _is_active_intrinsic_goal(goals) else 0
+    history = goals.get("history") if isinstance(goals.get("history"), list) else []
+    renewed_intrinsic_goal_count = sum(
+        1
+        for item in history
+        if isinstance(item, Mapping) and _is_active_intrinsic_goal(item)
     )
     active_quests = (
         quests.get("active") if isinstance(quests.get("active"), list) else []
@@ -343,23 +365,25 @@ def _extract_goal_signal(goals: dict, quests: dict, runs: list[dict]) -> dict:
     intrinsic_quest_count = sum(
         1
         for item in active_quests + paused_quests
-        if isinstance(item, Mapping) and item.get("origin") == "intrinsic"
+        if isinstance(item, Mapping) and _is_active_intrinsic_goal(item)
     )
     run_goal_events = [
         row
         for row in runs
         if any(token in _event_text(row) for token in ("goal", "quest", "objective"))
     ]
-    ok = (
-        active_goal_count > 0 or intrinsic_quest_count > 0 or bool(goals.get("history"))
-    )
+    ok = intrinsic_goal_weight_count > 0 or intrinsic_quest_count > 0 or renewed_intrinsic_goal_count > 0
     return _signal(
         ok,
         1.0 if ok else 0.0,
-        "intrinsic goals are present" if ok else "no intrinsic goal evidence found",
+        "active self-generated intrinsic goals are present"
+        if ok
+        else "no active self-generated intrinsic goal evidence found",
         {
             "active_goal_count": active_goal_count,
+            "intrinsic_goal_weight_count": intrinsic_goal_weight_count,
             "intrinsic_quest_count": intrinsic_quest_count,
+            "renewed_intrinsic_goal_count": renewed_intrinsic_goal_count,
             "history_count": _list_count(goals.get("history")),
             "run_goal_events_count": len(run_goal_events),
         },

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -60,7 +60,7 @@ def test_compute_life_status_aggregates_configured_signals(tmp_path) -> None:
         encoding="utf-8",
     )
     (mem / "goals.json").write_text(
-        '{"weights":{"coherence":0.5},"history":[]}', encoding="utf-8"
+        '{"source":"intrinsic","origin":"self_generated","kind":"intrinsic_goal","status":"active","weights":{"coherence":0.5},"history":[]}', encoding="utf-8"
     )
     (mem / "quests_state.json").write_text(
         '{"active":[{"origin":"intrinsic"}],"paused":[]}', encoding="utf-8"
@@ -91,6 +91,45 @@ def test_compute_life_status_aggregates_configured_signals(tmp_path) -> None:
     assert result.signals["stable_cycle"] is True
     assert result.signals["intrinsic_goals"] is True
     assert result.signals["narrative_continuity"] is True
+
+
+def test_compute_life_status_rejects_human_quest_as_intrinsic_goal(tmp_path) -> None:
+    from singular.life.life_status import compute_life_status
+
+    life_home = tmp_path
+    mem = life_home / "mem"
+    mem.mkdir()
+    (life_home / "runs").mkdir()
+    (mem / "world_state.json").write_text(
+        '{"global_health":{"score":90}}', encoding="utf-8"
+    )
+    (mem / "autopsy.json").write_text("{}", encoding="utf-8")
+    (mem / "self_narrative.json").write_text(
+        '{"identity":{"name":"Alpha","born_at":"2026-06-01T00:00:00+00:00"},"current_heading":"continuer","life_periods":[]}',
+        encoding="utf-8",
+    )
+    (mem / "goals.json").write_text(
+        '{"weights":{"coherence":0.5},"history":[{"origin":"external","status":"active"}]}',
+        encoding="utf-8",
+    )
+    (mem / "quests_state.json").write_text(
+        '{"active":[{"origin":"external","status":"active"}],"paused":[]}',
+        encoding="utf-8",
+    )
+
+    result = compute_life_status(
+        life_home,
+        registry_entry={
+            "name": "Alpha",
+            "slug": "alpha",
+            "created_at": "2026-06-01T00:00:00+00:00",
+            "status": "active",
+        },
+        runs=[],
+    )
+
+    assert result.signals["intrinsic_goals"] is False
+    assert result.signals["structured"]["goals"]["evidence"]["intrinsic_goal_weight_count"] == 0
 
 
 def test_compute_life_status_terminal_signal_dominates(tmp_path) -> None:
@@ -311,7 +350,17 @@ def test_compute_life_status_full_durable_signals_are_alive(life_home_factory) -
             "life_periods": [{"start_at": "2026-06-01T00:00:00+00:00"}],
         },
     )
-    _write_json(mem / "goals.json", {"weights": {"coherence": 0.7}, "history": []})
+    _write_json(
+        mem / "goals.json",
+        {
+            "source": "intrinsic",
+            "origin": "self_generated",
+            "kind": "intrinsic_goal",
+            "status": "active",
+            "weights": {"coherence": 0.7},
+            "history": [],
+        },
+    )
     _write_json(mem / "quests_state.json", {"active": [{"origin": "intrinsic"}]})
     (mem / "generations.jsonl").write_text(
         '{"event":"generation.accepted"}\n', encoding="utf-8"
@@ -419,7 +468,7 @@ def test_compute_life_status_corrupt_json_and_missing_files_are_explanatory(
     assert result.status == LifeStatus.NOT_ALIVE_YET
     assert (
         result.signals["structured"]["goals"]["reason"]
-        == "no intrinsic goal evidence found"
+        == "no active self-generated intrinsic goal evidence found"
     )
     assert "world_state" in result.missing_signals
     assert "autopsy" in result.missing_signals


### PR DESCRIPTION
### Motivation
- Ensure intrinsic goals persisted in `mem/goals.json` and history can be reliably distinguished from human/external quests using a stable marker field (e.g. `source`, `origin`, `kind`).
- Make `compute_life_status()` only signal `intrinsic_goals` positive when there is at least one self-generated intrinsic goal that is active, maintained, renewed or resumed.

### Description
- Add constants `INTRINSIC_GOAL_SOURCE`, `INTRINSIC_GOAL_ORIGIN`, `INTRINSIC_GOAL_KIND`, and `ACTIVE_INTRINSIC_GOAL_STATUS` and persist `source`, `origin`, `kind`, and `status` in `GoalState.to_dict()` and renewal history entries in `src/singular/goals/intrinsic.py`.
- Update life-status goal extraction by adding helpers `_is_self_generated_intrinsic_goal()` and `_is_active_intrinsic_goal()` and modify `_extract_goal_signal()` so that `intrinsic_goals` is true only when there is active self-generated evidence in weights, quests, or renewed history in `src/singular/life/life_status.py`.
- Treat quest items as intrinsic only when they contain the self-generated markers and an active-like `status` (accepting `active`, `maintained`, `renewed`, `resumed`).
- Add/adjust test coverage and example artifacts: update `tests/test_life_status.py` (add `test_compute_life_status_rejects_human_quest_as_intrinsic_goal`) and include baseline `mem/goals.json` and `mem/quests_state.json` fixtures used during development.

### Testing
- Ran `python -m pytest tests/test_life_status.py tests/test_objectives.py` and all tests passed (`30 passed`).
- Verified goal-detection regression by asserting that external/human-origin quests no longer count as intrinsic evidence in the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d8429d340832aa56dd8887476aa75)