### PR TITLE
Make episodic memory observable in decisions

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -18,7 +18,7 @@ from singular.life.life_status import compute_life_status
 from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
 from singular.metrics.behavioral_regulation import compute_behavioral_regulation_metrics
-from singular.memory import read_causal_timeline, read_skills
+from singular.memory import read_causal_timeline, read_episodes, read_skills
 from singular.storage_retention import retention_status_snapshot
 
 from singular.dashboard.actions import DashboardActionService
@@ -687,11 +687,32 @@ def create_app(
         except Exception:
             causal_items = []
         causal_count = len(causal_items) if isinstance(causal_items, list) else 0
+        episodic_items = []
+        try:
+            episodic_items = read_episodes()
+        except Exception:
+            episodic_items = []
+        used_memories = []
+        for episode in reversed(episodic_items):
+            if episode.get("event") != "memory.used_for_decision":
+                continue
+            used_memories.append({
+                "timestamp": episode.get("ts"),
+                "source": episode.get("source"),
+                "decision": episode.get("decision"),
+                "summary": episode.get("summary"),
+                "memories": episode.get("memories", []),
+                "skill": episode.get("skill"),
+                "operator": episode.get("operator"),
+            })
+            if len(used_memories) >= 10:
+                break
         return {
             "records_count": len(memory_records),
             "causal_timeline_items": causal_count,
             "latest_memory": latest_memory,
-            "has_memory_signal": bool(memory_records or causal_count),
+            "used_memories": used_memories,
+            "has_memory_signal": bool(memory_records or causal_count or used_memories),
         }
 
     def _summarize_performance(records: list[dict[str, object]]) -> dict[str, object]:
@@ -939,12 +960,7 @@ def create_app(
                 "global_status": "unknown",
                 "autonomy_metrics": {},
                 "behavioral_regulation_metrics": {},
-                "memory_metrics": {
-                    "records_count": 0,
-                    "causal_timeline_items": 0,
-                    "latest_memory": None,
-                    "has_memory_signal": False,
-                },
+                "memory_metrics": _summarize_memory([]),
                 "performance_metrics": {
                     "records_count": 0,
                     "mutation_count": 0,

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -30,6 +30,9 @@ from singular.memory import (
     register_memory_event_handlers,
     temporarily_disable_skill,
     update_score,
+    add_episode,
+    format_recalled_memories,
+    recall_relevant_episodes,
 )
 from singular.psyche import Psyche, Mood, choose_action_from_psyche
 from singular.runs.logger import RunLogger
@@ -1187,6 +1190,28 @@ def run(
 
             policy = psyche.mutation_policy()
             planner_narrative_signals = self_narrative.extract_planner_signals()
+            recall_objectives = [
+                str(item) for item in planner_narrative_signals if isinstance(item, str)
+            ]
+            recall_objectives.extend([selected_skill_key, policy])
+            recalled_memories = recall_relevant_episodes(
+                themes=[selected_skill_key, policy],
+                objectives=recall_objectives,
+                limit=3,
+            )
+            recalled_memory_summary = format_recalled_memories(recalled_memories)
+            if recalled_memories:
+                memory_event = {
+                    "source": "life.loop",
+                    "iteration": state.iteration,
+                    "organism": org_name,
+                    "skill": selected_skill_key,
+                    "policy": policy,
+                    "memories": recalled_memories,
+                    "summary": recalled_memory_summary,
+                }
+                add_episode({"event": "memory.recalled", **memory_event})
+                logger.log_interaction("memory.recalled", **memory_event, alive=True)
             last_health = (
                 float(state.health_history[-1].get("score", 50.0))
                 if state.health_history
@@ -1203,7 +1228,12 @@ def run(
                     "ecological_debt": resource_manager.ecological_debt,
                     "relational_debt": resource_manager.relational_debt,
                 },
-                perception_signals={**signals, "planner_narrative_signals": planner_narrative_signals},
+                perception_signals={
+                    **signals,
+                    "planner_narrative_signals": planner_narrative_signals,
+                    "recalled_memory_summary": recalled_memory_summary,
+                    "recalled_memories": recalled_memories,
+                },
             )
             baseline_failure_risk = (
                 float(state.health_counters.get("sandbox_failures", 0))
@@ -1252,7 +1282,10 @@ def run(
                     long_term=entry["long_term"],
                     sandbox_risk=entry["sandbox_risk"],
                     resource_cost=entry["resource_cost"],
-                    metadata={"goal_weights": asdict(goal_weights)},
+                    metadata={
+                        "goal_weights": asdict(goal_weights),
+                        "recalled_memory_summary": recalled_memory_summary,
+                    },
                 )
                 for entry in adjusted_hypotheses
             ]
@@ -1426,6 +1459,8 @@ def run(
                     "planner_narrative_signals": planner_narrative_signals,
                     "weights_after": asdict(goal_weights),
                     "combined_bias_after": combined_bias,
+                    "recalled_memory_summary": recalled_memory_summary,
+                    "recalled_memories": recalled_memories,
                     "identity_violations": identity_violations,
                     "identity_wounds": float(getattr(psyche, "identity_wounds", 0.0)),
                 },
@@ -1573,6 +1608,21 @@ def run(
                     score_after=mutated_score,
                 )
 
+            if recalled_memories:
+                used_event = {
+                    "source": "life.loop",
+                    "iteration": state.iteration,
+                    "organism": org_name,
+                    "skill": selected_skill_key,
+                    "operator": op_name,
+                    "decision": "mutation",
+                    "accepted": accepted,
+                    "memories": recalled_memories,
+                    "summary": recalled_memory_summary,
+                }
+                add_episode({"event": "memory.used_for_decision", **used_event})
+                logger.log_interaction("memory.used_for_decision", **used_event, alive=True)
+
             objective_weights = asdict(goal_weights)
             dominant_objective = max(
                 objective_weights,
@@ -1599,7 +1649,11 @@ def run(
                     for hypothesis_index, hypothesis in enumerate(weighted_hypotheses)
                 ],
                 final_choice=op_name,
-                justification=reflection.decision_reason,
+                justification=(
+                    f"{reflection.decision_reason}; souvenirs={recalled_memory_summary}"
+                    if recalled_memories
+                    else reflection.decision_reason
+                ),
                 objective=dominant_objective,
                 mood=mood_value,
                 energy=float(getattr(psyche, "energy", resource_manager.energy)),

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -7,7 +7,7 @@ when the optional :mod:`PyYAML <yaml>` package is available.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterable, Mapping
 import json
 import os
 from datetime import datetime, timedelta, timezone
@@ -229,6 +229,88 @@ def read_episodes(path: Path | str | None = None) -> list[dict[str, Any]]:
                 continue
             episodes.append(json.loads(line))
     return episodes
+
+
+def _episode_search_text(episode: Mapping[str, Any]) -> str:
+    parts: list[str] = []
+    for key in ("text", "summary", "message", "event", "event_type", "objective", "skill", "op"):
+        value = episode.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    structured = episode.get("structured_signals")
+    if isinstance(structured, Mapping):
+        parts.extend(str(value) for value in structured.values() if value is not None)
+    return " ".join(parts).lower()
+
+
+def summarize_episode_for_recall(episode: Mapping[str, Any], *, max_chars: int = 160) -> str:
+    """Return a short human-readable summary for a recalled episode."""
+
+    text = None
+    for key in ("text", "summary", "message", "human_summary", "event"):
+        value = episode.get(key)
+        if isinstance(value, str) and value.strip():
+            text = value.strip()
+            break
+    if text is None:
+        text = json.dumps(dict(episode), ensure_ascii=False, sort_keys=True)
+    cleaned = " ".join(text.split())
+    if len(cleaned) <= max_chars:
+        return cleaned
+    return f"{cleaned[: max(0, max_chars - 3)]}..."
+
+
+def recall_relevant_episodes(
+    *,
+    themes: Iterable[str] | None = None,
+    objectives: Iterable[str] | None = None,
+    limit: int = 3,
+    path: Path | str | None = None,
+) -> list[dict[str, Any]]:
+    """Retrieve recent episodic memories matching themes or objectives."""
+
+    terms = {str(term).strip().lower() for term in (themes or []) if str(term).strip()}
+    terms.update(str(term).strip().lower() for term in (objectives or []) if str(term).strip())
+    if not terms:
+        return []
+    episodes = read_episodes(path)
+    if not episodes:
+        return []
+
+    recalled: list[dict[str, Any]] = []
+    for episode in reversed(episodes):
+        if str(episode.get("event", "")).startswith("memory."):
+            continue
+        haystack = _episode_search_text(episode)
+        if terms and not any(term in haystack for term in terms):
+            continue
+        recalled.append(
+            {
+                "ts": episode.get("ts"),
+                "event": episode.get("event"),
+                "role": episode.get("role"),
+                "theme": (episode.get("structured_signals") or {}).get("theme")
+                if isinstance(episode.get("structured_signals"), Mapping)
+                else None,
+                "summary": summarize_episode_for_recall(episode),
+            }
+        )
+        if len(recalled) >= max(0, limit):
+            break
+    return recalled
+
+
+def format_recalled_memories(memories: Iterable[Mapping[str, Any]], *, max_chars: int = 360) -> str:
+    """Format recalled memories as a compact prompt fragment."""
+
+    fragments = []
+    for memory in memories:
+        label = memory.get("theme") or memory.get("event") or memory.get("role") or "episode"
+        fragments.append(f"- {label}: {memory.get('summary', '')}")
+    text = " ".join(fragments) if fragments else "aucun souvenir pertinent"
+    if len(text) <= max_chars:
+        return text
+    return f"{text[: max(0, max_chars - 3)]}..."
 
 
 def add_episode(

--- a/src/singular/memory_compaction.py
+++ b/src/singular/memory_compaction.py
@@ -140,6 +140,18 @@ def compact_episodic_jsonl(
                 }
             )
 
+        consolidated_rows = [
+            {
+                "event": "memory.consolidated",
+                "ts": generated_at,
+                "summary": (
+                    f"Consolidated {len(historical)} historical episodic events "
+                    f"into {len(snapshot_refs)} snapshots; kept {len(recent_events)} recent events."
+                ),
+                "snapshots": snapshot_refs,
+                "source": "mem/episodic.jsonl",
+            }
+        ]
         compacted_rows = [
             {
                 "event": "episodic.compaction.reference",
@@ -150,6 +162,7 @@ def compact_episodic_jsonl(
             }
             for ref in snapshot_refs
         ]
+        compacted_rows = consolidated_rows + compacted_rows
         compacted_rows.extend(recent_events)
 
         _write_jsonl_atomic(episodic_path, compacted_rows)

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -9,7 +9,14 @@ import re
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from ..memory import add_causal_trace, add_episode, ensure_memory_structure, read_episodes
+from ..memory import (
+    add_causal_trace,
+    add_episode,
+    ensure_memory_structure,
+    format_recalled_memories,
+    read_episodes,
+    recall_relevant_episodes,
+)
 from ..perception import capture_signals
 from ..psyche import Mood, Psyche
 from ..self_narrative import load as load_self_narrative, summarize_short
@@ -144,6 +151,7 @@ def _build_system_preamble(
     narrative_summary: str,
     last_event: str | None,
     mood_event: str | None,
+    recalled_memory_summary: str | None = None,
 ) -> str:
     available_for_summary = max(0, _CONTEXT_BUDGET_CHARS - len(_UNKNOWN_GUARD) - 120)
     summary = _trim_for_budget(narrative_summary, available_for_summary)
@@ -153,6 +161,7 @@ def _build_system_preamble(
         f"Contexte identitaire: {summary}\n"
         f"Dernier événement utilisateur: {event_fragment}\n"
         f"Humeur récente: {mood_fragment}\n"
+        f"Souvenirs pertinents: {_trim_for_budget(recalled_memory_summary or 'aucun souvenir pertinent', 120)}\n"
         f"{_UNKNOWN_GUARD}"
     )
     return _trim_for_budget(preamble, _CONTEXT_BUDGET_CHARS)
@@ -254,6 +263,17 @@ def talk(
         self_narrative_version: int,
     ) -> None:
         user_signals = _extract_structured_signals(user_input)
+        theme = str(user_signals.get("theme", "general"))
+        recall_terms = [theme] if theme != "general" else []
+        recalled_memories = recall_relevant_episodes(
+            themes=recall_terms,
+            objectives=[f"user_dialogue:{theme}"] if theme != "general" else [],
+            limit=3,
+        )
+        recall_summary = format_recalled_memories(recalled_memories)
+        if recalled_memories:
+            add_episode({"event": "memory.recalled", "source": "talk", "query": user_input, "memories": recalled_memories, "summary": recall_summary})
+            add_episode({"event": "memory.used_for_decision", "source": "talk", "decision": "assistant_reply", "memories": recalled_memories, "summary": recall_summary})
         add_episode({"role": "user", "text": user_input, "structured_signals": user_signals})
         mood = psyche.feel(Mood.NEUTRAL)
         mood_report = mood_event or mood.value
@@ -261,6 +281,7 @@ def talk(
             narrative_summary=self_narrative_summary,
             last_event=last_event,
             mood_event=mood_event,
+            recalled_memory_summary=format_recalled_memories(recalled_memories),
         )
         provider_prompt = f"{system_preamble}\n\nUtilisateur: {user_input}"
 
@@ -337,6 +358,8 @@ def talk(
                     "self_narrative_summary": _trim_for_budget(
                         self_narrative_summary, 180
                     ),
+                    "recalled_memories": recalled_memories,
+                    "recalled_memory_summary": recall_summary,
                 },
             }
         )
@@ -364,6 +387,8 @@ def talk(
                     "error_category": error_category,
                     "llm_real": llm_real,
                     "mood": mood_report,
+                    "recalled_memory_summary": recall_summary,
+                    "recalled_memories": recalled_memories,
                 },
                 "action": {
                     "kind": "assistant_reply",

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2348,3 +2348,31 @@ def test_chat_post_remains_the_message_execution_path(
     assert response.status_code == 200
     assert response.json()["status"] == "message_missing"
     assert response.json()["response"] == "Message vide: saisissez un contenu à envoyer."
+
+
+def test_dashboard_cockpit_exposes_used_memories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    mem_dir = tmp_path / "mem"
+    mem_dir.mkdir()
+    (mem_dir / "episodic.jsonl").write_text(
+        json.dumps(
+            {
+                "event": "memory.used_for_decision",
+                "source": "talk",
+                "decision": "assistant_reply",
+                "summary": "bug prioritaire rappelé",
+                "memories": [{"summary": "ancien bug urgent"}],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+
+    payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get(
+        "/api/cockpit"
+    ).json()
+
+    assert payload["memory_metrics"]["has_memory_signal"] is True
+    assert payload["memory_metrics"]["used_memories"][0]["summary"] == "bug prioritaire rappelé"

--- a/tests/test_memory_compaction.py
+++ b/tests/test_memory_compaction.py
@@ -130,3 +130,21 @@ def test_compact_generations_keeps_recent_and_minimal_audit(tmp_path: Path) -> N
 
     assert any(row.get("event") == "generations.rejected.aggregate" for row in compacted)
     assert any(row.get("event") == "generations.compaction.meta" for row in compacted)
+
+
+def test_compact_episodic_emits_memory_consolidated(tmp_path):
+    mem_dir = tmp_path / "mem"
+    mem_dir.mkdir()
+    episodic = mem_dir / "episodic.jsonl"
+    rows = [
+        {"event": "user", "text": f"souvenir bug {idx}", "ts": f"2026-01-01T00:00:0{idx}+00:00"}
+        for idx in range(4)
+    ]
+    episodic.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+    result = compact_episodic_jsonl(mem_dir=mem_dir, keep_last_events=1, snapshot_chunk_size=2)
+
+    assert result["compacted"] is True
+    compacted = [json.loads(line) for line in episodic.read_text(encoding="utf-8").splitlines()]
+    assert compacted[0]["event"] == "memory.consolidated"
+    assert "Consolidated 3 historical episodic events" in compacted[0]["summary"]

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -389,3 +389,33 @@ def test_talk_status_includes_active_fallback_and_error_category(monkeypatch, tm
 
     assert any("Provider active: missing" in out for out in outputs)
     assert any("fallback=true" in out and "error_category=provider_missing" in out for out in outputs)
+
+
+def test_talk_recalls_prior_episode_in_provider_prompt(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    captured: dict[str, str] = {}
+
+    class CapturingClient:
+        name = "stub"
+        llm_real = True
+
+        def generate_reply(self, prompt: str) -> str:
+            captured["prompt"] = prompt
+            return "je m'en souviens"
+
+    monkeypatch.setattr(
+        "singular.organisms.talk.load_llm_client", lambda _name: CapturingClient()
+    )
+    outputs: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda msg: outputs.append(msg))
+
+    talk(provider="stub", prompt="Peux-tu aider avec ce bug urgent ?")
+    talk(provider="stub", prompt="Le bug est-il toujours prioritaire ?")
+
+    assert "Peux-tu aider avec ce bug urgent" in captured["prompt"]
+    episodes = read_episodes()
+    assert any(e.get("event") == "memory.recalled" for e in episodes)
+    assert any(e.get("event") == "memory.used_for_decision" for e in episodes)
+    assistant = [e for e in episodes if e.get("role") == "assistant"][-1]
+    assert "Peux-tu aider avec ce bug urgent" in assistant["context"]["recalled_memory_summary"]


### PR DESCRIPTION
### Motivation
- Make episodic memory actively retrievable and usable by the interactive `talk` flow and by the life-loop decision machinery so past user events can influence replies and mutation/goal decisions.
- Surface memory usage as explicit events so compaction and decision-time recall remain auditable and visible in the dashboard.

### Description
- Add episodic recall utilities in `src/singular/memory.py`: `_episode_search_text`, `summarize_episode_for_recall`, `recall_relevant_episodes` and `format_recalled_memories` to fetch and summarize recent relevant episodes.
- Update `src/singular/organisms/talk.py` to retrieve relevant memories before replying, include a short `recalled_memory_summary` in the LLM system preamble and assistant context, and emit `memory.recalled` and `memory.used_for_decision` events when memories are used.  Also record recalled memories into the causal trace.
- Update `src/singular/life/loop.py` to recall relevant episodes prior to planner/goal/mutation decisions, inject recall summaries into `perception_signals` and hypothesis metadata, emit `memory.recalled` and `memory.used_for_decision` episodes, and annotate consciousness justifications with the recall context.
- Make compaction produce an observable consolidation event by emitting `memory.consolidated` in `src/singular/memory_compaction.py` when historical episodic events are snapshotted.
- Expose used memories in the cockpit by reading episodic `memory.used_for_decision` records and adding `used_memories` into `memory_metrics` in `src/singular/dashboard/__init__.py`.
- Add tests covering recall-in-prompt (`tests/test_talk.py::test_talk_recalls_prior_episode_in_provider_prompt`), compaction consolidation event (`tests/test_memory_compaction.py::test_compact_episodic_emits_memory_consolidated`) and dashboard visibility (`tests/test_dashboard.py::test_dashboard_cockpit_exposes_used_memories`).

### Testing
- Ran `python -m py_compile` for the modified modules (`memory.py`, `organisms/talk.py`, `life/loop.py`, `memory_compaction.py`, `dashboard/__init__.py`) which succeeded. 
- Executed the new/updated tests `tests/test_talk.py::test_talk_recalls_prior_episode_in_provider_prompt`, `tests/test_memory_compaction.py::test_compact_episodic_emits_memory_consolidated`, and `tests/test_dashboard.py::test_dashboard_cockpit_exposes_used_memories`, and they passed. 
- Ran related life-loop and perception test subsets for regression (`tests/test_talk.py`, `tests/test_memory_compaction.py` and targeted life-loop tests) and observed no failures in the runs performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a736823e63c832a904151bf3a72da7c)