### PR TITLE
Affiner la classification des échecs pour la quarantaine des skills

### DIFF
--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -22,12 +22,49 @@ AUTH_BLOCKED = "blocked"
 AUTH_FORCED = "forced"
 POLICY_SCHEMA_VERSION = 1
 
+SANDBOX_INFRASTRUCTURE_ERROR_TYPES = frozenset(
+    {
+        "timeout",
+        "sandbox_startup_timeout",
+        "sandbox_worker_no_payload",
+        "multiprocessing_error",
+    }
+)
+SANDBOX_INVALID_CANDIDATE_ERROR_TYPES = frozenset(
+    {"syntax_error", "missing_result", "non_numeric_result", "non_finite_result"}
+)
+SANDBOX_POLICY_VIOLATION_ERROR_TYPES = frozenset(
+    {"forbidden_syntax", "forbidden_name"}
+)
+
 _ROOT_POLICY_FILE = "policy.yaml"
 _POLICY_DECISIONS_LOG = "policy_decisions.jsonl"
 
 
 class PolicySchemaError(ValueError):
     """Raised when ``policy.yaml`` does not respect strict governance schema."""
+
+
+def classify_sandbox_error_type(
+    error_type: str | None, error_message: str | None = None
+) -> str:
+    """Classify stable ``SandboxScore.error_type`` values for governance."""
+
+    if error_type in SANDBOX_INFRASTRUCTURE_ERROR_TYPES:
+        return "infrastructure"
+    if error_type in SANDBOX_INVALID_CANDIDATE_ERROR_TYPES:
+        return "invalid_candidate"
+    message = (error_message or "").lower()
+    if error_type in SANDBOX_POLICY_VIOLATION_ERROR_TYPES or (
+        error_type == "sandbox_error"
+        and ("forbidden" in message or "use of" in message)
+    ):
+        return "policy_violation"
+    if error_type == "sandbox_error":
+        return "invalid_candidate"
+    if error_type is None:
+        return "none"
+    return "invalid_candidate"
 
 
 def _default_policy_payload() -> dict[str, Any]:

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -61,7 +61,10 @@ from singular.life.ecosystem import ARCHETYPES, EcosystemRulesConfig, compute_po
 
 from .death import DeathMonitor
 from .health import HealthTracker
-from singular.governance.policy import MutationGovernancePolicy
+from singular.governance.policy import (
+    MutationGovernancePolicy,
+    classify_sandbox_error_type,
+)
 from singular.governance.values import load_value_weights
 
 from .checkpointing import Checkpoint, CHECKPOINT_VERSION, load_checkpoint, save_checkpoint, _migrate_checkpoint_data
@@ -646,6 +649,25 @@ def _first_sandbox_error_type(
     """Prefer mutation diagnostics, falling back to source diagnostics."""
 
     return mutated_result.error_type or base_result.error_type
+
+
+def _sandbox_failure_classification(result: SandboxScore) -> str:
+    """Return the governance failure class for one sandbox score."""
+
+    return classify_sandbox_error_type(result.error_type, result.error_message)
+
+
+def _should_count_skill_quarantine_failure(
+    base_result: SandboxScore, mutated_result: SandboxScore
+) -> bool:
+    """Count only deterministic source failures observed in a healthy sandbox."""
+
+    if base_result.is_infrastructure_failure or mutated_result.is_infrastructure_failure:
+        return False
+    return (not base_result.ok) and _sandbox_failure_classification(base_result) in {
+        "invalid_candidate",
+        "policy_violation",
+    }
 
 
 def _choose_skill(
@@ -1907,18 +1929,37 @@ def run(
             }
             if sandbox_failure:
                 attempts = skill_sandbox_failures.get(selected_skill_key, 0)
+                skill_quarantine_failure = _should_count_skill_quarantine_failure(
+                    base_score_result,
+                    mutated_score_result,
+                )
                 if critical_sandbox_failure:
                     org.sandbox_violation_streak += 1
+                if skill_quarantine_failure:
                     attempts += 1
                     skill_sandbox_failures[selected_skill_key] = attempts
                     failed_skill_paths[selected_skill_key] = (org_name, skill_path)
+                elif not base_score_result.is_infrastructure_failure:
+                    skill_sandbox_failures.pop(selected_skill_key, None)
+                    failed_skill_paths.pop(selected_skill_key, None)
+                    attempts = 0
                 sandbox_diagnostic["sandbox_violation_streak"] = (
                     org.sandbox_violation_streak
                 )
                 sandbox_diagnostic["skill_sandbox_failure_streak"] = attempts
+                sandbox_diagnostic["skill_quarantine_failure_counted"] = (
+                    skill_quarantine_failure
+                )
+                sandbox_diagnostic["source_failure_classification"] = (
+                    _sandbox_failure_classification(base_score_result)
+                )
+                sandbox_diagnostic["mutation_failure_classification"] = (
+                    _sandbox_failure_classification(mutated_score_result)
+                )
                 logger.log_interaction("sandbox_violation", **sandbox_diagnostic)
-                quarantine_triggered = critical_sandbox_failure and attempts >= max(
-                    SKILL_SANDBOX_QUARANTINE_THRESHOLD, 1
+                quarantine_triggered = (
+                    skill_quarantine_failure
+                    and attempts >= max(SKILL_SANDBOX_QUARANTINE_THRESHOLD, 1)
                 )
                 if quarantine_triggered:
                     reason = "consecutive_sandbox_failures"

--- a/src/singular/life/sandbox_scoring.py
+++ b/src/singular/life/sandbox_scoring.py
@@ -25,6 +25,7 @@ class SandboxScore:
     _legacy_exception_type: str | None
 
     INFRASTRUCTURE_ERROR_TYPES: ClassVar[frozenset[str]] = frozenset({
+        "timeout",
         "sandbox_startup_timeout",
         "sandbox_worker_no_payload",
         "multiprocessing_error",
@@ -38,7 +39,6 @@ class SandboxScore:
         "forbidden_name",
         "sandbox_error",
         "runtime_exception",
-        "timeout",
     })
 
     def __init__(
@@ -200,6 +200,10 @@ def _classify_score_exception(exception: BaseException) -> str:
         return "syntax_error"
     if isinstance(exception, sandbox.SandboxError):
         message = str(exception).lower()
+        if "forbidden syntax" in message:
+            return "forbidden_syntax"
+        if "forbidden" in message and "use of" in message:
+            return "forbidden_name"
         if "worker" in message and (
             "without payload" in message or "without returning" in message
         ):

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -58,6 +58,21 @@ def test_sandbox_score_startup_timeout_is_infrastructure_failure(monkeypatch):
     assert result.is_candidate_failure is False
 
 
+def test_sandbox_score_execution_timeout_is_infrastructure_failure(monkeypatch):
+    def fail_execution(_code: str):
+        raise TimeoutError("sandbox execution timed out")
+
+    monkeypatch.setattr(sandbox, "run", fail_execution)
+
+    result = score_code_with_error("result = 1")
+
+    assert result.ok is False
+    assert result.error_type == "timeout"
+    assert result.comparable_score is None
+    assert result.is_infrastructure_failure is True
+    assert result.is_candidate_failure is False
+
+
 def test_sandbox_failure_category_distinguishes_base_and_mutation_failures():
     base = SandboxScore(score=float("-inf"), ok=False, error_type="syntax_error")
     mutation = SandboxScore(score=1.0)

--- a/tests/test_skill_quarantine.py
+++ b/tests/test_skill_quarantine.py
@@ -61,6 +61,70 @@ def test_loop_quarantines_skill_after_repeated_sandbox_failures(
     payload = quarantines[-1]["payload"]
     assert payload["skill"] == "unsafe"
     assert payload["reason"] == "consecutive_sandbox_failures"
-    assert payload["sandbox_error_type"] == "sandbox_error"
+    assert payload["sandbox_error_type"] == "forbidden_syntax"
     assert payload["disabled_until"] == lifecycle["disabled_until"]
     assert payload["attempts"] == 2
+
+
+def test_valid_skill_is_not_quarantined_after_sandbox_timeouts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        life_loop, "RunLogger", functools.partial(BaseRunLogger, root=tmp_path / "runs")
+    )
+    monkeypatch.setattr(
+        life_loop.Psyche, "load_state", staticmethod(lambda: life_loop.Psyche())
+    )
+    monkeypatch.setattr(life_loop, "SKILL_SANDBOX_QUARANTINE_THRESHOLD", 3)
+    monkeypatch.setattr(life_loop, "SKILL_SANDBOX_QUARANTINE_HOURS", 1)
+    monkeypatch.setattr(
+        life_loop,
+        "score_code_with_error",
+        lambda _code: life_loop.SandboxScore(
+            score=float("-inf"),
+            ok=False,
+            error_type="timeout",
+            error_message="sandbox execution timed out",
+        ),
+    )
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "valid.py").write_text("result = 1\n", encoding="utf-8")
+
+    life_loop.run(
+        skills_dirs=skills_dir,
+        checkpoint_path=tmp_path / "checkpoint.json",
+        budget_seconds=10.0,
+        rng=random.Random(0),
+        run_id="timeout-no-quarantine",
+        operators={"noop": _noop_operator},
+        max_iterations=3,
+    )
+
+    skills = json.loads((tmp_path / "mem" / "skills.json").read_text(encoding="utf-8"))
+    lifecycle = skills.get("valid", {}).get("lifecycle", {})
+    assert lifecycle.get("state") != "temporarily_disabled"
+
+    events = [
+        json.loads(line)
+        for line in (tmp_path / "runs" / "timeout-no-quarantine" / "events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line
+    ]
+    assert not [
+        event for event in events if event.get("event_type") == "skill.quarantined"
+    ]
+    infrastructure_events = [
+        event
+        for event in events
+        if event.get("event_type") == "interaction"
+        and event.get("payload", {}).get("interaction") == "sandbox_infrastructure_failure"
+    ]
+    assert len(infrastructure_events) >= 3
+    assert all(
+        event["payload"]["action"] == "retry_scoring_later"
+        for event in infrastructure_events
+    )


### PR DESCRIPTION
### Motivation

- Éviter de mettre en quarantaine des skills valides lorsque la sandbox subit des problèmes d'infrastructure (timeouts, worker sans payload). 
- Distinguer les échecs liés à l'infrastructure, les candidats invalides et les violations de politique afin d'appliquer des règles de quarantaine plus précises.

### Description

- Ajout d'une classification centralisée dans `src/singular/governance/policy.py` via `classify_sandbox_error_type` et de constantes `SANDBOX_*_ERROR_TYPES` pour regrouper les types d'erreurs (infrastructure / invalid_candidate / policy_violation). 
- Normalisation des diagnostics côté sandbox dans `src/singular/life/sandbox_scoring.py` pour : reconnaître `timeout` (exécution) comme erreur d'infrastructure et extraire `forbidden_syntax` / `forbidden_name` depuis les messages `SandboxError`.
- Changement de la logique de quarantaine dans `src/singular/life/loop.py` pour compter uniquement les échecs déterministes observés dans une sandbox saine : ajout de ` _should_count_skill_quarantine_failure` et utilisation de cette fonction pour incrémenter/vider le compteur de retests avant quarantaine.
- Ajout de diagnostics supplémentaires lors d'un `sandbox_violation` : `skill_quarantine_failure_counted`, `source_failure_classification`, `mutation_failure_classification` pour faciliter l'audit des décisions.
- Tests mis à jour/ajoutés : `tests/test_skill_quarantine.py` étend le scénario pour vérifier qu'une skill valide n'est pas mise en quarantaine par des `timeout` simulés, et `tests/test_score.py` ajoute un test pour considérer l'exécution timeout comme erreur d'infrastructure.

### Testing

- Exécuté `pytest tests/test_score.py tests/test_skill_quarantine.py` ; tous les tests ciblés ont réussi (`12 passed`).
- Les nouveaux tests vérifient que : `timeout` déclenche des événements d'infrastructure (`sandbox_infrastructure_failure` / `retry_scoring_later`) mais n'incrémente pas le compteur de quarantaine, et que les violations de syntaxe interdites sont classées comme `forbidden_syntax` et entraînent la quarantaine après le seuil configuré.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7356de5fe0832abae2d93809c87c24)