### PR TITLE
Make quest specs self-documenting and improve validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,24 @@ Les sous-commandes qui consultent la mémoire (``talk``, ``run``, ``loop``,
 sélectionnée. Utilisez ``singular lives delete <nom>`` pour supprimer une vie et
 libérer son espace disque.
 
+### Format de quête auto-documenté
+
+La commande ``quest`` synthétise une compétence depuis une specification JSON.
+Pour découvrir le format sans modifier le disque ni sélectionner de vie active,
+utilisez les sorties intégrées :
+
+```bash
+singular quest --example
+singular quest --schema
+```
+
+Un exemple complet versionné est également disponible dans
+``examples/quest/complete_quest.json``. Les champs obligatoires sont ``name``,
+``signature``, ``examples`` et ``constraints``. Chaque erreur de validation
+indique le champ concerné, le type attendu et un exemple minimal. Une
+spécification invalide est rejetée avant toute création de mémoire ou de fichier
+de compétence.
+
 ### Piège courant : changer de root sans le voir
 
 La résolution du root de registre est désormais **unique et explicite** :

--- a/examples/quest/complete_quest.json
+++ b/examples/quest/complete_quest.json
@@ -1,0 +1,48 @@
+{
+  "name": "repair_loop",
+  "signature": "repair_loop(x)",
+  "examples": [
+    {
+      "input": [
+        1
+      ],
+      "output": 1
+    },
+    {
+      "input": [
+        2
+      ],
+      "output": 2
+    }
+  ],
+  "constraints": {
+    "pure": true,
+    "no_import": true,
+    "time_ms_max": 50
+  },
+  "triggers": [
+    {
+      "signal": "noise",
+      "gte": 0.5
+    }
+  ],
+  "reward": {
+    "mood": "pleasure",
+    "resource_delta": {
+      "food": 2
+    }
+  },
+  "penalty": {
+    "mood": "pain",
+    "resource_delta": {
+      "energy": -1
+    }
+  },
+  "cooldown": 60,
+  "success": {
+    "resource_min": {
+      "energy": 80
+    }
+  },
+  "origin": "intrinsic"
+}

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -139,13 +139,16 @@ def _suggest_life_flag_for_unknown_args(argv: list[str] | None) -> str | None:
             return message
     return None
 
+
 def _looks_like_dev_repo_root(path: Path) -> bool:
     """Heuristic to detect a development repository root."""
 
     return (path / "pyproject.toml").exists() and (path / "src" / "singular").is_dir()
 
 
-def _run_retention_at_safe_point(*, dry_run: bool = False, enforce_minimum_interval: bool = True) -> int:
+def _run_retention_at_safe_point(
+    *, dry_run: bool = False, enforce_minimum_interval: bool = True
+) -> int:
     """Run storage retention service and print a concise summary."""
 
     from .storage_retention import run_retention_service
@@ -202,7 +205,9 @@ def _retention_status() -> int:
     thresholds = status.get("thresholds", {})
     threshold_flags = status.get("active_thresholds", {})
     last_purge = status.get("last_purge", {})
-    purge_summary = last_purge.get("summary", {}) if isinstance(last_purge, dict) else {}
+    purge_summary = (
+        last_purge.get("summary", {}) if isinstance(last_purge, dict) else {}
+    )
 
     print("Retention status")
     print(
@@ -225,10 +230,7 @@ def _retention_status() -> int:
         f"max_total_runs_size_mb={thresholds.get('max_total_runs_size_mb')}"
     )
     exceeded = [name for name, value in threshold_flags.items() if value]
-    print(
-        "Exceeded: "
-        + (", ".join(sorted(exceeded)) if exceeded else "none")
-    )
+    print("Exceeded: " + (", ".join(sorted(exceeded)) if exceeded else "none"))
 
     def _print_entries(label: str, entries: Any) -> None:
         print(f"{label}:")
@@ -579,11 +581,15 @@ def _configure_openai(api_key: str, *, shell_profile: str | None, test: bool) ->
             )
             if answer.strip() == "OUI":
                 _append_export_to_shell_profile(profile_path, api_key)
-                print("➡️ Ouvrez un nouveau shell (ou `source` le profil) pour appliquer.")
+                print(
+                    "➡️ Ouvrez un nouveau shell (ou `source` le profil) pour appliquer."
+                )
             else:
                 print("Écriture annulée. Aucune persistance shell effectuée.")
         else:
-            print("Pour persister la clé sur Linux/macOS, ajoutez à votre profil shell:")
+            print(
+                "Pour persister la clé sur Linux/macOS, ajoutez à votre profil shell:"
+            )
             print("export OPENAI_API_KEY='sk-...'")
 
     if test:
@@ -606,21 +612,45 @@ _POLICY_SETTERS: dict[str, tuple[str, str]] = {
     "forgetting.max_episodic_entries": ("int", "forgetting_max_episodic_entries"),
     "autonomy.safe_mode": ("bool", "safe_mode"),
     "autonomy.mutation_quota_per_window": ("int", "mutation_quota_per_window"),
-    "autonomy.mutation_quota_window_seconds": ("float", "mutation_quota_window_seconds"),
+    "autonomy.mutation_quota_window_seconds": (
+        "float",
+        "mutation_quota_window_seconds",
+    ),
     "autonomy.runtime_call_quota_per_hour": ("int", "runtime_call_quota_per_hour"),
-    "autonomy.runtime_blacklisted_capabilities": ("strings", "runtime_blacklisted_capabilities"),
-    "autonomy.auto_rollback_failure_threshold": ("int", "auto_rollback_failure_threshold"),
+    "autonomy.runtime_blacklisted_capabilities": (
+        "strings",
+        "runtime_blacklisted_capabilities",
+    ),
+    "autonomy.auto_rollback_failure_threshold": (
+        "int",
+        "auto_rollback_failure_threshold",
+    ),
     "autonomy.auto_rollback_cost_threshold": ("float", "auto_rollback_cost_threshold"),
     "autonomy.safe_mode_review_required_skill_families": (
         "strings",
         "safe_mode_review_required_skill_families",
     ),
     "autonomy.circuit_breaker_threshold": ("int", "circuit_breaker_threshold"),
-    "autonomy.circuit_breaker_window_seconds": ("float", "circuit_breaker_window_seconds"),
-    "autonomy.circuit_breaker_cooldown_seconds": ("float", "circuit_breaker_cooldown_seconds"),
-    "autonomy.skill_circuit_breaker_failure_threshold": ("int", "skill_circuit_breaker_failure_threshold"),
-    "autonomy.skill_circuit_breaker_cost_threshold": ("float", "skill_circuit_breaker_cost_threshold"),
-    "autonomy.skill_circuit_breaker_cooldown_seconds": ("float", "skill_circuit_breaker_cooldown_seconds"),
+    "autonomy.circuit_breaker_window_seconds": (
+        "float",
+        "circuit_breaker_window_seconds",
+    ),
+    "autonomy.circuit_breaker_cooldown_seconds": (
+        "float",
+        "circuit_breaker_cooldown_seconds",
+    ),
+    "autonomy.skill_circuit_breaker_failure_threshold": (
+        "int",
+        "skill_circuit_breaker_failure_threshold",
+    ),
+    "autonomy.skill_circuit_breaker_cost_threshold": (
+        "float",
+        "skill_circuit_breaker_cost_threshold",
+    ),
+    "autonomy.skill_circuit_breaker_cooldown_seconds": (
+        "float",
+        "skill_circuit_breaker_cooldown_seconds",
+    ),
     "permissions.modifiable_paths": ("paths", "modifiable_paths"),
     "permissions.review_required_paths": ("paths", "review_required_paths"),
     "permissions.forbidden_paths": ("paths", "forbidden_paths"),
@@ -680,7 +710,11 @@ def _preparse_environment(argv: list[str] | None) -> argparse.Namespace:
     if command is not None:
         command_index = remaining.index(command)
         subcommand = next(
-            (token for token in remaining[command_index + 1 :] if not token.startswith("-")),
+            (
+                token
+                for token in remaining[command_index + 1 :]
+                if not token.startswith("-")
+            ),
             None,
         )
     is_creation_bootstrap_command = command == "birth" or (
@@ -775,8 +809,10 @@ def _print_table(headers: list[str], rows: list[list[str]]) -> None:
     for row in rows:
         for idx, cell in enumerate(row):
             widths[idx] = max(widths[idx], len(cell))
+
     def _fmt(row: list[str]) -> str:
         return " | ".join(cell.ljust(widths[idx]) for idx, cell in enumerate(row))
+
     print(_fmt(headers))
     print("-+-".join("-" * width for width in widths))
     for row in rows:
@@ -902,7 +938,9 @@ def _create_life_with_bootstrap(
 def main(argv: list[str] | None = None) -> int:
     """Run the singular command line interface."""
 
-    implicit_root_before_override = _implicit_registry_root_from_env_or_default().resolve()
+    implicit_root_before_override = (
+        _implicit_registry_root_from_env_or_default().resolve()
+    )
     argv_list = list(argv) if argv is not None else None
     _preparse_environment(argv_list)
 
@@ -1034,7 +1072,17 @@ def main(argv: list[str] | None = None) -> int:
     quest_parser = subparsers.add_parser(
         "quest", help="Generate a skill from a specification"
     )
-    quest_parser.add_argument("spec", type=Path, help="Path to specification JSON")
+    quest_parser.add_argument(
+        "spec", nargs="?", type=Path, help="Path to specification JSON"
+    )
+    quest_parser.add_argument(
+        "--example",
+        action="store_true",
+        help="Print a complete quest JSON example and exit",
+    )
+    quest_parser.add_argument(
+        "--schema", action="store_true", help="Print the quest JSON schema and exit"
+    )
 
     synth_parser = subparsers.add_parser("synthesize", help="Synthesize results")
     synth_parser.add_argument("code", help="Code snippet to store in memory")
@@ -1042,7 +1090,9 @@ def main(argv: list[str] | None = None) -> int:
     report_parser = subparsers.add_parser(
         "report", help="Summarize performance from a run"
     )
-    report_parser.add_argument("--id", required=False, default=None, help="Run identifier")
+    report_parser.add_argument(
+        "--id", required=False, default=None, help="Run identifier"
+    )
     report_parser.add_argument(
         "--format",
         dest="report_output_format",
@@ -1237,9 +1287,7 @@ def main(argv: list[str] | None = None) -> int:
         default="global",
         help="Global (~/.singular/config.json) ou projet (.singular/config.json)",
     )
-    config_root_subparsers.add_parser(
-        "show", help="Afficher le root implicite résolu"
-    )
+    config_root_subparsers.add_parser("show", help="Afficher le root implicite résolu")
 
     lives_parser = subparsers.add_parser("lives", help="Manage lives")
     lives_subparsers = lives_parser.add_subparsers(dest="lives_command", required=True)
@@ -1270,35 +1318,57 @@ def main(argv: list[str] | None = None) -> int:
     )
     lives_clone.add_argument("name", help="Slug or name of the source life")
     lives_clone.add_argument("--new-name", default=None, help="Nom de la nouvelle vie")
-    lives_relations = lives_subparsers.add_parser("relations", help="Afficher relations d'une vie")
-    lives_relations.add_argument("--name", default=None, help="Vie ciblée (sinon vie active)")
+    lives_relations = lives_subparsers.add_parser(
+        "relations", help="Afficher relations d'une vie"
+    )
+    lives_relations.add_argument(
+        "--name", default=None, help="Vie ciblée (sinon vie active)"
+    )
     lives_ally = lives_subparsers.add_parser("ally", help="Déclarer deux vies alliées")
     lives_ally.add_argument("name", help="Vie source")
     lives_ally.add_argument("other", help="Vie alliée")
-    lives_rival = lives_subparsers.add_parser("rival", help="Déclarer deux vies rivales")
+    lives_rival = lives_subparsers.add_parser(
+        "rival", help="Déclarer deux vies rivales"
+    )
     lives_rival.add_argument("name", help="Vie source")
     lives_rival.add_argument("other", help="Vie rivale")
-    lives_reconcile = lives_subparsers.add_parser("reconcile", help="Réconcilier deux vies")
+    lives_reconcile = lives_subparsers.add_parser(
+        "reconcile", help="Réconcilier deux vies"
+    )
     lives_reconcile.add_argument("name", help="Vie source")
     lives_reconcile.add_argument("other", help="Vie à réconcilier")
-    lives_proximity = lives_subparsers.add_parser("proximity", help="Ajuster score proximité")
+    lives_proximity = lives_subparsers.add_parser(
+        "proximity", help="Ajuster score proximité"
+    )
     lives_proximity.add_argument("name", help="Vie ciblée")
-    lives_proximity.add_argument("--score", type=float, required=True, help="Score [0..1]")
+    lives_proximity.add_argument(
+        "--score", type=float, required=True, help="Score [0..1]"
+    )
 
-    values_parser = subparsers.add_parser("values", help="Inspecter les poids de valeurs")
-    values_subparsers = values_parser.add_subparsers(dest="values_command", required=True)
-    values_subparsers.add_parser("show", help="Afficher la configuration des valeurs chargée")
+    values_parser = subparsers.add_parser(
+        "values", help="Inspecter les poids de valeurs"
+    )
+    values_subparsers = values_parser.add_subparsers(
+        dest="values_command", required=True
+    )
+    values_subparsers.add_parser(
+        "show", help="Afficher la configuration des valeurs chargée"
+    )
 
     policy_parser = subparsers.add_parser(
         "policy", help="Inspecter et modifier la politique globale"
     )
-    policy_subparsers = policy_parser.add_subparsers(dest="policy_command", required=True)
+    policy_subparsers = policy_parser.add_subparsers(
+        dest="policy_command", required=True
+    )
     policy_subparsers.add_parser("show", help="Afficher la politique active")
     policy_set_parser = policy_subparsers.add_parser(
         "set",
         help="Modifier une clé de politique (validation stricte)",
     )
-    policy_set_parser.add_argument("--key", required=True, choices=tuple(sorted(_POLICY_SETTERS.keys())))
+    policy_set_parser.add_argument(
+        "--key", required=True, choices=tuple(sorted(_POLICY_SETTERS.keys()))
+    )
     policy_set_parser.add_argument("--value", required=True, help="Nouvelle valeur")
 
     ecosystem_parser = subparsers.add_parser(
@@ -1480,7 +1550,9 @@ def main(argv: list[str] | None = None) -> int:
         from .runs.loop import loop as loop_run
 
         if args.ecosystem_command != "run":
-            raise SystemExit(f"Sous-commande ecosystem inconnue: {args.ecosystem_command}")
+            raise SystemExit(
+                f"Sous-commande ecosystem inconnue: {args.ecosystem_command}"
+            )
 
         names = list(args.ecosystem_lives)
         for group in args.ecosystem_groups:
@@ -1523,6 +1595,23 @@ def main(argv: list[str] | None = None) -> int:
         talk(provider=args.provider, seed=args.seed, prompt=args.prompt)
 
     elif args.command == "quest":
+        if args.example or args.schema:
+            import json
+
+            from .life.quest import FULL_SPEC_EXAMPLE, QUEST_SCHEMA
+
+            print(
+                json.dumps(
+                    QUEST_SCHEMA if args.schema else FULL_SPEC_EXAMPLE,
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return
+        if args.spec is None:
+            parser.error(
+                "quest requires a spec path unless --example or --schema is used"
+            )
         from .organisms.quest import quest
 
         _ensure_active_life(resolve_life, args.life)
@@ -1581,7 +1670,9 @@ def main(argv: list[str] | None = None) -> int:
         metadata = bootstrap_life(name, seed=args.seed)
         os.environ["SINGULAR_HOME"] = str(metadata.path)
         print(f"Vie créée: {metadata.name} ({metadata.slug}) → {metadata.path}")
-        if _can_prompt() and _prompt_yes_no("Lancer un diagnostic `doctor` maintenant ?"):
+        if _can_prompt() and _prompt_yes_no(
+            "Lancer un diagnostic `doctor` maintenant ?"
+        ):
             _doctor(fix=False)
 
     elif args.command == "monitor":
@@ -1637,7 +1728,10 @@ def main(argv: list[str] | None = None) -> int:
             )
         if args.retention_command == "status":
             return _retention_status()
-        if args.retention_command == "config" and args.retention_config_command == "show":
+        if (
+            args.retention_command == "config"
+            and args.retention_config_command == "show"
+        ):
             return _retention_config_show()
 
     elif args.command == "doctor":
@@ -1688,7 +1782,11 @@ def main(argv: list[str] | None = None) -> int:
                     for slug, meta in sorted(lives.items())
                 ]
                 if args.output_format == "json":
-                    print(json.dumps({"active": active, "lives": items}, ensure_ascii=False))
+                    print(
+                        json.dumps(
+                            {"active": active, "lives": items}, ensure_ascii=False
+                        )
+                    )
                 elif args.output_format == "table":
                     rows = [
                         [
@@ -1736,15 +1834,17 @@ def main(argv: list[str] | None = None) -> int:
                 metadata = archive_life(args.name)
             except KeyError as exc:
                 raise SystemExit(f"Vie introuvable: {args.name}") from exc
-            print(f"Vie archivée: {metadata.name} ({metadata.slug}) → statut={metadata.status}")
-            print("Conseil: exécutez `singular lives memorial <vie> --message \"...\"`.")
+            print(
+                f"Vie archivée: {metadata.name} ({metadata.slug}) → statut={metadata.status}"
+            )
+            print('Conseil: exécutez `singular lives memorial <vie> --message "..."`.')
         elif args.lives_command == "memorial":
             try:
                 memorial_path = memorialize_life(args.name, message=args.message)
             except KeyError as exc:
                 raise SystemExit(f"Vie introuvable: {args.name}") from exc
             print(f"Mémorial enregistré: {memorial_path}")
-            print("Conseil: exécutez `singular lives clone <vie> --new-name \"...\"`.")
+            print('Conseil: exécutez `singular lives clone <vie> --new-name "..."`.')
         elif args.lives_command == "clone":
             try:
                 metadata = clone_life(args.name, new_name=args.new_name)
@@ -1752,7 +1852,9 @@ def main(argv: list[str] | None = None) -> int:
                 raise SystemExit(f"Vie introuvable: {args.name}") from exc
             os.environ["SINGULAR_HOME"] = str(metadata.path)
             print(f"Vie clonée: {metadata.name} ({metadata.slug}) → {metadata.path}")
-            print("Conseil: exécutez `singular status --verbose` puis `singular loop --budget-seconds 10`.")
+            print(
+                "Conseil: exécutez `singular status --verbose` puis `singular loop --budget-seconds 10`."
+            )
         elif args.lives_command == "relations":
             try:
                 payload = list_relations(args.name)
@@ -1792,7 +1894,9 @@ def main(argv: list[str] | None = None) -> int:
                 meta = set_proximity(args.name, args.score)
             except (KeyError, ValueError, PermissionError) as exc:
                 raise SystemExit(str(exc)) from exc
-            print(f"Score proximité mis à jour: {meta.slug} = {meta.proximity_score:.2f}")
+            print(
+                f"Score proximité mis à jour: {meta.slug} = {meta.proximity_score:.2f}"
+            )
 
     elif args.command == "values":
         _ensure_active_life(resolve_life, args.life)
@@ -1832,7 +1936,11 @@ def main(argv: list[str] | None = None) -> int:
             if args.output_format == "json":
                 print(json.dumps({"policy": payload}, ensure_ascii=False))
             elif args.output_format == "table":
-                rows = [[key, str(value)] for key, value in payload.items() if key != "impact"]
+                rows = [
+                    [key, str(value)]
+                    for key, value in payload.items()
+                    if key != "impact"
+                ]
                 _print_table(["Section", "Valeur"], rows)
                 print("Impact:")
                 for item in payload["impact"]:

--- a/src/singular/life/quest.py
+++ b/src/singular/life/quest.py
@@ -12,6 +12,71 @@ class SpecValidationError(ValueError):
     """Raised when a specification fails validation."""
 
 
+MINIMAL_SPEC_EXAMPLE: dict[str, Any] = {
+    "name": "add_two",
+    "signature": "add_two(x)",
+    "examples": [{"input": [1], "output": 3}],
+    "constraints": {"pure": True, "no_import": True, "time_ms_max": 50},
+}
+
+FULL_SPEC_EXAMPLE: dict[str, Any] = {
+    "name": "repair_loop",
+    "signature": "repair_loop(x)",
+    "examples": [
+        {"input": [1], "output": 1},
+        {"input": [2], "output": 2},
+    ],
+    "constraints": {"pure": True, "no_import": True, "time_ms_max": 50},
+    "triggers": [{"signal": "noise", "gte": 0.5}],
+    "reward": {"mood": "pleasure", "resource_delta": {"food": 2}},
+    "penalty": {"mood": "pain", "resource_delta": {"energy": -1}},
+    "cooldown": 60,
+    "success": {"resource_min": {"energy": 80}},
+    "origin": "intrinsic",
+}
+
+QUEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["name", "signature", "examples", "constraints"],
+    "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "signature": {"type": "string", "minLength": 1},
+        "examples": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["input", "output"],
+                "properties": {"input": {}, "output": {}},
+            },
+        },
+        "constraints": {
+            "type": "object",
+            "required": ["pure", "no_import", "time_ms_max"],
+            "properties": {
+                "pure": {"const": True},
+                "no_import": {"const": True},
+                "time_ms_max": {"type": "integer", "minimum": 1},
+            },
+        },
+        "triggers": {"type": "array", "items": {"type": "object"}},
+        "reward": {"type": "object"},
+        "penalty": {"type": "object"},
+        "cooldown": {"type": "integer", "minimum": 0},
+        "success": {"type": "object"},
+        "origin": {"enum": ["intrinsic", "external"]},
+    },
+    "additionalProperties": True,
+}
+
+
+def _validation_error(field: str, expected: str, example: Any) -> SpecValidationError:
+    return SpecValidationError(
+        f"Invalid quest spec field {field!r}: expected {expected}. "
+        f"Minimal example: {json.dumps(example, ensure_ascii=False, sort_keys=True)}"
+    )
+
+
 @dataclass
 class Example:
     """Single input/output pair."""
@@ -52,72 +117,116 @@ def load(path: Path) -> Spec:
 
     name = data.get("name")
     if not isinstance(name, str) or not name.strip():
-        raise SpecValidationError("'name' must be a non-empty string")
+        raise _validation_error(
+            "name", "a non-empty string", {"name": MINIMAL_SPEC_EXAMPLE["name"]}
+        )
 
     signature = data.get("signature")
     if not isinstance(signature, str) or not signature.strip():
-        raise SpecValidationError("'signature' must be a non-empty string")
+        raise _validation_error(
+            "signature",
+            "a non-empty string such as function_name(arg)",
+            {"signature": MINIMAL_SPEC_EXAMPLE["signature"]},
+        )
 
     examples_raw = data.get("examples")
     if not isinstance(examples_raw, list) or not examples_raw:
-        raise SpecValidationError("'examples' must be a non-empty list")
+        raise _validation_error(
+            "examples",
+            "a non-empty list of input/output objects",
+            {"examples": MINIMAL_SPEC_EXAMPLE["examples"]},
+        )
 
     examples: List[Example] = []
     for idx, entry in enumerate(examples_raw):
         if not isinstance(entry, dict):
-            raise SpecValidationError(f"example {idx} must be an object")
+            raise _validation_error(
+                f"examples[{idx}]",
+                "an object with input and output",
+                {"input": [1], "output": 3},
+            )
         if "input" not in entry:
-            raise SpecValidationError(f"example {idx} missing 'input'")
+            raise _validation_error(
+                f"examples[{idx}].input",
+                "a value or list of function arguments",
+                {"input": [1]},
+            )
         if "output" not in entry:
-            raise SpecValidationError(f"example {idx} missing 'output'")
+            raise _validation_error(
+                f"examples[{idx}].output", "the expected return value", {"output": 3}
+            )
         inp = entry.get("input")
         inputs = inp if isinstance(inp, list) else [inp]
         examples.append(Example(inputs=inputs, output=entry.get("output")))
 
     constraints_raw = data.get("constraints")
     if not isinstance(constraints_raw, dict):
-        raise SpecValidationError("'constraints' must be an object")
+        raise _validation_error(
+            "constraints",
+            "an object declaring pure, no_import, and time_ms_max",
+            {"constraints": MINIMAL_SPEC_EXAMPLE["constraints"]},
+        )
 
     pure = constraints_raw.get("pure")
     if pure is not True:
-        raise SpecValidationError("'constraints.pure' must be true")
+        raise _validation_error(
+            "constraints.pure", "true", {"constraints": {"pure": True}}
+        )
 
     no_import = constraints_raw.get("no_import")
     if no_import is not True:
-        raise SpecValidationError("'constraints.no_import' must be true")
+        raise _validation_error(
+            "constraints.no_import", "true", {"constraints": {"no_import": True}}
+        )
 
     time_ms_max = constraints_raw.get("time_ms_max")
     if not isinstance(time_ms_max, int) or time_ms_max <= 0:
-        raise SpecValidationError(
-            "'constraints.time_ms_max' must be a positive integer"
+        raise _validation_error(
+            "constraints.time_ms_max",
+            "a positive integer number of milliseconds",
+            {"constraints": {"time_ms_max": 50}},
         )
 
     triggers = data.get("triggers", [])
     if not isinstance(triggers, list):
-        raise SpecValidationError("'triggers' must be a list")
+        raise _validation_error(
+            "triggers",
+            "a list of trigger objects",
+            {"triggers": FULL_SPEC_EXAMPLE["triggers"]},
+        )
     for idx, trigger in enumerate(triggers):
         if not isinstance(trigger, dict):
-            raise SpecValidationError(f"trigger {idx} must be an object")
+            raise _validation_error(
+                f"triggers[{idx}]", "an object", {"signal": "noise", "gte": 0.5}
+            )
 
     reward = data.get("reward", {})
     if not isinstance(reward, dict):
-        raise SpecValidationError("'reward' must be an object")
+        raise _validation_error(
+            "reward", "an object", {"reward": FULL_SPEC_EXAMPLE["reward"]}
+        )
 
     penalty = data.get("penalty", {})
     if not isinstance(penalty, dict):
-        raise SpecValidationError("'penalty' must be an object")
+        raise _validation_error(
+            "penalty", "an object", {"penalty": FULL_SPEC_EXAMPLE["penalty"]}
+        )
 
     cooldown = data.get("cooldown", 0)
     if not isinstance(cooldown, int) or cooldown < 0:
-        raise SpecValidationError("'cooldown' must be a non-negative integer")
+        raise _validation_error("cooldown", "a non-negative integer", {"cooldown": 0})
 
     success = data.get("success", {})
     if not isinstance(success, dict):
-        raise SpecValidationError("'success' must be an object")
+        raise _validation_error(
+            "success", "an object", {"success": FULL_SPEC_EXAMPLE["success"]}
+        )
 
     origin = data.get("origin", "external")
     if origin not in {"intrinsic", "external"}:
-        raise SpecValidationError("'origin' must be 'intrinsic' or 'external'")
+        raise _validation_error(
+            "origin", "'intrinsic' or 'external'", {"origin": "external"}
+        )
 
     constraints = Constraints(pure=True, no_import=True, time_ms_max=time_ms_max)
 

--- a/src/singular/organisms/quest.py
+++ b/src/singular/organisms/quest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from singular.life.quest import SpecValidationError, load
 from singular.life.synthesis import synthesise
 
 from ..memory import add_episode, ensure_memory_structure, update_score
@@ -19,6 +20,13 @@ def quest(spec: Path) -> None:
     spec:
         Path to the JSON specification describing the desired skill.
     """
+
+    # Validate before touching memory or skill directories so malformed user specs
+    # do not create any files as a side effect.
+    try:
+        load(spec)
+    except SpecValidationError:
+        raise
 
     ensure_memory_structure()
     psyche = Psyche.load_state()

--- a/tests/test_cli_quest.py
+++ b/tests/test_cli_quest.py
@@ -86,3 +86,59 @@ def test_quest_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
     psyche = json.loads((life_path / "mem" / "psyche.json").read_text())
     assert psyche["last_mood"] == "frustrated"
+
+
+def test_quest_example_prints_complete_json(capsys: pytest.CaptureFixture[str]) -> None:
+    main(["quest", "--example"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["name"] == "repair_loop"
+    assert payload["constraints"] == {
+        "pure": True,
+        "no_import": True,
+        "time_ms_max": 50,
+    }
+    assert payload["triggers"] == [{"signal": "noise", "gte": 0.5}]
+
+
+def test_quest_schema_prints_without_active_life(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    main(["quest", "--schema"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["required"] == ["name", "signature", "examples", "constraints"]
+    assert payload["properties"]["constraints"]["properties"]["pure"] == {"const": True}
+
+
+def test_quest_invalid_spec_does_not_create_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "world"
+    spec_path = tmp_path / "invalid.json"
+    spec_path.write_text(
+        json.dumps(
+            {
+                "name": "broken",
+                "signature": "broken(x)",
+                "examples": [],
+                "constraints": {"pure": True, "no_import": True, "time_ms_max": 50},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+
+    main(["--root", str(root), "birth", "--name", "Vie Quest Invalid"])
+    life_path = resolve_life(None)
+    assert life_path is not None
+    before = {path.relative_to(life_path) for path in life_path.rglob("*")}
+
+    with pytest.raises(ValueError, match="examples"):
+        main(["--root", str(root), "quest", str(spec_path)])
+
+    after = {path.relative_to(life_path) for path in life_path.rglob("*")}
+    assert after == before
+    assert not (life_path / "skills" / "broken.py").exists()

--- a/tests/test_quest.py
+++ b/tests/test_quest.py
@@ -83,3 +83,57 @@ def test_load_invalid_origin(tmp_path):
 
     with pytest.raises(quest.SpecValidationError):
         quest.load(path)
+
+
+def test_validation_error_names_field_and_minimal_example(tmp_path):
+    path = tmp_path / "spec.json"
+    path.write_text(
+        json.dumps(
+            {
+                "name": "adder",
+                "signature": "adder(a, b)",
+                "examples": [{"input": [1, 2]}],
+                "constraints": {"pure": True, "no_import": True, "time_ms_max": 50},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(quest.SpecValidationError) as excinfo:
+        quest.load(path)
+
+    message = str(excinfo.value)
+    assert "examples[0].output" in message
+    assert "expected the expected return value" in message
+    assert "Minimal example" in message
+    assert '"output": 3' in message
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_field"),
+    [
+        ("examples", [], "examples"),
+        ("triggers", {"signal": "noise"}, "triggers"),
+        ("cooldown", -1, "cooldown"),
+    ],
+)
+def test_validation_errors_are_self_explanatory_for_common_user_mistakes(
+    tmp_path, field, value, expected_field
+):
+    spec_data = {
+        "name": "adder",
+        "signature": "adder(a, b)",
+        "examples": [{"input": [1, 2], "output": 3}],
+        "constraints": {"pure": True, "no_import": True, "time_ms_max": 50},
+    }
+    spec_data[field] = value
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(spec_data), encoding="utf-8")
+
+    with pytest.raises(quest.SpecValidationError) as excinfo:
+        quest.load(path)
+
+    message = str(excinfo.value)
+    assert expected_field in message
+    assert "expected" in message
+    assert "Minimal example" in message


### PR DESCRIPTION
### Motivation

- Rendre le format de spécification de `quest` facile à découvrir et réduire les erreurs utilisateur en fournissant un exemple complet et un schéma minimal. 
- Éviter les effets secondaires indésirables (création de mémoire/fichiers) lorsque la spécification fournie est invalide.

### Description

- Ajout d’un exemple complet `FULL_SPEC_EXAMPLE`, d’un `MINIMAL_SPEC_EXAMPLE` et d’un `QUEST_SCHEMA` dans `src/singular/life/quest.py` pour documenter le format JSON attendu. 
- Amélioration des erreurs de validation via `_validation_error(...)` pour que `SpecValidationError` indique le champ invalide, le type/format attendu et un exemple minimal réutilisable. 
- Exposition de deux options CLI informatives `--example` et `--schema` pour la commande `singular quest` (impression JSON) et acceptation optionnelle de `spec` (sans exiger de vie active pour ces sorties) dans `src/singular/cli.py`. 
- Validation préalable dans `src/singular/organisms/quest.py` en appelant `load(spec)` avant toute modification de la structure de mémoire ou création de répertoires afin d’empêcher la création de fichiers quand la spec est invalide. 
- Ajout d’un fichier versionné d’exemple complet `examples/quest/complete_quest.json` et documentation dans `README.md` expliquant les sorties CLI et la garantie "no-side-effect" pour les specs invalides. 
- Ajout de tests pour couvrir les nouveaux messages d’erreur, les sorties CLI `--example`/`--schema` et la propriété qu’une spec invalide ne crée aucun fichier (`tests/test_quest.py`, `tests/test_cli_quest.py`).

### Testing

- Exécution des tests ciblés : `pytest -q tests/test_quest.py tests/test_cli_quest.py` a réussi (15 passed). 
- Les nouveaux tests vérifient que les messages de `SpecValidationError` contiennent le champ, l’attendu et un exemple minimal, que `singular quest --example` et `--schema` impriment les JSON attendus, et que l’exécution d’une spec invalide ne crée pas de fichiers dans la vie active. 
- Aucun test automatisé n’a échoué lors de la validation réalisée dans cet ensemble de modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7360e3b770832a87f2a6a8ff3b7eac)