### PR TITLE
Clarify life state semantics and add autonomy / mutation metrics

### DIFF
--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -94,6 +94,55 @@ def _normalized_event(record: dict[str, object]) -> str:
     return ""
 
 
+def _is_voluntary_budget_record(record: dict[str, object]) -> bool:
+    return record.get("voluntary_budget") is True or _normalized_event(record) in {
+        "loop.budget_exhausted",
+        "daemon.budget_exhausted",
+    }
+
+
+def compute_mutation_viability(records: list[dict[str, object]]) -> dict[str, object]:
+    mutation_records = [
+        record for record in records
+        if any(key in record for key in ("score_base", "score_new", "accepted", "ok", "operator", "op"))
+    ]
+    decided = []
+    useful = 0
+    failures = 0
+    for record in mutation_records:
+        accepted = record.get("accepted")
+        if not isinstance(accepted, bool):
+            accepted = record.get("ok")
+        if isinstance(accepted, bool):
+            decided.append(accepted)
+            if not accepted:
+                failures += 1
+        score_base = record.get("score_base")
+        score_new = record.get("score_new")
+        improved = (
+            isinstance(score_base, (int, float))
+            and isinstance(score_new, (int, float))
+            and float(score_new) < float(score_base)
+        )
+        health = record.get("health")
+        has_health = isinstance(health, dict) and isinstance(health.get("score"), (int, float))
+        if accepted is True and (improved or has_health):
+            useful += 1
+    score = None
+    if mutation_records:
+        acceptance = sum(1 for value in decided if value) / len(decided) if decided else 0.0
+        usefulness = useful / len(mutation_records)
+        failure_penalty = failures / len(mutation_records)
+        score = round(max(0.0, min(1.0, (acceptance * 0.5) + (usefulness * 0.5) - (failure_penalty * 0.25))) * 100.0, 1)
+    return {
+        "score": score,
+        "mutation_count": len(mutation_records),
+        "accepted_count": sum(1 for value in decided if value),
+        "rejected_count": sum(1 for value in decided if not value),
+        "accepted_useful_changes": useful,
+    }
+
+
 def compute_liveness_index(
     records: list[dict[str, object]],
     *,
@@ -101,6 +150,8 @@ def compute_liveness_index(
 ) -> dict[str, object]:
     reference = now or datetime.now(timezone.utc)
     sorted_records = sorted(records, key=lambda rec: str(rec.get("ts", "")))
+    autonomy_records = [record for record in sorted_records if not _is_voluntary_budget_record(record)]
+    budgeted_periods_ignored = len(sorted_records) - len(autonomy_records)
     recent_cutoff = reference - timedelta(hours=24)
     loop_cutoff = reference - timedelta(hours=48)
     interaction_cutoff = reference - timedelta(days=7)
@@ -308,6 +359,12 @@ def compute_liveness_index(
         )
     ]
     index = round((sum(component_scores) / 5.0) * 100.0, 1)
+    if budgeted_periods_ignored:
+        autonomy_payload = compute_liveness_index(autonomy_records, now=reference)
+        autonomy_index = autonomy_payload["index"]
+    else:
+        autonomy_index = index
+    mutation_viability = compute_mutation_viability(sorted_records)
 
     sorted_proofs = sorted(
         proofs,
@@ -316,6 +373,9 @@ def compute_liveness_index(
     )
     return {
         "index": index,
+        "autonomy_index": autonomy_index,
+        "budgeted_periods_ignored": budgeted_periods_ignored,
+        "mutation_viability": mutation_viability,
         "components": component_details,
         "proofs": sorted_proofs[:5],
     }
@@ -406,6 +466,8 @@ def aggregate_lives(
                 registry_status=registry_status,
             ),
             "life_liveness_index": 0.0,
+            "autonomy_index": 0.0,
+            "mutation_viability": {"score": None, "mutation_count": 0, "accepted_count": 0, "rejected_count": 0, "accepted_useful_changes": 0},
             "life_liveness_components": {
                 "recent_activity": {"score": 0.0, "count": 0},
                 "perception_decision_action_loop": {"score": 0.0, "completed": False},
@@ -550,6 +612,8 @@ def aggregate_lives(
                 registry_status=registry_status,
             ),
             "life_liveness_index": liveness["index"],
+            "autonomy_index": liveness.get("autonomy_index", liveness["index"]),
+            "mutation_viability": liveness.get("mutation_viability", compute_mutation_viability(all_records)),
             "life_liveness_components": liveness["components"],
             "life_liveness_proofs": liveness["proofs"],
         }

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -171,7 +171,7 @@ const showCockpitEndpointWarnings=issues=>{
   const labels=issues.map(issue=>{
     const label=endpointLabels[issue.key]||issue.key;
     if(issue.type==='invalid'){return `${label}: payload invalide`;}
-    return `${label}: endpoint indisponible (${endpointFailureMessage(issue.result)})`;
+    return `${label}: ${endpointFailureMessage(issue.result)}`;
   }).join(' · ');
   banner.classList.remove('panel-hidden');
   banner.textContent=`⚠️ Données cockpit partielles : ${labels}. Les données disponibles restent affichées, sans confondre données vides et erreur API.`;
@@ -513,7 +513,7 @@ export const loadCockpit=()=>Promise.allSettled([
   if(cockpitResult.status==='fulfilled'&&!isObjectPayload(cockpitResult.value)){invalidIssues.push({key:'cockpit',result:cockpitResult,type:'invalid'});}
   const issues=[...endpointIssues,...invalidIssues];
   showCockpitEndpointWarnings(issues);
-  const shouldRethrow=issues.filter(issue=>['context','comparison','cockpit'].includes(issue.key));
+  const shouldRethrow=issues.filter(issue=>['context','comparison'].includes(issue.key));
   if(cockpitResult.status==='rejected'){
     setPanelState('cockpit','error',`Endpoint principal ${endpointLabels.cockpit} indisponible : ${endpointFailureMessage(cockpitResult)}.`);
   }
@@ -567,9 +567,9 @@ export const loadCockpit=()=>Promise.allSettled([
   if(selectedLifeEl){selectedLifeEl.textContent=String(essentialPayload.selected_life||'Aucune');}
   const incidentsEl=document.getElementById('essential-active-incidents');
   if(incidentsEl){incidentsEl.textContent=String(essentialPayload.active_incidents_count??alertsCount);}
-  setText('kpi-autonomy-proactive',fmtPct(autonomy.proactive_initiative_rate));
+  setText('kpi-autonomy-proactive',`${fmtNum(autonomy.autonomy_index)} / ${fmtPct(autonomy.proactive_initiative_rate)}`);
   setText('kpi-autonomy-stability',fmtPct(autonomy.long_term_stability));
-  setText('kpi-autonomy-decision',`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)}`);
+  setText('kpi-autonomy-decision',`${fmtPct(decisionQuality.acceptance_rate)} / ${fmtPct(decisionQuality.regression_rate)} · viabilité=${fmtNum(autonomy.mutation_viability)}`);
   setText('kpi-autonomy-latency',fmtNum(autonomy.perception_to_action_latency_ms,' ms'));
   setText('kpi-autonomy-cost',fmtNum(autonomy.resource_cost_per_gain));
   const behavior=d.behavioral_regulation_metrics||{};

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -203,6 +203,7 @@ const renderLivesTable=(rows)=>{
     if(row.life&&row.life===livesUiState.selectedLife){tr.classList.add('selected');}
     const score=row.current_health_score===null||row.current_health_score===undefined?na():Number(row.current_health_score).toFixed(1);
     const liveness=row.life_liveness_index===null||row.life_liveness_index===undefined?na():Number(row.life_liveness_index).toFixed(1);
+    const autonomy=row.autonomy_index===null||row.autonomy_index===undefined?na():Number(row.autonomy_index).toFixed(1);
     const lastActivity=row.last_activity||na();
     const state=rowStateSummary(row);
     const risk=rowRiskSummary(row);
@@ -219,7 +220,7 @@ const renderLivesTable=(rows)=>{
     lifeCell.appendChild(auditLink);
     appendCell(tr,score);
     appendCell(tr,lastActivity);
-    appendCell(tr,liveness);
+    appendCell(tr,`${liveness} / auto ${autonomy}`);
     for(const summary of [state,risk,activity]){
       const cell=document.createElement('td');
       const pill=document.createElement('span');
@@ -272,6 +273,8 @@ const showLifeDetails=lifeName=>{
     ['Score courant',row.current_health_score===null||row.current_health_score===undefined?na():Number(row.current_health_score).toFixed(1)],
     ['Dernière activité',row.last_activity],
     ['Life liveness index',row.life_liveness_index===null||row.life_liveness_index===undefined?na():Number(row.life_liveness_index).toFixed(1)],
+    ['Autonomy index',row.autonomy_index===null||row.autonomy_index===undefined?na():Number(row.autonomy_index).toFixed(1)],
+    ['Mutation viability',row.mutation_viability?.score===null||row.mutation_viability?.score===undefined?na():Number(row.mutation_viability.score).toFixed(1)],
     ['Alertes',row.alerts_count??0],
   ];
   const expertMetadata=[

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -24,11 +24,19 @@ if TYPE_CHECKING:  # pragma: no cover - imported only for static typing.
 class LifeStatus(str, Enum):
     """Authorized philosophical-operational life statuses."""
 
-    NOT_ALIVE_YET = "not_alive_yet"
-    FRAGILE = "fragile"
-    ALIVE = "alive"
-    DYING = "dying"
-    EXTINCT = "extinct"
+    RUNNING = "running"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    DEGRADED = "degraded"
+    MUTATION_PAUSED = "mutation_paused"
+    TERMINAL = "terminal"
+    DEAD = "dead"
+
+    # Backward-compatible aliases for callers that still import the old names.
+    ALIVE = "running"
+    FRAGILE = "degraded"
+    DYING = "terminal"
+    EXTINCT = "dead"
+    NOT_ALIVE_YET = "degraded"
 
 
 AUTHORIZED_LIFE_STATUSES: tuple[str, ...] = tuple(status.value for status in LifeStatus)
@@ -194,6 +202,8 @@ def _event_text(row: Mapping[str, Any]) -> str:
 
 REQUIRED_CYCLE_PHASES = ("veille", "action", "introspection", "sommeil")
 TERMINAL_PHASE_TOKENS = ("extinct", "extinction", "death", "terminal", "dying", "stop")
+BUDGET_EXHAUSTED_EVENTS = {"loop.budget_exhausted", "daemon.budget_exhausted"}
+MUTATION_PAUSED_TOKENS = ("mutation_paused", "mutation.paused", "safe_mode", "quota_exhausted")
 
 
 def _row_phase(row: Mapping[str, Any]) -> str | None:
@@ -787,6 +797,9 @@ def compute_life_status(
         registry_status=registry_status or None,
     )
     vital_state = str(vital_timeline.get("state", ""))
+    latest_event = str(run_rows[-1].get("event", "")).strip().lower() if run_rows else ""
+    budget_exhausted = latest_event in BUDGET_EXHAUSTED_EVENTS
+    mutation_paused = any(token in _event_text(row) for row in run_rows[-10:] for token in MUTATION_PAUSED_TOKENS)
     terminal = vital_state in {"terminal", "extinct"}
     reproduction_eligible = vital_timeline.get("reproduction_eligible") is True
     reproduction_capability = bool(
@@ -824,7 +837,6 @@ def compute_life_status(
         return value * total_points if 0.0 <= value <= 1.0 else value
 
     alive_minimum_score = _score_threshold(cfg.thresholds.alive_minimum_score)
-    fragile_minimum_score = _score_threshold(cfg.thresholds.fragile_minimum_score)
     required_for_alive = [
         name
         for name, (configured, _) in criteria.items()
@@ -835,18 +847,18 @@ def compute_life_status(
     required_for_alive_present = all(criteria[name][1] for name in required_for_alive)
     if vital_state == "extinct":
         score = min(score, 20.0)
-        status = LifeStatus.EXTINCT
+        status = LifeStatus.DEAD
     elif vital_state == "terminal":
         score = min(score, 40.0)
-        status = LifeStatus.DYING
-    elif not persistent_identity and not run_rows:
-        status = LifeStatus.NOT_ALIVE_YET
+        status = LifeStatus.TERMINAL
+    elif budget_exhausted:
+        status = LifeStatus.BUDGET_EXHAUSTED
+    elif mutation_paused:
+        status = LifeStatus.MUTATION_PAUSED
     elif score >= alive_minimum_score and required_for_alive_present:
-        status = LifeStatus.ALIVE
-    elif score >= fragile_minimum_score:
-        status = LifeStatus.FRAGILE
+        status = LifeStatus.RUNNING
     else:
-        status = LifeStatus.NOT_ALIVE_YET
+        status = LifeStatus.DEGRADED
 
     positives = [name for name, value in enabled if value]
     negatives = [name for name, value in enabled if not value]
@@ -876,7 +888,9 @@ def compute_life_status(
         "narrative_continuity": narrative_continuity,
         "narrative_age_days": age_days,
         "terminal": terminal,
-        "extinction": status is LifeStatus.EXTINCT,
+        "budget_exhausted": budget_exhausted,
+        "mutation_paused": mutation_paused,
+        "extinction": status is LifeStatus.DEAD,
         "vital_state": vital_state,
         "vital_risk_level": vital_timeline.get("risk_level"),
         "structured": {

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -2532,6 +2532,15 @@ def run(
             persistent_world_state.save(persistent_world_state_path)
             tick_count += 1
 
+        if time.time() - start >= budget_seconds:
+            logger.log_event(
+                "loop.budget_exhausted",
+                budget_seconds=budget_seconds,
+                elapsed_seconds=round(time.time() - start, 6),
+                voluntary_budget=True,
+                status="budget_exhausted",
+            )
+
     for org in world.organisms.values():
         if org.last_score != float("-inf"):
             continue

--- a/src/singular/metrics/autonomy.py
+++ b/src/singular/metrics/autonomy.py
@@ -42,10 +42,21 @@ def _is_proactive_record(record: dict[str, Any]) -> bool:
     return event in {"mutation", "interaction", "test_coevolution"} or "score_new" in record
 
 
-def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float | dict[str, float] | None]:
-    """Compute autonomy-oriented metrics from run records."""
+def _is_voluntary_budget_record(record: dict[str, Any]) -> bool:
+    event = str(record.get("event", "")).strip().lower()
+    return record.get("voluntary_budget") is True or event in {"loop.budget_exhausted", "daemon.budget_exhausted"}
 
-    action_records = [record for record in records if _is_action_record(record)]
+
+def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float | dict[str, float] | None]:
+    """Compute autonomy-oriented metrics from run records.
+
+    ``autonomy_index`` deliberately excludes voluntary wall-clock budget markers so
+    a deliberately bounded ``loop --budget-seconds`` run is not interpreted as a
+    loss of autonomy or death.
+    """
+
+    effective_records = [record for record in records if not _is_voluntary_budget_record(record)]
+    action_records = [record for record in effective_records if _is_action_record(record)]
     proactive_records = [record for record in action_records if _is_proactive_record(record)]
     proactive_rate = (
         len(proactive_records) / len(action_records) if action_records else None
@@ -103,7 +114,7 @@ def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float |
 
     latencies_ms: list[float] = []
     last_perception_ts: datetime | None = None
-    for record in records:
+    for record in effective_records:
         if record.get("event") == "consciousness":
             parsed = _parse_ts(record.get("ts"))
             if parsed is not None:
@@ -151,7 +162,14 @@ def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float |
     if resource_costs and total_positive_gain > 0:
         resource_cost_per_gain = sum(resource_costs) / total_positive_gain
 
+    autonomy_components = [value for value in (proactive_rate, long_term_stability, acceptance_rate) if value is not None]
+    autonomy_index = round((sum(autonomy_components) / len(autonomy_components)) * 100.0, 1) if autonomy_components else None
+    mutation_viability = round((acceptance_rate or 0.0) * 100.0, 1) if decisions else None
+
     return {
+        "autonomy_index": autonomy_index,
+        "budgeted_periods_ignored": len(records) - len(effective_records),
+        "mutation_viability": mutation_viability,
         "proactive_initiative_rate": proactive_rate,
         "long_term_stability": long_term_stability,
         "decision_quality": {

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -407,6 +407,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             ["Verdict de vie", str((payload.get("life_status") or {}).get("status") or "-")],
             ["Score de vie", _fmt_number((payload.get("life_status") or {}).get("score"))],
             ["Explication", str((payload.get("life_status") or {}).get("explanation") or "-")],
+            ["Autonomy index", _fmt_number(autonomy.get("autonomy_index"))],
+            ["Mutation viability", _fmt_number(autonomy.get("mutation_viability"))],
+            ["Périodes budgétées ignorées", str(autonomy.get("budgeted_periods_ignored") or 0)],
             ["Taux d’initiatives proactives", _fmt_ratio(autonomy.get("proactive_initiative_rate"))],
             ["Stabilité long terme", _fmt_ratio(autonomy.get("long_term_stability"))],
             [
@@ -501,6 +504,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         print(f"Mutation count: {payload['mutation_count']}")
         autonomy = payload.get("autonomy_metrics") if isinstance(payload.get("autonomy_metrics"), dict) else {}
         decision_quality = autonomy.get("decision_quality") if isinstance(autonomy.get("decision_quality"), dict) else {}
+        print(f"Autonomy index: {_fmt_number(autonomy.get('autonomy_index'))}")
+        print(f"Mutation viability: {_fmt_number(autonomy.get('mutation_viability'))}")
+        print(f"Périodes budgétées ignorées: {autonomy.get('budgeted_periods_ignored') or 0}")
         print(f"Taux d’initiatives proactives: {_fmt_ratio(autonomy.get('proactive_initiative_rate'))}")
         print(f"Stabilité long terme: {_fmt_ratio(autonomy.get('long_term_stability'))}")
         print(

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -13,18 +13,19 @@ from singular.life.life_status import (
 
 def test_authorized_life_statuses_are_stable_contract() -> None:
     assert AUTHORIZED_LIFE_STATUSES == (
-        "not_alive_yet",
-        "fragile",
-        "alive",
-        "dying",
-        "extinct",
+        "running",
+        "budget_exhausted",
+        "degraded",
+        "mutation_paused",
+        "terminal",
+        "dead",
     )
 
 
 def test_life_status_result_to_payload_serializes_portable_contract() -> None:
     computed_at = datetime(2026, 7, 7, 12, 30, tzinfo=UTC)
     result = LifeStatusResult(
-        status=LifeStatus.ALIVE,
+        status=LifeStatus.RUNNING,
         score=0.91,
         explanation="Stable identity and cycle are observed.",
         signals={"stable_cycle": True, "observed_cycles": 4},
@@ -34,7 +35,7 @@ def test_life_status_result_to_payload_serializes_portable_contract() -> None:
     )
 
     assert result.to_payload() == {
-        "status": "alive",
+        "status": "running",
         "score": 0.91,
         "explanation": "Stable identity and cycle are observed.",
         "signals": {"stable_cycle": True, "observed_cycles": 4},
@@ -87,7 +88,7 @@ def test_compute_life_status_aggregates_configured_signals(tmp_path) -> None:
         runs=runs,
     )
 
-    assert result.status == LifeStatus.ALIVE
+    assert result.status == LifeStatus.RUNNING
     assert result.score == 100.0
     assert result.signals["persistent_identity"] is True
     assert result.signals["stable_cycle"] is True
@@ -158,7 +159,7 @@ def test_compute_life_status_terminal_signal_dominates(tmp_path) -> None:
         runs=[],
     )
 
-    assert result.status == LifeStatus.EXTINCT
+    assert result.status == LifeStatus.DEAD
     assert result.signals["terminal"] is True
 
 
@@ -188,7 +189,7 @@ def test_compute_life_status_uses_vital_terminal_without_extinction(tmp_path) ->
         runs=runs,
     )
 
-    assert result.status == LifeStatus.DYING
+    assert result.status == LifeStatus.TERMINAL
     assert result.signals["terminal"] is True
     assert result.signals["extinction"] is False
     assert result.evidence["vital_timeline"]["state"] == "terminal"
@@ -378,7 +379,7 @@ def test_compute_life_status_no_artifacts_is_not_alive_yet(life_home_factory) ->
 
     result = compute_life_status(life_home, registry_entry={}, runs=[])
 
-    assert result.status == LifeStatus.NOT_ALIVE_YET
+    assert result.status == LifeStatus.DEGRADED
     assert "world_state" in result.missing_signals
     assert "self_narrative" in result.missing_signals
     assert "registry_entry" in result.missing_signals
@@ -405,7 +406,7 @@ def test_compute_life_status_identity_and_partial_cycle_is_fragile(
         config=config,
     )
 
-    assert result.status == LifeStatus.FRAGILE
+    assert result.status == LifeStatus.DEGRADED
     assert result.signals["persistent_identity"] is True
     assert result.signals["observed_cycles"] == 1
     assert result.signals["stable_cycle"] is False
@@ -447,7 +448,7 @@ def test_compute_life_status_full_durable_signals_are_alive(life_home_factory) -
         runs=_cycle_runs(3),
     )
 
-    assert result.status == LifeStatus.ALIVE
+    assert result.status == LifeStatus.RUNNING
     assert result.signals["persistent_identity"] is True
     assert result.signals["generation_registry"] is True
     assert result.signals["stable_cycle"] is True
@@ -487,7 +488,7 @@ def test_compute_life_status_terminal_health_or_long_failures_are_dying(
         runs=runs,
     )
 
-    assert result.status == LifeStatus.DYING
+    assert result.status == LifeStatus.TERMINAL
     assert result.signals["terminal"] is True
     assert result.signals["extinction"] is False
     _assert_status_contract(result)
@@ -520,7 +521,7 @@ def test_compute_life_status_extinction_evidence_is_extinct(
         runs=runs,
     )
 
-    assert result.status == LifeStatus.EXTINCT
+    assert result.status == LifeStatus.DEAD
     assert result.signals["extinction"] is True
     _assert_status_contract(result)
 
@@ -540,7 +541,7 @@ def test_compute_life_status_corrupt_json_and_missing_files_are_explanatory(
         runs=[],
     )
 
-    assert result.status == LifeStatus.NOT_ALIVE_YET
+    assert result.status == LifeStatus.DEGRADED
     assert (
         result.signals["structured"]["goals"]["reason"]
         == "no active self-generated intrinsic goal evidence found"
@@ -648,3 +649,22 @@ def test_compute_life_status_stable_cycle_rejects_terminal_dominance(
     assert result.signals["observed_cycles"] == 3
     assert result.signals["stable_cycle"] is False
     assert cycle["terminal_dominates"] is True
+
+
+def test_compute_life_status_budget_exhaustion_is_not_death(life_home_factory) -> None:
+    from singular.life.life_status import LifeStatus, compute_life_status
+
+    life_home, mem = life_home_factory()
+    _write_json(mem / "world_state.json", {"global_health": {"score": 90}})
+    _write_json(mem / "self_narrative.json", {"identity": {"name": "Alpha", "slug": "alpha"}})
+    _write_json(mem / "quests_state.json", {})
+
+    result = compute_life_status(
+        life_home,
+        registry_entry={"name": "Alpha", "slug": "alpha", "status": "active"},
+        runs=[{"event": "loop.budget_exhausted", "voluntary_budget": True}],
+    )
+
+    assert result.status == LifeStatus.BUDGET_EXHAUSTED
+    assert result.signals["budget_exhausted"] is True
+    assert result.signals["extinction"] is False

--- a/tests/test_liveness_index.py
+++ b/tests/test_liveness_index.py
@@ -117,3 +117,27 @@ def test_lives_comparison_exposes_liveness_fields() -> None:
     assert "recent_activity" in alpha["life_liveness_components"]
     assert isinstance(alpha["life_liveness_proofs"], list)
     assert len(alpha["life_liveness_proofs"]) <= 5
+
+
+def test_autonomy_index_ignores_voluntary_budget_records() -> None:
+    payload = compute_liveness_index(
+        [
+            {"ts": "2026-04-15T10:00:00+00:00", "event": "perception"},
+            {"ts": "2026-04-15T10:01:00+00:00", "event": "loop.budget_exhausted", "voluntary_budget": True},
+        ],
+        now=NOW,
+    )
+
+    assert payload["budgeted_periods_ignored"] == 1
+    assert payload["autonomy_index"] == 10.0
+    assert payload["mutation_viability"]["mutation_count"] == 0
+
+
+def test_liveness_index_reports_mutation_viability_separately() -> None:
+    payload = compute_liveness_index(
+        [{"ts": "2026-04-15T10:00:00+00:00", "event": "mutation", "accepted": True, "score_base": 5, "score_new": 4}],
+        now=NOW,
+    )
+
+    assert payload["mutation_viability"]["score"] == 100.0
+    assert payload["mutation_viability"]["accepted_useful_changes"] == 1

--- a/tests/test_vital_transitions.py
+++ b/tests/test_vital_transitions.py
@@ -65,3 +65,18 @@ def test_vital_reproduction_window_boundary_conditions() -> None:
     assert eligible["reproduction_eligible"] is True
     assert too_old["reproduction_eligible"] is False
 
+
+
+def test_vital_budget_exhaustion_is_not_extinction_marker(tmp_path) -> None:
+    from singular.life.life_status import LifeStatus, compute_life_status
+
+    mem = tmp_path / "mem"
+    mem.mkdir()
+    (mem / "world_state.json").write_text('{"global_health":{"score":80}}', encoding="utf-8")
+    (mem / "self_narrative.json").write_text('{"identity":{"name":"Alpha","slug":"alpha"}}', encoding="utf-8")
+    (mem / "quests_state.json").write_text('{}', encoding="utf-8")
+
+    result = compute_life_status(tmp_path, registry_entry={"status": "active"}, runs=[{"event": "loop.budget_exhausted", "voluntary_budget": True}])
+
+    assert result.status == LifeStatus.BUDGET_EXHAUSTED
+    assert result.evidence["vital_timeline"]["state"] != "extinct"


### PR DESCRIPTION
### Motivation

- Clarifier la sémantique des états de vie pour séparer "running" (vie active) des conditions opérationnelles non létales telles que l'épuisement volontaire du budget et les pauses de mutation. 
- Éviter de marquer une vie comme morte seulement parce qu'un `loop --budget-seconds` s'est terminé volontairement. 
- Exposer une métrique d'« autonomie » qui ignore les périodes explicitement budgétées et mesurer séparément la viabilité des mutations. 
- Rendre ces états et métriques visibles dans la sortie `status` et dans le dashboard.

### Description

- Remplace le contrat d'états dans `LifeStatus` par les valeurs `running`, `budget_exhausted`, `degraded`, `mutation_paused`, `terminal`, `dead` et ajoute des alias rétro-compatibles pour les anciens noms. (`src/singular/life/life_status.py`).
- `compute_life_status` détecte désormais les événements de fin de budget volontaire (`loop.budget_exhausted` / `daemon.budget_exhausted`) et les tokens de pause mutation, et expose les signaux `budget_exhausted` et `mutation_paused` sans les confondre avec l'extinction technique/biologique. (`src/singular/life/life_status.py`).
- Le loop journalise explicitement une entrée `loop.budget_exhausted` marquée `voluntary_budget=True` quand le run s'arrête sur budget, au lieu d'émettre un marqueur d'extinction. (`src/singular/life/loop.py`).
- Ajout de `autonomy_index` (qui ignore les enregistrements volontairement budgétés) et `mutation_viability` dans les métriques d'autonomie; `compute_autonomy_metrics` et `compute_liveness_index` produisent maintenant `autonomy_index`, `budgeted_periods_ignored` et `mutation_viability`. (`src/singular/metrics/autonomy.py`, `src/singular/dashboard/services/lives_comparison.py`).
- Intégration des nouvelles métriques dans la comparaison/agrégation des vies et exposition dans le payload retourné au dashboard (`aggregate_lives`). (`src/singular/dashboard/services/lives_comparison.py`).
- Affichage des nouveaux champs dans le CLI `status` et dans le dashboard (cockpit et tableau des vies), ainsi qu'amélioration du chargement cockpit pour conserver les données disponibles lorsque `/api/cockpit` échoue. (`src/singular/organisms/status.py`, `src/singular/dashboard/static/render-cockpit.js`, `src/singular/dashboard/static/render-lives.js`).
- Tests ajoutés/ajustés pour valider le nouveau contrat d'états, que l'épuisement de budget volontaire n'est pas une extinction, et pour vérifier `autonomy_index` et `mutation_viability`. (`tests/test_life_status.py`, `tests/test_liveness_index.py`, `tests/test_vital_transitions.py`).

### Testing

- Linter: `ruff check src/singular/life/life_status.py src/singular/life/loop.py src/singular/metrics/autonomy.py src/singular/dashboard/services/lives_comparison.py src/singular/organisms/status.py tests/test_life_status.py tests/test_liveness_index.py tests/test_vital_transitions.py` — réussi. 
- Tests unitaires: `pytest tests/test_life_status.py tests/test_liveness_index.py tests/test_vital_transitions.py tests/test_dashboard_static_smoke.py tests/test_autonomy_metrics.py -q` — tous les tests automatisés exécutés ont réussi (`42 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a736b11befc832a93410072e8181ac0)