### PR TITLE
Add Ollama LLM provider (HTTP) with tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ unique et quitter immédiatement :
 singular talk --prompt "Bonjour"
 ```
 
+### Utiliser Ollama comme fournisseur LLM local
+
+Si Ollama tourne sur votre machine (API HTTP locale par défaut sur
+``http://127.0.0.1:11434``), sélectionnez le provider ``ollama`` avec
+``LLM_PROVIDER`` :
+
+```bash
+LLM_PROVIDER=ollama singular talk --prompt "Bonjour, qui es-tu ?"
+```
+
+Configuration utile :
+
+- ``OLLAMA_HOST`` : URL de l'API Ollama (défaut : ``http://127.0.0.1:11434``) ;
+- ``OLLAMA_MODEL`` : modèle de génération (défaut : ``llama3.2``) ;
+- ``OLLAMA_EMBED_MODEL`` : modèle d'embeddings si différent du modèle de génération.
+
+La chaîne de fallback intégrée essaie ``local``, ``ollama``, ``openai`` puis
+``dummy``. Vous pouvez la personnaliser avec ``LLM_PROVIDER_FALLBACK`` (ex.
+``LLM_PROVIDER_FALLBACK=ollama,dummy``).
+
 ### CLI `loop` (budget en secondes)
 
 La syntaxe officielle utilise désormais un budget temporel explicite :

--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Protocol
 
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 8.0
 DEFAULT_PROVIDER_MAX_RETRIES = 2
-DEFAULT_FALLBACK_CHAIN = ("local", "openai", "dummy")
+DEFAULT_FALLBACK_CHAIN = ("local", "ollama", "openai", "dummy")
 
 
 class LLMProviderError(RuntimeError):

--- a/src/singular/providers/llm_ollama.py
+++ b/src/singular/providers/llm_ollama.py
@@ -1,0 +1,132 @@
+"""Ollama LLM provider using the local HTTP API."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import time
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from . import ProviderExecutionError, ProviderMetrics, ProviderTimeoutError, ProviderUnavailableError
+
+MAX_RETRIES = 1
+DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434"
+DEFAULT_OLLAMA_MODEL = "llama3.2"
+DEFAULT_OLLAMA_EMBED_MODEL = "nomic-embed-text"
+
+LAST_METRICS = ProviderMetrics(provider="ollama")
+
+
+def _host() -> str:
+    return (os.getenv("OLLAMA_HOST") or DEFAULT_OLLAMA_HOST).strip().rstrip("/")
+
+
+def _model() -> str:
+    return (os.getenv("OLLAMA_MODEL") or DEFAULT_OLLAMA_MODEL).strip()
+
+
+def _embed_model() -> str:
+    return (os.getenv("OLLAMA_EMBED_MODEL") or "").strip() or _model() or DEFAULT_OLLAMA_EMBED_MODEL
+
+
+def _filter(text: str) -> str:
+    """Return only printable characters from ``text``."""
+
+    return "".join(ch for ch in text if ch.isprintable())
+
+
+def _post_json(path: str, payload: dict[str, Any], *, timeout: float) -> dict[str, Any]:
+    url = f"{_host()}{path}"
+    data = json.dumps(payload).encode("utf-8")
+    request = Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urlopen(request, timeout=timeout) as response:  # noqa: S310 - configured local provider URL
+            raw = response.read().decode("utf-8")
+    except TimeoutError as exc:
+        raise ProviderTimeoutError("Ollama request timed out") from exc
+    except socket.timeout as exc:
+        raise ProviderTimeoutError("Ollama request timed out") from exc
+    except HTTPError as exc:
+        message = exc.reason or exc.read().decode("utf-8", errors="replace")
+        raise ProviderExecutionError(f"Ollama HTTP error {exc.code}: {message}") from exc
+    except URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        if isinstance(reason, TimeoutError | socket.timeout):
+            raise ProviderTimeoutError("Ollama request timed out") from exc
+        raise ProviderUnavailableError("Unable to connect to Ollama") from exc
+    except OSError as exc:
+        raise ProviderUnavailableError("Unable to connect to Ollama") from exc
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProviderExecutionError("Ollama response is not valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise ProviderExecutionError("Ollama response schema error: expected object")
+    return parsed
+
+
+def generate(prompt: str, *, timeout: float = 8.0) -> str:
+    """Generate a reply with Ollama's local ``/api/generate`` endpoint."""
+
+    start = time.perf_counter()
+    response = _post_json(
+        "/api/generate",
+        {"model": _model(), "prompt": prompt, "stream": False},
+        timeout=timeout,
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    LAST_METRICS.latency_ms = round(elapsed_ms, 2)
+
+    text = response.get("response")
+    if not isinstance(text, str):
+        raise ProviderExecutionError("Ollama response schema error: missing response text")
+
+    filtered = _filter(text)
+    LAST_METRICS.input_tokens = len(prompt.split())
+    LAST_METRICS.output_tokens = len(filtered.split())
+    LAST_METRICS.estimated_cost_usd = cost_estimate(prompt, filtered)
+    return filtered
+
+
+def embed(text: str, *, timeout: float = 8.0) -> list[float]:
+    """Return embeddings from Ollama's local embedding endpoint."""
+
+    response = _post_json(
+        "/api/embeddings",
+        {"model": _embed_model(), "prompt": text},
+        timeout=timeout,
+    )
+    values = response.get("embedding")
+    if not isinstance(values, list):
+        raise ProviderExecutionError("Ollama response schema error: missing embedding")
+    try:
+        return [float(value) for value in values]
+    except (TypeError, ValueError) as exc:
+        raise ProviderExecutionError("Ollama response schema error: invalid embedding values") from exc
+
+
+def healthcheck() -> dict[str, object]:
+    """Return provider configuration and whether the local Ollama API responds."""
+
+    try:
+        _post_json("/api/generate", {"model": _model(), "prompt": "", "stream": False}, timeout=1.0)
+    except Exception as exc:  # healthchecks report instead of raising
+        return {"ok": False, "provider": "ollama", "host": _host(), "model": _model(), "error": str(exc)}
+    return {"ok": True, "provider": "ollama", "host": _host(), "model": _model()}
+
+
+def cost_estimate(prompt: str, completion: str = "", **_kwargs: object) -> float:
+    """Ollama runs locally, so direct provider cost is zero."""
+
+    del prompt, completion
+    return 0.0
+
+
+def generate_reply(prompt: str, *, timeout: float = 8.0) -> str:
+    """Backward-compatible alias to unified ``generate``."""
+
+    return generate(prompt, timeout=timeout)

--- a/tests/providers/test_llm_ollama.py
+++ b/tests/providers/test_llm_ollama.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import socket
+from urllib.error import URLError
+
+import pytest
+
+from singular.providers import ProviderExecutionError, ProviderTimeoutError, ProviderUnavailableError
+from singular.providers import llm_ollama
+
+
+class FakeHTTPResponse:
+    def __init__(self, payload: dict[str, object]):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_generate_reply_posts_to_configured_ollama_host(monkeypatch):
+    calls = []
+    monkeypatch.setenv("OLLAMA_HOST", "http://ollama.test/")
+    monkeypatch.setenv("OLLAMA_MODEL", " mistral ")
+
+    def fake_urlopen(request, timeout):
+        calls.append((request.full_url, json.loads(request.data.decode("utf-8")), timeout))
+        return FakeHTTPResponse({"response": "bonjour\x00"})
+
+    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+
+    assert llm_ollama.generate_reply("salut", timeout=2.5) == "bonjour"
+    assert calls == [
+        (
+            "http://ollama.test/api/generate",
+            {"model": "mistral", "prompt": "salut", "stream": False},
+            2.5,
+        )
+    ]
+
+
+def test_embed_uses_configured_embedding_model(monkeypatch):
+    calls = []
+    monkeypatch.setenv("OLLAMA_EMBED_MODEL", " nomic-embed-text ")
+
+    def fake_urlopen(request, timeout):
+        calls.append((request.full_url, json.loads(request.data.decode("utf-8")), timeout))
+        return FakeHTTPResponse({"embedding": [1, "2.5", 3.0]})
+
+    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+
+    assert llm_ollama.embed("texte", timeout=4.0) == [1.0, 2.5, 3.0]
+    assert calls[0][1] == {"model": "nomic-embed-text", "prompt": "texte"}
+    assert calls[0][2] == 4.0
+
+
+def test_timeout_maps_to_provider_timeout(monkeypatch):
+    def fake_urlopen(_request, timeout):
+        raise socket.timeout("too slow")
+
+    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+
+    with pytest.raises(ProviderTimeoutError):
+        llm_ollama.generate_reply("salut")
+
+
+def test_network_error_maps_to_provider_unavailable(monkeypatch):
+    def fake_urlopen(_request, timeout):
+        raise URLError("connection refused")
+
+    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+
+    with pytest.raises(ProviderUnavailableError):
+        llm_ollama.generate_reply("salut")
+
+
+def test_schema_errors_map_to_provider_execution(monkeypatch):
+    def fake_urlopen(_request, timeout):
+        return FakeHTTPResponse({"not_response": "missing"})
+
+    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+
+    with pytest.raises(ProviderExecutionError, match="missing response text"):
+        llm_ollama.generate_reply("salut")
+
+
+def test_healthcheck_reports_unavailable(monkeypatch):
+    def fake_urlopen(_request, timeout):
+        raise URLError("connection refused")
+
+    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+
+    result = llm_ollama.healthcheck()
+    assert result["ok"] is False
+    assert result["provider"] == "ollama"
+    assert result["host"] == llm_ollama.DEFAULT_OLLAMA_HOST
+
+
+def test_cost_estimate_is_zero_for_local_ollama():
+    assert llm_ollama.cost_estimate("prompt", "completion") == 0.0


### PR DESCRIPTION
### Motivation

- Provide a local Ollama-backed LLM provider that conforms to the existing `LLMProviderContract` so it can be used interchangeably with `local`, `openai`, and `dummy` providers.  
- Allow configuring Ollama via environment variables (`OLLAMA_HOST`, `OLLAMA_MODEL`, `OLLAMA_EMBED_MODEL`) and include it in the default fallback chain.  
- Ensure runtime errors from the Ollama HTTP API map to the project's typed provider exceptions for consistent error handling.

### Description

- Add `src/singular/providers/llm_ollama.py` implementing `generate_reply`/`generate`, `embed`, `healthcheck`, and `cost_estimate`, using the local Ollama HTTP endpoints and `LAST_METRICS` for provider metrics.  
- Map network/timeouts/HTTP/JSON/schema failures to `ProviderUnavailableError`, `ProviderTimeoutError`, and `ProviderExecutionError` as appropriate, and set `MAX_RETRIES = 1`.  
- Insert `"ollama"` into `DEFAULT_FALLBACK_CHAIN` so the fallback order becomes `local, ollama, openai, dummy`.  
- Add unit tests in `tests/providers/test_llm_ollama.py` that mock `urlopen` to verify request payloads, embedding behavior, timeout/network/schema error mapping, healthcheck behavior, and the zero-cost estimate for local Ollama, and update `README.md` with usage examples and environment variable documentation.

### Testing

- Ran `pytest tests/providers/test_llm_ollama.py tests/providers/test_llm_fallback_chain.py tests/providers/test_llm_provider_loader.py -q` and the tests passed.  
- Ran `pytest tests/providers -q` which passed (all provider-related provider tests succeeded).  
- Ran `python -m py_compile src/singular/providers/llm_ollama.py` which succeeded, and a full project `pytest -q` was attempted but failed during collection due to a pre-existing unrelated import error (`ImportError: cannot import name 'CHECKPOINT_VERSION' from 'singular.life.loop'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73624094e4832aace85f2f12eabf7c)