### PR TITLE
Improve LLM fallback diagnostics and add provider doctor

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -606,6 +606,31 @@ def _configure_openai(api_key: str, *, shell_profile: str | None, test: bool) ->
     return 0
 
 
+def _doctor_providers() -> int:
+    """Display LLM provider diagnostics for OpenAI, Ollama and local backends."""
+
+    from .providers import doctor_providers
+
+    print("Diagnostic providers LLM")
+    exit_code = 0
+    for result in doctor_providers():
+        ok = bool(result.get("ok"))
+        if not ok:
+            exit_code = 1
+        status = "✅ ok" if ok else "⚠️ indisponible"
+        provider = result.get("provider", "inconnu")
+        llm_real = str(bool(result.get("llm_real"))).lower()
+        error_category = result.get("error_category") or "none"
+        details = []
+        for key in ("model", "host", "error"):
+            value = result.get(key)
+            if value:
+                details.append(f"{key}={value}")
+        suffix = f" ({', '.join(details)})" if details else ""
+        print(f"- {provider}: {status} | llm_real={llm_real} | error_category={error_category}{suffix}")
+    return exit_code
+
+
 _POLICY_SETTERS: dict[str, tuple[str, str]] = {
     "memory.preserve_threshold": ("float", "memory_preserve_threshold"),
     "forgetting.enabled": ("bool", "forgetting_enabled"),
@@ -1271,6 +1296,15 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run a short provider ping after configuration",
     )
+    config_providers_parser = config_subparsers.add_parser(
+        "providers", help="Diagnose LLM providers"
+    )
+    config_providers_subparsers = config_providers_parser.add_subparsers(
+        dest="config_providers_command", required=True
+    )
+    config_providers_subparsers.add_parser(
+        "doctor", help="Vérifie OpenAI, Ollama et local"
+    )
     config_root_parser = config_subparsers.add_parser(
         "root", help="Configurer le root de registre persistant"
     )
@@ -1503,10 +1537,9 @@ def main(argv: list[str] | None = None) -> int:
         os.environ["SINGULAR_SAFE_MODE"] = "1"
 
     if args.command == "birth":
-        print(
+        sys.stderr.write(
             "⚠️ `singular birth` est déprécié et sera supprimé après la période "
-            "de transition. Migrez vers `singular lives create --name ...`.",
-            file=sys.stderr,
+            "de transition. Migrez vers `singular lives create --name ...`.\n"
         )
         _create_life_with_bootstrap(
             args,
@@ -1736,6 +1769,7 @@ def main(argv: list[str] | None = None) -> int:
 
     elif args.command == "doctor":
         _doctor(fix=args.fix)
+        _doctor_providers()
 
     elif args.command == "config":
         if args.config_command == "openai":
@@ -1749,6 +1783,9 @@ def main(argv: list[str] | None = None) -> int:
                 shell_profile=args.shell_profile,
                 test=args.test,
             )
+        if args.config_command == "providers":
+            if args.config_providers_command == "doctor":
+                return _doctor_providers()
         if args.config_command == "root":
             if args.config_root_command == "set":
                 config_path, resolved_root = set_configured_registry_root(

--- a/src/singular/metrics/autonomy.py
+++ b/src/singular/metrics/autonomy.py
@@ -26,6 +26,8 @@ def _parse_ts(value: object) -> datetime | None:
 
 
 def _is_action_record(record: dict[str, Any]) -> bool:
+    if record.get("fallback_used") is True and record.get("llm_real") is False:
+        return False
     event = record.get("event")
     if event in {"mutation", "interaction", "refuse", "delay", "test_coevolution"}:
         return True

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -20,6 +20,7 @@ from ..providers import (
     ProviderRetryExhaustedError,
     ProviderTimeoutError,
     ProviderUnavailableError,
+    describe_client,
     load_llm_client,
 )
 from ..runs.logger import log_provider_event
@@ -174,6 +175,11 @@ def talk(
     print(f"Provider: {provider_name}")
 
     client = load_llm_client(provider_name)
+    provider_status = describe_client(client, provider_name)
+    print(
+        f"Provider active: {provider_status['active_provider']} | "
+        f"llm_real={str(provider_status['llm_real']).lower()} | fallback=not-yet"
+    )
     if client is None:
         print(
             f"Provider '{provider_name}' not found. "
@@ -261,17 +267,34 @@ def talk(
         start = time.perf_counter()
         fallback_used = client is None
         error_category: str | None = "provider_missing" if client is None else None
+        active_provider = str(provider_status["active_provider"])
+        llm_real = bool(provider_status["llm_real"]) and not fallback_used
 
         if client is None:
+            print(
+                f"LLM status: active={active_provider} fallback=true "
+                f"error_category={error_category} llm_real=false"
+            )
             reply = _default_reply(user_input, rng)
         else:
             try:
                 reply = client.generate_reply(provider_prompt)
             except LLMProviderError as err:
                 fallback_used = True
+                llm_real = False
                 error_category = getattr(err, "category", "provider_error")
                 print(_user_message_for_error(provider_name, err))
+                print(
+                    f"LLM status: active={active_provider} fallback=true "
+                    f"error_category={error_category} llm_real=false"
+                )
                 reply = _default_reply(user_input, rng)
+            else:
+                print(
+                    f"LLM status: active={active_provider} fallback=false "
+                    "error_category=none "
+                    f"llm_real={str(llm_real).lower()}"
+                )
 
         latency_ms = (time.perf_counter() - start) * 1000
         log_provider_event(
@@ -279,6 +302,8 @@ def talk(
             latency_ms=latency_ms,
             fallback=fallback_used,
             error_category=error_category,
+            llm_real=llm_real,
+            active_provider=active_provider,
         )
 
         parts = [reply]
@@ -303,6 +328,9 @@ def talk(
                 "text": response,
                 "raw_reply": reply,
                 "mood": mood.value,
+                "llm_real": llm_real,
+                "fallback_used": fallback_used,
+                "error_category": error_category,
                 "structured_signals": user_signals,
                 "context": {
                     "self_narrative_version": self_narrative_version,
@@ -317,6 +345,8 @@ def talk(
             - float(user_signals.get("frustration", 0.0)),
             3,
         )
+        cognitive_success = llm_real and not fallback_used
+        cognitive_gain = gain_estimate if cognitive_success else 0.0
         add_causal_trace(
             {
                 "ts": datetime.now(timezone.utc).isoformat(),
@@ -329,8 +359,10 @@ def talk(
                 },
                 "decision": {
                     "provider": provider_name,
+                    "active_provider": active_provider,
                     "fallback_used": fallback_used,
                     "error_category": error_category,
+                    "llm_real": llm_real,
                     "mood": mood_report,
                 },
                 "action": {
@@ -339,10 +371,11 @@ def talk(
                     "response": response,
                 },
                 "result": {
-                    "gain_loss": gain_estimate,
+                    "cognitive_success": cognitive_success,
+                    "gain_loss": cognitive_gain,
                     "objective_impact": {
                         "objective": f"user_dialogue:{user_signals.get('theme', 'general')}",
-                        "impact": gain_estimate,
+                        "impact": cognitive_gain,
                     },
                 },
             }

--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -155,6 +155,77 @@ class FallbackLLMClient(LLMProviderClient):
         raise ProviderUnavailableError("No provider available in fallback chain")
 
 
+def provider_is_real(name: str | None) -> bool:
+    """Return whether a provider name points to a real LLM backend."""
+
+    if not name:
+        return False
+    return name.strip().lower() not in {"stub", "dummy"}
+
+
+def describe_client(client: LLMProviderClient | None, requested: str) -> dict[str, Any]:
+    """Return status details for a loaded provider client."""
+
+    active = client.name if client is not None else requested
+    chain = (
+        [child.name for child in client.chain]
+        if isinstance(client, FallbackLLMClient)
+        else ([client.name] if client else [])
+    )
+    return {
+        "requested_provider": requested,
+        "active_provider": active,
+        "provider_chain": chain,
+        "llm_real": (
+            any(provider_is_real(name) for name in chain)
+            if chain
+            else provider_is_real(active)
+        ),
+    }
+
+
+def doctor_providers(names: list[str] | None = None) -> list[dict[str, Any]]:
+    """Healthcheck configured providers without issuing a conversational success signal."""
+
+    provider_names = names or ["openai", "ollama", "local"]
+    results: list[dict[str, Any]] = []
+    for name in provider_names:
+        try:
+            contract = _load_provider_contract(name)
+            if contract is None:
+                results.append(
+                    {
+                        "provider": name,
+                        "ok": False,
+                        "llm_real": provider_is_real(name),
+                        "error_category": "provider_missing",
+                    }
+                )
+                continue
+            status = contract.healthcheck()
+            ok = bool(status.get("ok"))
+            results.append(
+                {
+                    **status,
+                    "provider": str(status.get("provider") or name),
+                    "ok": ok,
+                    "llm_real": provider_is_real(name),
+                    "error_category": None if ok else "unavailable",
+                }
+            )
+        except LLMProviderError as exc:
+            results.append(
+                {
+                    "provider": name,
+                    "ok": False,
+                    "llm_real": provider_is_real(name),
+                    "error_category": getattr(exc, "category", "provider_error"),
+                    "error": str(exc),
+                }
+            )
+    return results
+
+
 def _invoke_provider(fn: Callable[..., Any], **kwargs: Any) -> Any:
     """Invoke provider callables while supporting legacy signatures."""
 

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -64,15 +64,19 @@ def log_provider_event(
     latency_ms: float,
     fallback: bool,
     error_category: str | None,
+    llm_real: bool,
+    active_provider: str | None = None,
 ) -> None:
     """Emit a structured provider log entry."""
 
     payload = {
         "event": "provider_call",
         "provider": provider,
+        "active_provider": active_provider or provider,
         "latency_ms": round(latency_ms, 2),
         "fallback": fallback,
         "error_category": error_category,
+        "llm_real": llm_real,
     }
     _provider_logger.info("provider_call", extra={"payload": payload})
 

--- a/tests/providers/test_provider_doctor.py
+++ b/tests/providers/test_provider_doctor.py
@@ -1,0 +1,43 @@
+import singular.providers as providers
+from singular.providers import LLMProviderContract, doctor_providers, provider_is_real
+
+
+def test_provider_is_real_excludes_offline_stubs():
+    assert provider_is_real("openai") is True
+    assert provider_is_real("ollama") is True
+    assert provider_is_real("local") is True
+    assert provider_is_real("stub") is False
+    assert provider_is_real("dummy") is False
+
+
+def test_doctor_providers_reports_missing_provider_category(monkeypatch):
+    monkeypatch.setattr(providers, "_load_provider_contract", lambda _name: None)
+
+    results = doctor_providers(["openai"])
+
+    assert results == [
+        {
+            "provider": "openai",
+            "ok": False,
+            "llm_real": True,
+            "error_category": "provider_missing",
+        }
+    ]
+
+
+def test_doctor_providers_normalizes_healthcheck_failures(monkeypatch):
+    contract = LLMProviderContract(
+        name="ollama",
+        generate=lambda prompt, timeout=8.0: prompt,
+        embed=lambda text, timeout=8.0: [1.0],
+        healthcheck=lambda: {"ok": False, "provider": "ollama", "error": "offline"},
+        cost_estimate=lambda prompt, completion="": 0.0,
+    )
+    monkeypatch.setattr(providers, "_load_provider_contract", lambda _name: contract)
+
+    result = doctor_providers(["ollama"])[0]
+
+    assert result["provider"] == "ollama"
+    assert result["ok"] is False
+    assert result["llm_real"] is True
+    assert result["error_category"] == "unavailable"

--- a/tests/test_cli_provider_doctor.py
+++ b/tests/test_cli_provider_doctor.py
@@ -1,0 +1,26 @@
+from singular import cli
+
+
+def test_config_providers_doctor_prints_provider_status(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "singular.providers.doctor_providers",
+        lambda: [
+            {
+                "provider": "openai",
+                "ok": False,
+                "llm_real": True,
+                "error_category": "misconfigured",
+                "error": "OPENAI_API_KEY not configured",
+            },
+            {"provider": "ollama", "ok": True, "llm_real": True, "error_category": None},
+        ],
+    )
+
+    rc = cli.main(["config", "providers", "doctor"])
+
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "Diagnostic providers LLM" in out
+    assert "openai" in out
+    assert "error_category=misconfigured" in out
+    assert "ollama" in out

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -353,3 +353,39 @@ def test_unknown_argument_that_looks_like_life_suggests_life_flag(
     stderr = capsys.readouterr().err
     assert "singular --life <slug> talk" in stderr
     assert "singular --root <root> --life <slug> talk" in stderr
+
+
+def test_talk_marks_fallback_as_not_real_llm_in_memory_and_traces(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    inputs = iter(["hello", "quit"])
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    monkeypatch.setattr("builtins.print", lambda _msg: None)
+
+    talk(provider="missing", seed=1)
+
+    assistant = [e for e in read_episodes() if e.get("role") == "assistant"][-1]
+    assert assistant["llm_real"] is False
+    assert assistant["fallback_used"] is True
+    assert assistant["error_category"] == "provider_missing"
+    trace = read_causal_timeline()[-1]
+    assert trace["decision"]["llm_real"] is False
+    assert trace["decision"]["fallback_used"] is True
+    assert trace["result"]["cognitive_success"] is False
+    assert trace["result"]["gain_loss"] == 0.0
+
+
+def test_talk_status_includes_active_fallback_and_error_category(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    inputs = iter(["hello", "quit"])
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
+    monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
+    outputs: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
+
+    talk(provider="missing", seed=2)
+
+    assert any("Provider active: missing" in out for out in outputs)
+    assert any("fallback=true" in out and "error_category=provider_missing" in out for out in outputs)


### PR DESCRIPTION
### Motivation
- Provide clear runtime visibility when a real LLM is unavailable and avoid counting local fallbacks as cognitive successes in autonomy metrics.
- Offer a lightweight `doctor`-style check for common LLM backends (OpenAI, Ollama, local) so users can inspect provider health without misreporting success.

### Description
- Emit richer provider status at talk time with `active_provider`, `llm_real`, and explicit fallback/error indicators in `src/singular/organisms/talk.py` and print human-readable LLM status lines.
- Persist `llm_real`, `fallback_used`, and `error_category` into assistant episodic entries and causal traces, and add `cognitive_success` + conditional zeroed `gain_loss` when fallback is used.
- Extend provider utilities in `src/singular/providers/__init__.py` with `provider_is_real`, `describe_client`, and `doctor_providers` to assess provider health without signalling conversational success.
- Add `singular config providers doctor` and run provider checks from the top-level `doctor` flow in `src/singular/cli.py` and present normalized provider output.
- Enrich structured provider logs in `src/singular/runs/logger.py` to include `active_provider` and `llm_real`.
- Exclude fallback-only interactions from autonomy action records in `src/singular/metrics/autonomy.py` so metrics do not treat local stub replies as autonomous cognitive wins.
- Add tests: updated `tests/test_talk.py` and new `tests/providers/test_provider_doctor.py` and `tests/test_cli_provider_doctor.py` that cover fallback marking, trace fields, provider doctor normalization, and CLI output.

### Testing
- Ran `python -m compileall -q src/singular` which completed successfully.
- Ran targeted test suites with `pytest -q tests/test_talk.py tests/providers/test_provider_doctor.py tests/providers/test_llm_fallback_chain.py tests/test_autonomy_metrics.py tests/test_cli_doctor.py tests/test_cli_provider_doctor.py` which reported `32 passed`.
- Ran `python -m ruff check` against modified files and no issues were reported.
- Note: a full `pytest -q` of the whole repo initially surfaced an unrelated import error in an existing test (`ImportError: cannot import name 'CHECKPOINT_VERSION' from 'singular.life.loop'`) which prevented collection of every test, but all new/modified tests and relevant provider tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7363652900832ab57b24d200492cd6)