### PR TITLE
Require specs for coverage-gap skill genesis

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -26,7 +26,6 @@ from singular.beliefs.meta_learning import (
 from singular.events import EventBus, get_global_event_bus
 from singular.memory import (
     add_causal_trace,
-    add_episode,
     read_skills,
     register_memory_event_handlers,
     temporarily_disable_skill,
@@ -67,7 +66,7 @@ from singular.governance.policy import (
 )
 from singular.governance.values import load_value_weights
 
-from .checkpointing import Checkpoint, CHECKPOINT_VERSION, load_checkpoint, save_checkpoint, _migrate_checkpoint_data
+from .checkpointing import Checkpoint, load_checkpoint, save_checkpoint
 from .sandbox_scoring import SandboxScore, score_code_with_error, score_code, _sandbox_failure_category
 from .mutation_flow import apply_mutation, select_operator, _load_default_operators
 from .resource_flow import manage_resources
@@ -393,11 +392,33 @@ def _critical_extinction_indicators(
     return organism.energy <= 0.0 and organism.resources <= 0.0
 
 
+def _coverage_gap_spec_signals(signals: Mapping[str, object]) -> dict[str, object]:
+    """Extract optional structured coverage-gap specification inputs."""
+
+    spec: dict[str, object] = {}
+    direct_keys = {
+        "coverage_gap_examples",
+        "coverage_gap_success_criteria",
+        "coverage_gap_signature",
+        "coverage_gap_cooldown",
+        "coverage_gap_expected_impact",
+    }
+    for key in direct_keys:
+        if key in signals:
+            spec[key] = signals[key]
+    coverage_spec = signals.get("coverage_gap_spec")
+    if isinstance(coverage_spec, Mapping):
+        for key in ("examples", "success_criteria", "signature", "cooldown", "expected_impact"):
+            if key in coverage_spec:
+                spec[key] = coverage_spec[key]
+    return spec
+
+
 def _should_trigger_skill_genesis(
     *,
     signals: Mapping[str, object],
     health_counters: Mapping[str, float | int],
-) -> tuple[bool, str, dict[str, float]]:
+) -> tuple[bool, str, dict[str, object]]:
     tech_debt_markers = 0.0
     artifact_events = signals.get("artifact_events")
     if isinstance(artifact_events, list):
@@ -431,6 +452,7 @@ def _should_trigger_skill_genesis(
     if repeated_failures >= SKILL_GENESIS_FAILURE_STREAK_THRESHOLD:
         return True, "repeated_failures", snapshot
     if coverage_gap >= SKILL_GENESIS_COVERAGE_GAP_THRESHOLD:
+        snapshot.update(_coverage_gap_spec_signals(signals))
         return True, "coverage_gap", snapshot
     return False, "", snapshot
 
@@ -1620,7 +1642,6 @@ def run(
             can_mutate, state_flag = resource_manager.apply_capability_cost("mutation")
             if not can_mutate:
                 accepted = False
-                decision_reason = f"blocked_by_homeostasis:{state_flag.value}"
             elif state_flag == CapabilityStatus.FATIGUED:
                 accepted = accepted and (mutated_score <= base_score)
             if "tired" in moods:

--- a/src/singular/life/skill_genesis.py
+++ b/src/singular/life/skill_genesis.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Mapping
 
+from singular.events import get_global_event_bus
 from singular.governance.policy import MutationGovernancePolicy
 from singular.memory import read_skills, write_skills
 
@@ -23,6 +26,18 @@ class SkillGenesisResult:
     rolled_back: bool = False
 
 
+@dataclass(frozen=True)
+class SkillSpec:
+    """Minimal mandatory specification for coverage-gap skill genesis."""
+
+    name: str
+    signature: str
+    examples: list[dict[str, object]]
+    success_criteria: str
+    cooldown: int
+    expected_impact: str
+
+
 def _utc_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -36,11 +51,15 @@ def _safe_skill_name(seed: str) -> str:
     return normalized
 
 
-def _render_skill_template(skill_name: str) -> str:
+def _render_skill_template(skill_name: str, spec: SkillSpec | None = None) -> str:
+    spec_block = ""
+    if spec is not None:
+        spec_block = "\nSPEC = " + repr(asdict(spec)) + "\n"
     return (
         '"""Auto-generated skill scaffold.\n'
         "Created by life.skill_genesis with governance safeguards.\n"
         '"""\n\n'
+        f"{spec_block}\n"
         "def run(context: dict | None = None) -> dict:\n"
         '    """Run a deterministic safe placeholder skill."""\n'
         "    context = context or {}\n"
@@ -52,11 +71,105 @@ def _render_skill_template(skill_name: str) -> str:
     )
 
 
+def _publish_unresolved(payload: dict[str, object]) -> None:
+    """Publish and journal a coverage-gap unresolved event."""
+
+    get_global_event_bus().publish("coverage_gap.unresolved", payload)
+
+
 def _append_journal(mem_dir: Path, payload: dict[str, object]) -> None:
     journal = mem_dir / "skill_genesis.jsonl"
     journal.parent.mkdir(parents=True, exist_ok=True)
     with journal.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+
+def _coerce_examples(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    examples: list[dict[str, object]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        input_value = item.get("input", item.get("inputs"))
+        output_value = item.get("output", item.get("expected_output"))
+        if input_value is None or output_value is None:
+            continue
+        examples.append({"input": input_value, "output": output_value})
+    return examples
+
+
+def _coverage_gap_spec_from_snapshot(
+    skill_name: str,
+    signal_snapshot: Mapping[str, object],
+) -> tuple[SkillSpec | None, str]:
+    raw_examples = signal_snapshot.get(
+        "examples", signal_snapshot.get("coverage_gap_examples")
+    )
+    examples = _coerce_examples(raw_examples)
+    success_criteria = signal_snapshot.get(
+        "success_criteria", signal_snapshot.get("coverage_gap_success_criteria")
+    )
+    if not examples:
+        return None, "coverage gap genesis requires at least one input/output example"
+    if not isinstance(success_criteria, str) or not success_criteria.strip():
+        return None, "coverage gap genesis requires a success criterion"
+    signature = signal_snapshot.get(
+        "signature", signal_snapshot.get("coverage_gap_signature")
+    )
+    if not isinstance(signature, str) or not signature.strip():
+        signature = "run(context: dict | None = None) -> dict"
+    cooldown = signal_snapshot.get(
+        "cooldown", signal_snapshot.get("coverage_gap_cooldown", 1)
+    )
+    try:
+        normalized_cooldown = max(1, int(cooldown))
+    except (TypeError, ValueError):
+        normalized_cooldown = 1
+    impact = signal_snapshot.get(
+        "expected_impact", signal_snapshot.get("coverage_gap_expected_impact")
+    )
+    if not isinstance(impact, str) or not impact.strip():
+        impact = "reduce observed coverage_gap by satisfying the supplied examples"
+    return (
+        SkillSpec(
+            name=skill_name,
+            signature=signature,
+            examples=examples,
+            success_criteria=success_criteria.strip(),
+            cooldown=normalized_cooldown,
+            expected_impact=impact.strip(),
+        ),
+        "",
+    )
+
+
+def _spec_fingerprint(
+    trigger: str, spec: SkillSpec | None, signal_snapshot: Mapping[str, object]
+) -> str:
+    if spec is None:
+        payload: object = {"trigger": trigger, "signals": signal_snapshot}
+    else:
+        payload = {"trigger": trigger, "spec": asdict(spec) | {"name": "<normalized>"}}
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _journal_has_duplicate(mem_dir: Path, *, trigger: str, fingerprint: str) -> bool:
+    journal = mem_dir / "skill_genesis.jsonl"
+    if not journal.exists():
+        return False
+    for line in journal.read_text(encoding="utf-8").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            payload.get("trigger") == trigger
+            and payload.get("spec_fingerprint") == fingerprint
+        ):
+            return True
+    return False
 
 
 def create_skill(
@@ -74,6 +187,48 @@ def create_skill(
         suffix += 1
         target = skills_dir / f"{stem}_{suffix}.py"
     skill_name = target.stem
+    spec: SkillSpec | None = None
+    if trigger == "coverage_gap":
+        spec, spec_error = _coverage_gap_spec_from_snapshot(skill_name, signal_snapshot)
+        if spec_error:
+            payload = {
+                "ts": _utc_iso(),
+                "event": "coverage_gap.unresolved",
+                "skill": skill_name,
+                "target": str(target),
+                "trigger": trigger,
+                "reason": spec_error,
+                "signals": dict(signal_snapshot),
+            }
+            _append_journal(mem_dir, payload)
+            _publish_unresolved(payload)
+            return SkillGenesisResult(
+                accepted=False,
+                skill_name=skill_name,
+                target=target,
+                reason=spec_error,
+                policy_level="unresolved",
+            )
+    fingerprint = _spec_fingerprint(trigger, spec, signal_snapshot)
+    if _journal_has_duplicate(mem_dir, trigger=trigger, fingerprint=fingerprint):
+        reason = "duplicate skill genesis request suppressed by diversity limit"
+        payload = {
+            "ts": _utc_iso(),
+            "event": (
+                "coverage_gap.unresolved"
+                if trigger == "coverage_gap"
+                else "skill_genesis_duplicate"
+            ),
+            "skill": skill_name,
+            "target": str(target),
+            "trigger": trigger,
+            "reason": reason,
+            "spec_fingerprint": fingerprint,
+        }
+        _append_journal(mem_dir, payload)
+        if trigger == "coverage_gap":
+            _publish_unresolved(payload)
+        return SkillGenesisResult(False, skill_name, target, reason, "diversity_limit")
 
     proposal = governance_policy.simulate_write(
         target,
@@ -91,6 +246,7 @@ def create_skill(
                 "policy_level": proposal.level,
                 "reason": proposal.reason,
                 "trigger": trigger,
+                "spec_fingerprint": fingerprint,
             },
         )
         return SkillGenesisResult(
@@ -101,7 +257,11 @@ def create_skill(
             policy_level=proposal.level,
         )
 
-    source = _render_skill_template(skill_name)
+    source = (
+        _render_skill_template(skill_name, spec)
+        if spec is not None
+        else _render_skill_template(skill_name)
+    )
     skills_before = read_skills(mem_dir / "skills.json")
     staging_dir = skills_dir / ".staging"
     staged_path = staging_dir / target.name
@@ -121,6 +281,7 @@ def create_skill(
             "note": "auto-generated by skill genesis",
             "created_at": _utc_iso(),
             "trigger": trigger,
+            "spec": asdict(spec) if spec is not None else None,
         }
         write_skills(skills_after, mem_dir / "skills.json")
         refresh_skill_catalog(skills_dir=skills_dir, mem_dir=mem_dir)
@@ -135,6 +296,8 @@ def create_skill(
                 "reason": decision.reason,
                 "trigger": trigger,
                 "signals": signal_snapshot,
+                "spec": asdict(spec) if spec is not None else None,
+                "spec_fingerprint": fingerprint,
             },
         )
         return SkillGenesisResult(
@@ -169,4 +332,3 @@ def create_skill(
             policy_level="validation_failed",
             rolled_back=True,
         )
-

--- a/tests/test_loop_perception_goals.py
+++ b/tests/test_loop_perception_goals.py
@@ -13,7 +13,9 @@ class _CaptureGoals:
     def __init__(self, *args, **kwargs):
         pass
 
-    def update_tick(self, *, tick, psyche, health_score, resources, perception_signals=None):
+    def update_tick(
+        self, *, tick, psyche, health_score, resources, perception_signals=None
+    ):
         _CaptureGoals.last_perception_signals = perception_signals
         return GoalWeights()
 
@@ -28,7 +30,9 @@ class _CaptureGoals:
             for h in hypotheses
         ]
 
-    def influence_operator_scores(self, operator_stats, skill_reputation=None):
+    def influence_operator_scores(
+        self, operator_stats, skill_reputation=None, **_kwargs
+    ):
         _CaptureGoals.last_skill_reputation = skill_reputation
         return {name: 0.0 for name in operator_stats}
 
@@ -37,7 +41,9 @@ def _dec_operator(tree, rng=None):
     return tree
 
 
-def test_run_passes_capture_signals_to_intrinsic_goals(tmp_path: Path, monkeypatch) -> None:
+def test_run_passes_capture_signals_to_intrinsic_goals(
+    tmp_path: Path, monkeypatch
+) -> None:
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()
     (skills_dir / "foo.py").write_text("result = 1", encoding="utf-8")
@@ -66,7 +72,10 @@ def test_run_passes_capture_signals_to_intrinsic_goals(tmp_path: Path, monkeypat
 
     assert _CaptureGoals.last_perception_signals is not None
     assert "artifact_events" in _CaptureGoals.last_perception_signals
-    assert _CaptureGoals.last_perception_signals["artifact_events"][0]["type"] == "artifact.tech_debt.simple"
+    assert (
+        _CaptureGoals.last_perception_signals["artifact_events"][0]["type"]
+        == "artifact.tech_debt.simple"
+    )
     assert isinstance(_CaptureGoals.last_skill_reputation, dict)
     traces = read_causal_timeline()
     assert traces

--- a/tests/test_skill_genesis.py
+++ b/tests/test_skill_genesis.py
@@ -5,6 +5,7 @@ import random
 from pathlib import Path
 
 import singular.life.loop as life_loop
+from singular.events import EventBus
 from singular.governance.policy import AUTH_REVIEW_REQUIRED, MutationGovernancePolicy
 from singular.life.loop import run
 from singular.life.skill_genesis import create_skill
@@ -68,7 +69,11 @@ def test_skill_genesis_creation_refused_by_policy(monkeypatch, tmp_path: Path) -
         mem_dir=mem_dir,
         governance_policy=policy,
         trigger="coverage_gap",
-        signal_snapshot={"coverage_gap": 0.9},
+        signal_snapshot={
+            "coverage_gap": 0.9,
+            "coverage_gap_examples": [{"input": {"value": 1}, "output": {"ok": True}}],
+            "coverage_gap_success_criteria": "returns ok for the documented gap example",
+        },
     )
 
     assert result.accepted is False
@@ -76,7 +81,100 @@ def test_skill_genesis_creation_refused_by_policy(monkeypatch, tmp_path: Path) -
     assert not result.target.exists()
 
 
-def test_skill_genesis_rolls_back_on_invalid_generation(monkeypatch, tmp_path: Path) -> None:
+def test_coverage_gap_requires_spec_and_publishes_unresolved(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    from singular.life import skill_genesis as genesis_mod
+
+    events = []
+    bus = EventBus()
+    bus.subscribe("coverage_gap.unresolved", events.append)
+    monkeypatch.setattr(genesis_mod, "get_global_event_bus", lambda: bus)
+
+    skills_dir = tmp_path / "life" / "skills"
+    mem_dir = tmp_path / "mem"
+    skills_dir.mkdir(parents=True)
+    policy = MutationGovernancePolicy(
+        modifiable_paths=("skills",),
+        review_required_paths=("skills/review",),
+        forbidden_paths=("src",),
+    )
+
+    result = create_skill(
+        skills_dir=skills_dir,
+        mem_dir=mem_dir,
+        governance_policy=policy,
+        trigger="coverage_gap",
+        signal_snapshot={"coverage_gap": 0.9},
+    )
+
+    assert result.accepted is False
+    assert result.policy_level == "unresolved"
+    assert "requires at least one input/output example" in result.reason
+    assert not result.target.exists()
+    assert events and events[-1].event_type == "coverage_gap.unresolved"
+    journal = [
+        json.loads(line)
+        for line in (mem_dir / "skill_genesis.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert journal[-1]["event"] == "coverage_gap.unresolved"
+
+
+def test_coverage_gap_skill_spec_and_diversity_limit(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    skills_dir = tmp_path / "life" / "skills"
+    mem_dir = tmp_path / "mem"
+    skills_dir.mkdir(parents=True)
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    (mem_dir / "skills.json").write_text("{}", encoding="utf-8")
+    policy = MutationGovernancePolicy(
+        modifiable_paths=("skills",),
+        review_required_paths=("skills/review",),
+        forbidden_paths=("src",),
+    )
+    snapshot = {
+        "coverage_gap": 0.9,
+        "coverage_gap_signature": "run(context: dict) -> dict",
+        "coverage_gap_examples": [
+            {"input": {"case": "missing"}, "output": {"covered": True}}
+        ],
+        "coverage_gap_success_criteria": "covers the missing case deterministically",
+        "coverage_gap_cooldown": 3,
+        "coverage_gap_expected_impact": "increase functional coverage",
+    }
+
+    first = create_skill(
+        skills_dir=skills_dir,
+        mem_dir=mem_dir,
+        governance_policy=policy,
+        trigger="coverage_gap",
+        signal_snapshot=snapshot,
+    )
+    second = create_skill(
+        skills_dir=skills_dir,
+        mem_dir=mem_dir,
+        governance_policy=policy,
+        trigger="coverage_gap",
+        signal_snapshot=snapshot,
+    )
+
+    assert first.accepted is True
+    assert "SPEC =" in first.target.read_text(encoding="utf-8")
+    assert second.accepted is False
+    assert second.policy_level == "diversity_limit"
+    assert not second.target.exists()
+
+
+def test_skill_genesis_rolls_back_on_invalid_generation(
+    monkeypatch, tmp_path: Path
+) -> None:
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
     from singular.life import skill_genesis as genesis_mod
@@ -85,8 +183,12 @@ def test_skill_genesis_rolls_back_on_invalid_generation(monkeypatch, tmp_path: P
     mem_dir = tmp_path / "mem"
     skills_dir.mkdir(parents=True)
     mem_dir.mkdir(parents=True, exist_ok=True)
-    (mem_dir / "skills.json").write_text(json.dumps({"keep": {"score": 1.0}}), encoding="utf-8")
-    monkeypatch.setattr(genesis_mod, "_render_skill_template", lambda _name: "def bad(:\n")
+    (mem_dir / "skills.json").write_text(
+        json.dumps({"keep": {"score": 1.0}}), encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        genesis_mod, "_render_skill_template", lambda _name: "def bad(:\n"
+    )
 
     policy = MutationGovernancePolicy(
         modifiable_paths=("skills",),
@@ -151,13 +253,21 @@ def test_skill_genesis_traceability_in_run_logs(monkeypatch, tmp_path: Path) -> 
     )
 
     log_file = next((tmp_path / "logs").glob("loop-*.jsonl"))
-    records = [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+    records = [
+        json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()
+    ]
     assert any(rec.get("interaction") == "skill_genesis" for rec in records)
-    journal = (tmp_path / "mem" / "skill_genesis.jsonl").read_text(encoding="utf-8").splitlines()
+    journal = (
+        (tmp_path / "mem" / "skill_genesis.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    )
     assert journal
 
 
-def test_skill_genesis_rejects_empty_scaffold_without_publication(monkeypatch, tmp_path: Path) -> None:
+def test_skill_genesis_rejects_empty_scaffold_without_publication(
+    monkeypatch, tmp_path: Path
+) -> None:
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
     from singular.life import skill_genesis as genesis_mod
@@ -186,11 +296,18 @@ def test_skill_genesis_rejects_empty_scaffold_without_publication(monkeypatch, t
     assert result.policy_level == "validation_failed"
     assert not result.target.exists()
     assert not list(skills_dir.glob("*.py"))
-    journal = [json.loads(line) for line in (mem_dir / "skill_genesis.jsonl").read_text(encoding="utf-8").splitlines()]
+    journal = [
+        json.loads(line)
+        for line in (mem_dir / "skill_genesis.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
     assert journal[-1]["event"] == "autogen.validation_failed"
 
 
-def test_skill_genesis_rejects_missing_function_without_publication(monkeypatch, tmp_path: Path) -> None:
+def test_skill_genesis_rejects_missing_function_without_publication(
+    monkeypatch, tmp_path: Path
+) -> None:
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
     from singular.life import skill_genesis as genesis_mod
@@ -200,7 +317,9 @@ def test_skill_genesis_rejects_missing_function_without_publication(monkeypatch,
     skills_dir.mkdir(parents=True)
     mem_dir.mkdir(parents=True, exist_ok=True)
     (mem_dir / "skills.json").write_text("{}", encoding="utf-8")
-    monkeypatch.setattr(genesis_mod, "_render_skill_template", lambda _name: "result = 1\n")
+    monkeypatch.setattr(
+        genesis_mod, "_render_skill_template", lambda _name: "result = 1\n"
+    )
 
     policy = MutationGovernancePolicy(
         modifiable_paths=("skills",),
@@ -220,7 +339,9 @@ def test_skill_genesis_rejects_missing_function_without_publication(monkeypatch,
     assert not list(skills_dir.glob("*.py"))
 
 
-def test_skill_genesis_rejects_always_none_function_without_publication(monkeypatch, tmp_path: Path) -> None:
+def test_skill_genesis_rejects_always_none_function_without_publication(
+    monkeypatch, tmp_path: Path
+) -> None:
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
     from singular.life import skill_genesis as genesis_mod
@@ -230,7 +351,11 @@ def test_skill_genesis_rejects_always_none_function_without_publication(monkeypa
     skills_dir.mkdir(parents=True)
     mem_dir.mkdir(parents=True, exist_ok=True)
     (mem_dir / "skills.json").write_text("{}", encoding="utf-8")
-    monkeypatch.setattr(genesis_mod, "_render_skill_template", lambda _name: "def run():\n    return None\n")
+    monkeypatch.setattr(
+        genesis_mod,
+        "_render_skill_template",
+        lambda _name: "def run():\n    return None\n",
+    )
 
     policy = MutationGovernancePolicy(
         modifiable_paths=("skills",),


### PR DESCRIPTION
### Motivation
- Prevent empty or under-specified auto-generated skills when the loop detects a `coverage_gap` by requiring a minimal, actionable spec before generating a skill.
- Make coverage-gap triggers observable and actionable by publishing an unresolved event instead of creating a no-op scaffold when insufficient information is provided.
- Avoid repeated duplicate auto-generated skills flooding the skills directory by suppressing identical requests.

### Description
- Added extraction of optional structured coverage-gap spec signals in the loop via `_coverage_gap_spec_signals` and include them in the trigger snapshot returned by `_should_trigger_skill_genesis` so `coverage_gap` signals can carry `examples`, `signature`, `success_criteria`, `cooldown`, and `expected_impact`.
- Introduced a `SkillSpec` dataclass and validation logic in `create_skill` to require `examples` and `success_criteria` for `coverage_gap` genesis, and embed the spec into the generated scaffold when present via `SPEC = ...`.
- When the required spec fields are missing the code now journals and publishes a `coverage_gap.unresolved` event (using `get_global_event_bus`) and rejects generation with `policy_level="unresolved"` instead of creating an empty skill.
- Added a spec fingerprint and journaled duplicate check to suppress repeated identical `coverage_gap` genesis requests and return a `diversity_limit` outcome when duplicates are detected.
- Minor compatibility/test adjustments: render template calls remain backward-compatible, and the test helper `influence_operator_scores` accepts extra kwargs.

### Testing
- Ran linting with `python -m ruff check` which passed for the modified files.
- Ran unit tests with `pytest tests/test_skill_genesis.py tests/test_loop_perception_goals.py` and all tests passed (`11 passed`).
- Verified code formatting with `black` and that added logic is journaled and published as expected by the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a735ee62b78832aa6505b8528abfb89)