### PR TITLE
Enhance life stable cycle detection

### DIFF
--- a/configs/life_definition.yaml
+++ b/configs/life_definition.yaml
@@ -49,6 +49,7 @@ weighted_score:
 thresholds:
   minimum_narrative_trajectory_days: 7
   minimum_observed_cycles: 3
+  maximum_cycle_anomalies: 1
   alive_minimum_score: 80
   fragile_minimum_score: 50
   dying_degradation_minimum_score: 40

--- a/docs/technical_life_status.md
+++ b/docs/technical_life_status.md
@@ -131,7 +131,7 @@ Le dashboard n'infère plus un statut de vie uniquement à partir des runs:
 
 ## Horloge vitale (cycles, transitions, priorités)
 
-L'orchestrateur suit les transitions cycliques `veille → action → introspection → sommeil`.
+L'orchestrateur suit les transitions cycliques `veille → action → introspection → sommeil`. `compute_life_status()` analyse les runs et événements orchestrateur pour reconstruire ces phases, compter les cycles complets et exposer dans `evidence.stable_cycle.last_cycles` les derniers cycles observés.
 
 ### Paramètres de cycle
 
@@ -141,6 +141,8 @@ Le fichier versionné `configs/lifecycle.yaml` définit:
 - `cycle.sommeil_seconds`
 - `cycle.introspection_frequency_ticks`
 - `cycle.mutation_window_seconds`
+- `life_definition.thresholds.minimum_observed_cycles`: nombre minimal de cycles complets requis pour `stable_cycle`.
+- `life_definition.thresholds.maximum_cycle_anomalies`: nombre maximal de phases manquantes ou écarts d'ordre tolérés avant de rendre `stable_cycle` négatif.
 
 Les valeurs peuvent être surchargées via `singular orchestrate run --lifecycle-config`.
 

--- a/src/singular/life/life_definition.py
+++ b/src/singular/life/life_definition.py
@@ -35,6 +35,7 @@ class LifeThresholds:
 
     minimum_narrative_trajectory_days: int = 7
     minimum_observed_cycles: int = 3
+    maximum_cycle_anomalies: int = 1
     alive_minimum_score: float = 0.8
     fragile_minimum_score: float = 0.5
     dying_degradation_minimum_score: float = 0.4
@@ -154,6 +155,11 @@ def load_life_definition_config(path: Path | None = None) -> LifeDefinitionConfi
                 "minimum_observed_cycles", cfg.thresholds.minimum_observed_cycles
             )
         ),
+        maximum_cycle_anomalies=int(
+            thresholds_raw.get(
+                "maximum_cycle_anomalies", cfg.thresholds.maximum_cycle_anomalies
+            )
+        ),
         alive_minimum_score=float(
             thresholds_raw.get(
                 "alive_minimum_score", cfg.thresholds.alive_minimum_score
@@ -221,6 +227,8 @@ def load_life_definition_config(path: Path | None = None) -> LifeDefinitionConfi
         raise ValueError("minimum_narrative_trajectory_days must be >= 0")
     if thresholds.minimum_observed_cycles < 0:
         raise ValueError("minimum_observed_cycles must be >= 0")
+    if thresholds.maximum_cycle_anomalies < 0:
+        raise ValueError("maximum_cycle_anomalies must be >= 0")
     if thresholds.alive_minimum_score < thresholds.fragile_minimum_score:
         raise ValueError("alive_minimum_score must be >= fragile_minimum_score")
     if weighted_score.total_points <= 0:

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -192,21 +192,127 @@ def _event_text(row: Mapping[str, Any]) -> str:
     ).lower()
 
 
-def _cycle_count(rows: Sequence[Mapping[str, Any]]) -> int:
-    phases = ("veille", "action", "introspection", "sommeil")
-    expected = 0
-    count = 0
-    for row in rows:
-        text = _event_text(row)
-        phase = phases[expected]
+REQUIRED_CYCLE_PHASES = ("veille", "action", "introspection", "sommeil")
+TERMINAL_PHASE_TOKENS = ("extinct", "extinction", "death", "terminal", "dying", "stop")
+
+
+def _row_phase(row: Mapping[str, Any]) -> str | None:
+    text = _event_text(row)
+    for phase in REQUIRED_CYCLE_PHASES:
         if phase in text:
+            return phase
+    return None
+
+
+def _row_timestamp(row: Mapping[str, Any]) -> str | None:
+    for key in ("ts", "time", "timestamp", "created_at"):
+        value = row.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _cycle_analysis(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    required_cycles: int,
+    tolerated_anomalies: int,
+) -> dict[str, Any]:
+    expected = 0
+    observed_cycles = 0
+    anomalies = 0
+    current_cycle: list[dict[str, Any]] = []
+    completed_cycles: list[list[dict[str, Any]]] = []
+    phase_events = 0
+    terminal_events: list[dict[str, Any]] = []
+
+    for index, row in enumerate(rows):
+        text = _event_text(row)
+        terminal = any(token in text for token in TERMINAL_PHASE_TOKENS)
+        if terminal:
+            terminal_events.append(
+                {
+                    "index": index,
+                    "event": row.get("event"),
+                    "phase": row.get("phase"),
+                    "ts": _row_timestamp(row),
+                }
+            )
+        phase = _row_phase(row)
+        if phase is None:
+            continue
+        phase_events += 1
+        expected_phase = REQUIRED_CYCLE_PHASES[expected]
+        event_evidence = {
+            "phase": phase,
+            "index": index,
+            "event": row.get("event"),
+            "ts": _row_timestamp(row),
+        }
+        if phase == expected_phase:
+            current_cycle.append(event_evidence)
             expected += 1
-            if expected == len(phases):
-                count += 1
+            if expected == len(REQUIRED_CYCLE_PHASES):
+                observed_cycles += 1
+                completed_cycles.append(current_cycle)
+                current_cycle = []
                 expected = 0
-        elif phases[0] in text:
+        elif phase == REQUIRED_CYCLE_PHASES[0]:
+            if current_cycle:
+                anomalies += 1
+            current_cycle = [event_evidence]
             expected = 1
-    return count
+        else:
+            anomalies += 1
+
+    missing_phases = list(REQUIRED_CYCLE_PHASES[expected:]) if expected else []
+    if missing_phases:
+        anomalies += len(missing_phases)
+
+    recent_window = max(
+        len(REQUIRED_CYCLE_PHASES), required_cycles * len(REQUIRED_CYCLE_PHASES)
+    )
+    recent_rows = list(rows)[-recent_window:] if recent_window > 0 else list(rows)
+    recent_phase_count = sum(1 for row in recent_rows if _row_phase(row) is not None)
+    recent_terminal_count = sum(
+        1
+        for row in recent_rows
+        if any(token in _event_text(row) for token in TERMINAL_PHASE_TOKENS)
+    )
+    terminal_dominates = bool(
+        recent_terminal_count and recent_terminal_count >= max(1, recent_phase_count)
+    )
+    ok = (
+        observed_cycles >= required_cycles
+        and anomalies <= tolerated_anomalies
+        and not terminal_dominates
+    )
+    return {
+        "ok": ok,
+        "observed_cycles": observed_cycles,
+        "required_cycles": required_cycles,
+        "tolerated_anomalies": tolerated_anomalies,
+        "anomalies": anomalies,
+        "missing_phases": missing_phases,
+        "terminal_dominates": terminal_dominates,
+        "recent_terminal_events_count": recent_terminal_count,
+        "recent_phase_events_count": recent_phase_count,
+        "terminal_events_count": len(terminal_events),
+        "last_cycles": (
+            completed_cycles[-required_cycles:]
+            if required_cycles > 0
+            else completed_cycles[-3:]
+        ),
+        "current_incomplete_cycle": current_cycle,
+    }
+
+
+def _cycle_count(rows: Sequence[Mapping[str, Any]]) -> int:
+    return int(
+        _cycle_analysis(rows, required_cycles=0, tolerated_anomalies=10**9)[
+            "observed_cycles"
+        ]
+    )
 
 
 def _health_score_from_payload(payload: Mapping[str, Any]) -> float | None:
@@ -279,9 +385,11 @@ def _extract_identity_signal(self_narrative: dict) -> dict:
     return _signal(
         ok,
         1.0 if ok else 0.0,
-        "persistent identity found"
-        if ok
-        else "identity is incomplete: " + ", ".join(missing),
+        (
+            "persistent identity found"
+            if ok
+            else "identity is incomplete: " + ", ".join(missing)
+        ),
         {"name": name, "born_at": born_at, "slug": slug, "missing": missing},
     )
 
@@ -315,9 +423,11 @@ def _extract_narrative_continuity_signal(
     return _signal(
         ok,
         1.0 if ok else 0.0,
-        "narrative continuity threshold reached"
-        if ok
-        else "narrative content or age is insufficient",
+        (
+            "narrative continuity threshold reached"
+            if ok
+            else "narrative content or age is insufficient"
+        ),
         {
             "age_days": age_days,
             "threshold_days": threshold_days,
@@ -349,7 +459,9 @@ def _extract_goal_signal(goals: dict, quests: dict, runs: list[dict]) -> dict:
         for value in weights.values()
         if isinstance(value, (int, float)) and float(value) > 0
     )
-    intrinsic_goal_weight_count = active_goal_count if _is_active_intrinsic_goal(goals) else 0
+    intrinsic_goal_weight_count = (
+        active_goal_count if _is_active_intrinsic_goal(goals) else 0
+    )
     history = goals.get("history") if isinstance(goals.get("history"), list) else []
     renewed_intrinsic_goal_count = sum(
         1
@@ -372,13 +484,19 @@ def _extract_goal_signal(goals: dict, quests: dict, runs: list[dict]) -> dict:
         for row in runs
         if any(token in _event_text(row) for token in ("goal", "quest", "objective"))
     ]
-    ok = intrinsic_goal_weight_count > 0 or intrinsic_quest_count > 0 or renewed_intrinsic_goal_count > 0
+    ok = (
+        intrinsic_goal_weight_count > 0
+        or intrinsic_quest_count > 0
+        or renewed_intrinsic_goal_count > 0
+    )
     return _signal(
         ok,
         1.0 if ok else 0.0,
-        "active self-generated intrinsic goals are present"
-        if ok
-        else "no active self-generated intrinsic goal evidence found",
+        (
+            "active self-generated intrinsic goals are present"
+            if ok
+            else "no active self-generated intrinsic goal evidence found"
+        ),
         {
             "active_goal_count": active_goal_count,
             "intrinsic_goal_weight_count": intrinsic_goal_weight_count,
@@ -401,9 +519,11 @@ def _extract_generation_signal(life_home: Path, runs: list[dict]) -> dict:
     return _signal(
         ok,
         1.0 if ok else 0.0,
-        "generation registry evidence found"
-        if ok
-        else "no generation registry evidence found",
+        (
+            "generation registry evidence found"
+            if ok
+            else "no generation registry evidence found"
+        ),
         {
             "generations_count": len(generation_rows),
             "run_generation_events_count": len(run_generation_events),
@@ -509,8 +629,13 @@ def compute_life_status(
     generation_signal = _extract_generation_signal(life_home, run_rows)
     generation_registry = bool(generation_signal["ok"])
 
-    observed_cycles = _cycle_count(run_rows)
-    stable_cycle = observed_cycles >= cfg.thresholds.minimum_observed_cycles
+    cycle_evidence = _cycle_analysis(
+        run_rows,
+        required_cycles=cfg.thresholds.minimum_observed_cycles,
+        tolerated_anomalies=cfg.thresholds.maximum_cycle_anomalies,
+    )
+    observed_cycles = int(cycle_evidence["observed_cycles"])
+    stable_cycle = bool(cycle_evidence["ok"])
 
     goal_signal = _extract_goal_signal(goals, quests, run_rows)
     goal_evidence = goal_signal.get("evidence", {})
@@ -709,6 +834,16 @@ def compute_life_status(
             "goals": goal_signal,
             "generation": generation_signal,
             "extinction": extinction_signal,
+            "stable_cycle": _signal(
+                stable_cycle,
+                1.0 if stable_cycle else 0.0,
+                (
+                    "required orchestrator cycles observed in order"
+                    if stable_cycle
+                    else "required orchestrator cycles are incomplete, anomalous or dominated by terminal events"
+                ),
+                cycle_evidence,
+            ),
         },
     }
     evidence = {
@@ -730,10 +865,12 @@ def compute_life_status(
         "extinction_events_count": extinction_events_count,
         "confirmed_extinction_events_count": confirmed_extinction_events_count,
         "reproduction_events_count": len(reproduction_events),
+        "stable_cycle": cycle_evidence,
         "vital_timeline": vital_timeline,
         "thresholds": {
             "minimum_narrative_trajectory_days": cfg.thresholds.minimum_narrative_trajectory_days,
             "minimum_observed_cycles": cfg.thresholds.minimum_observed_cycles,
+            "maximum_cycle_anomalies": cfg.thresholds.maximum_cycle_anomalies,
             "alive_minimum_score": cfg.thresholds.alive_minimum_score,
             "fragile_minimum_score": cfg.thresholds.fragile_minimum_score,
             "dying_degradation_minimum_score": cfg.thresholds.dying_degradation_minimum_score,

--- a/tests/test_life_definition_config.py
+++ b/tests/test_life_definition_config.py
@@ -19,7 +19,13 @@ def test_load_life_definition_defaults_when_file_missing(tmp_path: Path) -> None
     assert cfg.thresholds.minimum_observed_cycles == 3
     assert cfg.thresholds.alive_minimum_score == 0.8
     assert cfg.thresholds.fragile_minimum_score == 0.5
-    assert set(cfg.statuses) == {"not_alive_yet", "fragile", "alive", "dying", "extinct"}
+    assert set(cfg.statuses) == {
+        "not_alive_yet",
+        "fragile",
+        "alive",
+        "dying",
+        "extinct",
+    }
 
 
 def test_load_life_definition_from_dedicated_file(tmp_path: Path) -> None:
@@ -33,6 +39,7 @@ criteria:
 thresholds:
   minimum_narrative_trajectory_days: 14
   minimum_observed_cycles: 9
+  maximum_cycle_anomalies: 2
   alive_minimum_score: 0.9
   fragile_minimum_score: 0.4
 statuses:
@@ -52,6 +59,7 @@ statuses:
     assert cfg.criteria.stable_cycle is True
     assert cfg.thresholds.minimum_narrative_trajectory_days == 14
     assert cfg.thresholds.minimum_observed_cycles == 9
+    assert cfg.thresholds.maximum_cycle_anomalies == 2
     assert cfg.thresholds.alive_minimum_score == 0.9
     assert cfg.thresholds.fragile_minimum_score == 0.4
 

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -60,7 +60,8 @@ def test_compute_life_status_aggregates_configured_signals(tmp_path) -> None:
         encoding="utf-8",
     )
     (mem / "goals.json").write_text(
-        '{"source":"intrinsic","origin":"self_generated","kind":"intrinsic_goal","status":"active","weights":{"coherence":0.5},"history":[]}', encoding="utf-8"
+        '{"source":"intrinsic","origin":"self_generated","kind":"intrinsic_goal","status":"active","weights":{"coherence":0.5},"history":[]}',
+        encoding="utf-8",
     )
     (mem / "quests_state.json").write_text(
         '{"active":[{"origin":"intrinsic"}],"paused":[]}', encoding="utf-8"
@@ -129,7 +130,10 @@ def test_compute_life_status_rejects_human_quest_as_intrinsic_goal(tmp_path) -> 
     )
 
     assert result.signals["intrinsic_goals"] is False
-    assert result.signals["structured"]["goals"]["evidence"]["intrinsic_goal_weight_count"] == 0
+    assert (
+        result.signals["structured"]["goals"]["evidence"]["intrinsic_goal_weight_count"]
+        == 0
+    )
 
 
 def test_compute_life_status_terminal_signal_dominates(tmp_path) -> None:
@@ -474,3 +478,102 @@ def test_compute_life_status_corrupt_json_and_missing_files_are_explanatory(
     assert "autopsy" in result.missing_signals
     assert "Manquants ou insuffisants" in result.explanation
     _assert_status_contract(result)
+
+
+def test_compute_life_status_stable_cycle_records_last_cycles_and_tolerates_small_gap(
+    life_home_factory,
+) -> None:
+    from singular.life.life_status import compute_life_status
+
+    life_home, _mem = life_home_factory()
+    runs = [
+        {
+            "event": "orchestrator.phase",
+            "phase": "veille",
+            "ts": "2026-06-02T00:00:00+00:00",
+        },
+        {
+            "event": "orchestrator.phase",
+            "phase": "action",
+            "ts": "2026-06-02T00:01:00+00:00",
+        },
+        {
+            "event": "orchestrator.phase",
+            "phase": "introspection",
+            "ts": "2026-06-02T00:02:00+00:00",
+        },
+        {
+            "event": "orchestrator.phase",
+            "phase": "sommeil",
+            "ts": "2026-06-02T00:03:00+00:00",
+        },
+        {
+            "event": "orchestrator.phase",
+            "phase": "action",
+            "ts": "2026-06-02T00:04:00+00:00",
+        },
+        {
+            "event": "orchestrator.phase",
+            "phase": "veille",
+            "ts": "2026-06-02T00:05:00+00:00",
+        },
+        {
+            "event": "orchestrator.phase",
+            "phase": "action",
+            "ts": "2026-06-02T00:06:00+00:00",
+        },
+        {
+            "event": "orchestrator.phase",
+            "phase": "introspection",
+            "ts": "2026-06-02T00:07:00+00:00",
+        },
+        {
+            "event": "orchestrator.phase",
+            "phase": "sommeil",
+            "ts": "2026-06-02T00:08:00+00:00",
+        },
+    ]
+    config = LifeDefinitionConfig(
+        thresholds=LifeThresholds(minimum_observed_cycles=2, maximum_cycle_anomalies=1)
+    )
+
+    result = compute_life_status(
+        life_home, registry_entry={"status": "active"}, runs=runs, config=config
+    )
+
+    cycle = result.evidence["stable_cycle"]
+    assert result.signals["stable_cycle"] is True
+    assert result.signals["observed_cycles"] == 2
+    assert cycle["anomalies"] == 1
+    assert len(cycle["last_cycles"]) == 2
+    assert [event["phase"] for event in cycle["last_cycles"][-1]] == [
+        "veille",
+        "action",
+        "introspection",
+        "sommeil",
+    ]
+
+
+def test_compute_life_status_stable_cycle_rejects_terminal_dominance(
+    life_home_factory,
+) -> None:
+    from singular.life.life_status import compute_life_status
+
+    life_home, _mem = life_home_factory()
+    runs = _cycle_runs(3) + [
+        {
+            "event": "death.confirmed",
+            "status": "terminal",
+            "ts": "2026-06-03T00:00:00+00:00",
+        }
+        for _ in range(12)
+    ]
+
+    result = compute_life_status(
+        life_home, registry_entry={"status": "active"}, runs=runs
+    )
+
+    cycle = result.evidence["stable_cycle"]
+    assert result.signals["observed_cycles"] == 3
+    assert result.signals["stable_cycle"] is False
+    assert cycle["terminal_dominates"] is True


### PR DESCRIPTION
### Motivation
- Improve `compute_life_status()` to robustly detect orchestrator phase cycles `veille → action → introspection → sommeil` and make `stable_cycle` a provable signal. 
- Allow a configurable tolerance for small phase ordering gaps while rejecting cases dominated by recent terminal/extinction events. 
- Surface concrete evidence about the last observed cycles so dashboards and reports can explain the `stable_cycle` decision. 

### Description
- Added a new threshold `maximum_cycle_anomalies` to `LifeThresholds` and the life definition loader, and updated `configs/life_definition.yaml` to include the default value. 
- Replaced the simple `_cycle_count` with a full `_cycle_analysis(rows, required_cycles, tolerated_anomalies)` implementation and helpers `_row_phase`/`_row_timestamp` in `src/singular/life/life_status.py`, identifying terminal tokens and reconstructing completed cycles in order. 
- `compute_life_status()` now uses `cycle_evidence = _cycle_analysis(...)` to compute `observed_cycles` and boolean `stable_cycle`, and exposes the analysis under `evidence['stable_cycle']` as well as a structured `signals.structured['stable_cycle']` signal containing `last_cycles`, `anomalies`, `terminal_dominates`, and related diagnostics. 
- Updated documentation in `docs/technical_life_status.md` to describe the thresholds and evidence, and added/updated regression tests in `tests/test_life_status.py` and `tests/test_life_definition_config.py` to cover tolerated gaps and terminal-dominance behavior. 

### Testing
- Ran `pytest -q tests/test_life_status.py tests/test_life_definition_config.py` and the modified tests passed (`23 passed`). 
- Running the full test run (`pytest -q -x`) surfaced an unrelated, platform-specific existing failure in `tests/test_cli_config.py::test_config_openai_windows_writes_hkcu_environment` (`NotImplementedError: cannot instantiate 'WindowsPath' on your system`), which is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eb8128008832a83526b172c5e926d)