### PR TITLE
Add evolution diagnostics CLI

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -313,6 +313,7 @@ def _sandbox_diagnosis_recommendation(
         "non_finite_result": "Retournez un nombre fini; évitez `inf`, `-inf` et `nan`.",
         "timeout": "Réduisez les boucles ou ajoutez une borne de calcul déterministe.",
         "syntax_error": "Corrigez la syntaxe Python du fichier.",
+        "forbidden_syntax": "Supprimez les imports/with; n'utilisez que le sous-ensemble sandbox autorisé.",
         "runtime_exception": "Corrigez l'exception levée pendant l'exécution sandboxée.",
     }
     if error_type == "sandbox_error":
@@ -402,6 +403,32 @@ def _diagnose_sandbox(*, output_format: str = "plain") -> int:
             )
 
     return 0 if all(row["status"] == "OK" for row in rows) else 1
+
+
+def _diagnose_evolution(*, output_format: str = "plain") -> int:
+    """Print static diagnostics for recent evolution runs."""
+
+    from .diagnostics.evolution import analyze_evolution
+
+    singular_home = Path(os.environ.get("SINGULAR_HOME", ".")).expanduser()
+    report = analyze_evolution(singular_home)
+    patterns = report["patterns"]
+
+    if output_format == "json":
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(f"Diagnostic évolution: {report['life_home']}")
+        print(f"Events analysés: {report['events_analyzed']}")
+        print("pattern | statut | occurrences | preuve | recommandation")
+        print("--- | --- | --- | --- | ---")
+        for row in patterns:
+            status = "KO" if row["detected"] else "OK"
+            print(
+                f"{row['pattern']} | {status} | {row['count']} | "
+                f"{row['evidence']} | {row['recommendation']}"
+            )
+
+    return 1 if any(row["detected"] for row in patterns) else 0
 
 
 def _doctor_fix_windows_user_path(scripts_path: Path) -> bool:
@@ -1271,6 +1298,15 @@ def main(argv: list[str] | None = None) -> int:
         "sandbox",
         help="Diagnostiquer les skills de SINGULAR_HOME/skills via la sandbox",
     )
+    diagnose_evolution_parser = diagnose_subparsers.add_parser(
+        "evolution",
+        help="Analyser statiquement les runs et mémoires récents",
+    )
+    diagnose_evolution_parser.add_argument(
+        "--life",
+        default=None,
+        help="Nom ou slug de la vie à diagnostiquer",
+    )
 
     retention_parser = subparsers.add_parser(
         "retention",
@@ -1809,6 +1845,10 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "diagnose":
         if args.diagnose_command == "sandbox":
             return _diagnose_sandbox(output_format=args.output_format)
+        if args.diagnose_command == "evolution":
+            if args.life or not os.environ.get("SINGULAR_HOME"):
+                _ensure_active_life(resolve_life, args.life)
+            return _diagnose_evolution(output_format=args.output_format)
 
     elif args.command == "retention":
         _ensure_active_life(resolve_life, args.life)

--- a/src/singular/diagnostics/__init__.py
+++ b/src/singular/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Diagnostics helpers for Singular."""

--- a/src/singular/diagnostics/evolution.py
+++ b/src/singular/diagnostics/evolution.py
@@ -1,0 +1,158 @@
+"""Static diagnostics for recent evolution events."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Iterable
+
+RECENT_LIMIT = 200
+
+_RECOMMENDATIONS = {
+    "timeout_rate": "Réduisez le coût des skills, bornez les boucles et augmentez les timeouts seulement après profilage.",
+    "negative_infinite_scores": "Filtrez les scores non finis avant promotion et corrigez les skills qui retournent -inf/nan.",
+    "breaker_open": "Laissez expirer le cooldown, inspectez les dernières violations et baissez temporairement le quota de mutations.",
+    "repeated_quarantine": "Désactivez ou réparez les skills en quarantaine répétée puis relancez leur validation sandbox.",
+    "invalid_autogen": "Durcissez les prompts/templates autogen et ajoutez une validation syntaxique avant écriture.",
+}
+
+
+def _iter_jsonl(path: Path) -> Iterable[dict[str, Any]]:
+    if not path.exists():
+        return
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(value, dict):
+            yield value
+
+
+def _recent_run_event_files(runs_dir: Path, limit: int) -> list[Path]:
+    if not runs_dir.exists():
+        return []
+    candidates = [path for path in runs_dir.glob("*/events.jsonl") if path.is_file()]
+    candidates.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    return candidates[:limit]
+
+
+def load_recent_evolution_events(
+    life_home: Path, *, limit: int = RECENT_LIMIT
+) -> list[dict[str, Any]]:
+    """Load recent events from ``runs/*/events.jsonl`` and ``mem/episodic.jsonl``."""
+
+    events: list[dict[str, Any]] = []
+    for path in _recent_run_event_files(life_home / "runs", limit):
+        for event in _iter_jsonl(path):
+            event.setdefault("source_file", str(path.relative_to(life_home)))
+            events.append(event)
+    episodic_path = life_home / "mem" / "episodic.jsonl"
+    for event in _iter_jsonl(episodic_path):
+        event.setdefault("source_file", "mem/episodic.jsonl")
+        events.append(event)
+    return events[-limit:]
+
+
+def _event_name(event: dict[str, Any]) -> str:
+    return str(event.get("event") or event.get("event_type") or event.get("type") or "")
+
+
+def _payload(event: dict[str, Any]) -> dict[str, Any]:
+    payload = event.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _contains_timeout(event: dict[str, Any]) -> bool:
+    name = _event_name(event).lower()
+    data = {**event, **_payload(event)}
+    text = json.dumps(data, ensure_ascii=False, default=str).lower()
+    return "timeout" in name or "timeout" in text
+
+
+def _has_negative_inf(event: dict[str, Any]) -> bool:
+    for value in [event.get("score"), _payload(event).get("score")]:
+        if value == "-inf":
+            return True
+        if isinstance(value, float) and math.isinf(value) and value < 0:
+            return True
+    return "-inf" in json.dumps(event, ensure_ascii=False, default=str).lower()
+
+
+def _count_autogen_invalid(events: list[dict[str, Any]]) -> int:
+    total = 0
+    for event in events:
+        name = _event_name(event).lower()
+        text = json.dumps(event, ensure_ascii=False, default=str).lower()
+        if "autogen" in name and (
+            "invalid" in text or "failed" in name or "validation_failed" in name
+        ):
+            total += 1
+    return total
+
+
+def analyze_evolution(life_home: Path, *, limit: int = RECENT_LIMIT) -> dict[str, Any]:
+    """Return a static diagnostic report for recent evolution patterns."""
+
+    life_home = life_home.expanduser()
+    events = load_recent_evolution_events(life_home, limit=limit)
+    total = len(events)
+    timeout_count = sum(1 for event in events if _contains_timeout(event))
+    neg_inf_count = sum(1 for event in events if _has_negative_inf(event))
+    breaker_count = sum(
+        1 for event in events if "circuit_breaker_opened" in _event_name(event)
+    )
+    quarantine_count = sum(
+        1 for event in events if "quarantin" in _event_name(event).lower()
+    )
+    autogen_invalid_count = _count_autogen_invalid(events)
+
+    pattern_specs = [
+        (
+            "timeout_rate",
+            timeout_count,
+            total > 0 and timeout_count / total >= 0.25,
+            f"{timeout_count}/{total}",
+        ),
+        (
+            "negative_infinite_scores",
+            neg_inf_count,
+            neg_inf_count > 0,
+            str(neg_inf_count),
+        ),
+        ("breaker_open", breaker_count, breaker_count > 0, str(breaker_count)),
+        (
+            "repeated_quarantine",
+            quarantine_count,
+            quarantine_count >= 2,
+            str(quarantine_count),
+        ),
+        (
+            "invalid_autogen",
+            autogen_invalid_count,
+            autogen_invalid_count > 0,
+            str(autogen_invalid_count),
+        ),
+    ]
+    patterns = [
+        {
+            "pattern": pattern,
+            "detected": bool(detected),
+            "count": count,
+            "evidence": evidence,
+            "recommendation": (
+                _RECOMMENDATIONS[pattern]
+                if detected
+                else "Aucune correction nécessaire."
+            ),
+        }
+        for pattern, count, detected, evidence in pattern_specs
+    ]
+    return {"life_home": str(life_home), "events_analyzed": total, "patterns": patterns}

--- a/tests/test_cli_diagnose_sandbox.py
+++ b/tests/test_cli_diagnose_sandbox.py
@@ -45,7 +45,7 @@ def test_diagnose_sandbox_reports_forbidden_import(
 
     out = capsys.readouterr().out
     assert exit_code == 1
-    assert "import_os.py | KO | - | sandbox_error" in out
+    assert "import_os.py | KO | - | forbidden_syntax" in out
     assert "forbidden syntax detected" in out
     assert "Supprimez les imports/with" in out
 
@@ -74,3 +74,68 @@ def test_diagnose_sandbox_reports_timeout(monkeypatch, tmp_path, capsys) -> None
     assert exit_code == 1
     assert "timeout.py | KO | - | timeout" in out
     assert "Réduisez les boucles" in out
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json_line(row) for row in rows), encoding="utf-8")
+
+
+def json_line(row: dict[str, object]) -> str:
+    import json
+
+    return json.dumps(row) + "\n"
+
+
+def test_diagnose_evolution_reports_table_patterns(tmp_path, capsys) -> None:
+    home = tmp_path / "life"
+    _write_jsonl(
+        home / "runs" / "run-1" / "events.jsonl",
+        [
+            {"event": "skill.timeout", "error_type": "timeout"},
+            {"event": "skill.timeout", "message": "timeout"},
+            {"event": "skill.scored", "score": "-inf"},
+            {
+                "event_type": "governance.circuit_breaker_opened",
+                "payload": {"category": "sandbox_violation"},
+            },
+            {"event_type": "skill.quarantined", "payload": {"skill": "a"}},
+        ],
+    )
+    _write_jsonl(
+        home / "mem" / "episodic.jsonl",
+        [
+            {"event": "skill.quarantined", "skill": "b"},
+            {"event": "autogen.validation_failed", "reason": "invalid syntax"},
+        ],
+    )
+
+    exit_code = cli.main(["--home", str(home), "diagnose", "evolution"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "Diagnostic évolution:" in out
+    assert "timeout_rate | KO | 2 | 2/7" in out
+    assert "negative_infinite_scores | KO | 1" in out
+    assert "breaker_open | KO | 1" in out
+    assert "repeated_quarantine | KO | 2" in out
+    assert "invalid_autogen | KO | 1" in out
+    assert "recommandation" in out
+
+
+def test_diagnose_evolution_json_ok_when_no_patterns(tmp_path, capsys) -> None:
+    home = tmp_path / "life"
+    _write_jsonl(
+        home / "runs" / "run-1" / "events.jsonl", [{"event": "tick.ok", "score": 1.0}]
+    )
+
+    exit_code = cli.main(
+        ["--home", str(home), "--format", "json", "diagnose", "evolution"]
+    )
+
+    import json
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["events_analyzed"] == 1
+    assert all(not row["detected"] for row in payload["patterns"])


### PR DESCRIPTION
### Motivation
- Fournir un diagnostic statique des runs et de la mémoire épisodique pour détecter des régressions d'évolution (timeouts, scores non finis, circuit breaker, quarantaines répétées, autogen invalides).

### Description
- Ajout du module `src/singular/diagnostics/evolution.py` exposant `analyze_evolution` qui lit `runs/*/events.jsonl` et `mem/episodic.jsonl`, détecte les patterns demandés et fournit des recommandations par pattern.
- Intégration CLI dans `src/singular/cli.py` avec la commande `singular diagnose evolution` et option de format `--format` pour afficher en tableau (par défaut) ou en JSON via `--format json`.
- Comportement d'activation de vie ajusté pour appeler `_ensure_active_life` uniquement quand nécessaire (`--life` fourni ou `SINGULAR_HOME` absent).
- Ajout/extension des recommandations correctives et adaptation de la sortie table/JSON; tests mis à jour/créés dans `tests/test_cli_diagnose_sandbox.py` avec fixtures JSONL couvrant cas anormaux et cas propre.

### Testing
- `pytest -q tests/test_cli_diagnose_sandbox.py` — tests exécutés et tous réussis (`7 passed`).
- `python -m compileall -q src/singular/diagnostics/evolution.py src/singular/cli.py` — compilation OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a736ed4796c832a9875ea467796e3b4)