### PR TITLE
Add realistic life reproduction flow, CLI command and tests

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -1009,6 +1009,7 @@ def main(argv: list[str] | None = None) -> int:
         load_registry,
         memorialize_life,
         reconcile_lives,
+        reproduce_lives,
         resolve_life,
         rival_lives,
         set_proximity,
@@ -1427,6 +1428,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     lives_clone.add_argument("name", help="Slug or name of the source life")
     lives_clone.add_argument("--new-name", default=None, help="Nom de la nouvelle vie")
+    lives_reproduce = lives_subparsers.add_parser(
+        "reproduce", help="Créer une vie enfant depuis deux vies éligibles"
+    )
+    lives_reproduce.add_argument("parent_a", help="Première vie parente")
+    lives_reproduce.add_argument("parent_b", help="Seconde vie parente")
+    lives_reproduce.add_argument(
+        "--new-name", default=None, help="Nom de la vie enfant"
+    )
     lives_relations = lives_subparsers.add_parser(
         "relations", help="Afficher relations d'une vie"
     )
@@ -1704,8 +1713,6 @@ def main(argv: list[str] | None = None) -> int:
 
     elif args.command == "quest":
         if args.example or args.schema:
-            import json
-
             from .life.quest import FULL_SPEC_EXAMPLE, QUEST_SCHEMA
 
             print(
@@ -1990,6 +1997,19 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 "Conseil: exécutez `singular status --verbose` puis `singular loop --budget-seconds 10`."
             )
+        elif args.lives_command == "reproduce":
+            try:
+                payload = reproduce_lives(
+                    args.parent_a, args.parent_b, new_name=args.new_name, seed=args.seed
+                )
+            except (KeyError, ValueError, PermissionError) as exc:
+                raise SystemExit(str(exc)) from exc
+            if args.output_format == "json":
+                print(json.dumps(payload, ensure_ascii=False))
+            elif payload["status"] == "suspended":
+                print(f"Reproduction suspendue: {payload['reason']}")
+            else:
+                print(f"Vie enfant créée: {payload['child']}")
         elif args.lives_command == "relations":
             try:
                 payload = list_relations(args.name)

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -63,7 +63,9 @@ class LifeMetadata:
         missing_fields = [field for field in required_fields if field not in data]
         if missing_fields:
             fields = ", ".join(missing_fields)
-            raise ValueError(f"invalid life metadata payload: missing required field(s): {fields}")
+            raise ValueError(
+                f"invalid life metadata payload: missing required field(s): {fields}"
+            )
 
         invalid_fields = [
             field
@@ -72,7 +74,9 @@ class LifeMetadata:
         ]
         if invalid_fields:
             fields = ", ".join(invalid_fields)
-            raise ValueError(f"invalid life metadata payload: required field(s) must be non-empty strings: {fields}")
+            raise ValueError(
+                f"invalid life metadata payload: required field(s) must be non-empty strings: {fields}"
+            )
 
         proximity_score = data.get("proximity_score", 0.5)
         if not isinstance(proximity_score, (int, float)):
@@ -88,10 +92,18 @@ class LifeMetadata:
             path=Path(data["path"]),
             created_at=data["created_at"].strip(),
             status=str(data.get("status", "active")),
-            parents=tuple(str(item) for item in data.get("parents", []) if isinstance(item, str)),
-            children=tuple(str(item) for item in data.get("children", []) if isinstance(item, str)),
-            allies=tuple(str(item) for item in data.get("allies", []) if isinstance(item, str)),
-            rivals=tuple(str(item) for item in data.get("rivals", []) if isinstance(item, str)),
+            parents=tuple(
+                str(item) for item in data.get("parents", []) if isinstance(item, str)
+            ),
+            children=tuple(
+                str(item) for item in data.get("children", []) if isinstance(item, str)
+            ),
+            allies=tuple(
+                str(item) for item in data.get("allies", []) if isinstance(item, str)
+            ),
+            rivals=tuple(
+                str(item) for item in data.get("rivals", []) if isinstance(item, str)
+            ),
             proximity_score=max(0.0, min(1.0, float(proximity_score))),
             lineage_depth=lineage_depth,
         )
@@ -151,7 +163,13 @@ def _legacy_transfers_journal_path() -> Path:
     return get_registry_root() / "mem" / _LEGACY_TRANSFERS_JOURNAL
 
 
-def _log_relations_event(event: str, *, actor: str, target: str | None = None, details: dict[str, Any] | None = None) -> None:
+def _log_relations_event(
+    event: str,
+    *,
+    actor: str,
+    target: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> None:
     journal = _relations_journal_path()
     journal.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -218,8 +236,16 @@ def _is_sensitive_record(record: dict[str, Any], policy: InheritancePolicy) -> b
 
 def _safe_memory_summary(record: dict[str, Any]) -> dict[str, Any]:
     return {
-        "event": record.get("event") or record.get("op") or record.get("kind") or "unknown",
-        "status": record.get("status") or ("success" if record.get("success") else "failure" if record.get("success") is False else "unknown"),
+        "event": record.get("event")
+        or record.get("op")
+        or record.get("kind")
+        or "unknown",
+        "status": record.get("status")
+        or (
+            "success"
+            if record.get("success")
+            else "failure" if record.get("success") is False else "unknown"
+        ),
         "mood": record.get("mood"),
         "ts": record.get("ts"),
     }
@@ -243,14 +269,21 @@ def _aggregate_lessons(records: list[dict[str, Any]], limit: int) -> dict[str, A
     }
 
 
-def _apply_inheritance_policy(*, source: LifeMetadata, target: LifeMetadata, policy: InheritancePolicy) -> None:
+def _apply_inheritance_policy(
+    *, source: LifeMetadata, target: LifeMetadata, policy: InheritancePolicy
+) -> None:
     source_mem = source.path / "mem"
     target_mem = target.path / "mem"
     target_mem.mkdir(parents=True, exist_ok=True)
 
     source_episodes = _read_jsonl(source_mem / "episodic.jsonl")
-    non_sensitive = [rec for rec in source_episodes if not _is_sensitive_record(rec, policy)]
-    memory_summary = [_safe_memory_summary(rec) for rec in non_sensitive[-policy.memory_summary_max_entries :]]
+    non_sensitive = [
+        rec for rec in source_episodes if not _is_sensitive_record(rec, policy)
+    ]
+    memory_summary = [
+        _safe_memory_summary(rec)
+        for rec in non_sensitive[-policy.memory_summary_max_entries :]
+    ]
     (target_mem / "legacy_memory_summary.json").write_text(
         json.dumps(memory_summary, ensure_ascii=False, indent=2),
         encoding="utf-8",
@@ -314,10 +347,16 @@ def _apply_inheritance_policy(*, source: LifeMetadata, target: LifeMetadata, pol
 
 def _govern_relation_operation(op_name: str) -> None:
     policy = MutationGovernancePolicy()
-    decision = policy.evaluate_skill_execution(skill_name=f"lives.{op_name}", capability="filesystem.write")
-    policy.record_skill_execution(skill_name=f"lives.{op_name}", success=decision.allowed)
+    decision = policy.evaluate_skill_execution(
+        skill_name=f"lives.{op_name}", capability="filesystem.write"
+    )
+    policy.record_skill_execution(
+        skill_name=f"lives.{op_name}", success=decision.allowed
+    )
     if not decision.allowed:
-        raise PermissionError(f"opération bloquée par la gouvernance: {decision.reason}")
+        raise PermissionError(
+            f"opération bloquée par la gouvernance: {decision.reason}"
+        )
 
 
 def get_registry_root() -> Path:
@@ -356,7 +395,9 @@ def load_registry() -> dict[str, Any]:
         try:
             lives[slug] = LifeMetadata.from_payload(data)
         except (TypeError, ValueError) as exc:
-            _LOGGER.warning("Skipping invalid life entry '%s' in %s: %s", slug, path, exc)
+            _LOGGER.warning(
+                "Skipping invalid life entry '%s' in %s: %s", slug, path, exc
+            )
             continue
 
     active = payload.get("active")
@@ -484,7 +525,11 @@ def set_proximity(name: str, score: float) -> LifeMetadata:
     registry, slug, metadata = _resolve_life_metadata(name)
     metadata.proximity_score = max(0.0, min(1.0, float(score)))
     save_registry(registry)
-    _log_relations_event("proximity.set", actor=slug, details={"proximity_score": metadata.proximity_score})
+    _log_relations_event(
+        "proximity.set",
+        actor=slug,
+        details={"proximity_score": metadata.proximity_score},
+    )
     return metadata
 
 
@@ -509,7 +554,9 @@ def list_relations(name: str | None = None) -> dict[str, Any]:
     social_nodes = []
     social_edges = []
     for slug, meta in sorted(lives.items()):
-        social_nodes.append({"slug": slug, "name": meta.name, "proximity_score": meta.proximity_score})
+        social_nodes.append(
+            {"slug": slug, "name": meta.name, "proximity_score": meta.proximity_score}
+        )
         for ally in meta.allies:
             if ally in lives:
                 social_edges.append({"source": slug, "target": ally, "kind": "ally"})
@@ -517,7 +564,14 @@ def list_relations(name: str | None = None) -> dict[str, Any]:
             if rival in lives:
                 social_edges.append({"source": slug, "target": rival, "kind": "rival"})
 
-    active_conflicts = sorted({tuple(sorted((slug, rival))) for slug, meta in lives.items() for rival in meta.rivals if rival in lives})
+    active_conflicts = sorted(
+        {
+            tuple(sorted((slug, rival)))
+            for slug, meta in lives.items()
+            for rival in meta.rivals
+            if rival in lives
+        }
+    )
     return {
         "active": active,
         "focus": {
@@ -550,7 +604,6 @@ def _unlink_relation(actor: LifeMetadata, target_slug: str, *, relation: str) ->
 def ally_lives(name: str, ally_name: str) -> tuple[LifeMetadata, LifeMetadata]:
     _govern_relation_operation("ally")
     registry, slug, meta = _resolve_life_metadata(name)
-    lives: dict[str, LifeMetadata] = registry.setdefault("lives", {})
     _, ally_slug, ally_meta = _resolve_life_metadata(ally_name)
     if slug == ally_slug:
         raise ValueError("une vie ne peut pas devenir son propre allié")
@@ -566,7 +619,6 @@ def ally_lives(name: str, ally_name: str) -> tuple[LifeMetadata, LifeMetadata]:
 def rival_lives(name: str, rival_name: str) -> tuple[LifeMetadata, LifeMetadata]:
     _govern_relation_operation("rival")
     registry, slug, meta = _resolve_life_metadata(name)
-    lives: dict[str, LifeMetadata] = registry.setdefault("lives", {})
     _, rival_slug, rival_meta = _resolve_life_metadata(rival_name)
     if slug == rival_slug:
         raise ValueError("une vie ne peut pas devenir sa propre rivale")
@@ -623,13 +675,111 @@ def resolve_life(name: str | None) -> Path | None:
     return target.path
 
 
-def bootstrap_life(name: str, seed: int | None = None, *, psyche_overrides: dict[str, float] | None = None, starter_profile: str = "minimal", starter_skills: list[str] | None = None) -> LifeMetadata:
+def bootstrap_life(
+    name: str,
+    seed: int | None = None,
+    *,
+    psyche_overrides: dict[str, float] | None = None,
+    starter_profile: str = "minimal",
+    starter_skills: list[str] | None = None,
+) -> LifeMetadata:
     metadata = create_life(name)
     from .organisms.birth import birth
-    birth(seed=seed, home=metadata.path, psyche_overrides=psyche_overrides, starter_profile=starter_profile, starter_skills=starter_skills)
+
+    birth(
+        seed=seed,
+        home=metadata.path,
+        psyche_overrides=psyche_overrides,
+        starter_profile=starter_profile,
+        starter_skills=starter_skills,
+    )
     registry = load_registry()
     lives: dict[str, LifeMetadata] = registry.get("lives", {})
     return lives.get(metadata.slug, metadata)
+
+
+def _parent_reproduction_gate(
+    metadata: LifeMetadata, *, stable_ticks_required: int = 3, min_maturity: float = 0.7
+) -> tuple[bool, str]:
+    if metadata.status != "active":
+        return False, f"parent_status_not_active:{metadata.status}"
+    state = _read_json(metadata.path / "mem" / "reproduction_state.json")
+    if state.get("mode") == "degraded" or state.get("degraded") is True:
+        return False, "reproduction_suspended:degraded_mode"
+    psyche = _read_json(metadata.path / "mem" / "psyche.json")
+    maturity = psyche.get("maturity_score", state.get("maturity_score", 0.0))
+    try:
+        maturity_score = float(maturity)
+    except (TypeError, ValueError):
+        maturity_score = 0.0
+    if maturity_score < min_maturity:
+        return (
+            False,
+            f"maturity_below_threshold:{maturity_score:.2f}<{min_maturity:.2f}",
+        )
+    ticks = _read_jsonl(metadata.path / "mem" / "life_events.jsonl")
+    stable_ticks = [
+        event
+        for event in ticks
+        if event.get("event") == "tick"
+        and event.get("status") == "stable"
+        and not event.get("breaker")
+        and event.get("mode") != "degraded"
+    ]
+    if len(stable_ticks) < stable_ticks_required:
+        return (
+            False,
+            f"stable_ticks_below_threshold:{len(stable_ticks)}<{stable_ticks_required}",
+        )
+    return True, "eligible"
+
+
+def reproduce_lives(
+    parent_a_name: str,
+    parent_b_name: str,
+    *,
+    new_name: str | None = None,
+    seed: int | None = None,
+) -> dict[str, Any]:
+    """Create a child life from two eligible registered parents."""
+
+    registry, parent_a_slug, parent_a = _resolve_life_metadata(parent_a_name)
+    _, parent_b_slug, parent_b = _resolve_life_metadata(parent_b_name)
+    if parent_a_slug == parent_b_slug:
+        raise ValueError("une vie ne peut pas se reproduire avec elle-même")
+
+    reasons: list[str] = []
+    for metadata in (parent_a, parent_b):
+        eligible, reason = _parent_reproduction_gate(metadata)
+        if not eligible:
+            reasons.append(f"{metadata.slug}:{reason}")
+    if reasons:
+        return {"status": "suspended", "reason": ";".join(reasons), "child": None}
+
+    child_name = new_name or f"{parent_a.name} × {parent_b.name}"
+    child_meta = create_life(child_name, parents=(parent_a_slug, parent_b_slug))
+    from .organisms.spawn import spawn
+
+    spawn(parent_a.path, parent_b.path, out_dir=child_meta.path, seed=seed)
+    child_mem = child_meta.path / "mem"
+    child_mem.mkdir(parents=True, exist_ok=True)
+    (child_mem / "lineage.json").write_text(
+        json.dumps(
+            {
+                "child": child_meta.slug,
+                "parents": [parent_a_slug, parent_b_slug],
+                "lineage_depth": child_meta.lineage_depth,
+                "created_at": child_meta.created_at,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    registry = load_registry()
+    registry["active"] = child_meta.slug
+    save_registry(registry)
+    return {"status": "created", "reason": "eligible", "child": child_meta.slug}
 
 
 def delete_life(name: str) -> LifeMetadata:
@@ -655,7 +805,9 @@ def archive_life(name: str) -> LifeMetadata:
     registry, slug, metadata = _resolve_life_metadata(name)
     metadata.status = "extinct"
     if registry.get("active") == slug:
-        registry["active"] = next((key for key in registry["lives"] if key != slug), None)
+        registry["active"] = next(
+            (key for key in registry["lives"] if key != slug), None
+        )
     save_registry(registry)
     return metadata
 
@@ -665,8 +817,14 @@ def memorialize_life(name: str, *, message: str) -> Path:
     memorial_dir = metadata.path / "mem"
     memorial_dir.mkdir(parents=True, exist_ok=True)
     memorial_file = memorial_dir / "memorial.json"
-    payload = {"life": metadata.slug, "written_at": _now_iso(), "message": message.strip()}
-    memorial_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    payload = {
+        "life": metadata.slug,
+        "written_at": _now_iso(),
+        "message": message.strip(),
+    }
+    memorial_file.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
     return memorial_file
 
 
@@ -675,7 +833,9 @@ def clone_life(name: str, *, new_name: str | None = None) -> LifeMetadata:
     clone_name = new_name or f"{source.name} clone"
     clone_meta = create_life(clone_name, parents=(source_slug,))
     shutil.copytree(source.path, clone_meta.path, dirs_exist_ok=True)
-    _apply_inheritance_policy(source=source, target=clone_meta, policy=DEFAULT_INHERITANCE_POLICY)
+    _apply_inheritance_policy(
+        source=source, target=clone_meta, policy=DEFAULT_INHERITANCE_POLICY
+    )
     registry = load_registry()
     lives: dict[str, LifeMetadata] = registry.get("lives", {})
     current = lives.get(clone_meta.slug)

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -60,3 +60,55 @@ def test_create_lineage_record_rejects_empty_ids() -> None:
         assert "organism_id" in str(exc)
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_life_registry_lineage_records_realistic_reproduction(
+    tmp_path, monkeypatch
+) -> None:
+    import json
+
+    from singular.lives import create_life, load_registry, reproduce_lives
+
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path / "root"))
+    parent_a = create_life("Alpha")
+    parent_b = create_life("Beta")
+    for parent, skill in ((parent_a, "observe"), (parent_b, "plan")):
+        (parent.path / "skills").mkdir(parents=True, exist_ok=True)
+        (parent.path / "mem").mkdir(parents=True, exist_ok=True)
+        (parent.path / "skills" / f"{skill}.py").write_text(
+            "def mix(x):\n    y = x + 1\n    return y\n",
+            encoding="utf-8",
+        )
+        (parent.path / "mem" / "psyche.json").write_text(
+            json.dumps({"curiosity": 0.75, "maturity_score": 0.9}),
+            encoding="utf-8",
+        )
+        (parent.path / "mem" / "life_events.jsonl").write_text(
+            "".join(
+                json.dumps(
+                    {
+                        "event": "tick",
+                        "status": "stable",
+                        "mode": "normal",
+                        "breaker": False,
+                    }
+                )
+                + "\n"
+                for _ in range(3)
+            ),
+            encoding="utf-8",
+        )
+
+    result = reproduce_lives("alpha", "beta", new_name="Gamma", seed=2)
+
+    assert result["status"] == "created"
+    registry = load_registry()
+    gamma = registry["lives"]["gamma"]
+    assert gamma.parents == ("alpha", "beta")
+    assert gamma.lineage_depth == 1
+    assert "gamma" in registry["lives"]["alpha"].children
+    assert "gamma" in registry["lives"]["beta"].children
+    lineage_payload = json.loads(
+        (gamma.path / "mem" / "lineage.json").read_text(encoding="utf-8")
+    )
+    assert lineage_payload["parents"] == ["alpha", "beta"]

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import ast
+import json
 import pytest
 
 from singular.organisms.spawn import spawn
@@ -64,22 +65,36 @@ def test_reproduction_inherits_partial_memory(tmp_path: Path):
     parent_b = tmp_path / "parent_b"
     (parent_a / "skills").mkdir(parents=True)
     (parent_b / "skills").mkdir(parents=True)
-    (parent_a / "skills" / "skill_a.py").write_text("def mix(x):\n    return x\n", encoding="utf-8")
-    (parent_b / "skills" / "skill_b.py").write_text("def mix(x):\n    return x + 1\n", encoding="utf-8")
+    (parent_a / "skills" / "skill_a.py").write_text(
+        "def mix(x):\n    return x\n", encoding="utf-8"
+    )
+    (parent_b / "skills" / "skill_b.py").write_text(
+        "def mix(x):\n    return x + 1\n", encoding="utf-8"
+    )
 
     (parent_a / "mem").mkdir()
     (parent_b / "mem").mkdir()
-    (parent_a / "mem" / "psyche.json").write_text('{"curiosity": 0.2}', encoding="utf-8")
-    (parent_b / "mem" / "psyche.json").write_text('{"curiosity": 0.8}', encoding="utf-8")
-    (parent_a / "mem" / "episodic.jsonl").write_text('{"ts":"1","text":"a"}\n', encoding="utf-8")
-    (parent_b / "mem" / "episodic.jsonl").write_text('{"ts":"2","text":"b"}\n', encoding="utf-8")
+    (parent_a / "mem" / "psyche.json").write_text(
+        '{"curiosity": 0.2}', encoding="utf-8"
+    )
+    (parent_b / "mem" / "psyche.json").write_text(
+        '{"curiosity": 0.8}', encoding="utf-8"
+    )
+    (parent_a / "mem" / "episodic.jsonl").write_text(
+        '{"ts":"1","text":"a"}\n', encoding="utf-8"
+    )
+    (parent_b / "mem" / "episodic.jsonl").write_text(
+        '{"ts":"2","text":"b"}\n', encoding="utf-8"
+    )
 
     child = spawn(
         parent_a,
         parent_b,
         out_dir=tmp_path / "child",
         seed=1,
-        inheritance_rules=InheritanceRules(inherit_partial_memory=True, memory_episode_limit=1),
+        inheritance_rules=InheritanceRules(
+            inherit_partial_memory=True, memory_episode_limit=1
+        ),
     )
     lines = (child / "mem" / "episodic.jsonl").read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
@@ -90,12 +105,20 @@ def test_reproduction_blocks_incompatible_parents(tmp_path: Path):
     parent_b = tmp_path / "parent_b"
     (parent_a / "skills").mkdir(parents=True)
     (parent_b / "skills").mkdir(parents=True)
-    (parent_a / "skills" / "skill_a.py").write_text("def mix(x):\n    return x\n", encoding="utf-8")
-    (parent_b / "skills" / "skill_b.py").write_text("def mix(x):\n    return x + 1\n", encoding="utf-8")
+    (parent_a / "skills" / "skill_a.py").write_text(
+        "def mix(x):\n    return x\n", encoding="utf-8"
+    )
+    (parent_b / "skills" / "skill_b.py").write_text(
+        "def mix(x):\n    return x + 1\n", encoding="utf-8"
+    )
     (parent_a / "mem").mkdir()
     (parent_b / "mem").mkdir()
-    (parent_a / "mem" / "psyche.json").write_text('{"curiosity": 0.2}', encoding="utf-8")
-    (parent_b / "mem" / "psyche.json").write_text('{"resilience": 0.8}', encoding="utf-8")
+    (parent_a / "mem" / "psyche.json").write_text(
+        '{"curiosity": 0.2}', encoding="utf-8"
+    )
+    (parent_b / "mem" / "psyche.json").write_text(
+        '{"resilience": 0.8}', encoding="utf-8"
+    )
 
     with pytest.raises(ValueError, match="compatibility"):
         spawn(
@@ -197,7 +220,9 @@ def test_reproduction_decision_refuses_incompatible_pair(tmp_path: Path):
     skills_a.mkdir(parents=True)
     skills_b.mkdir(parents=True)
     (skills_a / "sum.py").write_text("def sum_it(x):\n    return x\n", encoding="utf-8")
-    (skills_b / "sum.py").write_text("def sum_it(x):\n    return x + 1\n", encoding="utf-8")
+    (skills_b / "sum.py").write_text(
+        "def sum_it(x):\n    return x + 1\n", encoding="utf-8"
+    )
 
     social = SocialGraph(path=tmp_path / "mem" / "social_graph.json")
     for _ in range(8):
@@ -219,7 +244,9 @@ def test_reproduction_decision_refuses_incompatible_pair(tmp_path: Path):
     )
 
     assert decision.accepted is False
-    assert any("compatibility_score_below_threshold" in reason for reason in decision.reasons)
+    assert any(
+        "compatibility_score_below_threshold" in reason for reason in decision.reasons
+    )
     assert any("parent_health_below_min" in reason for reason in decision.reasons)
 
 
@@ -228,8 +255,12 @@ def test_reproduction_decision_accepts_high_affinity_and_viability(tmp_path: Pat
     skills_b = tmp_path / "b" / "skills"
     skills_a.mkdir(parents=True)
     skills_b.mkdir(parents=True)
-    (skills_a / "vision.py").write_text("def solve(x):\n    return x\n", encoding="utf-8")
-    (skills_b / "planning.py").write_text("def solve(x):\n    return x + 2\n", encoding="utf-8")
+    (skills_a / "vision.py").write_text(
+        "def solve(x):\n    return x\n", encoding="utf-8"
+    )
+    (skills_b / "planning.py").write_text(
+        "def solve(x):\n    return x + 2\n", encoding="utf-8"
+    )
 
     social = SocialGraph(path=tmp_path / "mem" / "social_graph.json")
     for _ in range(6):
@@ -251,3 +282,146 @@ def test_reproduction_decision_accepts_high_affinity_and_viability(tmp_path: Pat
     assert decision.score >= 0.6
     assert decision.components["social_affinity"] > 0.7
     assert decision.components["viability"] > 0.8
+
+
+def _prepare_realistic_parent(
+    life_dir: Path, *, skill_name: str, maturity: float = 0.86
+) -> None:
+    (life_dir / "skills").mkdir(parents=True, exist_ok=True)
+    (life_dir / "mem").mkdir(parents=True, exist_ok=True)
+    (life_dir / "skills" / f"{skill_name}.py").write_text(
+        "def mix(x):\n    baseline = x + 1\n    return baseline\n",
+        encoding="utf-8",
+    )
+    (life_dir / "mem" / "psyche.json").write_text(
+        json.dumps({"curiosity": 0.7, "resilience": 0.8, "maturity_score": maturity}),
+        encoding="utf-8",
+    )
+    (life_dir / "mem" / "skills.json").write_text(
+        json.dumps({skill_name: {"inheritable": True, "level": 3}}),
+        encoding="utf-8",
+    )
+    (life_dir / "mem" / "episodic.jsonl").write_text(
+        "".join(
+            json.dumps(
+                {"event": "lesson", "status": "success", "text": f"{skill_name}-{idx}"}
+            )
+            + "\n"
+            for idx in range(4)
+        ),
+        encoding="utf-8",
+    )
+    (life_dir / "mem" / "life_events.jsonl").write_text(
+        "".join(
+            json.dumps(
+                {
+                    "event": "tick",
+                    "status": "stable",
+                    "mode": "normal",
+                    "breaker": False,
+                    "tick": idx,
+                }
+            )
+            + "\n"
+            for idx in range(5)
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_realistic_reproduction_keeps_inheritance_and_files_scoped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from singular.cli import main
+    from singular.lives import load_registry
+
+    root = tmp_path / "root"
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+    main(["--root", str(root), "lives", "create", "--name", "Beta"])
+    registry = load_registry()
+    alpha = registry["lives"]["alpha"]
+    beta = registry["lives"]["beta"]
+    _prepare_realistic_parent(alpha.path, skill_name="observe")
+    _prepare_realistic_parent(beta.path, skill_name="plan")
+
+    exit_code = main(
+        [
+            "--root",
+            str(root),
+            "--format",
+            "json",
+            "--seed",
+            "4",
+            "lives",
+            "reproduce",
+            "alpha",
+            "beta",
+            "--new-name",
+            "Alpha Beta Child",
+        ]
+    )
+
+    assert exit_code == 0
+    updated = load_registry()
+    child = updated["lives"]["alpha-beta-child"]
+    assert updated["active"] == child.slug
+    assert child.parents == ("alpha", "beta")
+    assert child.slug in updated["lives"]["alpha"].children
+    assert child.slug in updated["lives"]["beta"].children
+
+    lineage = json.loads(
+        (child.path / "mem" / "lineage.json").read_text(encoding="utf-8")
+    )
+    assert lineage["parents"] == ["alpha", "beta"]
+    assert lineage["lineage_depth"] == 1
+
+    inherited_memory = (
+        (child.path / "mem" / "episodic.jsonl").read_text(encoding="utf-8").splitlines()
+    )
+    assert 0 < len(inherited_memory) <= 50
+    assert all("lesson" in line for line in inherited_memory)
+    child_skills = {path.name for path in (child.path / "skills").glob("*.py")}
+    assert any(name.startswith("hybrid_") for name in child_skills)
+
+    root_resolved = root.resolve()
+    for path in child.path.rglob("*"):
+        assert path.resolve().is_relative_to(root_resolved)
+
+
+def test_lives_reproduction_reports_suspended_when_degraded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from singular.cli import main
+    from singular.lives import load_registry
+
+    root = tmp_path / "root"
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    main(["--root", str(root), "lives", "create", "--name", "Alpha"])
+    main(["--root", str(root), "lives", "create", "--name", "Beta"])
+    registry = load_registry()
+    alpha = registry["lives"]["alpha"]
+    beta = registry["lives"]["beta"]
+    _prepare_realistic_parent(alpha.path, skill_name="observe")
+    _prepare_realistic_parent(beta.path, skill_name="plan")
+    (beta.path / "mem" / "reproduction_state.json").write_text(
+        '{"mode":"degraded"}', encoding="utf-8"
+    )
+
+    main(
+        [
+            "--root",
+            str(root),
+            "lives",
+            "reproduce",
+            "alpha",
+            "beta",
+            "--new-name",
+            "Paused Child",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert "Reproduction suspendue" in out
+    assert "degraded_mode" in out
+    assert "paused-child" not in load_registry()["lives"]


### PR DESCRIPTION
### Motivation

- Provide a realistic reproduction scenario for lives that enforces eligibility checks (stability, maturity, degraded mode) before creating a child life. 
- Expose the reproduction flow via the CLI so operators can spawn an offspring from two registered lives with clear outputs and suspension reasons.
- Ensure reproduction writes are contained inside the registry root and record lineage/registry relationships and inherited artefacts for auditability.

### Description

- Added a parent eligibility gate `_parent_reproduction_gate` that checks `status`, `maturity_score`, recent stable `tick` events, and suspends reproduction when a parent is in degraded mode in `src/singular/lives.py`.
- Implemented `reproduce_lives` to create a child life, run `spawn` to build skills/memory, write `mem/lineage.json`, update the registry and return structured payloads (`created` or `suspended`) in `src/singular/lives.py`.
- Added a new CLI subcommand `singular lives reproduce <parent_a> <parent_b> [--new-name]` with JSON/plain output and a clear "Reproduction suspendue" message when suspended in `src/singular/cli.py`.
- Added realistic integration-style tests covering reproduction success, lineage registry recording, controlled memory/skills inheritance and a suspension case for degraded mode in `tests/test_reproduction.py` and `tests/test_lineage.py`.
- Small refactors and formatting adjustments to keep style consistent (minor whitespace/reflow changes in `src/singular/lives.py` and `src/singular/cli.py`).

### Testing

- Ran code formatting with `python -m black` and static checks with `python -m ruff` (both succeeded).
- Executed the new and related tests with `pytest -q tests/test_reproduction.py tests/test_lineage.py` and observed `16 passed`.
- Verified the CLI reproduce flow in tests exercises registry changes, `mem/lineage.json` creation, hybrid skill files under the child life `skills/`, and that no files were created outside the configured `SINGULAR_ROOT` (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7375d134f8832aaa60c3c130241318)