### PR TITLE
Link system perceptions to runtime decisions and add per-sensor policy gates

### DIFF
--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -9,7 +9,6 @@ from singular.governance.values import ValueWeights
 from singular.memory import _atomic_write_text, get_mem_dir
 from singular.goals.perception_rules import apply_perception_rules
 
-
 OBJECTIVE_CATALOGUE = ("coherence", "robustesse", "efficacite", "exploration")
 INTRINSIC_MODULATION_VERSION = "intrinsic-mod-v2"
 INTRINSIC_GOAL_SOURCE = "intrinsic"
@@ -52,7 +51,9 @@ class GoalWeights:
         total = sum(max(0.0, float(v)) for v in values.values())
         if total <= 0.0:
             return GoalWeights()
-        return GoalWeights(**{name: max(0.0, float(value)) / total for name, value in values.items()})
+        return GoalWeights(
+            **{name: max(0.0, float(value)) / total for name, value in values.items()}
+        )
 
 
 @dataclass
@@ -122,7 +123,9 @@ class IntrinsicGoals:
         return GoalState.from_dict(data)
 
     def _save(self) -> None:
-        _atomic_write_text(self.path, json.dumps(self.state.to_dict(), ensure_ascii=False))
+        _atomic_write_text(
+            self.path, json.dumps(self.state.to_dict(), ensure_ascii=False)
+        )
 
     def update_tick(
         self,
@@ -146,22 +149,42 @@ class IntrinsicGoals:
 
         curiosity = _clamp(float(getattr(psyche, "curiosity", 0.5))) if psyche else 0.5
         patience = _clamp(float(getattr(psyche, "patience", 0.5))) if psyche else 0.5
-        resilience = _clamp(float(getattr(psyche, "resilience", 0.5))) if psyche else 0.5
+        resilience = (
+            _clamp(float(getattr(psyche, "resilience", 0.5))) if psyche else 0.5
+        )
         optimism = _clamp(float(getattr(psyche, "optimism", 0.5))) if psyche else 0.5
-        playfulness = _clamp(float(getattr(psyche, "playfulness", 0.5))) if psyche else 0.5
+        playfulness = (
+            _clamp(float(getattr(psyche, "playfulness", 0.5))) if psyche else 0.5
+        )
 
-        health_norm = _clamp((float(health_score) if health_score is not None else 50.0) / 100.0)
+        health_norm = _clamp(
+            (float(health_score) if health_score is not None else 50.0) / 100.0
+        )
         energy = _clamp(float((resources or {}).get("energy", 50.0)) / 100.0)
         food = _clamp(float((resources or {}).get("food", 50.0)) / 100.0)
         warmth = _clamp(float((resources or {}).get("warmth", 50.0)) / 100.0)
-        ecological_debt = _clamp(float((resources or {}).get("ecological_debt", 0.0)) / 100.0)
-        relational_debt = _clamp(float((resources or {}).get("relational_debt", 0.0)) / 100.0)
+        ecological_debt = _clamp(
+            float((resources or {}).get("ecological_debt", 0.0)) / 100.0
+        )
+        relational_debt = _clamp(
+            float((resources or {}).get("relational_debt", 0.0)) / 100.0
+        )
         resource_stability = (energy + food + warmth) / 3.0
         telemetry_efficiency_penalty = 0.0
         telemetry_quality_pressure = 0.0
         telemetry_failure_pressure = 0.0
         host_environmental_pressure = 0.0
         host_environmental_variance = 0.0
+        system_decisions = (perception_signals or {}).get("perception_decisions")
+        system_decision_names = (
+            [
+                str(entry.get("decision"))
+                for entry in system_decisions
+                if isinstance(entry, Mapping) and entry.get("decision")
+            ]
+            if isinstance(system_decisions, list)
+            else []
+        )
         narrative = (perception_signals or {}).get("narrative_indicators")
         planner_narrative = (perception_signals or {}).get("planner_narrative_signals")
         execution_history = (perception_signals or {}).get("execution_history")
@@ -176,25 +199,47 @@ class IntrinsicGoals:
         narrative_regret = 0.0
         narrative_pride = 0.0
         identity_drift = 0.0
-        identity_wounds = _clamp(_as_float(getattr(psyche, "identity_wounds", 0.0), default=0.0)) if psyche else 0.0
+        identity_wounds = (
+            _clamp(_as_float(getattr(psyche, "identity_wounds", 0.0), default=0.0))
+            if psyche
+            else 0.0
+        )
         if isinstance(narrative, Mapping):
-            risk_aversion = _mean_mapping_value(narrative.get("risk_aversion_by_action_family"))
+            risk_aversion = _mean_mapping_value(
+                narrative.get("risk_aversion_by_action_family")
+            )
             confidence_map = narrative.get("accumulated_confidence_by_action_family")
             if isinstance(confidence_map, Mapping) and confidence_map:
                 accumulated_confidence = _mean_mapping_value(confidence_map)
             else:
-                accumulated_confidence = _clamp(_as_float(narrative.get("accumulated_confidence", 0.5), default=0.5))
+                accumulated_confidence = _clamp(
+                    _as_float(narrative.get("accumulated_confidence", 0.5), default=0.5)
+                )
         if isinstance(execution_history, Mapping):
-            injuries_pressure = _clamp(_as_float(execution_history.get("recent_injuries", 0.0)) / 5.0)
-            success_boost = _clamp(_as_float(execution_history.get("recent_successes", 0.0)) / 6.0)
+            injuries_pressure = _clamp(
+                _as_float(execution_history.get("recent_injuries", 0.0)) / 5.0
+            )
+            success_boost = _clamp(
+                _as_float(execution_history.get("recent_successes", 0.0)) / 6.0
+            )
             repeated_failure_pressure = _clamp(
-                _as_float(execution_history.get("repeated_failure_pressure", 0.0), default=0.0)
+                _as_float(
+                    execution_history.get("repeated_failure_pressure", 0.0), default=0.0
+                )
             )
         if isinstance(planner_narrative, Mapping):
-            narrative_coherence = _clamp(_as_float(planner_narrative.get("coherence_signal", 0.5), default=0.5))
-            narrative_regret = _clamp(_as_float(planner_narrative.get("regret_pressure", 0.0), default=0.0))
-            narrative_pride = _clamp(_as_float(planner_narrative.get("pride_drive", 0.0), default=0.0))
-            identity_drift = _clamp(_as_float(planner_narrative.get("identity_drift", 0.0), default=0.0))
+            narrative_coherence = _clamp(
+                _as_float(planner_narrative.get("coherence_signal", 0.5), default=0.5)
+            )
+            narrative_regret = _clamp(
+                _as_float(planner_narrative.get("regret_pressure", 0.0), default=0.0)
+            )
+            narrative_pride = _clamp(
+                _as_float(planner_narrative.get("pride_drive", 0.0), default=0.0)
+            )
+            identity_drift = _clamp(
+                _as_float(planner_narrative.get("identity_drift", 0.0), default=0.0)
+            )
         world_events = (perception_signals or {}).get("world_events")
         if isinstance(world_events, list):
             total_events = float(len(world_events))
@@ -242,27 +287,41 @@ class IntrinsicGoals:
                 ram_roll = rolling.get("ram_used_percent")
                 temp_roll = rolling.get("host_temperature_c")
                 cpu_pressure = (
-                    _clamp(_as_float(cpu_roll.get("20", cpu_roll.get("5", 0.0))) / 100.0)
+                    _clamp(
+                        _as_float(cpu_roll.get("20", cpu_roll.get("5", 0.0))) / 100.0
+                    )
                     if isinstance(cpu_roll, Mapping)
                     else 0.0
                 )
                 ram_pressure = (
-                    _clamp(_as_float(ram_roll.get("20", ram_roll.get("5", 0.0))) / 100.0)
+                    _clamp(
+                        _as_float(ram_roll.get("20", ram_roll.get("5", 0.0))) / 100.0
+                    )
                     if isinstance(ram_roll, Mapping)
                     else 0.0
                 )
                 thermal_pressure = (
-                    _clamp(_as_float(temp_roll.get("20", temp_roll.get("5", 0.0))) / 95.0)
+                    _clamp(
+                        _as_float(temp_roll.get("20", temp_roll.get("5", 0.0))) / 95.0
+                    )
                     if isinstance(temp_roll, Mapping)
                     else 0.0
                 )
                 host_environmental_pressure = _clamp(
-                    (cpu_pressure * 0.45) + (ram_pressure * 0.35) + (thermal_pressure * 0.2)
+                    (cpu_pressure * 0.45)
+                    + (ram_pressure * 0.35)
+                    + (thermal_pressure * 0.2)
                 )
             if isinstance(variance, Mapping):
-                cpu_variance = _clamp(_as_float(variance.get("cpu_percent", 0.0)) / 400.0)
-                ram_variance = _clamp(_as_float(variance.get("ram_used_percent", 0.0)) / 400.0)
-                host_environmental_variance = _clamp((cpu_variance + ram_variance) / 2.0)
+                cpu_variance = _clamp(
+                    _as_float(variance.get("cpu_percent", 0.0)) / 400.0
+                )
+                ram_variance = _clamp(
+                    _as_float(variance.get("ram_used_percent", 0.0)) / 400.0
+                )
+                host_environmental_variance = _clamp(
+                    (cpu_variance + ram_variance) / 2.0
+                )
 
         base_weights = GoalWeights(
             coherence=0.2
@@ -304,7 +363,11 @@ class IntrinsicGoals:
             - 0.25 * risk_aversion
             - 0.18 * repeated_failure_pressure,
         )
-        base_weights.coherence += (0.25 * narrative_coherence) + (0.12 * narrative_pride) - (0.2 * identity_drift)
+        base_weights.coherence += (
+            (0.25 * narrative_coherence)
+            + (0.12 * narrative_pride)
+            - (0.2 * identity_drift)
+        )
         base_weights.robustesse += (0.2 * narrative_regret) + (0.25 * identity_wounds)
         base_weights.efficacite += (0.12 * narrative_pride) - (0.1 * narrative_regret)
         base_weights.exploration -= (0.15 * narrative_regret) + (0.2 * identity_wounds)
@@ -354,8 +417,12 @@ class IntrinsicGoals:
                     "intrinsic_modulation_version": INTRINSIC_MODULATION_VERSION,
                     "perception_rules_version": modulation["version"],
                     "perception_rule_count": len(modulation["applied_rules"]),
+                    "system_decisions": system_decision_names,
                 },
                 "perception_rules": modulation,
+                "system_decision_log": (
+                    list(system_decisions) if isinstance(system_decisions, list) else []
+                ),
             }
         )
         if len(self.state.history) > self.history_limit:
@@ -378,30 +445,74 @@ class IntrinsicGoals:
         """
 
         memory = (perception_signals or {}).get("episode_memory", {})
-        structured = memory.get("structured_feedback", {}) if isinstance(memory, Mapping) else {}
+        structured = (
+            memory.get("structured_feedback", {}) if isinstance(memory, Mapping) else {}
+        )
         narrative = (perception_signals or {}).get("narrative_indicators")
         execution_history = (perception_signals or {}).get("execution_history")
-        frustration = _clamp(_as_float(structured.get("frustration", 0.0))) if isinstance(structured, Mapping) else 0.0
-        satisfaction = _clamp(_as_float(structured.get("satisfaction", 0.0))) if isinstance(structured, Mapping) else 0.0
-        urgency = _clamp(_as_float(structured.get("urgency", 0.0))) if isinstance(structured, Mapping) else 0.0
-        theme = str(structured.get("theme", "general")) if isinstance(structured, Mapping) else "general"
-        negative_streak = int(memory.get("negative_feedback_streak", 0)) if isinstance(memory, Mapping) else 0
-        risk_aversion = _mean_mapping_value(narrative.get("risk_aversion_by_action_family")) if isinstance(narrative, Mapping) else 0.0
+        frustration = (
+            _clamp(_as_float(structured.get("frustration", 0.0)))
+            if isinstance(structured, Mapping)
+            else 0.0
+        )
+        satisfaction = (
+            _clamp(_as_float(structured.get("satisfaction", 0.0)))
+            if isinstance(structured, Mapping)
+            else 0.0
+        )
+        urgency = (
+            _clamp(_as_float(structured.get("urgency", 0.0)))
+            if isinstance(structured, Mapping)
+            else 0.0
+        )
+        theme = (
+            str(structured.get("theme", "general"))
+            if isinstance(structured, Mapping)
+            else "general"
+        )
+        negative_streak = (
+            int(memory.get("negative_feedback_streak", 0))
+            if isinstance(memory, Mapping)
+            else 0
+        )
+        risk_aversion = (
+            _mean_mapping_value(narrative.get("risk_aversion_by_action_family"))
+            if isinstance(narrative, Mapping)
+            else 0.0
+        )
         confidence = 0.5
         if isinstance(narrative, Mapping):
             confidence_map = narrative.get("accumulated_confidence_by_action_family")
             if isinstance(confidence_map, Mapping) and confidence_map:
                 confidence = _mean_mapping_value(confidence_map)
             else:
-                confidence = _clamp(_as_float(narrative.get("accumulated_confidence", 0.5), default=0.5))
+                confidence = _clamp(
+                    _as_float(narrative.get("accumulated_confidence", 0.5), default=0.5)
+                )
         repeated_failure_penalty = (
             _clamp(_as_float(execution_history.get("repeated_failure_pressure", 0.0)))
             if isinstance(execution_history, Mapping)
             else 0.0
         )
+        decisions = (perception_signals or {}).get("perception_decisions")
+        decision_names = (
+            {
+                str(entry.get("decision"))
+                for entry in decisions
+                if isinstance(entry, Mapping) and entry.get("decision")
+            }
+            if isinstance(decisions, list)
+            else set()
+        )
 
         mode = "balanced"
-        if frustration >= 0.6 or negative_streak >= 2 or repeated_failure_penalty >= 0.5 or risk_aversion >= 0.7:
+        if (
+            "trigger_economy_mode" in decision_names
+            or frustration >= 0.6
+            or negative_streak >= 2
+            or repeated_failure_penalty >= 0.5
+            or risk_aversion >= 0.7
+        ):
             mode = "cautious"
         elif urgency >= 0.6 and repeated_failure_penalty < 0.45:
             mode = "utility_focused"
@@ -418,6 +529,7 @@ class IntrinsicGoals:
             "risk_aversion": risk_aversion,
             "confidence": confidence,
             "repeated_failure_penalty": repeated_failure_penalty,
+            "system_decisions": sorted(decision_names),
             "intrinsic_modulation_version": INTRINSIC_MODULATION_VERSION,
         }
 
@@ -444,18 +556,30 @@ class IntrinsicGoals:
             prompt = str(payload.get("prompt", "")).lower()
             if mode == "cautious":
                 priority += int(10 + frustration * 20)
-                if any(token in routine_id or token in prompt for token in ("check", "verify", "monitor", "safety")):
+                if any(
+                    token in routine_id or token in prompt
+                    for token in ("check", "verify", "monitor", "safety")
+                ):
                     priority += 8
-                if any(token in routine_id or token in prompt for token in ("help", "user", "support", "respond")):
+                if any(
+                    token in routine_id or token in prompt
+                    for token in ("help", "user", "support", "respond")
+                ):
                     priority += int(12 + urgency * 12)
                 elif urgency >= 0.6:
                     priority -= int(8 + urgency * 18)
             elif mode == "utility_focused":
                 priority += int(6 + urgency * 18)
-                if any(token in routine_id or token in prompt for token in ("help", "user", "support", "respond")):
+                if any(
+                    token in routine_id or token in prompt
+                    for token in ("help", "user", "support", "respond")
+                ):
                     priority += 12
             elif mode == "exploratory":
-                if any(token in routine_id or token in prompt for token in ("research", "explore", "discover")):
+                if any(
+                    token in routine_id or token in prompt
+                    for token in ("research", "explore", "discover")
+                ):
                     priority += 14
                 else:
                     priority -= 4
@@ -480,7 +604,9 @@ class IntrinsicGoals:
         v = self.value_weights
         coherence_score = 1.0 - abs(_clamp(expected_gain + 0.5, 0.0, 1.0) - 0.5) * 2.0
         robustesse_score = 1.0 - _clamp(sandbox_risk * (1.0 + v.securite * 0.5))
-        efficacite_score = (1.0 - _clamp(resource_cost)) * (0.7 + 0.3 * v.utilite_utilisateur)
+        efficacite_score = (1.0 - _clamp(resource_cost)) * (
+            0.7 + 0.3 * v.utilite_utilisateur
+        )
         exploration_score = _clamp(novelty) * (0.3 + 0.7 * v.curiosite_bornee)
         arbitration = (
             w.coherence * coherence_score
@@ -492,7 +618,9 @@ class IntrinsicGoals:
         utility_bonus = v.utilite_utilisateur * _clamp(expected_gain + 0.5, 0.0, 1.0)
         return arbitration + 0.15 * preservation_bonus + 0.1 * utility_bonus
 
-    def influence_action_hypotheses(self, hypotheses: list[Any]) -> list[dict[str, Any]]:
+    def influence_action_hypotheses(
+        self, hypotheses: list[Any]
+    ) -> list[dict[str, Any]]:
         """Apply intrinsic-goal influence and return adjusted hypothesis payloads."""
 
         adjusted: list[dict[str, Any]] = []
@@ -508,8 +636,13 @@ class IntrinsicGoals:
             adjusted.append(
                 {
                     "action": getattr(hypothesis, "action", ""),
-                    "long_term": _clamp(float(getattr(hypothesis, "long_term", 0.0)) * 0.6 + arbitration * 0.6),
-                    "sandbox_risk": _clamp(float(getattr(hypothesis, "sandbox_risk", 0.0))),
+                    "long_term": _clamp(
+                        float(getattr(hypothesis, "long_term", 0.0)) * 0.6
+                        + arbitration * 0.6
+                    ),
+                    "sandbox_risk": _clamp(
+                        float(getattr(hypothesis, "sandbox_risk", 0.0))
+                    ),
                     "resource_cost": _clamp(
                         float(getattr(hypothesis, "resource_cost", 0.0))
                         * (0.7 + (1.0 - self.state.weights.efficacite) * 0.3)
@@ -528,7 +661,9 @@ class IntrinsicGoals:
 
         if not operator_stats:
             return {}
-        max_count = max(float(stats.get("count", 0.0)) for stats in operator_stats.values())
+        max_count = max(
+            float(stats.get("count", 0.0)) for stats in operator_stats.values()
+        )
         if max_count <= 0.0:
             max_count = 1.0
         reputation_cost = 0.0
@@ -541,13 +676,29 @@ class IntrinsicGoals:
                 reputation_failures += float(stats.get("recent_failures", 0.0))
                 reputation_quality += float(stats.get("mean_quality", 0.0))
                 reputation_samples += 1.0
-        mean_reputation_cost = reputation_cost / reputation_samples if reputation_samples else 0.0
-        mean_reputation_quality = reputation_quality / reputation_samples if reputation_samples else 0.5
-        reputation_failure_penalty = _clamp(reputation_failures / max(reputation_samples, 1.0) / 3.0, 0.0, 1.0)
+        mean_reputation_cost = (
+            reputation_cost / reputation_samples if reputation_samples else 0.0
+        )
+        mean_reputation_quality = (
+            reputation_quality / reputation_samples if reputation_samples else 0.5
+        )
+        reputation_failure_penalty = _clamp(
+            reputation_failures / max(reputation_samples, 1.0) / 3.0, 0.0, 1.0
+        )
 
         biases: dict[str, float] = {}
-        coherence_bonus = _clamp(_as_float((planner_narrative_signals or {}).get("coherence_signal", 0.0), default=0.0))
-        dissonance_malus = _clamp(_as_float((planner_narrative_signals or {}).get("dissonance_signal", 0.0), default=0.0))
+        coherence_bonus = _clamp(
+            _as_float(
+                (planner_narrative_signals or {}).get("coherence_signal", 0.0),
+                default=0.0,
+            )
+        )
+        dissonance_malus = _clamp(
+            _as_float(
+                (planner_narrative_signals or {}).get("dissonance_signal", 0.0),
+                default=0.0,
+            )
+        )
         for name, stats in operator_stats.items():
             count = float(stats.get("count", 0.0))
             reward = float(stats.get("reward", 0.0))
@@ -557,12 +708,18 @@ class IntrinsicGoals:
             telemetry_alignment = _clamp(
                 mean_reputation_quality * 0.7 + (1.0 - reputation_failure_penalty) * 0.3
             )
-            biases[name] = self.objective_arbitration(
-                expected_gain=mean_reward,
-                sandbox_risk=reputation_failure_penalty,
-                resource_cost=_clamp((count / max_count) * 0.6 + mean_reputation_cost * 0.4),
-                novelty=exploration_signal,
-            ) + self.state.weights.efficacite * efficiency_signal + self.state.weights.coherence * telemetry_alignment
-            biases[name] += (self.state.weights.coherence * 0.2 * coherence_bonus)
-            biases[name] -= (self.state.weights.robustesse * 0.25 * dissonance_malus)
+            biases[name] = (
+                self.objective_arbitration(
+                    expected_gain=mean_reward,
+                    sandbox_risk=reputation_failure_penalty,
+                    resource_cost=_clamp(
+                        (count / max_count) * 0.6 + mean_reputation_cost * 0.4
+                    ),
+                    novelty=exploration_signal,
+                )
+                + self.state.weights.efficacite * efficiency_signal
+                + self.state.weights.coherence * telemetry_alignment
+            )
+            biases[name] += self.state.weights.coherence * 0.2 * coherence_bonus
+            biases[name] -= self.state.weights.robustesse * 0.25 * dissonance_malus
         return biases

--- a/src/singular/goals/perception_rules.py
+++ b/src/singular/goals/perception_rules.py
@@ -2,8 +2,30 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-
 RULESET_VERSION = "2026-04-14.v1"
+
+SYSTEM_DECISION_DELTAS: dict[str, dict[str, float]] = {
+    "reduce_mutation_cadence": {
+        "efficacite": -0.04,
+        "robustesse": 0.08,
+        "exploration": -0.05,
+    },
+    "delay_heavy_synthesis": {
+        "efficacite": -0.03,
+        "robustesse": 0.06,
+        "exploration": -0.04,
+    },
+    "prioritize_memory_compaction": {
+        "robustesse": 0.09,
+        "efficacite": 0.03,
+        "exploration": -0.03,
+    },
+    "trigger_economy_mode": {
+        "robustesse": 0.12,
+        "efficacite": -0.05,
+        "exploration": -0.08,
+    },
+}
 
 
 def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
@@ -17,7 +39,9 @@ def _float(value: Any, default: float = 0.0) -> float:
         return default
 
 
-def _extract_tech_debt_markers(perception_signals: Mapping[str, Any]) -> tuple[float | None, float | None]:
+def _extract_tech_debt_markers(
+    perception_signals: Mapping[str, Any],
+) -> tuple[float | None, float | None]:
     artifact_events = perception_signals.get("artifact_events")
     latest: float | None = None
     if isinstance(artifact_events, list):
@@ -35,11 +59,14 @@ def _extract_tech_debt_markers(perception_signals: Mapping[str, Any]) -> tuple[f
         perception_signals.get("tech_debt_baseline_markers"),
         perception_signals.get("artifact_tech_debt_previous"),
     )
-    previous = next((
-        _float(candidate)
-        for candidate in previous_candidates
-        if candidate is not None
-    ), None)
+    previous = next(
+        (
+            _float(candidate)
+            for candidate in previous_candidates
+            if candidate is not None
+        ),
+        None,
+    )
     return latest, previous
 
 
@@ -72,7 +99,9 @@ def _extract_user_friction_index(perception_signals: Mapping[str, Any]) -> float
     return None
 
 
-def apply_perception_rules(perception_signals: Mapping[str, Any] | None) -> dict[str, Any]:
+def apply_perception_rules(
+    perception_signals: Mapping[str, Any] | None,
+) -> dict[str, Any]:
     """Return deterministic objective deltas derived from perception signals."""
 
     deltas = {
@@ -84,10 +113,18 @@ def apply_perception_rules(perception_signals: Mapping[str, Any] | None) -> dict
     applied_rules: list[dict[str, Any]] = []
 
     if not isinstance(perception_signals, Mapping):
-        return {"version": RULESET_VERSION, "deltas": deltas, "applied_rules": applied_rules}
+        return {
+            "version": RULESET_VERSION,
+            "deltas": deltas,
+            "applied_rules": applied_rules,
+        }
 
     current_markers, previous_markers = _extract_tech_debt_markers(perception_signals)
-    if current_markers is not None and previous_markers is not None and current_markers > previous_markers:
+    if (
+        current_markers is not None
+        and previous_markers is not None
+        and current_markers > previous_markers
+    ):
         delta = min(0.16, (current_markers - previous_markers) * 0.02)
         deltas["robustesse"] += delta
         deltas["exploration"] -= delta * 0.35
@@ -128,4 +165,31 @@ def apply_perception_rules(perception_signals: Mapping[str, Any] | None) -> dict
                 }
             )
 
-    return {"version": RULESET_VERSION, "deltas": deltas, "applied_rules": applied_rules}
+    perception_decisions = perception_signals.get("perception_decisions")
+    if isinstance(perception_decisions, list):
+        for decision_entry in perception_decisions:
+            if not isinstance(decision_entry, Mapping):
+                continue
+            decision = str(decision_entry.get("decision", ""))
+            decision_deltas = SYSTEM_DECISION_DELTAS.get(decision)
+            if not decision_deltas:
+                continue
+            for objective, delta in decision_deltas.items():
+                deltas[objective] += delta
+            applied_rules.append(
+                {
+                    "rule_id": f"R-010-system-{decision}",
+                    "decision": decision,
+                    "perception": decision_entry.get("perception"),
+                    "source_metric": decision_entry.get("source_metric"),
+                    "source_value": decision_entry.get("source_value"),
+                    "source_threshold": decision_entry.get("source_threshold"),
+                    "deltas": dict(decision_deltas),
+                }
+            )
+
+    return {
+        "version": RULESET_VERSION,
+        "deltas": deltas,
+        "applied_rules": applied_rules,
+    }

--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -33,9 +33,7 @@ SANDBOX_INFRASTRUCTURE_ERROR_TYPES = frozenset(
 SANDBOX_INVALID_CANDIDATE_ERROR_TYPES = frozenset(
     {"syntax_error", "missing_result", "non_numeric_result", "non_finite_result"}
 )
-SANDBOX_POLICY_VIOLATION_ERROR_TYPES = frozenset(
-    {"forbidden_syntax", "forbidden_name"}
-)
+SANDBOX_POLICY_VIOLATION_ERROR_TYPES = frozenset({"forbidden_syntax", "forbidden_name"})
 
 _ROOT_POLICY_FILE = "policy.yaml"
 _POLICY_DECISIONS_LOG = "policy_decisions.jsonl"
@@ -73,7 +71,16 @@ def _default_policy_payload() -> dict[str, Any]:
         "memory": {"preserve_threshold": 0.6},
         "forgetting": {"enabled": True, "max_episodic_entries": 5000},
         "sensors": {
-            "allowed": ["host_metrics", "artifact_scan", "virtual_environment"],
+            "allowed": [
+                "host_metrics",
+                "host_cpu",
+                "host_ram",
+                "host_disk",
+                "host_temperature",
+                "ambient_noise",
+                "artifact_scan",
+                "virtual_environment",
+            ],
             "blocked": [],
             "max_export_granularity": "standard",
             "anonymization": {
@@ -114,7 +121,11 @@ def _default_policy_payload() -> dict[str, Any]:
             "skill_creation_quota_per_window": 3,
             "skill_creation_quota_window_seconds": 900.0,
             "file_creation_review_required": False,
-            "safe_mode_review_required_skill_families": ["network", "shell", "filesystem"],
+            "safe_mode_review_required_skill_families": [
+                "network",
+                "shell",
+                "filesystem",
+            ],
             "circuit_breaker_threshold": 15,
             "circuit_breaker_window_seconds": 180.0,
             "circuit_breaker_cooldown_seconds": 60.0,
@@ -151,7 +162,9 @@ def _coerce_bool(payload: Mapping[str, Any], key: str) -> bool:
     return bool(payload[key])
 
 
-def _coerce_float(payload: Mapping[str, Any], key: str, *, minimum: float = 0.0) -> float:
+def _coerce_float(
+    payload: Mapping[str, Any], key: str, *, minimum: float = 0.0
+) -> float:
     if key not in payload:
         raise PolicySchemaError(f"missing required key: {key}")
     try:
@@ -285,7 +298,9 @@ class RuntimePolicy:
                 "mutation_quota_per_window": self.mutation_quota_per_window,
                 "mutation_quota_window_seconds": self.mutation_quota_window_seconds,
                 "runtime_call_quota_per_hour": self.runtime_call_quota_per_hour,
-                "runtime_blacklisted_capabilities": list(self.runtime_blacklisted_capabilities),
+                "runtime_blacklisted_capabilities": list(
+                    self.runtime_blacklisted_capabilities
+                ),
                 "auto_rollback_failure_threshold": self.auto_rollback_failure_threshold,
                 "auto_rollback_cost_threshold": self.auto_rollback_cost_threshold,
                 "skill_creation_quota_per_window": self.skill_creation_quota_per_window,
@@ -305,7 +320,9 @@ class RuntimePolicy:
             },
             "social": {
                 "max_influence_per_life": self.social_max_influence_per_life,
-                "blocked_hostile_behaviors": list(self.social_blocked_hostile_behaviors),
+                "blocked_hostile_behaviors": list(
+                    self.social_blocked_hostile_behaviors
+                ),
                 "conflict_events": list(self.social_conflict_events),
                 "conflict_mediation_threshold": self.social_conflict_mediation_threshold,
                 "conflict_window_seconds": self.social_conflict_window_seconds,
@@ -342,7 +359,15 @@ def _validate_runtime_policy(payload: Mapping[str, Any]) -> RuntimePolicy:
     mutable_payload.setdefault("sensors", _default_policy_payload()["sensors"])
     mutable_payload.setdefault("social", _default_policy_payload()["social"])
     payload = mutable_payload
-    root_keys = {"version", "memory", "forgetting", "sensors", "permissions", "autonomy", "social"}
+    root_keys = {
+        "version",
+        "memory",
+        "forgetting",
+        "sensors",
+        "permissions",
+        "autonomy",
+        "social",
+    }
     unexpected = sorted(set(payload.keys()) - root_keys)
     if unexpected:
         raise PolicySchemaError(f"unexpected root keys: {', '.join(unexpected)}")
@@ -458,16 +483,21 @@ def _validate_runtime_policy(payload: Mapping[str, Any]) -> RuntimePolicy:
     anonymization = sensors["anonymization"]
     if not isinstance(anonymization, Mapping):
         raise PolicySchemaError("section 'sensors.anonymization' must be a mapping")
-    anonymization_unexpected = sorted(set(anonymization.keys()) - expected_sensors_anonymization)
+    anonymization_unexpected = sorted(
+        set(anonymization.keys()) - expected_sensors_anonymization
+    )
     if anonymization_unexpected:
         raise PolicySchemaError(
             "section 'sensors.anonymization' has unexpected keys: "
             + ", ".join(anonymization_unexpected)
         )
-    anonymization_missing = sorted(expected_sensors_anonymization - set(anonymization.keys()))
+    anonymization_missing = sorted(
+        expected_sensors_anonymization - set(anonymization.keys())
+    )
     if anonymization_missing:
         raise PolicySchemaError(
-            "section 'sensors.anonymization' missing keys: " + ", ".join(anonymization_missing)
+            "section 'sensors.anonymization' missing keys: "
+            + ", ".join(anonymization_missing)
         )
 
     preserve_threshold = _coerce_float(memory, "preserve_threshold", minimum=0.0)
@@ -481,7 +511,9 @@ def _validate_runtime_policy(payload: Mapping[str, Any]) -> RuntimePolicy:
         version=version,
         memory_preserve_threshold=preserve_threshold,
         forgetting_enabled=_coerce_bool(forgetting, "enabled"),
-        forgetting_max_episodic_entries=_coerce_int(forgetting, "max_episodic_entries", minimum=1),
+        forgetting_max_episodic_entries=_coerce_int(
+            forgetting, "max_episodic_entries", minimum=1
+        ),
         sensors_allowed=_coerce_string_list(sensors, "allowed"),
         sensors_blocked=_coerce_string_list(sensors, "blocked"),
         sensors_max_export_granularity=_coerce_enum(
@@ -494,7 +526,9 @@ def _validate_runtime_policy(payload: Mapping[str, Any]) -> RuntimePolicy:
         sensors_allow_sensitive_metrics_opt_in=_coerce_bool(
             anonymization, "allow_sensitive_metrics_opt_in"
         ),
-        sensors_redact_machine_user_info=_coerce_bool(anonymization, "redact_machine_user_info"),
+        sensors_redact_machine_user_info=_coerce_bool(
+            anonymization, "redact_machine_user_info"
+        ),
         sensors_sensitive_metric_keys_blocklist=_coerce_string_list(
             anonymization, "sensitive_metric_keys_blocklist"
         ),
@@ -503,9 +537,15 @@ def _validate_runtime_policy(payload: Mapping[str, Any]) -> RuntimePolicy:
         forbidden_paths=_coerce_path_list(permissions, "forbidden_paths"),
         force_allow_paths=_coerce_path_list(permissions, "force_allow_paths"),
         safe_mode=_coerce_bool(autonomy, "safe_mode"),
-        mutation_quota_per_window=_coerce_int(autonomy, "mutation_quota_per_window", minimum=1),
-        mutation_quota_window_seconds=_coerce_float(autonomy, "mutation_quota_window_seconds", minimum=1.0),
-        runtime_call_quota_per_hour=_coerce_int(autonomy, "runtime_call_quota_per_hour", minimum=1),
+        mutation_quota_per_window=_coerce_int(
+            autonomy, "mutation_quota_per_window", minimum=1
+        ),
+        mutation_quota_window_seconds=_coerce_float(
+            autonomy, "mutation_quota_window_seconds", minimum=1.0
+        ),
+        runtime_call_quota_per_hour=_coerce_int(
+            autonomy, "runtime_call_quota_per_hour", minimum=1
+        ),
         runtime_blacklisted_capabilities=_coerce_string_list(
             autonomy,
             "runtime_blacklisted_capabilities",
@@ -526,14 +566,22 @@ def _validate_runtime_policy(payload: Mapping[str, Any]) -> RuntimePolicy:
             "skill_creation_quota_window_seconds",
             minimum=1.0,
         ),
-        file_creation_review_required=_coerce_bool(autonomy, "file_creation_review_required"),
+        file_creation_review_required=_coerce_bool(
+            autonomy, "file_creation_review_required"
+        ),
         safe_mode_review_required_skill_families=_coerce_string_list(
             autonomy,
             "safe_mode_review_required_skill_families",
         ),
-        circuit_breaker_threshold=_coerce_int(autonomy, "circuit_breaker_threshold", minimum=1),
-        circuit_breaker_window_seconds=_coerce_float(autonomy, "circuit_breaker_window_seconds", minimum=1.0),
-        circuit_breaker_cooldown_seconds=_coerce_float(autonomy, "circuit_breaker_cooldown_seconds", minimum=1.0),
+        circuit_breaker_threshold=_coerce_int(
+            autonomy, "circuit_breaker_threshold", minimum=1
+        ),
+        circuit_breaker_window_seconds=_coerce_float(
+            autonomy, "circuit_breaker_window_seconds", minimum=1.0
+        ),
+        circuit_breaker_cooldown_seconds=_coerce_float(
+            autonomy, "circuit_breaker_cooldown_seconds", minimum=1.0
+        ),
         circuit_breaker_critical_threshold=_coerce_int(
             autonomy, "circuit_breaker_critical_threshold", minimum=1
         ),
@@ -556,7 +604,9 @@ def _validate_runtime_policy(payload: Mapping[str, Any]) -> RuntimePolicy:
             minimum=1.0,
         ),
         social_max_influence_per_life=max_influence,
-        social_blocked_hostile_behaviors=_coerce_string_list(social, "blocked_hostile_behaviors"),
+        social_blocked_hostile_behaviors=_coerce_string_list(
+            social, "blocked_hostile_behaviors"
+        ),
         social_conflict_events=_coerce_string_list(social, "conflict_events"),
         social_conflict_mediation_threshold=_coerce_int(
             social, "conflict_mediation_threshold", minimum=1
@@ -567,7 +617,9 @@ def _validate_runtime_policy(payload: Mapping[str, Any]) -> RuntimePolicy:
         social_mediation_cooldown_seconds=_coerce_float(
             social, "mediation_cooldown_seconds", minimum=1.0
         ),
-        social_prudent_mode_on_mediation=_coerce_bool(social, "prudent_mode_on_mediation"),
+        social_prudent_mode_on_mediation=_coerce_bool(
+            social, "prudent_mode_on_mediation"
+        ),
     )
 
 
@@ -627,8 +679,6 @@ def _dump_policy_payload(payload: Mapping[str, Any]) -> str:
     except ImportError:
         return json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
     return yaml.safe_dump(dict(payload), sort_keys=False)
-
-
 
 
 @dataclass(frozen=True)
@@ -706,15 +756,19 @@ class MutationGovernancePolicy:
             p.strip("/") for p in (modifiable_paths or runtime_policy.modifiable_paths)
         )
         self.review_required_paths = tuple(
-            p.strip("/") for p in (review_required_paths or runtime_policy.review_required_paths)
+            p.strip("/")
+            for p in (review_required_paths or runtime_policy.review_required_paths)
         )
         self.forbidden_paths = tuple(
             p.strip("/") for p in (forbidden_paths or runtime_policy.forbidden_paths)
         )
-        self.force_allow_paths = tuple(p.strip("/") for p in runtime_policy.force_allow_paths)
+        self.force_allow_paths = tuple(
+            p.strip("/") for p in runtime_policy.force_allow_paths
+        )
         self.value_weights = (value_weights or ValueWeights()).normalized()
         self.mutation_quota_per_window = max(
-            int(mutation_quota_per_window or runtime_policy.mutation_quota_per_window), 1
+            int(mutation_quota_per_window or runtime_policy.mutation_quota_per_window),
+            1,
         )
         self.mutation_quota_window_seconds = max(
             float(
@@ -724,7 +778,10 @@ class MutationGovernancePolicy:
             1.0,
         )
         self.runtime_call_quota_per_hour = max(
-            int(runtime_call_quota_per_hour or runtime_policy.runtime_call_quota_per_hour),
+            int(
+                runtime_call_quota_per_hour
+                or runtime_policy.runtime_call_quota_per_hour
+            ),
             1,
         )
         blacklisted_capabilities = (
@@ -736,11 +793,17 @@ class MutationGovernancePolicy:
             item.strip().lower() for item in blacklisted_capabilities if item.strip()
         )
         self.auto_rollback_failure_threshold = max(
-            int(auto_rollback_failure_threshold or runtime_policy.auto_rollback_failure_threshold),
+            int(
+                auto_rollback_failure_threshold
+                or runtime_policy.auto_rollback_failure_threshold
+            ),
             1,
         )
         self.auto_rollback_cost_threshold = max(
-            float(auto_rollback_cost_threshold or runtime_policy.auto_rollback_cost_threshold),
+            float(
+                auto_rollback_cost_threshold
+                or runtime_policy.auto_rollback_cost_threshold
+            ),
             0.0,
         )
         self.skill_creation_quota_per_window = max(
@@ -758,7 +821,8 @@ class MutationGovernancePolicy:
             1.0,
         )
         self.file_creation_review_required = bool(
-            file_creation_review_required or runtime_policy.file_creation_review_required
+            file_creation_review_required
+            or runtime_policy.file_creation_review_required
         )
         required_skill_families = (
             safe_mode_review_required_skill_families
@@ -769,7 +833,8 @@ class MutationGovernancePolicy:
             item.strip().lower() for item in required_skill_families if item.strip()
         )
         self.circuit_breaker_threshold = max(
-            int(circuit_breaker_threshold or runtime_policy.circuit_breaker_threshold), 1
+            int(circuit_breaker_threshold or runtime_policy.circuit_breaker_threshold),
+            1,
         )
         self.circuit_breaker_window_seconds = max(
             float(
@@ -829,16 +894,30 @@ class MutationGovernancePolicy:
         self.safe_mode = bool(safe_mode or runtime_policy.safe_mode)
         self.memory_preserve_threshold = runtime_policy.memory_preserve_threshold
         self.sensors_allowed = frozenset(
-            item.strip().lower() for item in runtime_policy.sensors_allowed if item.strip()
+            item.strip().lower()
+            for item in runtime_policy.sensors_allowed
+            if item.strip()
         )
         self.sensors_blocked = frozenset(
-            item.strip().lower() for item in runtime_policy.sensors_blocked if item.strip()
+            item.strip().lower()
+            for item in runtime_policy.sensors_blocked
+            if item.strip()
         )
-        self.sensors_max_export_granularity = runtime_policy.sensors_max_export_granularity
-        self.sensors_anonymization_enabled = runtime_policy.sensors_anonymization_enabled
-        self.sensors_block_sensitive_by_default = runtime_policy.sensors_block_sensitive_by_default
-        self.sensors_allow_sensitive_metrics_opt_in = runtime_policy.sensors_allow_sensitive_metrics_opt_in
-        self.sensors_redact_machine_user_info = runtime_policy.sensors_redact_machine_user_info
+        self.sensors_max_export_granularity = (
+            runtime_policy.sensors_max_export_granularity
+        )
+        self.sensors_anonymization_enabled = (
+            runtime_policy.sensors_anonymization_enabled
+        )
+        self.sensors_block_sensitive_by_default = (
+            runtime_policy.sensors_block_sensitive_by_default
+        )
+        self.sensors_allow_sensitive_metrics_opt_in = (
+            runtime_policy.sensors_allow_sensitive_metrics_opt_in
+        )
+        self.sensors_redact_machine_user_info = (
+            runtime_policy.sensors_redact_machine_user_info
+        )
         self.sensors_sensitive_metric_keys_blocklist = frozenset(
             item.strip().lower()
             for item in runtime_policy.sensors_sensitive_metric_keys_blocklist
@@ -849,10 +928,14 @@ class MutationGovernancePolicy:
             0.0,
         )
         self.social_blocked_hostile_behaviors = frozenset(
-            item.strip().lower() for item in runtime_policy.social_blocked_hostile_behaviors if item.strip()
+            item.strip().lower()
+            for item in runtime_policy.social_blocked_hostile_behaviors
+            if item.strip()
         )
         self.social_conflict_events = frozenset(
-            item.strip().lower() for item in runtime_policy.social_conflict_events if item.strip()
+            item.strip().lower()
+            for item in runtime_policy.social_conflict_events
+            if item.strip()
         )
         self.social_conflict_mediation_threshold = max(
             int(runtime_policy.social_conflict_mediation_threshold), 1
@@ -863,7 +946,9 @@ class MutationGovernancePolicy:
         self.social_mediation_cooldown_seconds = max(
             float(runtime_policy.social_mediation_cooldown_seconds), 1.0
         )
-        self.social_prudent_mode_on_mediation = bool(runtime_policy.social_prudent_mode_on_mediation)
+        self.social_prudent_mode_on_mediation = bool(
+            runtime_policy.social_prudent_mode_on_mediation
+        )
         self._mutation_timestamps: deque[datetime] = deque()
         self._skill_creation_timestamps: deque[datetime] = deque()
         self._violation_timestamps: deque[datetime] = deque()
@@ -951,7 +1036,8 @@ class MutationGovernancePolicy:
             payload = {
                 key: value
                 for key, value in payload.items()
-                if key.strip().lower() not in self.sensors_sensitive_metric_keys_blocklist
+                if key.strip().lower()
+                not in self.sensors_sensitive_metric_keys_blocklist
             }
         if self.sensors_anonymization_enabled and self.sensors_redact_machine_user_info:
             payload = {
@@ -982,7 +1068,10 @@ class MutationGovernancePolicy:
     def mutation_lock_reason(self) -> str | None:
         if self.safe_mode:
             return "safe-mode enabled"
-        if self._circuit_open_until is not None and self._now() < self._circuit_open_until:
+        if (
+            self._circuit_open_until is not None
+            and self._now() < self._circuit_open_until
+        ):
             return "circuit-breaker open after repeated violations"
         return None
 
@@ -992,19 +1081,29 @@ class MutationGovernancePolicy:
         while self._mutation_timestamps and self._mutation_timestamps[0] < quota_cutoff:
             self._mutation_timestamps.popleft()
         violation_cutoff = now - timedelta(seconds=self.circuit_breaker_window_seconds)
-        while self._violation_timestamps and self._violation_timestamps[0] < violation_cutoff:
+        while (
+            self._violation_timestamps
+            and self._violation_timestamps[0] < violation_cutoff
+        ):
             self._violation_timestamps.popleft()
-        creation_cutoff = now - timedelta(seconds=self.skill_creation_quota_window_seconds)
+        creation_cutoff = now - timedelta(
+            seconds=self.skill_creation_quota_window_seconds
+        )
         while (
             self._skill_creation_timestamps
             and self._skill_creation_timestamps[0] < creation_cutoff
         ):
             self._skill_creation_timestamps.popleft()
         runtime_cutoff = now - timedelta(hours=1)
-        while self._runtime_call_timestamps and self._runtime_call_timestamps[0] < runtime_cutoff:
+        while (
+            self._runtime_call_timestamps
+            and self._runtime_call_timestamps[0] < runtime_cutoff
+        ):
             self._runtime_call_timestamps.popleft()
         for skill_name, failures in list(self._skill_failure_timestamps.items()):
-            failure_cutoff = now - timedelta(seconds=self.skill_circuit_breaker_cooldown_seconds)
+            failure_cutoff = now - timedelta(
+                seconds=self.skill_circuit_breaker_cooldown_seconds
+            )
             while failures and failures[0] < failure_cutoff:
                 failures.popleft()
             if not failures:
@@ -1060,7 +1159,9 @@ class MutationGovernancePolicy:
             return None
 
         now = self._now()
-        was_open = self._circuit_open_until is not None and now < self._circuit_open_until
+        was_open = (
+            self._circuit_open_until is not None and now < self._circuit_open_until
+        )
         self._violation_timestamps.append(now)
         threshold = (
             self.circuit_breaker_critical_threshold
@@ -1068,7 +1169,9 @@ class MutationGovernancePolicy:
             else self.circuit_breaker_threshold
         )
         if not was_open and len(self._violation_timestamps) >= threshold:
-            self._circuit_open_until = now + timedelta(seconds=self.circuit_breaker_cooldown_seconds)
+            self._circuit_open_until = now + timedelta(
+                seconds=self.circuit_breaker_cooldown_seconds
+            )
             state = CircuitBreakerState(
                 category=category,
                 severity=severity,
@@ -1111,7 +1214,10 @@ class MutationGovernancePolicy:
 
     def social_prudent_mode_enabled(self) -> bool:
         self._prune_history()
-        return self._social_prudent_until is not None and self._now() < self._social_prudent_until
+        return (
+            self._social_prudent_until is not None
+            and self._now() < self._social_prudent_until
+        )
 
     def evaluate_interlife_interaction(
         self,
@@ -1134,7 +1240,9 @@ class MutationGovernancePolicy:
             )
             self._journal_decision(
                 decision=decision,
-                target=Path(f"interaction://{source_life}->{target_life}/{interaction_key or 'unknown'}"),
+                target=Path(
+                    f"interaction://{source_life}->{target_life}/{interaction_key or 'unknown'}"
+                ),
                 justification="Décision bloquée: interaction inter-vies invalide (identifiants incohérents).",
                 category="inter_life",
             )
@@ -1185,7 +1293,9 @@ class MutationGovernancePolicy:
                 category="inter_life",
             )
             return decision
-        projected_influence = self._social_influence.get(pair, 0.0) + float(influence_delta)
+        projected_influence = self._social_influence.get(pair, 0.0) + float(
+            influence_delta
+        )
         if abs(projected_influence) > self.social_max_influence_per_life:
             decision = GovernanceDecision(
                 level=AUTH_REVIEW_REQUIRED,
@@ -1230,7 +1340,9 @@ class MutationGovernancePolicy:
         interaction_key = interaction.strip().lower()
         if not decision.allowed:
             return decision
-        self._social_influence[pair] = self._social_influence.get(pair, 0.0) + float(influence_delta)
+        self._social_influence[pair] = self._social_influence.get(pair, 0.0) + float(
+            influence_delta
+        )
         if interaction_key in self.social_conflict_events:
             now = self._now()
             timestamps = self._social_conflict_timestamps.setdefault(pair, deque())
@@ -1301,7 +1413,10 @@ class MutationGovernancePolicy:
                 corrective_action="wait for hourly window reset",
                 severity="medium",
             )
-        if self.safe_mode and skill_family in self.safe_mode_review_required_skill_families:
+        if (
+            self.safe_mode
+            and skill_family in self.safe_mode_review_required_skill_families
+        ):
             return GovernanceDecision(
                 level=AUTH_REVIEW_REQUIRED,
                 allowed=False,
@@ -1347,12 +1462,13 @@ class MutationGovernancePolicy:
             return
         failures = self._skill_failure_timestamps.setdefault(normalized_skill, deque())
         failures.append(now)
-        self._skill_cost_totals[normalized_skill] = (
-            self._skill_cost_totals.get(normalized_skill, 0.0) + max(operation_cost, 0.0)
-        )
+        self._skill_cost_totals[normalized_skill] = self._skill_cost_totals.get(
+            normalized_skill, 0.0
+        ) + max(operation_cost, 0.0)
         if (
             len(failures) >= self.skill_circuit_breaker_failure_threshold
-            or self._skill_cost_totals[normalized_skill] >= self.auto_rollback_cost_threshold
+            or self._skill_cost_totals[normalized_skill]
+            >= self.auto_rollback_cost_threshold
             or len(failures) >= self.auto_rollback_failure_threshold
         ):
             self._skill_circuit_open_until[normalized_skill] = now + timedelta(
@@ -1415,7 +1531,11 @@ class MutationGovernancePolicy:
             )
 
         if root is None:
-            root = target.parent.parent if target.parent.name == "skills" else target.parent
+            root = (
+                target.parent.parent
+                if target.parent.name == "skills"
+                else target.parent
+            )
         rel = self._relative(target, root)
 
         if rel.is_absolute():
@@ -1501,7 +1621,9 @@ class MutationGovernancePolicy:
 
         decision = self.simulate_write(target, root=root, operation=operation)
         if not decision.allowed:
-            self.record_violation(category="governance_violation", severity=decision.severity)
+            self.record_violation(
+                category="governance_violation", severity=decision.severity
+            )
             log.warning(
                 "governance blocked write: target=%s level=%s severity=%s reason=%s corrective_action=%s",
                 target,
@@ -1520,9 +1642,16 @@ class MutationGovernancePolicy:
             )
             return decision
 
-        if target.exists() and self.value_weights.preservation_memoire >= self.memory_preserve_threshold:
+        if (
+            target.exists()
+            and self.value_weights.preservation_memoire
+            >= self.memory_preserve_threshold
+        ):
             previous = target.read_text(encoding="utf-8")
-            if len(content.strip()) < len(previous.strip()) * self.memory_preserve_threshold:
+            if (
+                len(content.strip())
+                < len(previous.strip()) * self.memory_preserve_threshold
+            ):
                 blocked = GovernanceDecision(
                     level=AUTH_BLOCKED,
                     allowed=False,

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -634,6 +634,13 @@ class OrchestratorService:
         skip_action_tick = False
         allow_aggressive_exploration = False
         rule_triggers: list[str] = []
+        perception_decisions = self._latest_signals.get("perception_decisions")
+        system_decisions = (
+            [dict(entry) for entry in perception_decisions if isinstance(entry, dict)]
+            if isinstance(perception_decisions, list)
+            else []
+        )
+        decision_names = {str(entry.get("decision")) for entry in system_decisions}
 
         # Explicit rule 1: high CPU => reduce action frequency/tick budget.
         if cpu_percent >= self._host_thresholds.cpu_critical_percent:
@@ -678,6 +685,22 @@ class OrchestratorService:
             allow_aggressive_exploration = True
             rule_triggers.append("resources_stable_explore")
 
+        if "reduce_mutation_cadence" in decision_names:
+            tick_budget_scale *= 0.7
+            rule_triggers.append("perception_reduce_mutation_cadence")
+        if "delay_heavy_synthesis" in decision_names:
+            tick_budget_scale *= 0.85
+            rule_triggers.append("perception_delay_heavy_synthesis")
+        if "prioritize_memory_compaction" in decision_names:
+            enforce_prudent_mode = True
+            rule_triggers.append("perception_prioritize_memory_compaction")
+        if "trigger_economy_mode" in decision_names:
+            enforce_prudent_mode = True
+            cpu_budget_scale *= 0.75
+            rule_triggers.append("perception_trigger_economy_mode")
+        if system_decisions:
+            log.info("system perception decisions applied: %s", system_decisions)
+
         return {
             "tick_budget_scale": tick_budget_scale,
             "cpu_budget_scale": cpu_budget_scale,
@@ -695,6 +718,7 @@ class OrchestratorService:
                 "food": self.resource_manager.food,
                 "warmth": self.resource_manager.warmth,
             },
+            "system_decisions": system_decisions,
         }
 
     def _compute_behavioral_metrics(self) -> dict[str, Any]:

--- a/src/singular/perception.py
+++ b/src/singular/perception.py
@@ -144,6 +144,22 @@ class PerceptionNoiseFilter:
 _ARTIFACT_STATE = _ArtifactScanState()
 _NOISE_FILTER = PerceptionNoiseFilter()
 
+DERIVED_SYSTEM_PERCEPTIONS = (
+    "system.cpu.high",
+    "system.ram.high",
+    "system.disk.critical",
+    "system.temperature.high",
+    "system.environment.calm",
+)
+
+SYSTEM_PERCEPTION_SENSOR_NAMES = {
+    "cpu": "host_cpu",
+    "ram": "host_ram",
+    "disk": "host_disk",
+    "temperature": "host_temperature",
+    "noise": "ambient_noise",
+}
+
 
 def _build_perception_event(
     *,
@@ -161,8 +177,6 @@ def _build_perception_event(
         "timestamp": _iso_now(),
         "data": data,
     }
-
-
 
 
 def _collect_host_signals() -> dict[str, float | None] | None:
@@ -190,6 +204,109 @@ def _collect_host_signals() -> dict[str, float | None] | None:
         return None
 
 
+def _derive_system_perceptions(
+    *,
+    host_metrics: dict[str, Any] | None,
+    noise: float | None,
+) -> list[dict[str, Any]]:
+    """Derive policy-gated system perceptions that drive runtime decisions."""
+
+    try:
+        policy = MutationGovernancePolicy()
+    except Exception:
+        policy = None
+
+    def allowed(metric: str) -> bool:
+        sensor_name = SYSTEM_PERCEPTION_SENSOR_NAMES[metric]
+        if policy is None:
+            return True
+        if sensor_name in getattr(policy, "sensors_blocked", frozenset()):
+            return policy.allow_sensor(sensor_name)
+        return policy.allow_sensor(sensor_name) or policy.allow_sensor("host_metrics")
+
+    thresholds = load_host_sensor_thresholds()
+    metrics = host_metrics if isinstance(host_metrics, dict) else {}
+    perceptions: list[dict[str, Any]] = []
+
+    def append(
+        kind: str, metric: str, value: float, threshold: float, decisions: list[str]
+    ) -> None:
+        perceptions.append(
+            {
+                "type": kind,
+                "source": (
+                    "host_metrics" if metric != "noise" else "virtual_environment"
+                ),
+                "metric": metric,
+                "value": value,
+                "threshold": threshold,
+                "decisions": decisions,
+                "timestamp": _iso_now(),
+            }
+        )
+
+    cpu = metrics.get("cpu_percent")
+    if (
+        allowed("cpu")
+        and isinstance(cpu, (int, float))
+        and float(cpu) >= thresholds.cpu_warning_percent
+    ):
+        append(
+            "system.cpu.high",
+            "cpu_percent",
+            float(cpu),
+            thresholds.cpu_warning_percent,
+            ["reduce_mutation_cadence"],
+        )
+
+    ram = metrics.get("ram_used_percent")
+    if (
+        allowed("ram")
+        and isinstance(ram, (int, float))
+        and float(ram) >= thresholds.ram_warning_percent
+    ):
+        append(
+            "system.ram.high",
+            "ram_used_percent",
+            float(ram),
+            thresholds.ram_warning_percent,
+            ["prioritize_memory_compaction", "delay_heavy_synthesis"],
+        )
+
+    disk = metrics.get("disk_used_percent")
+    if (
+        allowed("disk")
+        and isinstance(disk, (int, float))
+        and float(disk) >= thresholds.disk_critical_percent
+    ):
+        append(
+            "system.disk.critical",
+            "disk_used_percent",
+            float(disk),
+            thresholds.disk_critical_percent,
+            ["prioritize_memory_compaction", "trigger_economy_mode"],
+        )
+
+    temp = metrics.get("host_temperature_c")
+    if (
+        allowed("temperature")
+        and isinstance(temp, (int, float))
+        and float(temp) >= thresholds.temperature_warning_c
+    ):
+        append(
+            "system.temperature.high",
+            "host_temperature_c",
+            float(temp),
+            thresholds.temperature_warning_c,
+            ["delay_heavy_synthesis", "trigger_economy_mode"],
+        )
+
+    if allowed("noise") and isinstance(noise, (int, float)) and float(noise) <= 0.2:
+        append("system.environment.calm", "noise", float(noise), 0.2, [])
+
+    return perceptions
+
+
 def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Emit normalized host events when predefined thresholds are exceeded."""
 
@@ -200,7 +317,10 @@ def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, A
     events: list[dict[str, Any]] = []
 
     cpu_percent = host_metrics.get("cpu_percent")
-    if isinstance(cpu_percent, (int, float)) and float(cpu_percent) >= thresholds.cpu_critical_percent:
+    if (
+        isinstance(cpu_percent, (int, float))
+        and float(cpu_percent) >= thresholds.cpu_critical_percent
+    ):
         events.append(
             _build_perception_event(
                 event_type="host.cpu.critical",
@@ -213,7 +333,10 @@ def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, A
                 },
             )
         )
-    elif isinstance(cpu_percent, (int, float)) and float(cpu_percent) >= thresholds.cpu_warning_percent:
+    elif (
+        isinstance(cpu_percent, (int, float))
+        and float(cpu_percent) >= thresholds.cpu_warning_percent
+    ):
         events.append(
             _build_perception_event(
                 event_type="host.cpu.warning",
@@ -228,7 +351,10 @@ def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, A
         )
 
     ram_used_percent = host_metrics.get("ram_used_percent")
-    if isinstance(ram_used_percent, (int, float)) and float(ram_used_percent) >= thresholds.ram_critical_percent:
+    if (
+        isinstance(ram_used_percent, (int, float))
+        and float(ram_used_percent) >= thresholds.ram_critical_percent
+    ):
         events.append(
             _build_perception_event(
                 event_type="host.memory.critical",
@@ -241,7 +367,10 @@ def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, A
                 },
             )
         )
-    elif isinstance(ram_used_percent, (int, float)) and float(ram_used_percent) >= thresholds.ram_warning_percent:
+    elif (
+        isinstance(ram_used_percent, (int, float))
+        and float(ram_used_percent) >= thresholds.ram_warning_percent
+    ):
         events.append(
             _build_perception_event(
                 event_type="host.memory.warning",
@@ -290,7 +419,10 @@ def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, A
         )
 
     disk_used_percent = host_metrics.get("disk_used_percent")
-    if isinstance(disk_used_percent, (int, float)) and float(disk_used_percent) >= thresholds.disk_critical_percent:
+    if (
+        isinstance(disk_used_percent, (int, float))
+        and float(disk_used_percent) >= thresholds.disk_critical_percent
+    ):
         events.append(
             _build_perception_event(
                 event_type="host.disk.critical",
@@ -307,7 +439,9 @@ def _derive_host_events(host_metrics: dict[str, Any] | None) -> list[dict[str, A
     return events
 
 
-def _collect_artifact_signals(root: Path, state: _ArtifactScanState) -> list[dict[str, Any]]:
+def _collect_artifact_signals(
+    root: Path, state: _ArtifactScanState
+) -> list[dict[str, Any]]:
     files_mtime = _list_sandbox_files(root)
     previous_files = state.files_mtime
 
@@ -362,7 +496,11 @@ def _derive_world_events(world_state: dict[str, Any] | None) -> list[dict[str, A
     if not isinstance(world_state, dict):
         return []
     events: list[dict[str, Any]] = []
-    health = world_state.get("global_health", {}) if isinstance(world_state.get("global_health"), dict) else {}
+    health = (
+        world_state.get("global_health", {})
+        if isinstance(world_state.get("global_health"), dict)
+        else {}
+    )
     trend = str(health.get("trend", "stable"))
     score = float(health.get("score", 50.0) or 50.0)
     if trend == "degrading" or score < 45.0:
@@ -375,8 +513,16 @@ def _derive_world_events(world_state: dict[str, Any] | None) -> list[dict[str, A
             )
         )
 
-    resources = world_state.get("resources", {}) if isinstance(world_state.get("resources"), dict) else {}
-    renewable = resources.get("renewable", {}) if isinstance(resources.get("renewable"), dict) else {}
+    resources = (
+        world_state.get("resources", {})
+        if isinstance(world_state.get("resources"), dict)
+        else {}
+    )
+    renewable = (
+        resources.get("renewable", {})
+        if isinstance(resources.get("renewable"), dict)
+        else {}
+    )
     scarcity: list[dict[str, float | str]] = []
     opportunities: list[dict[str, float | str]] = []
     for name, payload in renewable.items():
@@ -388,7 +534,9 @@ def _derive_world_events(world_state: dict[str, Any] | None) -> list[dict[str, A
         if coverage <= 0.2:
             scarcity.append({"resource": str(name), "coverage": round(coverage, 3)})
         if coverage >= 0.8:
-            opportunities.append({"resource": str(name), "coverage": round(coverage, 3)})
+            opportunities.append(
+                {"resource": str(name), "coverage": round(coverage, 3)}
+            )
 
     if scarcity:
         events.append(
@@ -408,7 +556,9 @@ def _derive_world_events(world_state: dict[str, Any] | None) -> list[dict[str, A
                 data={"resources": opportunities},
             )
         )
-    signals = health.get("signals", {}) if isinstance(health.get("signals"), dict) else {}
+    signals = (
+        health.get("signals", {}) if isinstance(health.get("signals"), dict) else {}
+    )
     delayed_risk = float(signals.get("delayed_risk", 0.0) or 0.0)
     if delayed_risk >= 0.35:
         events.append(
@@ -431,7 +581,6 @@ def _derive_world_events(world_state: dict[str, Any] | None) -> list[dict[str, A
     return events
 
 
-
 def reset_perception_state() -> None:
     """Reset in-memory artifact scan and anti-noise state (tests/helpers)."""
 
@@ -439,6 +588,7 @@ def reset_perception_state() -> None:
     _ARTIFACT_STATE.seen_logs.clear()
     _NOISE_FILTER._seen_signatures.clear()
     _NOISE_FILTER._last_emitted_at.clear()
+
 
 def get_temperature() -> float:
     """Return the current temperature.
@@ -491,6 +641,27 @@ def capture_signals(
             signals["host_metrics_aggregates"] = compute_host_metrics_aggregates()
         except Exception:
             pass
+    system_perceptions = _derive_system_perceptions(
+        host_metrics=host_metrics,
+        noise=(
+            float(signals["noise"])
+            if isinstance(signals.get("noise"), (int, float))
+            else None
+        ),
+    )
+    if system_perceptions:
+        signals["derived_perceptions"] = system_perceptions
+        signals["perception_decisions"] = [
+            {
+                "decision": decision,
+                "perception": perception["type"],
+                "source_metric": perception["metric"],
+                "source_value": perception["value"],
+                "source_threshold": perception["threshold"],
+            }
+            for perception in system_perceptions
+            for decision in perception.get("decisions", [])
+        ]
 
     root = _resolve_sandbox_root(sandbox_root)
     state = artifact_state or _ARTIFACT_STATE
@@ -505,34 +676,46 @@ def capture_signals(
             resolved_world_state = None
     world_events = _derive_world_events(resolved_world_state)
     candidate_events = [*artifact_events, *host_events, *world_events]
-    filtered_events = [event for event in candidate_events if filter_instance.allow(event)]
+    filtered_events = [
+        event for event in candidate_events if filter_instance.allow(event)
+    ]
     if filtered_events:
         signals["artifact_events"] = [
-            event for event in filtered_events if str(event.get("type", "")).startswith("artifact.")
+            event
+            for event in filtered_events
+            if str(event.get("type", "")).startswith("artifact.")
         ]
         signals["host_events"] = [
-            event for event in filtered_events if str(event.get("type", "")).startswith("host.")
+            event
+            for event in filtered_events
+            if str(event.get("type", "")).startswith("host.")
         ]
         if not signals["artifact_events"]:
             signals.pop("artifact_events")
         if not signals["host_events"]:
             signals.pop("host_events")
         signals["world_events"] = [
-            event for event in filtered_events if str(event.get("type", "")).startswith("world.")
+            event
+            for event in filtered_events
+            if str(event.get("type", "")).startswith("world.")
         ]
         if not signals["world_events"]:
             signals.pop("world_events")
 
     if publish_event:
         emitter = bus or get_global_event_bus()
-        emitter.publish("signal.captured", {"signals": dict(signals)}, payload_version=1)
+        emitter.publish(
+            "signal.captured", {"signals": dict(signals)}, payload_version=1
+        )
         for event in filtered_events:
             topic = (
                 "artifact.perception"
                 if str(event.get("type", "")).startswith("artifact.")
-                else "host.perception"
-                if str(event.get("type", "")).startswith("host.")
-                else "world.perception"
+                else (
+                    "host.perception"
+                    if str(event.get("type", "")).startswith("host.")
+                    else "world.perception"
+                )
             )
             emitter.publish(
                 topic,

--- a/tests/test_host_sensors.py
+++ b/tests/test_host_sensors.py
@@ -31,7 +31,9 @@ class _FakePsutil:
         temperatures: dict[str, list[object]] | None,
     ) -> None:
         self._cpu_percent = cpu_percent
-        self._vm = types.SimpleNamespace(percent=ram_percent, available=ram_available_bytes)
+        self._vm = types.SimpleNamespace(
+            percent=ram_percent, available=ram_available_bytes
+        )
         self._du = types.SimpleNamespace(percent=disk_percent, free=disk_free_bytes)
         self._process = _FakeProcess(process_cpu_percent, process_rss_bytes)
         self._temperatures = temperatures
@@ -92,9 +94,17 @@ def test_collect_host_metrics_nominal_with_psutil(monkeypatch) -> None:
 
 def test_collect_host_metrics_handles_unavailable_sensors(monkeypatch) -> None:
     monkeypatch.setattr(host, "psutil", None)
-    monkeypatch.setattr(host.os, "getloadavg", lambda: (_ for _ in ()).throw(OSError("unsupported")))
-    monkeypatch.setattr(host.os, "sysconf", lambda _key: (_ for _ in ()).throw(OSError("unsupported")))
-    monkeypatch.setattr(host.shutil, "disk_usage", lambda _path: (_ for _ in ()).throw(OSError("unsupported")))
+    monkeypatch.setattr(
+        host.os, "getloadavg", lambda: (_ for _ in ()).throw(OSError("unsupported"))
+    )
+    monkeypatch.setattr(
+        host.os, "sysconf", lambda _key: (_ for _ in ()).throw(OSError("unsupported"))
+    )
+    monkeypatch.setattr(
+        host.shutil,
+        "disk_usage",
+        lambda _path: (_ for _ in ()).throw(OSError("unsupported")),
+    )
     monkeypatch.setattr(host, "_collect_process_stdlib", lambda: (0.0, 0.0))
 
     metrics = host.collect_host_metrics()
@@ -171,10 +181,14 @@ def test_collect_host_metrics_unit_conversions(monkeypatch) -> None:
     assert metrics["process_rss_mb"] == 512.0
 
 
-def test_collect_host_metrics_windows_minimal_fallback_not_all_unsupported(monkeypatch) -> None:
+def test_collect_host_metrics_windows_minimal_fallback_not_all_unsupported(
+    monkeypatch,
+) -> None:
     monkeypatch.setattr(host, "psutil", None)
     monkeypatch.setattr(host.platform, "system", lambda: "Windows")
-    monkeypatch.setattr(host.os, "getloadavg", lambda: (_ for _ in ()).throw(OSError("unsupported")))
+    monkeypatch.setattr(
+        host.os, "getloadavg", lambda: (_ for _ in ()).throw(OSError("unsupported"))
+    )
     monkeypatch.setattr(host, "_collect_memory_stdlib", lambda: (0.0, 2048.0))
     monkeypatch.setattr(host, "_collect_disk_stdlib", lambda: (0.0, 0.0))
     monkeypatch.setattr(host, "_collect_uptime_seconds", lambda: (3600.0, None))
@@ -220,3 +234,19 @@ def test_collect_host_metrics_linux_and_macos_temperature_status(monkeypatch) ->
     monkeypatch.setattr(host.platform, "system", lambda: "Darwin")
     mac_metrics = host.collect_host_metrics()
     assert mac_metrics["metric_status"]["host_temperature_c"]["status"] == "available"
+
+
+def test_default_policy_allows_individual_host_decision_sensors(
+    tmp_path, monkeypatch
+) -> None:
+    from singular.governance.policy import MutationGovernancePolicy
+
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    policy = MutationGovernancePolicy()
+
+    assert policy.allow_sensor("host_cpu")
+    assert policy.allow_sensor("host_ram")
+    assert policy.allow_sensor("host_disk")
+    assert policy.allow_sensor("host_temperature")
+    assert policy.allow_sensor("ambient_noise")

--- a/tests/test_loop_perception_goals.py
+++ b/tests/test_loop_perception_goals.py
@@ -117,3 +117,32 @@ def test_choose_skill_prioritizes_frequent_low_quality_skills(tmp_path: Path) ->
         for seed in range(25)
     ]
     assert selections.count("high_use_low_quality") > selections.count("healthy")
+
+
+def test_perception_decisions_modulate_intrinsic_strategy_and_rules(
+    tmp_path: Path,
+) -> None:
+    from singular.goals.intrinsic import IntrinsicGoals
+    from singular.goals.perception_rules import apply_perception_rules
+
+    signals = {
+        "perception_decisions": [
+            {
+                "decision": "trigger_economy_mode",
+                "perception": "system.disk.critical",
+                "source_metric": "disk_used_percent",
+                "source_value": 98.0,
+                "source_threshold": 95.0,
+            }
+        ]
+    }
+
+    modulation = apply_perception_rules(signals)
+    assert modulation["deltas"]["robustesse"] > 0
+    assert modulation["deltas"]["exploration"] < 0
+    assert modulation["applied_rules"][0]["source_metric"] == "disk_used_percent"
+
+    goals = IntrinsicGoals(path=tmp_path / "goals.json")
+    strategy = goals.derive_execution_strategy(signals)
+    assert strategy["mode"] == "cautious"
+    assert strategy["system_decisions"] == ["trigger_economy_mode"]

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -78,9 +78,13 @@ def test_capture_signals_publishes_normalized_artifact_events(tmp_path):
     code.write_text("# FIXME: remove this hack\nprint('ok')\n", encoding="utf-8")
     signals = capture_signals(bus=bus, sandbox_root=sandbox)
 
-    assert any(evt.payload["event"]["type"] == "artifact.files.modified" for evt in captured)
+    assert any(
+        evt.payload["event"]["type"] == "artifact.files.modified" for evt in captured
+    )
     assert any(evt.payload["event"]["type"] == "artifact.logs.new" for evt in captured)
-    assert any(evt.payload["event"]["type"] == "artifact.tech_debt.simple" for evt in captured)
+    assert any(
+        evt.payload["event"]["type"] == "artifact.tech_debt.simple" for evt in captured
+    )
 
     for event in captured:
         assert event.payload_version == 1
@@ -92,7 +96,9 @@ def test_capture_signals_publishes_normalized_artifact_events(tmp_path):
     assert "artifact_events" in signals
 
 
-def test_capture_signals_integrates_host_metrics_and_publishes_host_events(tmp_path, monkeypatch):
+def test_capture_signals_integrates_host_metrics_and_publishes_host_events(
+    tmp_path, monkeypatch
+):
     reset_perception_state()
 
     monkeypatch.setattr(
@@ -132,8 +138,12 @@ def test_capture_signals_integrates_host_metrics_and_publishes_host_events(tmp_p
     }.issubset(event_types)
 
     assert any(evt.payload["event"]["type"] == "host.cpu.critical" for evt in captured)
-    assert any(evt.payload["event"]["type"] == "host.memory.critical" for evt in captured)
-    assert any(evt.payload["event"]["type"] == "host.thermal.critical" for evt in captured)
+    assert any(
+        evt.payload["event"]["type"] == "host.memory.critical" for evt in captured
+    )
+    assert any(
+        evt.payload["event"]["type"] == "host.thermal.critical" for evt in captured
+    )
     assert any(evt.payload["event"]["type"] == "host.disk.critical" for evt in captured)
 
     for event in captured:
@@ -154,7 +164,9 @@ def test_capture_signals_skips_host_metrics_when_sensor_unavailable(monkeypatch)
     assert "host_metrics" not in signals
 
 
-def test_capture_signals_blocks_disallowed_host_sensor_and_journals_refusal(tmp_path, monkeypatch):
+def test_capture_signals_blocks_disallowed_host_sensor_and_journals_refusal(
+    tmp_path, monkeypatch
+):
     reset_perception_state()
     monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
@@ -173,9 +185,16 @@ def test_capture_signals_blocks_disallowed_host_sensor_and_journals_refusal(tmp_
 
     journal = tmp_path / "mem" / "policy_decisions.jsonl"
     assert journal.exists()
-    entries = [json.loads(line) for line in journal.read_text(encoding="utf-8").splitlines() if line.strip()]
+    entries = [
+        json.loads(line)
+        for line in journal.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
     assert any(entry.get("category") == "sensor_access" for entry in entries)
-    assert any(str(entry.get("target", "")).startswith("sensor://host_metrics") for entry in entries)
+    assert any(
+        str(entry.get("target", "")).startswith("sensor://host_metrics")
+        for entry in entries
+    )
 
 
 def test_capture_signals_sanitizes_sensitive_host_metrics(monkeypatch):
@@ -202,7 +221,9 @@ def test_capture_signals_sanitizes_sensitive_host_metrics(monkeypatch):
     assert "username" not in host_metrics
 
 
-def test_capture_signals_publishes_host_star_events_on_host_perception_topic(monkeypatch):
+def test_capture_signals_publishes_host_star_events_on_host_perception_topic(
+    monkeypatch,
+):
     reset_perception_state()
     monkeypatch.setattr(
         "singular.perception.collect_host_metrics",
@@ -234,7 +255,9 @@ def test_capture_signals_publishes_host_star_events_on_host_perception_topic(mon
         "host.disk.critical",
     }
     assert all(event_type.startswith("host.") for event_type in emitted_types)
-    assert all(signal_event["type"] in emitted_types for signal_event in signals["host_events"])
+    assert all(
+        signal_event["type"] in emitted_types for signal_event in signals["host_events"]
+    )
 
 
 def test_capture_signals_derives_world_events(monkeypatch):
@@ -257,3 +280,65 @@ def test_capture_signals_derives_world_events(monkeypatch):
     assert "world.health.degradation" in event_types
     assert "world.resource.scarcity" in event_types
     assert "world.opportunity.window" in event_types
+
+
+def test_capture_signals_derives_system_perceptions_and_decisions(monkeypatch):
+    reset_perception_state()
+    monkeypatch.setattr("singular.perception.random.random", lambda: 0.1)
+    monkeypatch.setattr(
+        "singular.perception.collect_host_metrics",
+        lambda: {
+            "cpu_percent": 90.0,
+            "ram_used_percent": 85.0,
+            "disk_used_percent": 96.0,
+            "host_temperature_c": 80.0,
+        },
+    )
+
+    signals = capture_signals(publish_event=False)
+
+    perceptions = {entry["type"]: entry for entry in signals["derived_perceptions"]}
+    assert set(perceptions) >= {
+        "system.cpu.high",
+        "system.ram.high",
+        "system.disk.critical",
+        "system.temperature.high",
+        "system.environment.calm",
+    }
+    decisions = {entry["decision"]: entry for entry in signals["perception_decisions"]}
+    assert decisions["reduce_mutation_cadence"]["source_metric"] == "cpu_percent"
+    assert decisions["delay_heavy_synthesis"]["source_metric"] in {
+        "ram_used_percent",
+        "host_temperature_c",
+    }
+    assert decisions["prioritize_memory_compaction"]["source_metric"] in {
+        "ram_used_percent",
+        "disk_used_percent",
+    }
+    assert decisions["trigger_economy_mode"]["source_metric"] in {
+        "disk_used_percent",
+        "host_temperature_c",
+    }
+
+
+def test_capture_signals_policy_blocks_individual_derived_sensor(tmp_path, monkeypatch):
+    reset_perception_state()
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    policy = load_runtime_policy()
+    save_runtime_policy(replace(policy, sensors_blocked=("host_cpu",)))
+    monkeypatch.setattr(
+        "singular.perception.collect_host_metrics",
+        lambda: {
+            "cpu_percent": 99.0,
+            "ram_used_percent": 10.0,
+            "disk_used_percent": 10.0,
+        },
+    )
+
+    signals = capture_signals(publish_event=False)
+
+    assert all(
+        entry["type"] != "system.cpu.high"
+        for entry in signals.get("derived_perceptions", [])
+    )


### PR DESCRIPTION
### Motivation

- Surface derived system perceptions (high CPU, high RAM, critical disk, high temperature, calm environment) so runtime can adapt behavior proactively. 
- Map those perceptions to concrete mitigation decisions (reduce mutation cadence, delay heavy synthesis, prioritize memory compaction, trigger economy mode) so goals and orchestrator respond to host conditions. 
- Make each derived-sensor gateable via the existing governance policy and keep decision payloads auditable with source metric/threshold. 

### Description

- Added derived system perceptions and decision payloads in `src/singular/perception.py` including `DERIVED_SYSTEM_PERCEPTIONS`, `SYSTEM_PERCEPTION_SENSOR_NAMES`, `_derive_system_perceptions()` and populated `signals["derived_perceptions"]` and `signals["perception_decisions"]` with source metric/value/threshold. 
- Policy-gated the derived sensors using `MutationGovernancePolicy.allow_sensor` so each metric (e.g. `host_cpu`, `host_ram`, `host_disk`, `host_temperature`, `ambient_noise`) can be enabled/disabled independently. (Default allowlist entries added in `src/singular/governance/policy.py`.)
- Added `SYSTEM_DECISION_DELTAS` in `src/singular/goals/perception_rules.py` and applied these deltas when `perception_decisions` are present so perception-driven decisions directly modulate objective weights. 
- Persisted and surfaced system decision names and full decision log in `IntrinsicGoals.update_tick()` and included `system_decisions` in `derive_execution_strategy()` so intrinsic strategy (e.g. switching to `cautious`/economy mode) respects perception decisions. 
- Wired perception decisions into orchestrator adaptation in `src/singular/orchestrator/service.py` so `_compute_runtime_adaptation()` applies concrete runtime changes (tick and CPU budget scaling, prudent mode, skip action tick) and logs `system_decisions` in the adaptation audit payload. 
- Tests added to verify derived perceptions/decisions, per-sensor policy blocking, default policy allowlist and that perception decisions modulate intrinsic strategy: `tests/test_perception.py`, `tests/test_host_sensors.py`, and `tests/test_loop_perception_goals.py`.

### Testing

- Formatted changed files with `black` (ran successfully). 
- Ran unit tests with `pytest` for the modified test files using `python -m pytest tests/test_perception.py tests/test_host_sensors.py tests/test_loop_perception_goals.py` and all tests passed (`21 passed`). 
- Smoke-tested that `perception_decisions` flow through `apply_perception_rules`, `IntrinsicGoals.derive_execution_strategy`, and `OrchestratorService._compute_runtime_adaptation` and that decision payloads include source metric/value/threshold.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7369bbcb18832aba8bb71deec7073f)