### PR TITLE
Consolidation de la mémoire d'identité durant la phase SOMMEIL avec curseur durable

### DIFF
--- a/configs/lifecycle.yaml
+++ b/configs/lifecycle.yaml
@@ -21,9 +21,9 @@ phases:
     slowdown_on_fatigue: 1.5
   introspection:
     cpu_budget_percent: 40
-    allowed_actions: [self_review, memory_consolidation]
+    allowed_actions: [self_review]
     slowdown_on_fatigue: 1.2
   sommeil:
     cpu_budget_percent: 15
-    allowed_actions: [recovery, cooldown]
+    allowed_actions: [recovery, cooldown, memory_consolidation]
     slowdown_on_fatigue: 1.0

--- a/src/singular/identity/consolidation.py
+++ b/src/singular/identity/consolidation.py
@@ -45,8 +45,17 @@ class ConsolidationPipeline:
         self.semantic = SemanticMemoryStore(root / "semantic_memory.json")
         self.self_model = SelfModelStore(root / "self_model.json")
 
-    def run(self) -> ConsolidationResult:
-        episodes = self.episodic.read_all()
+    def run(
+        self, *, episodes: list[dict[str, Any]] | None = None
+    ) -> ConsolidationResult:
+        """Consolidate the supplied unprocessed episodes, then compact the journal.
+
+        When ``episodes`` is omitted the complete journal is consolidated, preserving
+        the public API used by standalone callers.  Orchestrators can pass only rows
+        after their durable cursor to avoid inflating fact mention counts.
+        """
+
+        episodes = self.episodic.read_all() if episodes is None else episodes
         facts = self.semantic.consolidate_from_episodes(episodes)
         self.self_model.apply_facts(facts)
         self.self_model.compact(self.policy.keep_top_self_model_entries)

--- a/src/singular/orchestrator/lifecycle_clock.py
+++ b/src/singular/orchestrator/lifecycle_clock.py
@@ -49,8 +49,8 @@ class LifecycleClockConfig:
         default_factory=lambda: {
             "veille": PhaseBehavior(30.0, 1.1, ("perception", "resource_scan")),
             "action": PhaseBehavior(75.0, 1.5, ("mutation", "evaluation", "checkpoint")),
-            "introspection": PhaseBehavior(40.0, 1.2, ("self_review", "memory_consolidation")),
-            "sommeil": PhaseBehavior(15.0, 1.0, ("recovery", "cooldown")),
+            "introspection": PhaseBehavior(40.0, 1.2, ("self_review",)),
+            "sommeil": PhaseBehavior(15.0, 1.0, ("recovery", "cooldown", "memory_consolidation")),
         }
     )
 

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+import hashlib
 import json
 import logging
 import signal
@@ -20,6 +21,7 @@ from singular.events import (
     get_global_event_bus,
 )
 from singular.goals import IntrinsicGoals
+from singular.identity import ConsolidationPipeline
 from singular.governance.policy import MutationGovernancePolicy
 from singular.life.coevolution_flow import LivingTestPool
 from singular.life.loop import WorldState, run_tick
@@ -88,6 +90,7 @@ class OrchestratorState:
     last_events: list[dict[str, Any]] = field(default_factory=list)
     last_run_mtime: float | None = None
     last_watch_mtime: float | None = None
+    last_consolidated_episode_id: str | None = None
 
 
 @dataclass
@@ -151,6 +154,7 @@ class OrchestratorService:
             state_path=self.mem_dir / "routines_state.json"
         )
         self.goals = IntrinsicGoals(path=self.mem_dir / "goals.json")
+        self.consolidation_pipeline = ConsolidationPipeline(mem_dir=self.mem_dir)
         self._running = False
         self._wake_requested = False
         self._pending_events: list[dict[str, Any]] = []
@@ -198,6 +202,7 @@ class OrchestratorService:
             last_events=list(raw.get("last_events", [])),
             last_run_mtime=raw.get("last_run_mtime"),
             last_watch_mtime=raw.get("last_watch_mtime"),
+            last_consolidated_episode_id=raw.get("last_consolidated_episode_id"),
         )
 
     def _save_state(self) -> None:
@@ -207,6 +212,7 @@ class OrchestratorService:
             "last_events": self.state.last_events[-100:],
             "last_run_mtime": self.state.last_run_mtime,
             "last_watch_mtime": self.state.last_watch_mtime,
+            "last_consolidated_episode_id": self.state.last_consolidated_episode_id,
             "updated_at": datetime.now(timezone.utc).isoformat(),
         }
         _atomic_write_text(
@@ -232,6 +238,65 @@ class OrchestratorService:
             }
         )
         self.state.last_events = self.state.last_events[-100:]
+
+    def _action_allowed(self, phase: LifecyclePhase, action: str) -> bool:
+        """Return whether phase configuration permits an action to execute.
+
+        An absent behavior remains permissive for programmatic/backward-compatible
+        configurations; once ``allowed_actions`` is supplied it is authoritative.
+        """
+
+        behavior = self.config.phase_behaviors.get(phase.value, {})
+        if "allowed_actions" not in behavior:
+            return True
+        actions = behavior.get("allowed_actions", [])
+        return action in actions if isinstance(actions, (list, tuple, set)) else False
+
+    @staticmethod
+    def _episode_id(episode: dict[str, Any]) -> str:
+        canonical = json.dumps(episode, sort_keys=True, ensure_ascii=False)
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def _run_memory_consolidation(self) -> dict[str, Any]:
+        """Consolidate episodes after the durable cursor and record every attempt."""
+
+        attempted_at = datetime.now(timezone.utc).isoformat()
+        episodes = self.consolidation_pipeline.episodic.read_all()
+        start = 0
+        cursor = self.state.last_consolidated_episode_id
+        if cursor:
+            for index, episode in enumerate(episodes):
+                if self._episode_id(episode) == cursor:
+                    start = index + 1
+        pending = episodes[start:]
+        details: dict[str, Any] = {
+            "event_type": "memory.consolidated",
+            "consolidated_at": attempted_at,
+            "episodes_seen": len(pending),
+            "facts_count": 0,
+            "episodic_compaction": None,
+            "errors": [],
+        }
+        try:
+            result = self.consolidation_pipeline.run(episodes=pending)
+            details.update(
+                {
+                    "consolidated_at": result.consolidated_at,
+                    "episodes_seen": result.episodes_seen,
+                    "facts_count": result.facts_count,
+                    "episodic_compaction": result.episodic_compaction,
+                }
+            )
+            if episodes:
+                self.state.last_consolidated_episode_id = self._episode_id(episodes[-1])
+            self.bus.publish("memory.consolidated", details, payload_version=1)
+        except Exception as exc:  # cycle errors must be durable and retryable
+            details["event_type"] = "memory.consolidation_failed"
+            details["errors"] = [f"{type(exc).__name__}: {exc}"]
+            log.exception("identity memory consolidation failed")
+            self.bus.publish("memory.consolidation_failed", details, payload_version=1)
+        self._push_event(LifecyclePhase.SOMMEIL, details)
+        return details
 
     def _runs_mtime(self) -> float | None:
         runs_dir = self.base_dir / "runs"
@@ -609,10 +674,21 @@ class OrchestratorService:
             )
             return
 
+        consolidation = None
+        if self._action_allowed(phase, "memory_consolidation"):
+            consolidation = self._run_memory_consolidation()
         self.psyche.sleep_tick()
         self.psyche.sleeping = True
         self.psyche.save_state()
-        self._push_event(phase, {"energy": self.psyche.energy})
+        self._push_event(
+            phase,
+            {
+                "energy": self.psyche.energy,
+                "memory_consolidation": (
+                    consolidation["event_type"] if consolidation else "disabled"
+                ),
+            },
+        )
 
     def _compute_runtime_adaptation(self) -> dict[str, Any]:
         host_metrics = self._latest_signals.get("host_metrics", {})

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -7,6 +7,7 @@ import random
 import pytest
 
 from singular.events import EventBus
+from singular.identity import EpisodicStore
 from singular.life.death import DeathMonitor
 from singular.life.loop import run as run_life_loop
 from singular.orchestrator.service import (
@@ -61,6 +62,110 @@ def test_orchestrator_tick_persists_state(monkeypatch, tmp_path: Path) -> None:
     assert state_path.exists()
     payload = state_path.read_text(encoding="utf-8")
     assert "current_phase" in payload
+
+
+def test_orchestrator_sleep_consolidates_identity_memory(
+    monkeypatch, tmp_path: Path
+) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+    store = EpisodicStore(life / "mem" / "episodic.jsonl")
+    store.append({"event": "conversation", "user_fact": "user_name:Alice"})
+    store.append({"event": "conversation", "preference": "likes:tea"})
+
+    service = OrchestratorService(
+        config=OrchestratorConfig(
+            dry_run=True,
+            phase_behaviors={
+                "sommeil": {"allowed_actions": ["memory_consolidation"]}
+            },
+        ),
+        bus=EventBus(),
+    )
+    service.state.current_phase = LifecyclePhase.SOMMEIL.value
+
+    service.tick()
+
+    semantic = json.loads(
+        (life / "mem" / "semantic_memory.json").read_text(encoding="utf-8")
+    )
+    self_model = json.loads(
+        (life / "mem" / "self_model.json").read_text(encoding="utf-8")
+    )
+    assert {fact["value"] for fact in semantic} == {"user_name:Alice", "likes:tea"}
+    assert "user_name:Alice" in self_model["traits"]
+    assert "likes:tea" in self_model["preferences"]
+    event = next(
+        item
+        for item in service.state.last_events
+        if item.get("details", {}).get("event_type") == "memory.consolidated"
+    )
+    assert event["details"]["episodes_seen"] == 2
+    assert event["details"]["facts_count"] == 2
+    assert event["details"]["episodic_compaction"] is not None
+    assert event["details"]["consolidated_at"]
+    assert event["details"]["errors"] == []
+
+    # The durable cursor prevents the next sleep from counting the same facts again.
+    service.state.current_phase = LifecyclePhase.SOMMEIL.value
+    service.tick()
+    semantic = json.loads(
+        (life / "mem" / "semantic_memory.json").read_text(encoding="utf-8")
+    )
+    assert all(fact["mentions"] == 1 for fact in semantic)
+
+
+def test_orchestrator_sleep_retries_after_interrupted_consolidation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+    EpisodicStore(life / "mem" / "episodic.jsonl").append(
+        {"event": "conversation", "constraint": "prefers:privacy"}
+    )
+    service = OrchestratorService(
+        config=OrchestratorConfig(
+            dry_run=True,
+            phase_behaviors={
+                "sommeil": {"allowed_actions": ["memory_consolidation"]}
+            },
+        ),
+        bus=EventBus(),
+    )
+    service.state.current_phase = LifecyclePhase.SOMMEIL.value
+    real_run = service.consolidation_pipeline.run
+    attempts = 0
+
+    def interrupted_run(*, episodes):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise InterruptedError("simulated interruption")
+        return real_run(episodes=episodes)
+
+    monkeypatch.setattr(service.consolidation_pipeline, "run", interrupted_run)
+    service.tick()
+    persisted = json.loads(service.state_path.read_text(encoding="utf-8"))
+    failed = next(
+        item
+        for item in persisted["last_events"]
+        if item.get("details", {}).get("event_type")
+        == "memory.consolidation_failed"
+    )
+    assert "InterruptedError" in failed["details"]["errors"][0]
+    assert persisted["last_consolidated_episode_id"] is None
+
+    service.state.current_phase = LifecyclePhase.SOMMEIL.value
+    service.tick()
+
+    self_model = json.loads(
+        (life / "mem" / "self_model.json").read_text(encoding="utf-8")
+    )
+    assert "prefers:privacy" in self_model["constraints"]
+    assert service.state.last_consolidated_episode_id is not None
+    assert attempts == 2
 
 
 def test_orchestrator_detects_external_stimulus(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Exécuter périodiquement la consolidation des épisodes courts vers les stores durables (`semantic_memory.json`, `self_model.json`) pendant la phase de sommeil au lieu de l’introspection.
- Faire de la clé `allowed_actions` une règle d’exécution (pas seulement informative) pour contrôler où `memory_consolidation` peut s’exécuter.
- Enregistrer un audit de chaque cycle de consolidation (dates, `episodes_seen`, `facts_count`, résultat de compaction et erreurs) et éviter le retraitement infini en conservant un curseur durable du dernier épisode consolidé.

### Description
- L’API `ConsolidationPipeline.run()` accepte désormais un paramètre facultatif `episodes` pour ne traiter que les épisodes non encore consolidés, tout en conservant le comportement par défaut si l’argument est omis.
- `OrchestratorService` instancie `ConsolidationPipeline(mem_dir=...)` et ajoute un champ d’état persistant `last_consolidated_episode_id` pour le curseur durable.
- Ajout de la logique d’exécution contrôlée par `allowed_actions` via la méthode `_action_allowed`, d’un calcul d’ID d’épisode (`_episode_id`) et d’une routine `_run_memory_consolidation` qui : lit les épisodes non traités, exécute la consolidation, publie un événement d’audit (`memory.consolidated` ou `memory.consolidation_failed`), et n’avance le curseur qu’en cas de succès.
- L’appel de consolidation est effectué pendant la phase `LifecyclePhase.SOMMEIL` (ou l’introspection précédente si la sémantique l’exige), et le fichier de configuration `configs/lifecycle.yaml` et les defaults de `lifecycle_clock` ont été ajustés pour déclarer `memory_consolidation` comme action de `sommeil`.
- Tests ajoutés dans `tests/test_orchestrator_service.py` pour couvrir un cycle de sommeil complet (vérification de `semantic_memory.json` et `self_model.json`, audit d’événement) et la reprise après interruption simulée pendant la consolidation.

### Testing
- Exécution des tests unitaires ciblés : `pytest -q tests/test_orchestrator_service.py tests/test_identity_consolidation_pipeline.py tests/test_lifecycle_clock_config.py` — tous les tests automatisés sont passés (`25 passed`).
- Vérifications de style/quality : `ruff` checks sur les fichiers modifiés — OK.
- Contrôles de cohérence (`git diff --check`) — OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a753d55415c832a92ab840a51f6df3e)