### PR TITLE
Use current failure streak for vital state

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -1168,7 +1168,7 @@ def create_app(
             age=len(mutations),
             current_health=health_score,
             failure_rate=(1 - accepted_rate) if accepted_rate is not None else None,
-            failure_streak=max_failure_streak,
+            failure_streak=failure_streak,
             extinction_seen=any(rec.get("event") == "death" for rec in records),
         )
         comparison, _ = _aggregate_lives(current_life_only=current_life_only)
@@ -1246,6 +1246,8 @@ def create_app(
                     "rejected": rejected_count,
                     "success_rate": accepted_rate,
                     "risk_level": code_risk,
+                    "current_failure_streak": failure_streak,
+                    "max_failure_streak": max_failure_streak,
                 },
                 "risks": [str(alert.get("kind", "")) for alert in critical_alerts],
             },

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -345,16 +345,16 @@ def _accepted_value(row: Mapping[str, Any]) -> bool | None:
 
 
 def _failure_streak(rows: Sequence[Mapping[str, Any]]) -> int:
+    """Return the consecutive failure count at the end of the known outcomes."""
+
     current = 0
-    longest = 0
     for row in rows:
         accepted = _accepted_value(row)
         if accepted is False:
             current += 1
-            longest = max(longest, current)
         elif accepted is True:
             current = 0
-    return longest
+    return current
 
 
 def _list_count(value: Any) -> int:

--- a/src/singular/life/vital.py
+++ b/src/singular/life/vital.py
@@ -11,6 +11,9 @@ class VitalThresholds:
     terminal_age: int = 120
     terminal_health: float = 25.0
     high_failure_rate: float = 0.6
+    # Five unresolved consecutive failures indicate a terminal condition. A
+    # subsequent success resets the current streak and therefore clears this
+    # cause; historical failure peaks must not be supplied here.
     terminal_failure_streak: int = 5
     reproduction_min_age: int = 3
     reproduction_max_age: int = 80
@@ -26,7 +29,14 @@ def compute_vital_timeline(
     registry_status: str | None = None,
     thresholds: VitalThresholds = VitalThresholds(),
 ) -> dict[str, object]:
-    """Return an observable timeline payload from deterministic rules."""
+    """Return an observable timeline payload from deterministic rules.
+
+    ``failure_streak`` is the *current* number of consecutive failed outcomes
+    at the end of the relevant sequence, not its historical maximum. A later
+    successful outcome resets it to zero. The terminal streak threshold is
+    intentionally applied only to this unresolved, current run of failures;
+    extinction remains driven by explicit extinction evidence/status.
+    """
 
     causes: list[str] = []
     if extinction_seen or registry_status == "extinct":
@@ -68,6 +78,7 @@ def compute_vital_timeline(
 
     return {
         "age": age,
+        "current_failure_streak": failure_streak,
         "state": state,
         "risk_level": risk_level,
         "terminal": state in {"terminal", "extinct"},
@@ -85,4 +96,3 @@ def compute_vital_timeline(
             ],
         },
     }
-

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -539,6 +539,37 @@ def test_dashboard_cockpit_endpoint_schema(tmp_path: Path) -> None:
     assert isinstance(payload["life_status_missing_signals"], list)
 
 
+def test_dashboard_vital_state_recovers_after_historical_failure_peak(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    records = [
+        {
+            "ts": f"2026-04-12T10:{index:02d}:00",
+            "accepted": accepted,
+            "score_base": 10.0,
+            "score_new": 11.0,
+            "health": {"score": 90.0},
+        }
+        for index, accepted in enumerate([False] * 5 + [True])
+    ]
+    (runs_dir / "recovery.jsonl").write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+    payload = TestClient(
+        create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    ).get("/api/cockpit").json()
+
+    assert payload["vital_timeline"]["state"] != "terminal"
+    assert payload["vital_timeline"]["current_failure_streak"] == 0
+    code_generation = payload["vital_metrics"]["code_generation"]
+    assert code_generation["current_failure_streak"] == 0
+    assert code_generation["max_failure_streak"] == 5
+
+
 def test_dashboard_cockpit_sandbox_governance_summary(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -8,7 +8,24 @@ from singular.life.life_status import (
     AUTHORIZED_LIFE_STATUSES,
     LifeStatus,
     LifeStatusResult,
+    _failure_streak,
 )
+
+
+@pytest.mark.parametrize(
+    ("outcomes", "expected"),
+    [
+        ([False, False, True], 0),
+        ([True, False, False], 2),
+        ([False] * 6 + [True, False], 1),
+    ],
+)
+def test_failure_streak_counts_only_trailing_failures(
+    outcomes: list[bool], expected: int
+) -> None:
+    rows = [{"accepted": outcome} for outcome in outcomes]
+
+    assert _failure_streak(rows) == expected
 
 
 def test_authorized_life_statuses_are_stable_contract() -> None:


### PR DESCRIPTION
### Motivation

- Clarifier la sémantique de la série d’échecs: ne compter que les échecs consécutifs en queue de la séquence pertinente et réinitialiser la série sur une réussite ultérieure.
- Utiliser cette série courante pour piloter l’état vital observable afin d’éviter que des pics historiques non résolus influent indûment sur le statut courant.
- Conserver la valeur maximale historique comme métrique d’observation distincte sans la laisser déclencher l’état terminal automatiquement.

### Description

- Modifié `src/singular/life/life_status.py` pour que `def _failure_streak(...)` retourne uniquement le nombre d’échecs consécutifs en fin de séquence (résolution sur réussite). 
- Modifié `src/singular/dashboard/__init__.py` pour transmettre la série courante (`failure_streak`) à `compute_vital_timeline()` et exposer à la fois `current_failure_streak` et `max_failure_streak` dans `vital_metrics["code_generation"]` sans que le maximum historique pilote l’état vital.
- Mis à jour `src/singular/life/vital.py` pour documenter explicitement que `failure_streak` est la série courante (et non le pic historique), ajouter `current_failure_streak` au payload et commenter le seuil terminal (`terminal_failure_streak`).
- Ajouté des tests dans `tests/test_life_status.py` couvrant `échec, échec, succès`, `succès, échec, échec` et une récupération après un pic historique, et un test de cockpit dans `tests/test_dashboard.py` vérifiant que la réussite postérieure fait sortir de l’état terminal tout en conservant le pic historique comme métrique distincte.

### Testing

- Exécuté `pytest -q tests/test_life_status.py tests/test_vital_transitions.py` et obtenu `29 passed`.
- Exécuté `pytest -q tests/test_dashboard.py -k 'vital_state_recovers_after_historical_failure_peak or cockpit_endpoint_schema'` et obtenu `2 passed`.
- Un run combiné précédemment exécuté (`tests/test_life_status.py tests/test_dashboard.py tests/test_vital_transitions.py`) a montré 74 tests réussis et 3 échecs préexistants non liés (attentes de configuration de gouvernance et différence historique `extinct` vs `dead`), considérés comme baseline et non causés par ce changement.
- `git diff --check` a été exécuté et ne signale pas d’erreurs de format dans la diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a742605d32c832a904888fc43f8b4ef)