### PR TITLE
Refine sandbox scoring failure contract and avoid treating -inf as comparable

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -618,6 +618,28 @@ def _map_elites_accept(
         return map_elites.add(mutated, mutated_score)
 
 
+def _sandbox_scores_are_comparable(
+    base_result: SandboxScore, mutated_result: SandboxScore
+) -> bool:
+    """Return True only when both sandbox outcomes have finite business scores."""
+
+    return (
+        base_result.comparable_score is not None
+        and mutated_result.comparable_score is not None
+    )
+
+
+def _should_retry_sandbox_scoring(
+    base_result: SandboxScore, mutated_result: SandboxScore
+) -> bool:
+    """Infrastructure failures should be retried instead of penalized."""
+
+    return (
+        base_result.is_infrastructure_failure
+        or mutated_result.is_infrastructure_failure
+    )
+
+
 def _first_sandbox_error_type(
     base_result: SandboxScore, mutated_result: SandboxScore
 ) -> str | None:
@@ -848,7 +870,8 @@ def run(
         else:
             with current_tick_profiler.phase("sandbox_scoring"):
                 result = score_code_with_error(code)
-        score_cache[code_hash] = result
+        if result.ok:
+            score_cache[code_hash] = result
         return result
 
     def _profiled_test_runner() -> int:
@@ -1284,9 +1307,19 @@ def run(
             mutated_score = mutated_score_result.score
             ms_new = (time.perf_counter() - t0) * 1000
 
-            base_failed = (not base_score_result.ok) or base_score == float("-inf")
-            mutation_failed = (
-                (not mutated_score_result.ok) or mutated_score == float("-inf")
+            base_comparable_score = base_score_result.comparable_score
+            mutated_comparable_score = mutated_score_result.comparable_score
+            base_infrastructure_failure = base_score_result.is_infrastructure_failure
+            mutation_infrastructure_failure = (
+                mutated_score_result.is_infrastructure_failure
+            )
+            infrastructure_failure = _should_retry_sandbox_scoring(
+                base_score_result, mutated_score_result
+            )
+            base_failed = base_score_result.is_candidate_failure
+            mutation_failed = mutated_score_result.is_candidate_failure
+            scores_comparable = _sandbox_scores_are_comparable(
+                base_score_result, mutated_score_result
             )
             (
                 sandbox_violation_category,
@@ -1295,10 +1328,39 @@ def run(
             ) = _sandbox_failure_category(base_failed, mutation_failed, mutated)
             critical_sandbox_failure = sandbox_violation_severity == "critical"
 
-            if mutated_score == float("-inf"):
+            if infrastructure_failure:
+                infrastructure_diagnostic = {
+                    "organism": org_name,
+                    "skill_path": str(skill_path),
+                    "operator": op_name,
+                    "base_score": base_score,
+                    "mutated_score": mutated_score,
+                    "base_error_type": base_score_result.error_type,
+                    "base_error_message": base_score_result.error_message,
+                    "mutation_error_type": mutated_score_result.error_type,
+                    "mutation_error_message": mutated_score_result.error_message,
+                    "base_infrastructure_failure": base_infrastructure_failure,
+                    "mutation_infrastructure_failure": mutation_infrastructure_failure,
+                    "action": "retry_scoring_later",
+                }
+                logger.log_interaction(
+                    "sandbox_infrastructure_failure", **infrastructure_diagnostic
+                )
+                event_bus.publish(
+                    "sandbox.infrastructure_failure",
+                    {
+                        "life": org_name,
+                        "iteration": state.iteration,
+                        **infrastructure_diagnostic,
+                    },
+                    payload_version=1,
+                )
+                continue
+
+            if mutation_failed:
                 if hasattr(psyche, "feel"):
                     psyche.feel(Mood.PAIN)
-            elif mutated_score <= base_score:
+            elif scores_comparable and mutated_comparable_score <= base_comparable_score:
                 if hasattr(psyche, "feel"):
                     psyche.feel(Mood.PLEASURE)
 
@@ -1342,11 +1404,13 @@ def run(
 
             accepted = (
                 False
-                if mutation_failed
+                if mutation_failed or not scores_comparable
                 else (
-                    _map_elites_accept(map_elites, mutated, mutated_score, tick_profiler)
+                    _map_elites_accept(
+                        map_elites, mutated, mutated_comparable_score, tick_profiler
+                    )
                     if map_elites
-                    else mutated_score <= base_score
+                    else mutated_comparable_score <= base_comparable_score
                 )
             )
             world_effects: list[dict[str, object]] = []
@@ -1406,8 +1470,9 @@ def run(
                         rejected_tests=list(coevo_decision.rejected_tests),
                         rejected_for_robustness=coevo_decision.rejected_for_robustness,
                     )
-            accepted = accepted and not mutation_failed
-            org.last_score = mutated_score
+            accepted = accepted and not mutation_failed and scores_comparable
+            if mutated_comparable_score is not None:
+                org.last_score = mutated_comparable_score
             if accepted:
                 governance_root = skill_path.parent.parent if skill_path.parent.name == "skills" else skill_path.parent
                 decision = governance_policy.enforce_write(skill_path, mutated, root=governance_root)

--- a/src/singular/life/sandbox_scoring.py
+++ b/src/singular/life/sandbox_scoring.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import math
 from dataclasses import dataclass
+from typing import ClassVar
 
 from . import sandbox
 
@@ -22,6 +23,23 @@ class SandboxScore:
     error_type: str | None
     error_message: str | None
     _legacy_exception_type: str | None
+
+    INFRASTRUCTURE_ERROR_TYPES: ClassVar[frozenset[str]] = frozenset({
+        "sandbox_startup_timeout",
+        "sandbox_worker_no_payload",
+        "multiprocessing_error",
+    })
+    CANDIDATE_ERROR_TYPES: ClassVar[frozenset[str]] = frozenset({
+        "syntax_error",
+        "missing_result",
+        "non_numeric_result",
+        "non_finite_result",
+        "forbidden_syntax",
+        "forbidden_name",
+        "sandbox_error",
+        "runtime_exception",
+        "timeout",
+    })
 
     def __init__(
         self,
@@ -76,6 +94,26 @@ class SandboxScore:
         """Backward-compatible alias for ``error_message``."""
 
         return self.error_message
+
+    @property
+    def is_infrastructure_failure(self) -> bool:
+        """Whether the failure came from sandbox machinery rather than code."""
+
+        return (not self.ok) and self.error_type in self.INFRASTRUCTURE_ERROR_TYPES
+
+    @property
+    def is_candidate_failure(self) -> bool:
+        """Whether the candidate code executed invalidly in a healthy sandbox."""
+
+        return (not self.ok) and not self.is_infrastructure_failure
+
+    @property
+    def comparable_score(self) -> float | None:
+        """Score to use for business comparisons, or ``None`` if unavailable."""
+
+        if not self.ok or not math.isfinite(float(self.score)):
+            return None
+        return float(self.score)
 
 
 DANGEROUS_MUTATION_NAMES = frozenset(
@@ -154,11 +192,20 @@ def _classify_score_exception(exception: BaseException) -> str:
     """Map sandbox exceptions to stable diagnostic categories."""
 
     if isinstance(exception, TimeoutError):
+        message = str(exception).lower()
+        if "startup" in message or "did not start" in message:
+            return "sandbox_startup_timeout"
         return "timeout"
     if isinstance(exception, SyntaxError):
         return "syntax_error"
     if isinstance(exception, sandbox.SandboxError):
         message = str(exception).lower()
+        if "worker" in message and (
+            "without payload" in message or "without returning" in message
+        ):
+            return "sandbox_worker_no_payload"
+        if "multiprocessing method" in message or "multiprocessing" in message:
+            return "multiprocessing_error"
         if "result" in message and ("missing" in message or "did not set" in message):
             return "missing_result"
         return "sandbox_error"

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -13,3 +13,111 @@ def test_complexity_penalty_increases_score():
     simple_score, _ = score(simple, runs=1, alpha=100.0)
     complex_score, _ = score(complex_code, runs=1, alpha=100.0)
     assert complex_score > simple_score
+
+from singular.life import sandbox
+from singular.life.sandbox_scoring import (
+    SandboxScore,
+    _sandbox_failure_category,
+    score_code_with_error,
+)
+
+
+def test_sandbox_score_finite_result_is_comparable():
+    result = score_code_with_error("result = 2.5")
+
+    assert result.ok is True
+    assert result.score == 2.5
+    assert result.comparable_score == 2.5
+    assert result.is_candidate_failure is False
+    assert result.is_infrastructure_failure is False
+
+
+def test_sandbox_score_non_finite_result_is_candidate_failure():
+    result = score_code_with_error("result = 1e309")
+
+    assert result.ok is False
+    assert result.score == float("-inf")
+    assert result.error_type == "non_finite_result"
+    assert result.comparable_score is None
+    assert result.is_candidate_failure is True
+    assert result.is_infrastructure_failure is False
+
+
+def test_sandbox_score_startup_timeout_is_infrastructure_failure(monkeypatch):
+    def fail_startup(_code: str):
+        raise TimeoutError("sandbox process startup timed out")
+
+    monkeypatch.setattr(sandbox, "run", fail_startup)
+
+    result = score_code_with_error("result = 1")
+
+    assert result.ok is False
+    assert result.error_type == "sandbox_startup_timeout"
+    assert result.comparable_score is None
+    assert result.is_infrastructure_failure is True
+    assert result.is_candidate_failure is False
+
+
+def test_sandbox_failure_category_distinguishes_base_and_mutation_failures():
+    base = SandboxScore(score=float("-inf"), ok=False, error_type="syntax_error")
+    mutation = SandboxScore(score=1.0)
+
+    assert _sandbox_failure_category(
+        base.is_candidate_failure, mutation.is_candidate_failure, "result = 1"
+    ) == ("source_sandbox_violation", "critical", True)
+
+    base = SandboxScore(score=1.0)
+    mutation = SandboxScore(
+        score=float("-inf"), ok=False, error_type="non_numeric_result"
+    )
+
+    assert _sandbox_failure_category(
+        base.is_candidate_failure, mutation.is_candidate_failure, "result = 'bad'"
+    ) == ("invalid_mutation_rejected", "medium", False)
+
+
+def test_double_failure_is_not_comparable():
+    base = SandboxScore(score=float("-inf"), ok=False, error_type="missing_result")
+    mutation = SandboxScore(
+        score=float("-inf"), ok=False, error_type="non_numeric_result"
+    )
+
+    assert base.comparable_score is None
+    assert mutation.comparable_score is None
+    assert not (
+        base.comparable_score is not None and mutation.comparable_score is not None
+    )
+
+
+def test_loop_retries_infrastructure_base_failure_without_penalty():
+    from singular.life.loop import (
+        _sandbox_failure_category,
+        _should_retry_sandbox_scoring,
+    )
+
+    base = SandboxScore(
+        score=float("-inf"), ok=False, error_type="sandbox_worker_no_payload"
+    )
+    mutation = SandboxScore(score=1.0)
+
+    assert _should_retry_sandbox_scoring(base, mutation) is True
+    assert _sandbox_failure_category(
+        base.is_candidate_failure, mutation.is_candidate_failure, "result = 1"
+    ) == (None, None, False)
+
+
+def test_loop_rejects_candidate_mutation_failure_without_global_breaker():
+    from singular.life.loop import (
+        _sandbox_failure_category,
+        _should_retry_sandbox_scoring,
+    )
+
+    base = SandboxScore(score=1.0)
+    mutation = SandboxScore(
+        score=float("-inf"), ok=False, error_type="non_numeric_result"
+    )
+
+    assert _should_retry_sandbox_scoring(base, mutation) is False
+    assert _sandbox_failure_category(
+        base.is_candidate_failure, mutation.is_candidate_failure, "result = 'bad'"
+    ) == ("invalid_mutation_rejected", "medium", False)


### PR DESCRIPTION
### Motivation

- Make sandbox scoring outcomes more actionable so `-inf` is not the only signal consumers can use. 
- Keep `SandboxScore.ok`, `error_type` and `error_message` as the diagnostic source of truth while adding explicit helpers for decision-making. 
- Distinguish infrastructure failures (sandbox startup, worker no payload, multiprocessing) from candidate/code failures (syntax, missing/non-numeric/non-finite results) so infrastructure problems can be retried instead of penalizing skills or opening global breakers. 
- Ensure the life loop avoids comparing two `-inf` outcomes as a business regression and only compares finite, comparable scores.

### Description

- Introduced explicit classification and comparison helpers on `SandboxScore`: added `INFRASTRUCTURE_ERROR_TYPES`, `CANDIDATE_ERROR_TYPES`, and properties `is_infrastructure_failure`, `is_candidate_failure`, and `comparable_score`. 
- Extended `_classify_score_exception` to detect `sandbox_startup_timeout`, `sandbox_worker_no_payload`, and `multiprocessing_error` in addition to existing candidate error types. 
- Updated `life.loop` to: add `_sandbox_scores_are_comparable` and `_should_retry_sandbox_scoring` helpers; only cache successful scoring results; treat infrastructure failures as retry/report events (publish `sandbox.infrastructure_failure` and continue) rather than penalizing skills or triggering global circuit breakers; require comparable finite scores for business comparisons and MAP-Elites decisions; and store `org.last_score` only when a comparable score is available. 
- Added unit tests in `tests/test_score.py` that cover finite results, non-finite results, startup timeout classification, base-vs-mutation failure classification, retry behavior for infrastructure failures, and the double-failure non-comparability case. 

### Testing

- Ran static checks with `python -m py_compile src/singular/life/sandbox_scoring.py src/singular/life/loop.py tests/test_score.py`, which succeeded. 
- Ran `pytest -q tests/test_score.py`, and all newly added and existing scoring tests passed. 
- Executed targeted life-loop tests (`test_score_code_with_error_returns_structured_sandbox_score`, `test_base_failure_remains_critical_violation`, `test_dangerous_mutation_failure_can_escalate_to_critical`) to verify the loop-side behavior for the new classification and retry logic, and those targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7351d12570832a83cb50bbe067df71)