### PR TITLE
Add `singular daemon` — simple per-life daemon and CLI

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -627,7 +627,9 @@ def _doctor_providers() -> int:
             if value:
                 details.append(f"{key}={value}")
         suffix = f" ({', '.join(details)})" if details else ""
-        print(f"- {provider}: {status} | llm_real={llm_real} | error_category={error_category}{suffix}")
+        print(
+            f"- {provider}: {status} | llm_real={llm_real} | error_category={error_category}{suffix}"
+        )
     return exit_code
 
 
@@ -1222,6 +1224,43 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Active les phases sans exécuter la mutation",
     )
+    daemon_parser = subparsers.add_parser(
+        "daemon",
+        help="Lance un daemon simple pour une vie enregistrée",
+    )
+    daemon_parser.add_argument(
+        "--life",
+        required=True,
+        help="Nom ou slug de la vie à exécuter",
+    )
+    daemon_parser.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Intervalle en secondes entre deux ticks",
+    )
+    daemon_parser.add_argument(
+        "--budget-seconds",
+        type=float,
+        default=None,
+        help="Budget total optionnel en secondes avant arrêt propre",
+    )
+    daemon_parser.add_argument(
+        "--max-errors",
+        type=int,
+        default=3,
+        help="Nombre maximal d'erreurs consécutives avant arrêt",
+    )
+    daemon_parser.add_argument(
+        "--dashboard",
+        action="store_true",
+        help="Ajoute les métadonnées dashboard aux logs du daemon",
+    )
+    daemon_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Exécute perception/objectifs/checkpoints sans mutation",
+    )
     diagnose_parser = subparsers.add_parser(
         "diagnose", help="Exécuter des diagnostics techniques"
     )
@@ -1730,6 +1769,25 @@ def main(argv: list[str] | None = None) -> int:
             dry_run=args.dry_run,
             watch_dir=args.watch_dir,
         )
+    elif args.command == "daemon":
+        from .orchestrator import run_life_daemon
+
+        _run_retention_at_safe_point()
+        try:
+            return run_life_daemon(
+                life_name=args.life,
+                interval_seconds=args.interval,
+                budget_seconds=args.budget_seconds,
+                max_errors=args.max_errors,
+                dashboard=args.dashboard,
+                dry_run=args.dry_run,
+                safe_mode=args.safe_mode,
+            )
+        except KeyError as exc:
+            raise SystemExit(f"Vie inconnue: {exc.args[0]}") from exc
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+
     elif args.command == "orchestrate":
         _ensure_active_life(resolve_life, args.life)
         if args.orchestrate_command == "run":

--- a/src/singular/orchestrator/__init__.py
+++ b/src/singular/orchestrator/__init__.py
@@ -6,6 +6,7 @@ from .service import (
     OrchestratorService,
     SchedulerConfig,
     run_orchestrator_daemon,
+    run_life_daemon,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "OrchestratorService",
     "SchedulerConfig",
     "run_orchestrator_daemon",
+    "run_life_daemon",
 ]

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -23,6 +23,7 @@ from singular.goals import IntrinsicGoals
 from singular.governance.policy import MutationGovernancePolicy
 from singular.life.coevolution_flow import LivingTestPool
 from singular.life.loop import WorldState, run_tick
+from singular.lives import resolve_life
 from singular.memory import (
     _atomic_write_text,
     get_base_dir,
@@ -42,7 +43,11 @@ from singular.quests import QuestRuntime
 from singular.sensors import load_host_sensor_thresholds
 from singular.skills.runtime import SkillRuntime
 from singular.routines import RoutinesOrchestrator
-from singular.metrics import compute_behavioral_regulation_metrics, compute_regulation_inputs
+from singular.runs.logger import RunLogger
+from singular.metrics import (
+    compute_behavioral_regulation_metrics,
+    compute_regulation_inputs,
+)
 
 log = logging.getLogger(__name__)
 
@@ -135,10 +140,16 @@ class OrchestratorService:
             mem_dir=self.mem_dir,
             bus=self.bus,
         )
-        self.governance_policy = MutationGovernancePolicy(safe_mode=self.config.safe_mode)
+        self.governance_policy = MutationGovernancePolicy(
+            safe_mode=self.config.safe_mode
+        )
         self.world_state = WorldState()
-        self.test_pool = LivingTestPool(initial_ttl=max(1, int(self.config.coevolution_ttl)))
-        self.routines = RoutinesOrchestrator(state_path=self.mem_dir / "routines_state.json")
+        self.test_pool = LivingTestPool(
+            initial_ttl=max(1, int(self.config.coevolution_ttl))
+        )
+        self.routines = RoutinesOrchestrator(
+            state_path=self.mem_dir / "routines_state.json"
+        )
         self.goals = IntrinsicGoals(path=self.mem_dir / "goals.json")
         self._running = False
         self._wake_requested = False
@@ -198,7 +209,9 @@ class OrchestratorService:
             "last_watch_mtime": self.state.last_watch_mtime,
             "updated_at": datetime.now(timezone.utc).isoformat(),
         }
-        _atomic_write_text(self.state_path, json.dumps(payload, ensure_ascii=False, indent=2))
+        _atomic_write_text(
+            self.state_path, json.dumps(payload, ensure_ascii=False, indent=2)
+        )
 
     def _next_phase(self, phase: LifecyclePhase) -> LifecyclePhase:
         order = [
@@ -249,19 +262,12 @@ class OrchestratorService:
         latest_run = self._runs_mtime()
         latest_watch = self._watch_mtime()
 
-        run_changed = (
-            latest_run is not None
-            and (
-                self.state.last_run_mtime is None
-                or latest_run > self.state.last_run_mtime
-            )
+        run_changed = latest_run is not None and (
+            self.state.last_run_mtime is None or latest_run > self.state.last_run_mtime
         )
-        watch_changed = (
-            latest_watch is not None
-            and (
-                self.state.last_watch_mtime is None
-                or latest_watch > self.state.last_watch_mtime
-            )
+        watch_changed = latest_watch is not None and (
+            self.state.last_watch_mtime is None
+            or latest_watch > self.state.last_watch_mtime
         )
 
         self.state.last_run_mtime = latest_run
@@ -305,11 +311,15 @@ class OrchestratorService:
         last_events = self.state.last_events[-20:]
 
         latest_goal = goal_history[-1] if goal_history else {}
-        latest_weights = latest_goal.get("weights", {}) if isinstance(latest_goal, dict) else {}
+        latest_weights = (
+            latest_goal.get("weights", {}) if isinstance(latest_goal, dict) else {}
+        )
         strategy = self.goals.derive_execution_strategy(self._latest_signals)
         dominant_goal = None
         if isinstance(latest_weights, dict) and latest_weights:
-            dominant_goal = max(latest_weights.items(), key=lambda item: float(item[1]))[0]
+            dominant_goal = max(
+                latest_weights.items(), key=lambda item: float(item[1])
+            )[0]
 
         heading_parts: list[str] = []
         if dominant_goal:
@@ -319,10 +329,21 @@ class OrchestratorService:
             heading_parts.append(f"Mode {mode}.")
         if isinstance(psyche_state, dict) and psyche_state.get("last_mood"):
             heading_parts.append(f"Humeur {psyche_state['last_mood']}.")
-        current_heading = " ".join(heading_parts).strip() or "Clarifier ma prochaine étape utile."
+        current_heading = (
+            " ".join(heading_parts).strip() or "Clarifier ma prochaine étape utile."
+        )
 
-        successes = [str(ep.get("event")) for ep in recent_episodes if ep.get("status") == "success"]
-        failures = [str(ep.get("event")) for ep in recent_episodes if ep.get("status") == "failure"]
+        successes = [
+            str(ep.get("event"))
+            for ep in recent_episodes
+            if ep.get("status") == "success"
+        ]
+        failures = [
+            str(ep.get("event"))
+            for ep in recent_episodes
+            if ep.get("status") == "failure"
+        ]
+
         def _trait_value(name: str) -> float:
             try:
                 return float(psyche_state.get(name, 0.5))
@@ -333,16 +354,27 @@ class OrchestratorService:
             {
                 "current_heading": current_heading,
                 "trait_trends": {
-                    "curiosity": {"value": _trait_value("curiosity"), "trend": "stable"},
+                    "curiosity": {
+                        "value": _trait_value("curiosity"),
+                        "trend": "stable",
+                    },
                     "patience": {"value": _trait_value("patience"), "trend": "stable"},
-                    "playfulness": {"value": _trait_value("playfulness"), "trend": "stable"},
+                    "playfulness": {
+                        "value": _trait_value("playfulness"),
+                        "trend": "stable",
+                    },
                     "optimism": {"value": _trait_value("optimism"), "trend": "stable"},
-                    "resilience": {"value": _trait_value("resilience"), "trend": "stable"},
+                    "resilience": {
+                        "value": _trait_value("resilience"),
+                        "trend": "stable",
+                    },
                 },
                 "regrets_and_pride": {
                     "significant_successes": successes[-3:],
                     "significant_failures": failures[-3:],
-                    "costly_incidents": [str(event.get("phase")) for event in last_events[-3:]],
+                    "costly_incidents": [
+                        str(event.get("phase")) for event in last_events[-3:]
+                    ],
                 },
             },
             self.mem_dir / "self_narrative.json",
@@ -398,7 +430,9 @@ class OrchestratorService:
             regulation_inputs = compute_regulation_inputs(behavior_metrics)
             tick_budget *= adaptation["tick_budget_scale"]
             tick_budget *= regulation_inputs["mutation_rate_scale"]
-            tick_budget = max(0.01, min(tick_budget, self.config.mutation_window_seconds))
+            tick_budget = max(
+                0.01, min(tick_budget, self.config.mutation_window_seconds)
+            )
             cpu_budget_percent *= adaptation["cpu_budget_scale"]
             cpu_budget_percent *= regulation_inputs["metabolic_pressure_scale"]
             previous_safe_mode = bool(self.governance_policy.safe_mode)
@@ -417,12 +451,16 @@ class OrchestratorService:
                     "tick_budget_seconds": tick_budget,
                     "cpu_budget_percent": cpu_budget_percent,
                     "safe_mode": self.governance_policy.safe_mode,
-                    "aggressive_exploration": adaptation["allow_aggressive_exploration"],
+                    "aggressive_exploration": adaptation[
+                        "allow_aggressive_exploration"
+                    ],
                     "skip_action_tick": adaptation["skip_action_tick"],
                     "behavioral_metrics": behavior_metrics,
                     "regulation_inputs": regulation_inputs,
                 }
-                self.bus.publish("orchestrator.adaptation", audit_payload, payload_version=1)
+                self.bus.publish(
+                    "orchestrator.adaptation", audit_payload, payload_version=1
+                )
                 log.info("orchestrator adaptation applied: %s", audit_payload)
                 self._push_event(phase, {"adaptation": audit_payload})
             if adaptation["skip_action_tick"]:
@@ -444,9 +482,14 @@ class OrchestratorService:
             if not self.config.dry_run:
                 strategy = self.goals.derive_execution_strategy(self._latest_signals)
                 execution_strategy = dict(strategy)
-                if adaptation["allow_aggressive_exploration"] or regulation_inputs["exploration_intensity_scale"] > 1.15:
+                if (
+                    adaptation["allow_aggressive_exploration"]
+                    or regulation_inputs["exploration_intensity_scale"] > 1.15
+                ):
                     execution_strategy["exploration_intensity"] = "aggressive"
-                    execution_strategy["adaptation_source"] = "stable_resources+behavioral_metrics"
+                    execution_strategy["adaptation_source"] = (
+                        "stable_resources+behavioral_metrics"
+                    )
                 routine_specs = [
                     {"id": spec.id, "prompt": spec.prompt, "priority": spec.priority}
                     for spec in self.routines.specs
@@ -502,7 +545,9 @@ class OrchestratorService:
                 )
             host_metrics = self._latest_signals.get("host_metrics", {})
             world_health = self._latest_signals.get("world.global_health.score")
-            health_score = world_health if isinstance(world_health, (int, float)) else None
+            health_score = (
+                world_health if isinstance(world_health, (int, float)) else None
+            )
             load_score = None
             if isinstance(host_metrics, dict):
                 cpu_percent = host_metrics.get("cpu_percent")
@@ -543,7 +588,11 @@ class OrchestratorService:
 
         if phase is LifecyclePhase.INTROSPECTION:
             self._introspection_tick_count += 1
-            if self._introspection_tick_count % self.config.introspection_frequency_ticks != 0:
+            if (
+                self._introspection_tick_count
+                % self.config.introspection_frequency_ticks
+                != 0
+            ):
                 self._push_event(phase, {"skipped": True, "reason": "frequency_gate"})
                 return
             mood = self.psyche.update_from_resource_manager(self.resource_manager)
@@ -619,7 +668,8 @@ class OrchestratorService:
         resources_stable = (
             cpu_percent < (self._host_thresholds.cpu_warning_percent * 0.6)
             and ram_used_percent < (self._host_thresholds.ram_warning_percent * 0.7)
-            and host_temperature_c < (self._host_thresholds.temperature_warning_c - 10.0)
+            and host_temperature_c
+            < (self._host_thresholds.temperature_warning_c - 10.0)
             and self.resource_manager.energy >= 60.0
             and self.resource_manager.food >= 40.0
         )
@@ -650,10 +700,14 @@ class OrchestratorService:
     def _compute_behavioral_metrics(self) -> dict[str, Any]:
         records = self._load_recent_run_events(limit=80)
         major_decisions = [
-            e for e in self.state.last_events
-            if isinstance(e, dict) and str(e.get("phase", "")) == LifecyclePhase.ACTION.value
+            e
+            for e in self.state.last_events
+            if isinstance(e, dict)
+            and str(e.get("phase", "")) == LifecyclePhase.ACTION.value
         ]
-        metrics = compute_behavioral_regulation_metrics(records, decision_events=major_decisions)
+        metrics = compute_behavioral_regulation_metrics(
+            records, decision_events=major_decisions
+        )
         self._behavioral_metrics = metrics
         return metrics
 
@@ -679,7 +733,10 @@ class OrchestratorService:
             helper_life=None,
             task=task_name,
             attempts=current,
-            metadata={"status": status, "reason": getattr(skill_execution, "reason", None)},
+            metadata={
+                "status": status,
+                "reason": getattr(skill_execution, "reason", None),
+            },
         )
         self.bus.publish(HELP_REQUESTED, payload, payload_version=1)
 
@@ -717,7 +774,9 @@ class OrchestratorService:
                 self._running = False
             while self._running:
                 if self.stop_signal_path.exists():
-                    log.info("orchestrator stop requested via %s", self.stop_signal_path)
+                    log.info(
+                        "orchestrator stop requested via %s", self.stop_signal_path
+                    )
                     self._running = False
                     break
                 try:
@@ -741,10 +800,14 @@ class OrchestratorService:
                         exc,
                         exc_info=True,
                     )
-                    max_failures = max(1, int(self.config.max_consecutive_tick_failures))
+                    max_failures = max(
+                        1, int(self.config.max_consecutive_tick_failures)
+                    )
                     if consecutive_tick_failures >= max_failures:
                         raise
-                    backoff_seconds = max(self.config.tick_failure_backoff_seconds, 0.05)
+                    backoff_seconds = max(
+                        self.config.tick_failure_backoff_seconds, 0.05
+                    )
                     time.sleep(backoff_seconds)
                     continue
                 if self._external_stimulus_detected():
@@ -849,9 +912,7 @@ def run_orchestrator_daemon(
         else lifecycle_clock.cycle.sommeil_seconds
     )
     resolved_introspection = (
-        introspection_seconds
-        if introspection_seconds is not None
-        else 1.0
+        introspection_seconds if introspection_seconds is not None else 1.0
     )
     resolved_action = action_seconds if action_seconds is not None else 1.0
     resolved_poll = poll_interval_seconds if poll_interval_seconds is not None else 0.3
@@ -897,4 +958,144 @@ def run_orchestrator_daemon(
     except KeyboardInterrupt:
         pass
     print("Orchestrateur arrêté proprement.")
+    return 0
+
+
+def run_life_daemon(
+    *,
+    life_name: str,
+    interval_seconds: float,
+    budget_seconds: float | None,
+    max_errors: int,
+    dashboard: bool,
+    dry_run: bool = False,
+    safe_mode: bool = False,
+) -> int:
+    """Run a simple periodic daemon for one registered life.
+
+    The daemon resolves ``life_name`` through the multi-life registry, makes that
+    life the active ``SINGULAR_HOME``, then executes orchestrator ticks until a
+    signal, error budget, stop file or wall-clock budget asks it to stop.
+    """
+
+    if interval_seconds <= 0:
+        raise ValueError("--interval doit être strictement positif")
+    if budget_seconds is not None and budget_seconds <= 0:
+        raise ValueError("--budget-seconds doit être strictement positif")
+    max_errors = max(1, int(max_errors))
+
+    life_dir = resolve_life(life_name)
+    if life_dir is None:
+        raise KeyError(life_name)
+
+    import os
+
+    os.environ["SINGULAR_HOME"] = str(life_dir)
+    service = OrchestratorService(
+        config=OrchestratorConfig(
+            scheduler=SchedulerConfig(
+                veille_seconds=interval_seconds,
+                action_seconds=interval_seconds,
+                introspection_seconds=interval_seconds,
+                sommeil_seconds=interval_seconds,
+            ),
+            poll_interval_seconds=interval_seconds,
+            tick_budget_seconds=min(interval_seconds, 1.0),
+            mutation_window_seconds=min(interval_seconds, 1.0),
+            dry_run=dry_run,
+            safe_mode=safe_mode,
+            max_consecutive_tick_failures=max_errors,
+        ),
+        base_dir=life_dir,
+    )
+    run_id = f"daemon-{life_name}"
+    logger = RunLogger(run_id=run_id, root=life_dir / "runs")
+    stop_requested = False
+    error_count = 0
+    started = time.monotonic()
+
+    def _handle_signal(signum: int, _frame: Any) -> None:
+        nonlocal stop_requested
+        stop_requested = True
+        logger.log_event("daemon.signal", life=life_name, signal=signum)
+
+    previous_int = signal.signal(signal.SIGINT, _handle_signal)
+    previous_term = signal.signal(signal.SIGTERM, _handle_signal)
+
+    logger.log_event(
+        "daemon.start",
+        life=life_name,
+        life_dir=str(life_dir),
+        interval_seconds=interval_seconds,
+        budget_seconds=budget_seconds,
+        max_errors=max_errors,
+        dashboard=dashboard,
+        dry_run=dry_run,
+        safe_mode=safe_mode,
+    )
+    if dashboard:
+        logger.log_event(
+            "daemon.dashboard",
+            life=life_name,
+            message="Dashboard demandé; lancez `singular dashboard` dans un autre processus pour l'UI.",
+        )
+
+    try:
+        while not stop_requested:
+            if (
+                budget_seconds is not None
+                and (time.monotonic() - started) >= budget_seconds
+            ):
+                logger.log_event("daemon.budget_exhausted", life=life_name)
+                break
+            if service.stop_signal_path.exists():
+                logger.log_event(
+                    "daemon.stop_file",
+                    life=life_name,
+                    path=str(service.stop_signal_path),
+                )
+                break
+            tick_started = time.monotonic()
+            try:
+                current_phase = service.state.current_phase
+                next_phase = service.tick()
+                logger.log_event(
+                    "daemon.tick",
+                    life=life_name,
+                    phase=current_phase,
+                    next_phase=next_phase.value,
+                    tick_count=service._tick_count,
+                    duration_seconds=round(time.monotonic() - tick_started, 6),
+                )
+                error_count = 0
+            except Exception as exc:
+                error_count += 1
+                service._save_state()
+                logger.log_event(
+                    "daemon.error",
+                    life=life_name,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                    error_count=error_count,
+                    max_errors=max_errors,
+                )
+                if error_count >= max_errors:
+                    raise
+            remaining_sleep = interval_seconds - (time.monotonic() - tick_started)
+            if remaining_sleep > 0:
+                time.sleep(remaining_sleep)
+    finally:
+        signal.signal(signal.SIGINT, previous_int)
+        signal.signal(signal.SIGTERM, previous_term)
+        service._save_state()
+        service.psyche.save_state()
+        logger.log_event(
+            "daemon.checkpoint",
+            life=life_name,
+            state_path=str(service.state_path),
+            checkpoint_path=str(service.checkpoint_path),
+            tick_count=service._tick_count,
+        )
+        logger.close()
+
     return 0

--- a/src/singular/watch/daemon.py
+++ b/src/singular/watch/daemon.py
@@ -7,13 +7,13 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
+import signal
 import tempfile
 import time
 from typing import Any
 
 from ..memory import get_mem_dir
 from ..perception import capture_signals
-
 
 SUPPORTED_SOURCES = {"file", "weather", "runs", "folder"}
 
@@ -92,7 +92,9 @@ class WatchDaemon:
             prev_file = previous.get("signals", {}).get("file")
             curr_file = current.get("signals", {}).get("file")
             if prev_file != curr_file:
-                changes.append({"source": "file", "before": prev_file, "after": curr_file})
+                changes.append(
+                    {"source": "file", "before": prev_file, "after": curr_file}
+                )
 
         if "weather" in enabled:
             prev_weather = previous.get("signals", {}).get("weather")
@@ -104,7 +106,11 @@ class WatchDaemon:
 
         if "runs" in enabled and previous.get("runs") != current.get("runs"):
             changes.append(
-                {"source": "runs", "before": previous.get("runs"), "after": current.get("runs")}
+                {
+                    "source": "runs",
+                    "before": previous.get("runs"),
+                    "after": current.get("runs"),
+                }
             )
 
         if "folder" in enabled and previous.get("folder") != current.get("folder"):
@@ -123,13 +129,21 @@ class WatchDaemon:
         for change in changes:
             source = change["source"]
             if source == "file":
-                suggestions.append("Valider les nouveaux signaux fichier avant la prochaine run.")
+                suggestions.append(
+                    "Valider les nouveaux signaux fichier avant la prochaine run."
+                )
             elif source == "weather":
-                suggestions.append("Adapter la stratégie selon les variations météo détectées.")
+                suggestions.append(
+                    "Adapter la stratégie selon les variations météo détectées."
+                )
             elif source == "runs":
-                suggestions.append("Relire les derniers runs pour prioriser les actions utiles.")
+                suggestions.append(
+                    "Relire les derniers runs pour prioriser les actions utiles."
+                )
             elif source == "folder":
-                suggestions.append("Analyser les nouveaux artefacts du dossier surveillé.")
+                suggestions.append(
+                    "Analyser les nouveaux artefacts du dossier surveillé."
+                )
         return suggestions
 
     def _persist_inbox(self, suggestions: list[str]) -> None:
@@ -190,11 +204,27 @@ class WatchDaemon:
         return changes
 
     def run_forever(self) -> None:
-        """Run the daemon loop until interrupted."""
+        """Run the daemon loop until interrupted, checkpointing the latest snapshot."""
 
-        while True:
-            self.tick()
-            time.sleep(max(self.config.interval_seconds, 0.1))
+        running = True
+
+        def _handle_signal(_signum: int, _frame: Any) -> None:
+            nonlocal running
+            running = False
+
+        previous_int = signal.signal(signal.SIGINT, _handle_signal)
+        previous_term = signal.signal(signal.SIGTERM, _handle_signal)
+        try:
+            while running:
+                self.tick()
+                time.sleep(max(self.config.interval_seconds, 0.1))
+        finally:
+            signal.signal(signal.SIGINT, previous_int)
+            signal.signal(signal.SIGTERM, previous_term)
+            if self.previous_snapshot is not None:
+                self.previous_snapshot["checkpointed_at"] = datetime.now(
+                    timezone.utc
+                ).isoformat()
 
 
 def _parse_sources(raw_sources: str | None) -> set[str]:
@@ -240,8 +270,6 @@ def run_watch_daemon(
         f"(interval={interval_seconds}s, sources={','.join(sorted(parsed_sources))}, "
         f"cpu={cpu_budget_percent}%, mem={memory_budget_mb}MB, dry_run={dry_run})."
     )
-    try:
-        daemon.run_forever()
-    except KeyboardInterrupt:
-        print("Watch daemon arrêté.")
+    daemon.run_forever()
+    print("Watch daemon arrêté.")
     return 0

--- a/tests/test_cli_orchestrate.py
+++ b/tests/test_cli_orchestrate.py
@@ -50,7 +50,9 @@ def test_cli_orchestrate_run_dispatches(monkeypatch, tmp_path) -> None:
     assert captured["safe_mode"] is False
 
 
-def test_cli_orchestrate_run_passes_lifecycle_config_path(monkeypatch, tmp_path) -> None:
+def test_cli_orchestrate_run_passes_lifecycle_config_path(
+    monkeypatch, tmp_path
+) -> None:
     root = tmp_path / "root"
     config = tmp_path / "lifecycle.yaml"
     config.write_text("cycle:\n  veille_seconds: 1.5\n", encoding="utf-8")
@@ -110,3 +112,45 @@ def test_cli_orchestrate_run_passes_safe_mode(monkeypatch, tmp_path) -> None:
 
     assert code == 0
     assert captured["safe_mode"] is True
+
+
+def test_cli_daemon_dispatches_registered_life(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "root"
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+
+    captured: dict[str, object] = {}
+
+    def fake_run_life_daemon(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("singular.orchestrator.run_life_daemon", fake_run_life_daemon)
+
+    code = main(
+        [
+            "--root",
+            str(root),
+            "daemon",
+            "--life",
+            "alpha",
+            "--interval",
+            "0.25",
+            "--budget-seconds",
+            "1.5",
+            "--max-errors",
+            "2",
+            "--dashboard",
+            "--dry-run",
+        ]
+    )
+
+    assert code == 0
+    assert captured == {
+        "life_name": "alpha",
+        "interval_seconds": 0.25,
+        "budget_seconds": 1.5,
+        "max_errors": 2,
+        "dashboard": True,
+        "dry_run": True,
+        "safe_mode": False,
+    }

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -120,7 +120,9 @@ def test_orchestrator_triggers_and_settles_quest(monkeypatch, tmp_path: Path) ->
     assert '"origin": "intrinsic"' in payload
 
 
-def test_orchestrator_action_executes_skill_runtime(monkeypatch, tmp_path: Path) -> None:
+def test_orchestrator_action_executes_skill_runtime(
+    monkeypatch, tmp_path: Path
+) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)
     (life / "mem").mkdir(parents=True)
@@ -151,7 +153,9 @@ def test_orchestrator_action_executes_skill_runtime(monkeypatch, tmp_path: Path)
     assert context["phase"] == "action"
 
 
-def test_orchestrator_action_passes_world_state_to_tick(monkeypatch, tmp_path: Path) -> None:
+def test_orchestrator_action_passes_world_state_to_tick(
+    monkeypatch, tmp_path: Path
+) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)
     (life / "mem").mkdir(parents=True)
@@ -164,12 +168,16 @@ def test_orchestrator_action_passes_world_state_to_tick(monkeypatch, tmp_path: P
         captured.update(kwargs)
 
     monkeypatch.setattr("singular.orchestrator.service.run_tick", _fake_run_tick)
-    service = OrchestratorService(config=OrchestratorConfig(dry_run=False), bus=EventBus())
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=False), bus=EventBus()
+    )
     service.state.current_phase = LifecyclePhase.ACTION.value
     monkeypatch.setattr(
         service.skill_runtime,
         "execute_best_skill",
-        lambda task, context: SkillExecutionResult(skill="a", status="succeeded", score=1.0),
+        lambda task, context: SkillExecutionResult(
+            skill="a", status="succeeded", score=1.0
+        ),
     )
 
     service.tick()
@@ -177,7 +185,9 @@ def test_orchestrator_action_passes_world_state_to_tick(monkeypatch, tmp_path: P
     assert captured["world"] is service.world_state
 
 
-def test_orchestrator_requests_help_after_failure_streak(monkeypatch, tmp_path: Path) -> None:
+def test_orchestrator_requests_help_after_failure_streak(
+    monkeypatch, tmp_path: Path
+) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)
     (life / "mem").mkdir(parents=True)
@@ -212,7 +222,9 @@ def test_orchestrator_requests_help_after_failure_streak(monkeypatch, tmp_path: 
     assert events[0]["attempts"] == 2
 
 
-def test_orchestrator_repeated_negative_feedback_reprioritizes_action_routines(monkeypatch, tmp_path: Path) -> None:
+def test_orchestrator_repeated_negative_feedback_reprioritizes_action_routines(
+    monkeypatch, tmp_path: Path
+) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)
     (life / "mem").mkdir(parents=True)
@@ -255,7 +267,9 @@ routines:
         calls.append({"task": task, "context": context})
         return SkillExecutionResult(skill="a", status="succeeded", score=0.9)
 
-    service = OrchestratorService(config=OrchestratorConfig(dry_run=False), bus=EventBus())
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=False), bus=EventBus()
+    )
     service.routines = RoutinesOrchestrator(
         config_path=routines_config,
         state_path=life / "mem" / "routines_state.json",
@@ -265,7 +279,11 @@ routines:
     service.tick()  # VEILLE
     service.tick()  # ACTION
 
-    routine_tasks = [entry["task"] for entry in calls if str(entry["task"].get("name", "")).startswith("routine.")]
+    routine_tasks = [
+        entry["task"]
+        for entry in calls
+        if str(entry["task"].get("name", "")).startswith("routine.")
+    ]
     assert routine_tasks
     assert routine_tasks[0]["name"] == "routine.user_support"
     assert routine_tasks[0]["priority"] > 90
@@ -277,7 +295,9 @@ def test_orchestrator_run_forever_consumes_stale_startup_stop_signal(
     fixed_timestamp: datetime,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=True), bus=EventBus()
+    )
     service._started_at = fixed_timestamp
     stale_requested_at = (fixed_timestamp - timedelta(minutes=5)).isoformat()
     service.stop_signal_path.write_text(
@@ -292,6 +312,7 @@ def test_orchestrator_run_forever_consumes_stale_startup_stop_signal(
     )
 
     called = {"tick": 0}
+
     def _fake_tick() -> LifecyclePhase:
         called["tick"] += 1
         service._running = False
@@ -311,8 +332,12 @@ def test_orchestrator_run_forever_consumes_stale_startup_stop_signal(
     assert "startup_stop_signal_consumed" in caplog.text
 
 
-def test_orchestrator_run_forever_honors_runtime_stop_signal(monkeypatch, mem_dir: Path) -> None:
-    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+def test_orchestrator_run_forever_honors_runtime_stop_signal(
+    monkeypatch, mem_dir: Path
+) -> None:
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=True), bus=EventBus()
+    )
     called = {"tick": 0}
 
     def _fake_tick() -> LifecyclePhase:
@@ -363,7 +388,9 @@ def test_life_extinction_stop_is_consumed_on_next_orchestrator_boot(
     stop_payload = json.loads(stop_path.read_text(encoding="utf-8"))
     assert stop_payload["reason"] == "life_extinction_detected"
 
-    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=True), bus=EventBus()
+    )
     called = {"tick": 0}
 
     def _fake_tick() -> LifecyclePhase:
@@ -394,7 +421,9 @@ def test_orchestrator_run_forever_recovers_from_transient_tick_failure(
     (life / "mem").mkdir(parents=True)
     monkeypatch.setenv("SINGULAR_HOME", str(life))
 
-    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=True), bus=EventBus()
+    )
     calls = {"tick": 0}
     sleep_calls: list[float] = []
 
@@ -407,7 +436,10 @@ def test_orchestrator_run_forever_recovers_from_transient_tick_failure(
 
     monkeypatch.setattr(service, "tick", _fake_tick)
     monkeypatch.setattr(service, "_external_stimulus_detected", lambda: True)
-    monkeypatch.setattr("singular.orchestrator.service.time.sleep", lambda seconds: sleep_calls.append(seconds))
+    monkeypatch.setattr(
+        "singular.orchestrator.service.time.sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
     caplog.set_level(logging.WARNING)
 
     service.run_forever()
@@ -435,14 +467,20 @@ def test_orchestrator_run_forever_raises_after_transient_tick_failure_threshold(
         ),
         bus=EventBus(),
     )
-    monkeypatch.setattr(service, "tick", lambda: (_ for _ in ()).throw(PermissionError("still locked")))
-    monkeypatch.setattr("singular.orchestrator.service.time.sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        service, "tick", lambda: (_ for _ in ()).throw(PermissionError("still locked"))
+    )
+    monkeypatch.setattr(
+        "singular.orchestrator.service.time.sleep", lambda seconds: None
+    )
 
     with pytest.raises(PermissionError):
         service.run_forever()
 
 
-def test_orchestrator_introspection_refreshes_self_narrative(monkeypatch, tmp_path: Path) -> None:
+def test_orchestrator_introspection_refreshes_self_narrative(
+    monkeypatch, tmp_path: Path
+) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)
     (life / "mem").mkdir(parents=True)
@@ -451,7 +489,9 @@ def test_orchestrator_introspection_refreshes_self_narrative(monkeypatch, tmp_pa
         '{"event":"quest","status":"success"}\n{"event":"repair","status":"failure"}\n',
         encoding="utf-8",
     )
-    (life / "runs" / "run-1.jsonl").write_text('{"event":"mutation.applied"}\n', encoding="utf-8")
+    (life / "runs" / "run-1.jsonl").write_text(
+        '{"event":"mutation.applied"}\n', encoding="utf-8"
+    )
     monkeypatch.setenv("SINGULAR_HOME", str(life))
 
     events: list[dict[str, object]] = []
@@ -476,7 +516,9 @@ def test_orchestrator_introspection_refreshes_self_narrative(monkeypatch, tmp_pa
     )
 
 
-def test_orchestrator_introspection_frequency_uses_introspection_ticks(monkeypatch, tmp_path: Path) -> None:
+def test_orchestrator_introspection_frequency_uses_introspection_ticks(
+    monkeypatch, tmp_path: Path
+) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)
     (life / "mem").mkdir(parents=True)
@@ -495,3 +537,55 @@ def test_orchestrator_introspection_frequency_uses_introspection_ticks(monkeypat
     service.state.current_phase = LifecyclePhase.INTROSPECTION.value
     service.tick()
     assert len(events) == 1
+
+
+def test_run_life_daemon_resolves_life_and_writes_checkpoint_logs(
+    monkeypatch, tmp_path: Path
+) -> None:
+    root = tmp_path / "root"
+    life = root / "lives" / "alpha"
+    (life / "skills").mkdir(parents=True)
+    (life / "mem").mkdir(parents=True)
+    registry = {
+        "active": None,
+        "lives": {
+            "alpha": {
+                "name": "Alpha",
+                "slug": "alpha",
+                "path": str(life),
+                "created_at": "2026-01-01T00:00:00+00:00",
+                "status": "active",
+            }
+        },
+    }
+    (root / "lives").mkdir(parents=True, exist_ok=True)
+    (root / "lives" / "registry.json").write_text(
+        json.dumps(registry), encoding="utf-8"
+    )
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    monkeypatch.setattr(
+        "singular.orchestrator.service.capture_signals", lambda bus=None: {}
+    )
+    monkeypatch.setattr("singular.orchestrator.service.run_tick", lambda **kwargs: None)
+
+    from singular.orchestrator.service import run_life_daemon
+
+    code = run_life_daemon(
+        life_name="alpha",
+        interval_seconds=0.001,
+        budget_seconds=0.05,
+        max_errors=1,
+        dashboard=True,
+        dry_run=True,
+        safe_mode=True,
+    )
+
+    assert code == 0
+    assert (life / "mem" / "orchestrator_state.json").exists()
+    run_logs = list((life / "runs").glob("daemon-alpha-*.jsonl"))
+    assert run_logs
+    payload = run_logs[0].read_text(encoding="utf-8")
+    assert "daemon.start" in payload
+    assert "daemon.tick" in payload
+    assert "daemon.checkpoint" in payload
+    assert "daemon.dashboard" in payload


### PR DESCRIPTION
### Motivation

- Provide a lightweight daemon mode to run periodic life ticks for a single registered life without the full orchestrator orchestration surface. 
- Allow running periodic perception/objectives/mutation checkpoints for a life resolved from the existing multi-life registry and provide durable run logs and clean checkpoints on shutdown.

### Description

- Add a new CLI command `singular daemon` with required `--life` and options `--interval`, `--budget-seconds`, `--max-errors`, `--dashboard` and `--dry-run` wired into the main CLI (`src/singular/cli.py`).
- Implement `run_life_daemon` in `src/singular/orchestrator/service.py` which resolves the life via the multi-life registry (`resolve_life`), sets `SINGULAR_HOME`, instantiates an `OrchestratorService` for that life, runs periodic `tick()` cycles, writes run logs with `RunLogger`, and checkpoints state and psyche on clean shutdown.
- Handle `SIGINT`/`SIGTERM` inside the simple daemon loop and in the watch daemon, ensuring a clean checkpoint and logging of shutdown reasons; export the new entry point from `src/singular/orchestrator/__init__.py`.
- Update `src/singular/watch/daemon.py` to handle OS signals and record a checkpoint timestamp in the latest snapshot on exit.
- Add targeted tests: `tests/test_orchestrator_service.py::test_run_life_daemon_resolves_life_and_writes_checkpoint_logs` and `tests/test_cli_orchestrate.py::test_cli_daemon_dispatches_registered_life` to verify life resolution, run logs, checkpointing and CLI dispatch.

### Testing

- Ran `pytest tests/test_orchestrator_service.py tests/test_cli_orchestrate.py tests/test_watch_daemon.py -q` and all tests passed (21 passed, warnings reported). 
- Ran `python -m compileall src/singular/cli.py src/singular/orchestrator/service.py src/singular/watch/daemon.py` successfully to verify byte-compilation.
- New tests assert the daemon writes `daemon.start`, `daemon.tick`, `daemon.checkpoint`, and optional `daemon.dashboard` entries to run logs and that the CLI dispatch passes the expected arguments to `run_life_daemon`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7364d6f5f4832ab8310034d52facd4)