### PR TITLE
Use automatic LLM provider fallback selection

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -33,9 +33,7 @@ from ..providers import (
 from ..runs.logger import log_provider_event
 
 _CONTEXT_BUDGET_CHARS = 420
-_UNKNOWN_GUARD = (
-    "Garde anti-hallucination: si une information demandée est inconnue, réponds explicitement \"inconnu\"."
-)
+_UNKNOWN_GUARD = 'Garde anti-hallucination: si une information demandée est inconnue, réponds explicitement "inconnu".'
 
 
 def _default_reply(prompt: str, rng: random.Random) -> str:
@@ -108,11 +106,13 @@ def _extract_structured_signals(text: str) -> dict[str, object]:
     token_count = max(1, len(re.findall(r"\w+", lowered)))
     frustration = min(
         1.0,
-        sum(1 for token in frustration_tokens if token in lowered) / max(1.0, token_count * 0.2),
+        sum(1 for token in frustration_tokens if token in lowered)
+        / max(1.0, token_count * 0.2),
     )
     satisfaction = min(
         1.0,
-        sum(1 for token in satisfaction_tokens if token in lowered) / max(1.0, token_count * 0.2),
+        sum(1 for token in satisfaction_tokens if token in lowered)
+        / max(1.0, token_count * 0.2),
     )
     urgency = min(
         1.0,
@@ -178,22 +178,28 @@ def talk(
 
     rng = random.Random(seed)
 
-    provider_name = provider or os.getenv("LLM_PROVIDER")
-    if not provider_name:
-        provider_name = "openai" if os.getenv("OPENAI_API_KEY") else "stub"
-    print(f"Provider: {provider_name}")
+    # Keep the user's selection separate from the backend (or fallback chain)
+    # resolved by the provider loader.  None deliberately enables its automatic
+    # fallback policy; credentials must not silently turn into a selection here.
+    requested_provider = provider or os.getenv("LLM_PROVIDER") or None
+    provider_selection = requested_provider or "automatic"
+    print(f"Provider: {provider_selection}")
 
-    client = load_llm_client(provider_name)
-    provider_status = describe_client(client, provider_name)
+    client = load_llm_client(requested_provider)
+    provider_status = describe_client(client, requested_provider)
     print(
         f"Provider active: {provider_status['active_provider']} | "
         f"llm_real={str(provider_status['llm_real']).lower()} | fallback=not-yet"
     )
     if client is None:
-        print(
-            f"Provider '{provider_name}' not found. "
-            "Using local fallback replies."
-        )
+        if requested_provider:
+            print(
+                f"Provider '{requested_provider}' not found. Using local fallback replies."
+            )
+        else:
+            print(
+                "Automatic provider selection found no available backend. Using local fallback replies."
+            )
 
     psyche = Psyche.load_state()
 
@@ -272,9 +278,27 @@ def talk(
         )
         recall_summary = format_recalled_memories(recalled_memories)
         if recalled_memories:
-            add_episode({"event": "memory.recalled", "source": "talk", "query": user_input, "memories": recalled_memories, "summary": recall_summary})
-            add_episode({"event": "memory.used_for_decision", "source": "talk", "decision": "assistant_reply", "memories": recalled_memories, "summary": recall_summary})
-        add_episode({"role": "user", "text": user_input, "structured_signals": user_signals})
+            add_episode(
+                {
+                    "event": "memory.recalled",
+                    "source": "talk",
+                    "query": user_input,
+                    "memories": recalled_memories,
+                    "summary": recall_summary,
+                }
+            )
+            add_episode(
+                {
+                    "event": "memory.used_for_decision",
+                    "source": "talk",
+                    "decision": "assistant_reply",
+                    "memories": recalled_memories,
+                    "summary": recall_summary,
+                }
+            )
+        add_episode(
+            {"role": "user", "text": user_input, "structured_signals": user_signals}
+        )
         mood = psyche.feel(Mood.NEUTRAL)
         mood_report = mood_event or mood.value
         system_preamble = _build_system_preamble(
@@ -304,7 +328,7 @@ def talk(
                 fallback_used = True
                 llm_real = False
                 error_category = getattr(err, "category", "provider_error")
-                print(_user_message_for_error(provider_name, err))
+                print(_user_message_for_error(provider_selection, err))
                 print(
                     f"LLM status: active={active_provider} fallback=true "
                     f"error_category={error_category} llm_real=false"
@@ -319,7 +343,7 @@ def talk(
 
         latency_ms = (time.perf_counter() - start) * 1000
         log_provider_event(
-            provider=provider_name,
+            provider=provider_selection,
             latency_ms=latency_ms,
             fallback=fallback_used,
             error_category=error_category,
@@ -381,7 +405,10 @@ def talk(
                     "structured_signals": user_signals,
                 },
                 "decision": {
-                    "provider": provider_name,
+                    "provider": provider_selection,
+                    "provider_selection": (
+                        "explicit" if requested_provider else "automatic"
+                    ),
                     "active_provider": active_provider,
                     "fallback_used": fallback_used,
                     "error_category": error_category,

--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -11,7 +11,9 @@ from typing import Any, Callable, Protocol
 
 DEFAULT_PROVIDER_TIMEOUT_SECONDS = 8.0
 DEFAULT_PROVIDER_MAX_RETRIES = 2
-DEFAULT_FALLBACK_CHAIN = ("local", "ollama", "openai", "dummy")
+# Automatic selection prefers a locally managed Ollama model, then the built-in
+# local backend, before trying the remote OpenAI service and deterministic dummy.
+DEFAULT_FALLBACK_CHAIN = ("ollama", "local", "openai", "dummy")
 
 
 class LLMProviderError(RuntimeError):
@@ -70,14 +72,18 @@ class ProviderMetrics:
 class ReplyGenerator(Protocol):
     """Runtime protocol for provider generation functions."""
 
-    def __call__(self, prompt: str, *, timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS) -> str:  # pragma: no cover - typing only
+    def __call__(
+        self, prompt: str, *, timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS
+    ) -> str:  # pragma: no cover - typing only
         ...
 
 
 class Embedder(Protocol):
     """Runtime protocol for provider embedding functions."""
 
-    def __call__(self, text: str, *, timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS) -> list[float]:  # pragma: no cover - typing only
+    def __call__(
+        self, text: str, *, timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS
+    ) -> list[float]:  # pragma: no cover - typing only
         ...
 
 
@@ -103,7 +109,9 @@ class LLMProviderClient:
     healthcheck: Callable[[], dict[str, Any]] | None = None
     cost_estimate: Callable[..., float] | None = None
     max_retries: int = DEFAULT_PROVIDER_MAX_RETRIES
-    metrics: ProviderMetrics = field(default_factory=lambda: ProviderMetrics(provider="unknown"))
+    metrics: ProviderMetrics = field(
+        default_factory=lambda: ProviderMetrics(provider="unknown")
+    )
 
     def __post_init__(self) -> None:
         if self.metrics.provider == "unknown":
@@ -142,7 +150,9 @@ class FallbackLLMClient(LLMProviderClient):
 
     chain: list[LLMProviderClient] = field(default_factory=list)
 
-    def generate_reply(self, prompt: str, *, timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS) -> str:
+    def generate_reply(
+        self, prompt: str, *, timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS
+    ) -> str:
         last_error: LLMProviderError | None = None
         for client in self.chain:
             try:
@@ -163,10 +173,12 @@ def provider_is_real(name: str | None) -> bool:
     return name.strip().lower() not in {"stub", "dummy"}
 
 
-def describe_client(client: LLMProviderClient | None, requested: str) -> dict[str, Any]:
+def describe_client(
+    client: LLMProviderClient | None, requested: str | None
+) -> dict[str, Any]:
     """Return status details for a loaded provider client."""
 
-    active = client.name if client is not None else requested
+    active = client.name if client is not None else (requested or "automatic")
     chain = (
         [child.name for child in client.chain]
         if isinstance(client, FallbackLLMClient)
@@ -261,7 +273,12 @@ def _load_provider_contract(name: str) -> LLMProviderContract | None:
         embed = getattr(module, "embed", None)
         healthcheck = getattr(module, "healthcheck", None)
         cost_estimate = getattr(module, "cost_estimate", None)
-        if callable(generate) and callable(embed) and callable(healthcheck) and callable(cost_estimate):
+        if (
+            callable(generate)
+            and callable(embed)
+            and callable(healthcheck)
+            and callable(cost_estimate)
+        ):
             retries = getattr(module, "MAX_RETRIES", DEFAULT_PROVIDER_MAX_RETRIES)
             return LLMProviderContract(
                 name=name,
@@ -284,8 +301,17 @@ def _load_provider_contract(name: str) -> LLMProviderContract | None:
             continue
         obj = ep.load()
         generate = getattr(obj, "generate", getattr(obj, "generate_reply", obj))
-        embed = getattr(obj, "embed", lambda text, timeout=DEFAULT_PROVIDER_TIMEOUT_SECONDS: [float(len(text)), float(timeout)])
-        healthcheck = getattr(obj, "healthcheck", lambda: {"ok": True, "provider": name})
+        embed = getattr(
+            obj,
+            "embed",
+            lambda text, timeout=DEFAULT_PROVIDER_TIMEOUT_SECONDS: [
+                float(len(text)),
+                float(timeout),
+            ],
+        )
+        healthcheck = getattr(
+            obj, "healthcheck", lambda: {"ok": True, "provider": name}
+        )
         cost_estimate = getattr(obj, "cost_estimate", lambda prompt, completion="": 0.0)
         if callable(generate):
             retries = getattr(obj, "MAX_RETRIES", DEFAULT_PROVIDER_MAX_RETRIES)

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -8,7 +8,9 @@ from singular.lives import load_registry
 from singular.memory import read_causal_timeline, read_episodes
 from singular.organisms.talk import _default_reply, talk
 from singular.providers import (
+    LLMProviderContract,
     LLMProviderClient,
+    ProviderUnavailableError,
     ProviderQuotaExceededError,
     ProviderTimeoutError,
 )
@@ -61,6 +63,76 @@ def test_cli_provider_precedence(monkeypatch, tmp_path):
     assert captured["provider"] == "cli"
 
 
+def test_talk_uses_automatic_provider_selection_without_configuration(
+    monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    captured: list[str | None] = []
+
+    def fake_load(name: str | None):
+        captured.append(name)
+        return None
+
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", fake_load)
+    outputs: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda message: outputs.append(message))
+
+    talk(prompt="hello", seed=1)
+
+    assert captured == [None]
+    assert outputs[0] == "Provider: automatic"
+    assert read_causal_timeline()[-1]["decision"]["provider"] == "automatic"
+    assert read_causal_timeline()[-1]["decision"]["provider_selection"] == "automatic"
+
+
+def test_talk_automatic_chain_tries_next_provider_after_failure(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_PROVIDER_FALLBACK", raising=False)
+    attempts: list[str] = []
+
+    def contract(name: str, generate):
+        return LLMProviderContract(
+            name=name,
+            generate=generate,
+            embed=lambda _text, timeout=8.0: [],
+            healthcheck=lambda: {"ok": True, "provider": name},
+            cost_estimate=lambda _prompt, completion="": 0.0,
+            max_retries=0,
+        )
+
+    def first(_prompt: str, *, timeout: float = 8.0) -> str:
+        attempts.append("first")
+        raise ProviderUnavailableError("offline")
+
+    def second(_prompt: str, *, timeout: float = 8.0) -> str:
+        attempts.append("second")
+        return "reply from second"
+
+    contracts = {
+        "first": contract("first", first),
+        "second": contract("second", second),
+    }
+    monkeypatch.setattr(
+        "singular.providers.DEFAULT_FALLBACK_CHAIN", ("first", "second")
+    )
+    monkeypatch.setattr(
+        "singular.providers._load_provider_contract", lambda name: contracts.get(name)
+    )
+    outputs: list[str] = []
+    monkeypatch.setattr("builtins.print", lambda message: outputs.append(message))
+
+    talk(prompt="hello")
+
+    assert attempts == ["first", "second"]
+    assert outputs[0] == "Provider: automatic"
+    assert outputs[-1] == "reply from second | Mood: neutral"
+
+
 def test_talk_handles_keyboard_interrupt(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
@@ -98,7 +170,7 @@ def test_talk_single_prompt(monkeypatch, tmp_path):
     assert episodes[0]["text"] == "hello"
     assert episodes[0]["structured_signals"]["theme"] == "general"
     expected = _default_reply("hello", random.Random(123)) + " | Mood: neutral"
-    assert outputs[0] == "Provider: stub"
+    assert outputs[0] == "Provider: automatic"
     assert outputs[-1] == expected
 
 
@@ -122,9 +194,9 @@ def test_talk_seed_controls_stub(monkeypatch, tmp_path):
     third = _run_talk(monkeypatch, tmp_path, 321, 3)
     expected_first = _default_reply("hello", random.Random(123)) + " | Mood: neutral"
     expected_third = _default_reply("hello", random.Random(321)) + " | Mood: neutral"
-    assert first[0] == "Provider: stub"
-    assert second[0] == "Provider: stub"
-    assert third[0] == "Provider: stub"
+    assert first[0] == "Provider: automatic"
+    assert second[0] == "Provider: automatic"
+    assert third[0] == "Provider: automatic"
     assert first[-1] == expected_first
     assert second[-1] == expected_first
     assert third[-1] == expected_third
@@ -355,7 +427,9 @@ def test_unknown_argument_that_looks_like_life_suggests_life_flag(
     assert "singular --root <root> --life <slug> talk" in stderr
 
 
-def test_talk_marks_fallback_as_not_real_llm_in_memory_and_traces(monkeypatch, tmp_path):
+def test_talk_marks_fallback_as_not_real_llm_in_memory_and_traces(
+    monkeypatch, tmp_path
+):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
     inputs = iter(["hello", "quit"])
@@ -388,7 +462,10 @@ def test_talk_status_includes_active_fallback_and_error_category(monkeypatch, tm
     talk(provider="missing", seed=2)
 
     assert any("Provider active: missing" in out for out in outputs)
-    assert any("fallback=true" in out and "error_category=provider_missing" in out for out in outputs)
+    assert any(
+        "fallback=true" in out and "error_category=provider_missing" in out
+        for out in outputs
+    )
 
 
 def test_talk_recalls_prior_episode_in_provider_prompt(monkeypatch, tmp_path):
@@ -418,4 +495,7 @@ def test_talk_recalls_prior_episode_in_provider_prompt(monkeypatch, tmp_path):
     assert any(e.get("event") == "memory.recalled" for e in episodes)
     assert any(e.get("event") == "memory.used_for_decision" for e in episodes)
     assistant = [e for e in episodes if e.get("role") == "assistant"][-1]
-    assert "Peux-tu aider avec ce bug urgent" in assistant["context"]["recalled_memory_summary"]
+    assert (
+        "Peux-tu aider avec ce bug urgent"
+        in assistant["context"]["recalled_memory_summary"]
+    )


### PR DESCRIPTION
### Motivation

- Avoid silently turning credentials into an implicit provider selection and make the distinction between an explicitly requested provider and the backend(s) actually resolved by the loader.
- Ensure unconfigured runs call `load_llm_client(None)` so the configured fallback chain (or `LLM_PROVIDER_FALLBACK`) determines the backend order instead of defaulting to `stub`/`openai` based on env vars.

### Description

- Separate the requested provider from the resolved backend in `talk()` by introducing `requested_provider` (may be `None`) and printing `Provider: automatic` when none is specified, and call `load_llm_client(requested_provider)` accordingly (`src/singular/organisms/talk.py`).
- Update provider event/logging and persisted causal traces to record `provider_selection` as `explicit` or `automatic`, and use the displayed selection when formatting user-visible error messages and events (`src/singular/organisms/talk.py`).
- Make `describe_client` accept a potentially-None `requested` value and report the active provider as `automatic` when no explicit request exists, and change the documented default fallback chain to prefer `ollama` before `local` then `openai` and `dummy` (`src/singular/providers/__init__.py`).
- Add two focused tests: one asserting that with no `LLM_PROVIDER`, no OpenAI key and no `--provider` the loader receives `None` and traces are marked `automatic`, and one integration-style test that simulates two provider contracts where failure of the first leads to the second being used (`tests/test_talk.py`).

### Testing

- Ran `pytest -q tests/test_talk.py tests/providers/test_llm_fallback_chain.py`, which completed successfully with `24 passed`.
- Ran `git diff --check` (no issues) and formatted changed files with `black` as part of the workflow.
- Attempting the full test suite (`pytest -q`) was blocked by an unrelated pre-existing test collection error that imports a missing `CHECKPOINT_VERSION` symbol; this is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7423761a18832a90e871abf3db0211)