### PR TITLE
Add SQLite storage repositories with JSON compatibility and importer

### DIFF
--- a/src/singular/dashboard/repositories/run_records.py
+++ b/src/singular/dashboard/repositories/run_records.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from ...storage import RunsRepository, SQLiteStorage, StorageConfig
+
 
 def is_run_jsonl_file(path: Path) -> bool:
     """Return whether *path* is a persisted or in-progress run JSONL file."""
@@ -114,7 +116,9 @@ class RunRecordsRepository:
         seen: set[str] = set()
         for life_dir in self._registry_lives_paths():
             candidate = life_dir / "runs"
-            candidate_key = str(candidate.resolve()) if candidate.exists() else str(candidate)
+            candidate_key = (
+                str(candidate.resolve()) if candidate.exists() else str(candidate)
+            )
             if candidate_key in seen:
                 continue
             seen.add(candidate_key)
@@ -123,8 +127,17 @@ class RunRecordsRepository:
             dirs.append(self.base_dir / "runs")
         return dirs
 
-    def load_run_records(self, current_life_only: bool = False) -> list[dict[str, object]]:
+    def load_run_records(
+        self, current_life_only: bool = False
+    ) -> list[dict[str, object]]:
         """Load valid records and annotate each one with its logical run id."""
+        db_path = self.base_dir / "mem" / "singular.sqlite3"
+        if db_path.exists():
+            sqlite_records = RunsRepository(
+                SQLiteStorage(StorageConfig(root=self.base_dir, db_path=db_path))
+            ).list_events()
+            if sqlite_records:
+                return sqlite_records
         records: list[dict[str, object]] = []
         for directory in self.runs_dirs(current_life_only=current_life_only):
             if not directory.exists():
@@ -192,10 +205,16 @@ class RunRecordsRepository:
 
         return max(
             files,
-            key=lambda path: (path.stat().st_mtime_ns, _latest_ts_in_file(path), path.name),
+            key=lambda path: (
+                path.stat().st_mtime_ns,
+                _latest_ts_in_file(path),
+                path.name,
+            ),
         )
 
-    def resolve_run_file(self, run_id: str, current_life_only: bool = False) -> Path | None:
+    def resolve_run_file(
+        self, run_id: str, current_life_only: bool = False
+    ) -> Path | None:
         """Resolve a logical run id to persisted or in-progress JSONL storage."""
         for directory in self.runs_dirs(current_life_only=current_life_only):
             for filename in (f"{run_id}.jsonl", f"{run_id}.jsonl.tmp"):
@@ -205,7 +224,10 @@ class RunRecordsRepository:
             if not directory.exists():
                 continue
             for candidate in self.iter_run_files(current_life_only=current_life_only):
-                if candidate.parent == directory and logical_run_file_stem(candidate) == run_id:
+                if (
+                    candidate.parent == directory
+                    and logical_run_file_stem(candidate) == run_id
+                ):
                     return candidate
         return None
 

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -11,6 +11,13 @@ import os
 from typing import Any, Mapping
 
 from ..storage_retention import run_retention_service
+from ..storage import (
+    ProviderEventsRepository,
+    RunsRepository,
+    SQLiteStorage,
+    SkillScoresRepository,
+    StorageConfig,
+)
 
 from ..psyche import Psyche
 from ..memory import add_episode, add_procedural_memory
@@ -22,7 +29,9 @@ _BASE_DIR = Path(os.environ.get("SINGULAR_HOME", "."))
 RUNS_DIR = _BASE_DIR / "runs"
 EVENT_SCHEMA_VERSION = 1
 USAGE_REPUTATION_SCHEMA_VERSION = 1
-DEFAULT_REPUTATION_UPDATE_EVERY = int(os.environ.get("SINGULAR_REPUTATION_UPDATE_EVERY", "5"))
+DEFAULT_REPUTATION_UPDATE_EVERY = int(
+    os.environ.get("SINGULAR_REPUTATION_UPDATE_EVERY", "5")
+)
 
 # ---------------------------------------------------------------------------
 # Mood style helpers
@@ -79,6 +88,11 @@ def log_provider_event(
         "llm_real": llm_real,
     }
     _provider_logger.info("provider_call", extra={"payload": payload})
+    try:
+        root = Path(os.environ.get("SINGULAR_HOME", "."))
+        ProviderEventsRepository(SQLiteStorage(StorageConfig(root=root))).add(payload)
+    except Exception:
+        _provider_logger.debug("provider_event_sqlite_persist_failed", exc_info=True)
 
 
 def _ensure_dir(path: Path) -> None:
@@ -117,7 +131,12 @@ class RunLogger:
         self.run_dir.mkdir(parents=True, exist_ok=True)
         self._active_lock_path = self.run_dir / ".active.lock"
         self._active_lock_path.write_text(
-            json.dumps({"run_id": self.run_id, "started_at": datetime.utcnow().isoformat(timespec="seconds")}),
+            json.dumps(
+                {
+                    "run_id": self.run_id,
+                    "started_at": datetime.utcnow().isoformat(timespec="seconds"),
+                }
+            ),
             encoding="utf-8",
         )
         self.events_path = self.run_dir / "events.jsonl"
@@ -128,6 +147,9 @@ class RunLogger:
         self._skill_telemetry: dict[str, dict[str, float | int]] = {}
         self._skill_reputation: dict[str, dict[str, float | int]] = {}
         self._load_skill_reputation()
+        self._storage = SQLiteStorage(StorageConfig(root=self.root.parent))
+        self._runs_repository = RunsRepository(self._storage)
+        self._skill_scores_repository = SkillScoresRepository(self._storage)
 
         # Resume from existing temporary file if present
         tmp_pattern = f"{self.run_id}-*.jsonl.tmp"
@@ -193,16 +215,27 @@ class RunLogger:
         )
         telemetry["count"] = int(telemetry["count"]) + 1
         telemetry["successes"] = int(telemetry["successes"]) + int(bool(success))
-        telemetry["total_latency_ms"] = float(telemetry["total_latency_ms"]) + float(latency_ms)
-        telemetry["total_resource_cost"] = float(telemetry["total_resource_cost"]) + float(resource_cost)
-        telemetry["total_quality"] = float(telemetry["total_quality"]) + float(perceived_quality)
-        telemetry["total_satisfaction"] = float(telemetry["total_satisfaction"]) + float(user_satisfaction)
+        telemetry["total_latency_ms"] = float(telemetry["total_latency_ms"]) + float(
+            latency_ms
+        )
+        telemetry["total_resource_cost"] = float(
+            telemetry["total_resource_cost"]
+        ) + float(resource_cost)
+        telemetry["total_quality"] = float(telemetry["total_quality"]) + float(
+            perceived_quality
+        )
+        telemetry["total_satisfaction"] = float(
+            telemetry["total_satisfaction"]
+        ) + float(user_satisfaction)
         telemetry["recent_failures"] = (
             0 if success else min(int(telemetry["recent_failures"]) + 1, 1000)
         )
 
     def _maybe_update_skill_reputation(self, *, force: bool = False) -> None:
-        pending = sum(int(skill_data.get("count", 0)) for skill_data in self._skill_telemetry.values())
+        pending = sum(
+            int(skill_data.get("count", 0))
+            for skill_data in self._skill_telemetry.values()
+        )
         threshold = max(1, int(self.reputation_update_every))
         if not force and pending < threshold:
             return
@@ -219,16 +252,26 @@ class RunLogger:
 
             previous = self._skill_reputation.get(skill_name, {})
             previous_count = int(previous.get("use_count", 0))
-            blend = 0.0 if previous_count <= 0 else min(0.8, previous_count / (previous_count + count))
+            blend = (
+                0.0
+                if previous_count <= 0
+                else min(0.8, previous_count / (previous_count + count))
+            )
             self._skill_reputation[skill_name] = {
-                "success_rate": (float(previous.get("success_rate", success_rate)) * blend)
+                "success_rate": (
+                    float(previous.get("success_rate", success_rate)) * blend
+                )
                 + (success_rate * (1.0 - blend)),
                 "mean_cost": (float(previous.get("mean_cost", mean_cost)) * blend)
                 + (mean_cost * (1.0 - blend)),
                 "recent_failures": recent_failures,
-                "mean_quality": (float(previous.get("mean_quality", mean_quality)) * blend)
+                "mean_quality": (
+                    float(previous.get("mean_quality", mean_quality)) * blend
+                )
                 + (mean_quality * (1.0 - blend)),
-                "mean_satisfaction": (float(previous.get("mean_satisfaction", mean_satisfaction)) * blend)
+                "mean_satisfaction": (
+                    float(previous.get("mean_satisfaction", mean_satisfaction)) * blend
+                )
                 + (mean_satisfaction * (1.0 - blend)),
                 "use_count": previous_count + count,
             }
@@ -239,6 +282,8 @@ class RunLogger:
             "skills": self._skill_reputation,
         }
         self.skill_reputation_path.write_text(json.dumps(payload), encoding="utf-8")
+        for skill_name, stats in self._skill_reputation.items():
+            self._skill_scores_repository.upsert(skill_name, stats)
         self._skill_telemetry.clear()
 
     def skill_reputation(self) -> dict[str, dict[str, float | int]]:
@@ -248,6 +293,7 @@ class RunLogger:
         self._file.write(json.dumps(record) + "\n")
         self._file.flush()
         os.fsync(self._file.fileno())
+        self._runs_repository.add_event(self.run_id, record)
 
     def _write_event(self, event_type: str, payload: dict[str, Any], ts: str) -> None:
         event = {
@@ -362,7 +408,6 @@ class RunLogger:
             {"event": "mutation", "mood": mood_val, **record}, mood_styles=mood_styles
         )
         add_procedural_memory(record)
-
 
     def log_phase_metrics(
         self,

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -12,6 +12,7 @@ from ..governance.policy import load_runtime_policy
 from ..life.health import detect_health_state
 from ..life.life_status import compute_life_status
 from ..memory import read_skills, get_skills_file
+from ..storage import RunsRepository, SQLiteStorage, StorageConfig
 from ..sensors import compute_host_metrics_aggregates, summarize_environmental_impact
 
 
@@ -20,6 +21,13 @@ def load_run_records(
 ) -> list[dict[str, Any]]:
     """Load run records for ``run_id`` from JSONL log file."""
     runs_dir = Path(runs_dir)
+    db_path = runs_dir.parent / "mem" / "singular.sqlite3"
+    if db_path.exists():
+        records = RunsRepository(
+            SQLiteStorage(StorageConfig(root=runs_dir.parent, db_path=db_path))
+        ).list_events(run_id)
+        if records:
+            return records
     event_path = runs_dir / run_id / "events.jsonl"
     records: list[dict[str, Any]] = []
     if event_path.exists():

--- a/src/singular/storage/__init__.py
+++ b/src/singular/storage/__init__.py
@@ -1,0 +1,23 @@
+"""SQLite-backed persistence repositories with JSON compatibility fallback."""
+
+from .sqlite import (
+    StorageConfig,
+    SQLiteStorage,
+    EpisodesRepository,
+    WorldStateRepository,
+    RunsRepository,
+    ProviderEventsRepository,
+    SkillScoresRepository,
+)
+from .importer import import_legacy_storage
+
+__all__ = [
+    "StorageConfig",
+    "SQLiteStorage",
+    "EpisodesRepository",
+    "WorldStateRepository",
+    "RunsRepository",
+    "ProviderEventsRepository",
+    "SkillScoresRepository",
+    "import_legacy_storage",
+]

--- a/src/singular/storage/importer.py
+++ b/src/singular/storage/importer.py
@@ -1,0 +1,106 @@
+"""Import legacy JSON/JSONL artifacts into SQLite storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Any
+
+from .sqlite import (
+    EpisodesRepository,
+    RunsRepository,
+    SQLiteStorage,
+    StorageConfig,
+    WorldStateRepository,
+)
+
+
+def _read_jsonl(path: Path):
+    if not path.exists():
+        return
+    for lineno, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            yield lineno, payload
+
+
+def _run_id_from_path(path: Path) -> str:
+    if path.name == "events.jsonl" and path.parent.name:
+        return path.parent.name
+    name = path.name
+    for suffix in (".jsonl.tmp", ".jsonl"):
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+    if "-" in name:
+        base, tail = name.rsplit("-", 1)
+        if base and tail.isdigit() and len(tail) >= 8:
+            return base
+    return name or "unknown"
+
+
+def import_legacy_storage(
+    root: Path | str, *, db_path: Path | str | None = None
+) -> dict[str, int]:
+    root = Path(root)
+    storage = SQLiteStorage(
+        StorageConfig(root=root, db_path=Path(db_path) if db_path else None)
+    )
+    counts = {"episodes": 0, "world_state_snapshots": 0, "run_events": 0}
+
+    episodes = EpisodesRepository(storage)
+    ep_path = root / "mem" / "episodic.jsonl"
+    for lineno, payload in _read_jsonl(ep_path) or []:
+        episodes.add(payload, source_path=str(ep_path), source_line=lineno)
+        counts["episodes"] += 1
+
+    world_path = root / "mem" / "world_state.json"
+    if world_path.exists():
+        try:
+            payload: Any = json.loads(world_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, dict):
+            WorldStateRepository(storage).save_snapshot(
+                payload, source_path=str(world_path)
+            )
+            counts["world_state_snapshots"] += 1
+
+    runs_repo = RunsRepository(storage)
+    runs_dir = root / "runs"
+    if runs_dir.exists():
+        run_files = (
+            list(runs_dir.glob("*.jsonl"))
+            + list(runs_dir.glob("*.jsonl.tmp"))
+            + list(runs_dir.glob("*/events.jsonl"))
+        )
+        for run_file in sorted(set(run_files)):
+            for lineno, payload in _read_jsonl(run_file) or []:
+                if "payload" in payload and isinstance(payload.get("payload"), dict):
+                    event_type = str(payload.get("event_type") or "") or None
+                    payload = {
+                        **payload["payload"],
+                        "_event_type": event_type,
+                        "_ts": payload.get("ts"),
+                    }
+                else:
+                    event_type = (
+                        str(payload.get("event") or payload.get("_event_type") or "")
+                        or None
+                    )
+                runs_repo.add_event(
+                    _run_id_from_path(run_file),
+                    payload,
+                    event_type=event_type,
+                    source_path=str(run_file),
+                    source_line=lineno,
+                )
+                counts["run_events"] += 1
+    return counts

--- a/src/singular/storage/sqlite.py
+++ b/src/singular/storage/sqlite.py
@@ -1,0 +1,280 @@
+"""SQLite repositories for durable Singular state.
+
+The repositories intentionally keep legacy JSON/JSONL files readable during the
+transition. Writes go to SQLite and, when ``compat_json`` is enabled, can still be
+mirrored by callers to their existing files.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import sqlite3
+from typing import Any, Mapping
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class StorageConfig:
+    root: Path
+    db_path: Path | None = None
+    compat_json: bool = True
+
+    @property
+    def database(self) -> Path:
+        return self.db_path or (self.root / "mem" / "singular.sqlite3")
+
+
+class SQLiteStorage:
+    def __init__(self, config: StorageConfig | Path | str) -> None:
+        if isinstance(config, StorageConfig):
+            self.config = config
+        else:
+            self.config = StorageConfig(root=Path(config))
+        self.db_path = self.config.database
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._migrate()
+
+    def connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _migrate(self) -> None:
+        with self.connect() as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT DEFAULT CURRENT_TIMESTAMP)"
+            )
+            applied = {
+                row[0] for row in conn.execute("SELECT version FROM schema_migrations")
+            }
+            if SCHEMA_VERSION not in applied:
+                conn.executescript("""
+                    CREATE TABLE IF NOT EXISTS episodes (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        ts TEXT,
+                        event TEXT,
+                        payload_json TEXT NOT NULL,
+                        source_path TEXT,
+                        source_line INTEGER,
+                        UNIQUE(source_path, source_line)
+                    );
+                    CREATE TABLE IF NOT EXISTS world_state_snapshots (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        ts TEXT DEFAULT CURRENT_TIMESTAMP,
+                        payload_json TEXT NOT NULL,
+                        source_path TEXT,
+                        UNIQUE(source_path, ts)
+                    );
+                    CREATE TABLE IF NOT EXISTS run_events (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        run_id TEXT NOT NULL,
+                        ts TEXT,
+                        event_type TEXT,
+                        payload_json TEXT NOT NULL,
+                        source_path TEXT,
+                        source_line INTEGER,
+                        UNIQUE(source_path, source_line)
+                    );
+                    CREATE TABLE IF NOT EXISTS provider_events (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        ts TEXT DEFAULT CURRENT_TIMESTAMP,
+                        provider TEXT NOT NULL,
+                        active_provider TEXT,
+                        latency_ms REAL,
+                        fallback INTEGER NOT NULL DEFAULT 0,
+                        error_category TEXT,
+                        llm_real INTEGER NOT NULL DEFAULT 0,
+                        payload_json TEXT NOT NULL
+                    );
+                    CREATE TABLE IF NOT EXISTS skill_scores (
+                        skill TEXT PRIMARY KEY,
+                        success_rate REAL NOT NULL DEFAULT 0,
+                        mean_cost REAL NOT NULL DEFAULT 0,
+                        recent_failures INTEGER NOT NULL DEFAULT 0,
+                        mean_quality REAL NOT NULL DEFAULT 0,
+                        mean_satisfaction REAL NOT NULL DEFAULT 0,
+                        use_count INTEGER NOT NULL DEFAULT 0,
+                        quarantined INTEGER NOT NULL DEFAULT 0,
+                        quarantine_reason TEXT,
+                        updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                        payload_json TEXT NOT NULL
+                    );
+                    """)
+                conn.execute(
+                    "INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)",
+                    (SCHEMA_VERSION,),
+                )
+
+
+def _dump(payload: Mapping[str, Any]) -> str:
+    return json.dumps(dict(payload), ensure_ascii=False, sort_keys=True)
+
+
+def _row_payload(row: sqlite3.Row) -> dict[str, Any]:
+    payload = json.loads(row["payload_json"])
+    return payload if isinstance(payload, dict) else {"value": payload}
+
+
+class EpisodesRepository:
+    def __init__(self, storage: SQLiteStorage) -> None:
+        self.storage = storage
+
+    def add(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        source_path: str | None = None,
+        source_line: int | None = None,
+    ) -> None:
+        with self.storage.connect() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO episodes(ts,event,payload_json,source_path,source_line) VALUES (?,?,?,?,?)",
+                (
+                    payload.get("ts"),
+                    payload.get("event"),
+                    _dump(payload),
+                    source_path,
+                    source_line,
+                ),
+            )
+
+    def list(self) -> list[dict[str, Any]]:
+        with self.storage.connect() as conn:
+            return [
+                _row_payload(r)
+                for r in conn.execute("SELECT payload_json FROM episodes ORDER BY id")
+            ]
+
+
+class WorldStateRepository:
+    def __init__(self, storage: SQLiteStorage) -> None:
+        self.storage = storage
+
+    def save_snapshot(
+        self, payload: Mapping[str, Any], *, source_path: str | None = None
+    ) -> None:
+        ts = str(payload.get("ts") or payload.get("updated_at") or "") or None
+        with self.storage.connect() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO world_state_snapshots(ts,payload_json,source_path) VALUES (COALESCE(?, CURRENT_TIMESTAMP),?,?)",
+                (ts, _dump(payload), source_path),
+            )
+
+    def latest(self) -> dict[str, Any] | None:
+        with self.storage.connect() as conn:
+            row = conn.execute(
+                "SELECT payload_json FROM world_state_snapshots ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            return _row_payload(row) if row else None
+
+
+class RunsRepository:
+    def __init__(self, storage: SQLiteStorage) -> None:
+        self.storage = storage
+
+    def add_event(
+        self,
+        run_id: str,
+        payload: Mapping[str, Any],
+        *,
+        event_type: str | None = None,
+        source_path: str | None = None,
+        source_line: int | None = None,
+    ) -> None:
+        with self.storage.connect() as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO run_events(run_id,ts,event_type,payload_json,source_path,source_line) VALUES (?,?,?,?,?,?)",
+                (
+                    run_id,
+                    payload.get("ts") or payload.get("_ts"),
+                    event_type or payload.get("event") or payload.get("_event_type"),
+                    _dump(payload),
+                    source_path,
+                    source_line,
+                ),
+            )
+
+    def list_events(self, run_id: str | None = None) -> list[dict[str, Any]]:
+        sql = (
+            "SELECT payload_json, run_id FROM run_events"
+            + (" WHERE run_id=?" if run_id else "")
+            + " ORDER BY id"
+        )
+        args = (run_id,) if run_id else ()
+        with self.storage.connect() as conn:
+            rows = conn.execute(sql, args).fetchall()
+            out = []
+            for r in rows:
+                payload = _row_payload(r)
+                payload.setdefault("_run_file", r["run_id"])
+                out.append(payload)
+            return out
+
+
+class ProviderEventsRepository:
+    def __init__(self, storage: SQLiteStorage) -> None:
+        self.storage = storage
+
+    def add(self, payload: Mapping[str, Any]) -> None:
+        with self.storage.connect() as conn:
+            conn.execute(
+                "INSERT INTO provider_events(provider,active_provider,latency_ms,fallback,error_category,llm_real,payload_json) VALUES (?,?,?,?,?,?,?)",
+                (
+                    payload.get("provider", "unknown"),
+                    payload.get("active_provider"),
+                    payload.get("latency_ms"),
+                    int(bool(payload.get("fallback"))),
+                    payload.get("error_category"),
+                    int(bool(payload.get("llm_real"))),
+                    _dump(payload),
+                ),
+            )
+
+
+class SkillScoresRepository:
+    def __init__(self, storage: SQLiteStorage) -> None:
+        self.storage = storage
+
+    def upsert(
+        self,
+        skill: str,
+        stats: Mapping[str, Any],
+        *,
+        quarantined: bool = False,
+        quarantine_reason: str | None = None,
+    ) -> None:
+        payload = {
+            **dict(stats),
+            "skill": skill,
+            "quarantined": quarantined,
+            "quarantine_reason": quarantine_reason,
+        }
+        with self.storage.connect() as conn:
+            conn.execute(
+                """INSERT INTO skill_scores(skill,success_rate,mean_cost,recent_failures,mean_quality,mean_satisfaction,use_count,quarantined,quarantine_reason,payload_json)
+            VALUES (?,?,?,?,?,?,?,?,?,?) ON CONFLICT(skill) DO UPDATE SET success_rate=excluded.success_rate, mean_cost=excluded.mean_cost, recent_failures=excluded.recent_failures, mean_quality=excluded.mean_quality, mean_satisfaction=excluded.mean_satisfaction, use_count=excluded.use_count, quarantined=excluded.quarantined, quarantine_reason=excluded.quarantine_reason, updated_at=CURRENT_TIMESTAMP, payload_json=excluded.payload_json""",
+                (
+                    skill,
+                    float(stats.get("success_rate", 0)),
+                    float(stats.get("mean_cost", 0)),
+                    int(stats.get("recent_failures", 0)),
+                    float(stats.get("mean_quality", 0)),
+                    float(stats.get("mean_satisfaction", 0)),
+                    int(stats.get("use_count", 0)),
+                    int(quarantined),
+                    quarantine_reason,
+                    _dump(payload),
+                ),
+            )
+
+    def get(self, skill: str) -> dict[str, Any] | None:
+        with self.storage.connect() as conn:
+            row = conn.execute(
+                "SELECT payload_json FROM skill_scores WHERE skill=?", (skill,)
+            ).fetchone()
+            return _row_payload(row) if row else None

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -133,7 +133,9 @@ def test_human_summary_quality_minimum() -> None:
     assert "perf" in summary
 
 
-def test_run_logger_aggregates_skill_reputation_from_usage_metrics(tmp_path: Path) -> None:
+def test_run_logger_aggregates_skill_reputation_from_usage_metrics(
+    tmp_path: Path,
+) -> None:
     logger = RunLogger("telemetry", root=tmp_path, reputation_update_every=1)
     logger.log(
         "skill_x",
@@ -200,5 +202,36 @@ def test_log_phase_metrics(tmp_path: Path) -> None:
     assert record["phase_metrics"]["slowest_phase"] == "sandbox_scoring"
     assert record["phase_metrics"]["cache_candidates"][0]["phase"] == "sandbox_scoring"
 
-    event = json.loads((tmp_path / "profile" / "events.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    event = json.loads(
+        (tmp_path / "profile" / "events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()[0]
+    )
     assert event["event_type"] == "life_loop_phase_metrics"
+
+
+def test_run_logger_persists_run_and_skill_reputation_to_sqlite(tmp_path: Path) -> None:
+    logger = RunLogger("sqlite", root=tmp_path / "runs", reputation_update_every=1)
+    logger.log(
+        "skill_sql",
+        "op",
+        "diff",
+        True,
+        1.0,
+        1.0,
+        0.2,
+        0.1,
+        usage_metrics={"success": True, "resource_cost": 0.2},
+    )
+    logger.close()
+
+    from singular.storage import (
+        RunsRepository,
+        SQLiteStorage,
+        StorageConfig,
+        SkillScoresRepository,
+    )
+
+    storage = SQLiteStorage(StorageConfig(root=tmp_path))
+    assert RunsRepository(storage).list_events("sqlite")[0]["skill"] == "skill_sql"
+    assert SkillScoresRepository(storage).get("skill_sql")["use_count"] == 1

--- a/tests/test_storage_repositories.py
+++ b/tests/test_storage_repositories.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+import json
+import sqlite3
+
+from singular.storage import (
+    EpisodesRepository,
+    RunsRepository,
+    SQLiteStorage,
+    StorageConfig,
+    WorldStateRepository,
+    SkillScoresRepository,
+    import_legacy_storage,
+)
+
+
+def test_sqlite_storage_enables_wal_and_repositories_roundtrip(tmp_path: Path) -> None:
+    storage = SQLiteStorage(StorageConfig(root=tmp_path))
+    with storage.connect() as conn:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+
+    EpisodesRepository(storage).add(
+        {"ts": "2026-01-01T00:00:00", "event": "memory", "text": "hello"}
+    )
+    WorldStateRepository(storage).save_snapshot(
+        {"ts": "2026-01-02T00:00:00", "weather": "clear"}
+    )
+    RunsRepository(storage).add_event(
+        "run-a", {"ts": "2026-01-03T00:00:00", "event": "mutation", "skill": "x"}
+    )
+    SkillScoresRepository(storage).upsert(
+        "x",
+        {"success_rate": 1.0, "mean_cost": 0.5, "use_count": 3},
+        quarantined=True,
+        quarantine_reason="test",
+    )
+
+    assert EpisodesRepository(storage).list()[0]["text"] == "hello"
+    assert WorldStateRepository(storage).latest()["weather"] == "clear"
+    assert RunsRepository(storage).list_events("run-a")[0]["_run_file"] == "run-a"
+    assert SkillScoresRepository(storage).get("x")["quarantined"] is True
+
+
+def test_import_legacy_storage_keeps_json_files_and_imports_tables(
+    tmp_path: Path,
+) -> None:
+    mem = tmp_path / "mem"
+    runs = tmp_path / "runs"
+    mem.mkdir()
+    runs.mkdir()
+    (mem / "episodic.jsonl").write_text(
+        '{"event":"episode","ts":"t1"}\n', encoding="utf-8"
+    )
+    (mem / "world_state.json").write_text(
+        json.dumps({"ts": "t2", "status": "ok"}), encoding="utf-8"
+    )
+    (runs / "alpha-20260101000000.jsonl").write_text(
+        '{"event":"mutation","ts":"t3","skill":"s"}\n', encoding="utf-8"
+    )
+
+    counts = import_legacy_storage(tmp_path)
+
+    assert counts == {"episodes": 1, "world_state_snapshots": 1, "run_events": 1}
+    assert (mem / "episodic.jsonl").exists()
+    assert (mem / "world_state.json").exists()
+    with sqlite3.connect(tmp_path / "mem" / "singular.sqlite3") as conn:
+        assert conn.execute("SELECT count(*) FROM episodes").fetchone()[0] == 1
+        assert conn.execute("SELECT run_id FROM run_events").fetchone()[0] == "alpha"

--- a/tests/test_storage_retention.py
+++ b/tests/test_storage_retention.py
@@ -213,7 +213,9 @@ def test_run_retention_service_respects_minimum_interval(tmp_path) -> None:
     assert outcome.skipped_reason == "minimum_interval_not_elapsed"
 
 
-def test_run_retention_service_persists_last_purge_summary(tmp_path, monkeypatch) -> None:
+def test_run_retention_service_persists_last_purge_summary(
+    tmp_path, monkeypatch
+) -> None:
     now = datetime(2026, 4, 15, tzinfo=timezone.utc)
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
@@ -234,11 +236,15 @@ def test_run_retention_service_persists_last_purge_summary(tmp_path, monkeypatch
     assert outcome.executed is True
     assert outcome.last_run_summary is not None
     assert outcome.last_run_summary["deleted"] == 1
-    state = json.loads((tmp_path / "mem" / "retention_state.json").read_text(encoding="utf-8"))
+    state = json.loads(
+        (tmp_path / "mem" / "retention_state.json").read_text(encoding="utf-8")
+    )
     assert state["last_run_summary"]["deleted"] == 1
 
 
-def test_retention_status_snapshot_reports_usage_and_thresholds(tmp_path, monkeypatch) -> None:
+def test_retention_status_snapshot_reports_usage_and_thresholds(
+    tmp_path, monkeypatch
+) -> None:
     runs_dir = tmp_path / "runs"
     mem_dir = tmp_path / "mem"
     lives_dir = tmp_path / "lives"
@@ -260,7 +266,9 @@ def test_retention_status_snapshot_reports_usage_and_thresholds(tmp_path, monkey
     monkeypatch.setenv("SINGULAR_RETENTION_MAX_RUNS", "1")
     monkeypatch.setenv("SINGULAR_RETENTION_MAX_TOTAL_RUNS_SIZE_MB", "1")
 
-    payload = retention_status_snapshot(base_dir=tmp_path, now=datetime(2026, 4, 15, tzinfo=timezone.utc))
+    payload = retention_status_snapshot(
+        base_dir=tmp_path, now=datetime(2026, 4, 15, tzinfo=timezone.utc)
+    )
 
     assert payload["usage"]["runs"]["size_mb"] >= 0
     assert payload["usage"]["mem"]["size_mb"] >= 0
@@ -268,3 +276,18 @@ def test_retention_status_snapshot_reports_usage_and_thresholds(tmp_path, monkey
     assert payload["thresholds"]["max_runs"] == 1
     assert payload["thresholds"]["max_total_runs_size_mb"] == 1
     assert payload["last_purge"]["summary"]["deleted"] == 3
+
+
+def test_retention_does_not_delete_sqlite_storage(tmp_path) -> None:
+    runs_dir = tmp_path / "runs"
+    mem_dir = tmp_path / "mem"
+    runs_dir.mkdir()
+    mem_dir.mkdir()
+    db = mem_dir / "singular.sqlite3"
+    db.write_text("sqlite placeholder", encoding="utf-8")
+    (runs_dir / "old.jsonl").write_text("{}\n", encoding="utf-8")
+
+    config = load_retention_config(environ={"SINGULAR_RETENTION_MAX_RUNS": "0"})
+    apply_runs_retention(runs_dir=runs_dir, config=config)
+
+    assert db.exists()


### PR DESCRIPTION
### Motivation
- Introduce a durable SQLite persistence layer to host episodes, world-state snapshots, run events, provider events and skill scores to improve reliability and enable migrations. 
- Keep existing JSON/JSONL files readable during a transition period to avoid immediate destructive migration of legacy artifacts. 
- Enable efficient DB characteristics (WAL, foreign keys, versioned migrations) for safe concurrent access and schema evolution. 
- Make dashboard/reporting and run logging read/write via repositories so the system can incrementally adopt SQLite without breaking current file-backed behavior. 

### Description
- Added a new `src/singular/storage/` package with `sqlite.py`, `importer.py`, and `__init__.py` implementing `StorageConfig`, `SQLiteStorage`, `EpisodesRepository`, `WorldStateRepository`, `RunsRepository`, `ProviderEventsRepository`, `SkillScoresRepository`, and `import_legacy_storage`.
- Implemented versioned migrations tracked in `schema_migrations`, enabled WAL and foreign keys via `PRAGMA` in `SQLiteStorage.connect()`, and defined schema for episodes, world state snapshots, run events, provider events and skill scores (including quarantine fields).
- Added `import_legacy_storage()` to import `mem/episodic.jsonl` → `episodes`, `mem/world_state.json` → `world_state_snapshots`, and run JSONL variants → `run_events` while leaving legacy files intact.
- Integrated storage into the run path: `RunLogger` now persists provider calls to `provider_events`, appends run records to the `RunsRepository` on write, and upserts skill reputation into `skill_scores`; `runs/report.py` and the dashboard `RunRecordsRepository` now prefer reading from SQLite (fallback to files if DB missing).
- Added unit tests `tests/test_storage_repositories.py`, extended `tests/test_runs_logger.py` and `tests/test_storage_retention.py` to cover DB roundtrips, importer behavior, logger->SQLite persistence, and retention protections.

### Testing
- Ran targeted test suite: `pytest -q tests/test_storage_repositories.py tests/test_runs_logger.py tests/test_storage_retention.py tests/test_dashboard_run_records_repository.py tests/test_report.py` and all targeted tests passed (37 passed, 0 failed) with warnings about `datetime.utcnow()` usage.
- New repository-level tests validate WAL activation, repository CRUD flows, the legacy importer counts, and that `RunLogger` writes are present in SQLite and that skill reputation is upserted into `skill_scores`.
- Retention tests were extended to assert the SQLite DB is preserved by retention logic and these assertions passed in the automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7366af3384832aab13897855002408)