### PR TITLE
Resolve life storage paths at runtime

### DIFF
--- a/src/singular/environment/artifacts.py
+++ b/src/singular/environment/artifacts.py
@@ -13,7 +13,7 @@ ARTIFACTS_DIR = _BASE_DIR / "runs" / "artifacts"
 
 
 def _ensure_dir(directory: Path | None = None) -> Path:
-    directory = directory or ARTIFACTS_DIR
+    directory = directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
     directory.mkdir(parents=True, exist_ok=True)
     return directory
 
@@ -76,7 +76,7 @@ def create_text_art(
 ) -> Path:
     """Create a text artifact and save accompanying metadata."""
 
-    directory = directory or ARTIFACTS_DIR
+    directory = directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
     path = save_text(name, text, directory)
     _save_metadata(path, mood, resources)
     return path
@@ -94,7 +94,7 @@ def create_ascii_drawing(
 ) -> Path:
     """Create a simple ASCII drawing and save accompanying metadata."""
 
-    directory = directory or ARTIFACTS_DIR
+    directory = directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
     path = save_drawing(name, width, height, char, directory)
     _save_metadata(path, mood, resources)
     return path
@@ -110,7 +110,7 @@ def create_simple_melody(
 ) -> Path:
     """Create a simple melody and save accompanying metadata."""
 
-    directory = directory or ARTIFACTS_DIR
+    directory = directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
     path = save_music(name, notes, directory)
     _save_metadata(path, mood, resources)
     return path

--- a/src/singular/environment/sim_world.py
+++ b/src/singular/environment/sim_world.py
@@ -275,7 +275,11 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
 def load_world_state(path: Path | str | None = None) -> dict[str, Any]:
     """Load world state from disk, creating defaults if absent."""
 
-    world_path = Path(path) if path is not None else DEFAULT_WORLD_STATE_PATH
+    world_path = (
+        Path(path)
+        if path is not None
+        else Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_state.json"
+    )
     if not world_path.exists():
         state = default_world_state()
         _atomic_write_json(world_path, state)
@@ -287,7 +291,11 @@ def load_world_state(path: Path | str | None = None) -> dict[str, Any]:
 def save_world_state(state: dict[str, Any], path: Path | str | None = None) -> None:
     """Persist world state to disk."""
 
-    world_path = Path(path) if path is not None else DEFAULT_WORLD_STATE_PATH
+    world_path = (
+        Path(path)
+        if path is not None
+        else Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_state.json"
+    )
     _atomic_write_json(world_path, state)
 
 
@@ -541,7 +549,9 @@ def apply_action_effects(
     save_world_state(next_state, state_path)
 
     ledger_path = (
-        Path(effects_path) if effects_path is not None else DEFAULT_WORLD_EFFECTS_PATH
+        Path(effects_path)
+        if effects_path is not None
+        else Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_effects.json"
     )
     ledger = {
         "version": 1,

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -89,6 +89,8 @@ from .profiling import LifeLoopProfiler
 
 log = logging.getLogger(__name__)
 
+_DEFAULT_RUN_LOGGER = RunLogger
+
 # Energy management during the evolutionary loop. When the psyche's energy
 # falls below ``SLEEP_THRESHOLD`` the organism will enter a sleeping phase for
 # ``SLEEP_TICKS`` iterations where no mutations are attempted.
@@ -929,11 +931,17 @@ def run(
         with current_tick_profiler.phase("test_runner"):
             return test_runner()
 
-    with RunLogger(run_id, psyche=psyche) as logger:
+    life_root = Path(os.environ.get("SINGULAR_HOME", "."))
+    logger_kwargs: dict[str, object] = {"psyche": psyche}
+    # Keep the injection point used by tests and downstream integrations while
+    # making the production logger's active-life destination explicit.
+    if RunLogger is _DEFAULT_RUN_LOGGER:
+        logger_kwargs["root"] = life_root / "runs"
+    with RunLogger(run_id, **logger_kwargs) as logger:
         health_tracker = HealthTracker.from_state(state.health_counters)
         delayed: list[tuple[float, str, Path]] = []
         tick_count = 0
-        persistent_world_state_path = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_state.lifecycle.json"
+        persistent_world_state_path = life_root / "mem" / "world_state.lifecycle.json"
         persistent_world_state = PersistentWorldState.load(persistent_world_state_path)
         while time.time() - start < budget_seconds:
             if max_iterations is not None and tick_count >= max_iterations:

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -103,7 +103,11 @@ def _ensure_dir(path: Path) -> None:
 def _enforce_retention(root: Path) -> None:
     """Apply retention policy to run logs and temporary files."""
 
-    run_retention_service(base_dir=_BASE_DIR, runs_dir=root)
+    run_retention_service(
+        base_dir=root.parent,
+        runs_dir=root,
+        enforce_minimum_interval=False,
+    )
 
 
 @dataclass
@@ -115,16 +119,21 @@ class RunLogger:
     run_id:
         Identifier for the run.
     root:
-        Directory in which log files are written. Defaults to :data:`RUNS_DIR`.
+        Directory in which log files are written. When omitted, it is resolved
+        from the current ``SINGULAR_HOME`` value at construction time.
     """
 
     run_id: str
-    root: Path = RUNS_DIR
+    root: Path | None = None
     psyche: Psyche = field(default_factory=Psyche.load_state)
     reputation_update_every: int = DEFAULT_REPUTATION_UPDATE_EVERY
 
     def __post_init__(self) -> None:
-        self.root = Path(self.root)
+        self.root = (
+            Path(self.root)
+            if self.root is not None
+            else Path(os.environ.get("SINGULAR_HOME", ".")) / "runs"
+        )
         self.root.mkdir(parents=True, exist_ok=True)
 
         self.run_dir = self.root / self.run_id

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -5,6 +5,34 @@ from singular.runs import RunLogger
 from singular.runs.explain import summarize_mutation
 
 
+def test_default_root_uses_singular_home_at_construction_time(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # RunLogger was imported above, before the environment changed.
+    home = tmp_path / "new-home"
+    monkeypatch.setenv("SINGULAR_HOME", str(home))
+
+    with RunLogger("late-home"):
+        pass
+
+    assert (home / "runs" / "late-home").is_dir()
+
+
+def test_default_root_follows_two_successive_lives(
+    tmp_path: Path, monkeypatch
+) -> None:
+    homes = [tmp_path / "life-a", tmp_path / "life-b"]
+
+    for index, home in enumerate(homes):
+        monkeypatch.setenv("SINGULAR_HOME", str(home))
+        with RunLogger(f"run-{index}"):
+            pass
+
+    assert (homes[0] / "runs" / "run-0").is_dir()
+    assert (homes[1] / "runs" / "run-1").is_dir()
+    assert not (homes[0] / "runs" / "run-1").exists()
+
+
 def test_log_creation(tmp_path: Path) -> None:
     logger = RunLogger("test", root=tmp_path)
     assert (tmp_path / "test" / ".active.lock").exists()


### PR DESCRIPTION
### Motivation

- Éviter que des chemins calculés au moment de l'import (basés sur `SINGULAR_HOME`) restent figés pendant toute la durée du processus quand la « vie » change. 
- Faire en sorte que le logger et les services apparentés utilisent le répertoire de la vie active résolu au moment d'instanciation plutôt que la constante module calculée à l'import.

### Description

- `RunLogger.root` n'a plus de valeur par défaut figée et accepte maintenant `None`; sa `__post_init__()` résout `Path(os.environ.get("SINGULAR_HOME", ".")) / "runs"` si aucun `root` explicite n'est fourni (`src/singular/runs/logger.py`).
- `_enforce_retention()` appelle `run_retention_service(base_dir=root.parent, runs_dir=root, enforce_minimum_interval=False)` afin d'appliquer la rétention au parent du répertoire réellement utilisé (`src/singular/runs/logger.py`).
- Le cycle de vie passe explicitement le répertoire de la vie active au logger en production tout en conservant le point d'injection pour les tests (`_DEFAULT_RUN_LOGGER` et logique d'appel dans `src/singular/life/loop.py`).
- Résolution à l'exécution des chemins dépendants de `SINGULAR_HOME` dans `src/singular/environment/artifacts.py` et `src/singular/environment/sim_world.py` afin d'éviter l'utilisation de chemins dérivés au niveau module.
- Ajout de deux tests pour vérifier que `RunLogger` utilise la valeur actuelle de `SINGULAR_HOME` au moment de la construction et qu'une même process peut créer des runs pour deux vies successives (`tests/test_runs_logger.py`).

### Testing

- Exécution du contrôle de style via `ruff` sur les fichiers modifiés et correctifs appliqués; la vérification est passée.
- Tests ciblés lancés avec `pytest` pour les fichiers modifiés et dépendances : `tests/test_runs_logger.py`, `tests/test_runs_retention.py`, `tests/test_singular_home.py`, `tests/test_environment.py`, et itérations de `tests/test_loop.py` lors du débogage; les tests ciblés ont été corrigés et les tests modifiés réussissent (`18 passed`, plusieurs warnings de dépréciation signalés).
- Correction itérative après runs initiaux ayant fait apparaître des échecs liés à l'injection du logger, puis revalidation complète des tests ciblés qui a réussi avant le commit final.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a742712c794832aa9e7b300316fc7db)