### PR TITLE
Record winning provider and fallback state for LLM fallback chain

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -21,6 +21,7 @@ from ..perception import capture_signals
 from ..psyche import Mood, Psyche
 from ..self_narrative import load as load_self_narrative, summarize_short
 from ..providers import (
+    FallbackLLMClient,
     LLMProviderError,
     ProviderMisconfiguredError,
     ProviderQuotaExceededError,
@@ -29,6 +30,7 @@ from ..providers import (
     ProviderUnavailableError,
     describe_client,
     load_llm_client,
+    provider_is_real,
 )
 from ..runs.logger import log_provider_event
 
@@ -187,11 +189,11 @@ def talk(
 
     client = load_llm_client(requested_provider)
     provider_status = describe_client(client, requested_provider)
-    print(
-        f"Provider active: {provider_status['active_provider']} | "
-        f"llm_real={str(provider_status['llm_real']).lower()} | fallback=not-yet"
-    )
     if client is None:
+        print(
+            f"Provider active: {provider_status['active_provider']} | "
+            "llm_real=false | fallback=true"
+        )
         if requested_provider:
             print(
                 f"Provider '{requested_provider}' not found. Using local fallback replies."
@@ -203,9 +205,9 @@ def talk(
 
     psyche = Psyche.load_state()
 
-    def gather_context() -> (
-        tuple[str | None, dict | None, dict | None, str | None, str | None]
-    ):
+    def gather_context() -> tuple[
+        str | None, dict | None, dict | None, str | None, str | None
+    ]:
         signals = capture_signals()
         add_episode({"event": "perception", **signals})
         psyche.consume()
@@ -335,9 +337,23 @@ def talk(
                 )
                 reply = _default_reply(user_input, rng)
             else:
+                if isinstance(client, FallbackLLMClient):
+                    active_provider = client.last_active_provider or active_provider
+                    fallback_used = client.last_fallback_used
+                    error_category = (
+                        client.last_errors[-1]["category"]
+                        if client.last_errors
+                        else None
+                    )
+                else:
+                    active_provider = client.name
+                    fallback_used = False
+                    error_category = None
+                llm_real = provider_is_real(active_provider)
                 print(
-                    f"LLM status: active={active_provider} fallback=false "
-                    "error_category=none "
+                    f"LLM status: active={active_provider} "
+                    f"fallback={str(fallback_used).lower()} "
+                    f"error_category={error_category or 'none'} "
                     f"llm_real={str(llm_real).lower()}"
                 )
 
@@ -374,6 +390,7 @@ def talk(
                 "raw_reply": reply,
                 "mood": mood.value,
                 "llm_real": llm_real,
+                "active_provider": active_provider,
                 "fallback_used": fallback_used,
                 "error_category": error_category,
                 "structured_signals": user_signals,

--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -149,17 +149,35 @@ class FallbackLLMClient(LLMProviderClient):
     """Client that tries multiple providers in order."""
 
     chain: list[LLMProviderClient] = field(default_factory=list)
+    last_active_provider: str | None = field(default=None, init=False)
+    last_fallback_used: bool = field(default=False, init=False)
+    last_errors: list[dict[str, str]] = field(default_factory=list, init=False)
 
     def generate_reply(
         self, prompt: str, *, timeout: float = DEFAULT_PROVIDER_TIMEOUT_SECONDS
     ) -> str:
+        # These values describe one generation only; do not leak the winner or
+        # failures from a previous call when this instance is reused.
+        self.last_active_provider = None
+        self.last_fallback_used = False
+        self.last_errors = []
         last_error: LLMProviderError | None = None
-        for client in self.chain:
+        for index, client in enumerate(self.chain):
             try:
-                return client.generate_reply(prompt, timeout=timeout)
+                reply = client.generate_reply(prompt, timeout=timeout)
             except LLMProviderError as exc:
                 last_error = exc
+                self.last_errors.append(
+                    {
+                        "provider": client.name,
+                        "category": getattr(exc, "category", "provider_error"),
+                        "error": str(exc),
+                    }
+                )
                 continue
+            self.last_active_provider = client.name
+            self.last_fallback_used = index > 0
+            return reply
         if last_error is not None:
             raise last_error
         raise ProviderUnavailableError("No provider available in fallback chain")

--- a/tests/providers/test_llm_fallback_chain.py
+++ b/tests/providers/test_llm_fallback_chain.py
@@ -1,7 +1,12 @@
 import pytest
 
 import singular.providers as providers
-from singular.providers import FallbackLLMClient, LLMProviderContract, ProviderUnavailableError, load_llm_client
+from singular.providers import (
+    FallbackLLMClient,
+    LLMProviderContract,
+    ProviderUnavailableError,
+    load_llm_client,
+)
 
 
 def _dummy_contract(name: str) -> LLMProviderContract:
@@ -17,7 +22,11 @@ def _dummy_contract(name: str) -> LLMProviderContract:
 def test_load_llm_client_none_without_env_uses_default_fallback_chain(monkeypatch):
     monkeypatch.delenv("LLM_PROVIDER_FALLBACK", raising=False)
     monkeypatch.setattr(providers, "DEFAULT_FALLBACK_CHAIN", ("dummy",))
-    monkeypatch.setattr(providers, "_load_provider_contract", lambda chain_name: _dummy_contract(chain_name))
+    monkeypatch.setattr(
+        providers,
+        "_load_provider_contract",
+        lambda chain_name: _dummy_contract(chain_name),
+    )
 
     client = load_llm_client(None)
     assert client is not None
@@ -28,7 +37,11 @@ def test_load_llm_client_none_without_env_uses_default_fallback_chain(monkeypatc
 def test_load_llm_client_env_fallback_chain_has_priority_over_default(monkeypatch):
     monkeypatch.setenv("LLM_PROVIDER_FALLBACK", "dummy")
     monkeypatch.setattr(providers, "DEFAULT_FALLBACK_CHAIN", ("local",))
-    monkeypatch.setattr(providers, "_load_provider_contract", lambda chain_name: _dummy_contract(chain_name))
+    monkeypatch.setattr(
+        providers,
+        "_load_provider_contract",
+        lambda chain_name: _dummy_contract(chain_name),
+    )
 
     client = load_llm_client(None)
     assert client is not None
@@ -38,7 +51,11 @@ def test_load_llm_client_env_fallback_chain_has_priority_over_default(monkeypatc
 
 def test_load_llm_client_explicit_name_has_priority_over_env(monkeypatch):
     monkeypatch.setenv("LLM_PROVIDER_FALLBACK", "dummy")
-    monkeypatch.setattr(providers, "_load_provider_contract", lambda chain_name: _dummy_contract(chain_name))
+    monkeypatch.setattr(
+        providers,
+        "_load_provider_contract",
+        lambda chain_name: _dummy_contract(chain_name),
+    )
 
     client = load_llm_client("openai")
     assert client is not None
@@ -47,6 +64,31 @@ def test_load_llm_client_explicit_name_has_priority_over_env(monkeypatch):
 
 
 def test_fallback_client_errors_when_chain_empty():
-    client = FallbackLLMClient(name="none", generate=lambda prompt, timeout=8.0: prompt, chain=[])
+    client = FallbackLLMClient(
+        name="none", generate=lambda prompt, timeout=8.0: prompt, chain=[]
+    )
     with pytest.raises(ProviderUnavailableError):
         client.generate_reply("x")
+
+
+def test_fallback_client_records_the_provider_that_succeeds():
+    def fail(_prompt: str, *, timeout: float = 8.0) -> str:
+        raise ProviderUnavailableError("offline")
+
+    client = FallbackLLMClient(
+        name="automatic",
+        generate=lambda prompt, timeout=8.0: prompt,
+        chain=[
+            providers.LLMProviderClient(name="first", generate=fail, max_retries=0),
+            providers.LLMProviderClient(
+                name="second", generate=lambda prompt, timeout=8.0: f"second:{prompt}"
+            ),
+        ],
+    )
+
+    assert client.generate_reply("hello") == "second:hello"
+    assert client.last_active_provider == "second"
+    assert client.last_fallback_used is True
+    assert client.last_errors == [
+        {"provider": "first", "category": "unavailable", "error": "offline"}
+    ]

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -130,7 +130,18 @@ def test_talk_automatic_chain_tries_next_provider_after_failure(monkeypatch, tmp
 
     assert attempts == ["first", "second"]
     assert outputs[0] == "Provider: automatic"
+    assert any("active=second fallback=true" in output for output in outputs)
     assert outputs[-1] == "reply from second | Mood: neutral"
+    assistant = next(
+        episode
+        for episode in reversed(read_episodes())
+        if episode.get("role") == "assistant"
+    )
+    assert assistant["active_provider"] == "second"
+    assert assistant["fallback_used"] is True
+    trace = read_causal_timeline()[-1]
+    assert trace["decision"]["active_provider"] == "second"
+    assert trace["decision"]["fallback_used"] is True
 
 
 def test_talk_handles_keyboard_interrupt(monkeypatch, tmp_path):


### PR DESCRIPTION
### Motivation
- Ensure the actual provider that succeeded in a fallback chain is recorded per generation so status, logs, episodes and causal traces reflect the real winning backend instead of a placeholder.
- Surface precise fallback diagnostics (which providers failed, error categories, and whether a fallback was used) for observability and downstream logic.

### Description
- Add per-call state to `FallbackLLMClient`: `last_active_provider`, `last_fallback_used`, and `last_errors`, and reset them at the start of `generate_reply()`; collect errors for failed providers and set the winner when a client succeeds (in `src/singular/providers/__init__.py`).
- Update `talk()` to derive `active_provider`, `fallback_used` and `llm_real` from the actual winning client when a `FallbackLLMClient` was used, include `active_provider` in assistant episodes, and print an exact LLM status instead of the fixed `fallback=not-yet` message (in `src/singular/organisms/talk.py`).
- Add a unit test that simulates a failing first provider and a succeeding second provider to verify `FallbackLLMClient` records the winner, fallback flag and prior errors (in `tests/providers/test_llm_fallback_chain.py`).
- Extend the talk integration test to verify the printed output, the assistant episode and the causal trace all report the same winning provider and fallback state (in `tests/test_talk.py`).

### Testing
- Ran `ruff format` across modified files (reformat applied) and static checks completed successfully.
- Ran `pytest -q tests/providers/test_llm_fallback_chain.py tests/test_talk.py` and all tests passed: 25 passed in the CI run.
- Verified `git diff --check` and repository status after committing the changes; working tree is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7425028278832a910936d307b0f41f)