### PR TITLE
feat(identity): add versioned canonical self-model and IdentityCoreService

### DIFF
--- a/src/singular/identity/__init__.py
+++ b/src/singular/identity/__init__.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from .coherence import CoherenceDecision, IdentityCoherenceGuard, IdentityInvariants, detect_contradictions
 from .consolidation import ConsolidationPipeline, ConsolidationPolicy, ConsolidationResult
+from .core import IdentityAggregationService, IdentityCoreService
 from .episodic_store import EpisodicStore
 from .self_model import IdentityInvariantError, SelfModelStore
 from .semantic_memory import SemanticMemoryStore
@@ -61,6 +62,8 @@ __all__ = [
     "ConsolidationPipeline",
     "ConsolidationPolicy",
     "IdentityCoherenceGuard",
+    "IdentityAggregationService",
+    "IdentityCoreService",
     "IdentityInvariants",
     "ConsolidationResult",
     "EpisodicStore",

--- a/src/singular/identity/consolidation.py
+++ b/src/singular/identity/consolidation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .episodic_store import EpisodicStore
+from .core import IdentityCoreService
 from .semantic_memory import SemanticMemoryStore
 from .self_model import SelfModelStore
 
@@ -40,6 +41,7 @@ class ConsolidationPipeline:
         policy: ConsolidationPolicy | None = None,
     ) -> None:
         root = Path(mem_dir)
+        self.mem_dir = root
         self.policy = policy or ConsolidationPolicy()
         self.episodic = EpisodicStore(root / "episodic.jsonl")
         self.semantic = SemanticMemoryStore(root / "semantic_memory.json")
@@ -59,6 +61,9 @@ class ConsolidationPipeline:
         facts = self.semantic.consolidate_from_episodes(episodes)
         self.self_model.apply_facts(facts)
         self.self_model.compact(self.policy.keep_top_self_model_entries)
+        # Reconcile projections after every consolidation so narrative, psyche,
+        # birth artifacts and coherence do not drift into competing identities.
+        IdentityCoreService(self.mem_dir).synchronize()
         compaction = self.episodic.compact(
             keep_last=self.policy.keep_last_episodes,
             preserve_identity_events=True,

--- a/src/singular/identity/core.py
+++ b/src/singular/identity/core.py
@@ -1,0 +1,129 @@
+"""Aggregation service making :mod:`identity.self_model` the single source of truth."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .coherence import IdentityInvariants
+from .self_model import SelfModelStore, _now
+
+
+class IdentityCoreService:
+    """Import legacy identity projections once and synchronize all consumers.
+
+    ``root`` may be either a life directory (containing ``mem``) or its memory
+    directory.  The core is always stored beside the other memory artifacts.
+    """
+
+    def __init__(self, root: Path | str) -> None:
+        candidate = Path(root)
+        self.mem = candidate if candidate.name == "mem" else candidate / "mem"
+        self.mem.mkdir(parents=True, exist_ok=True)
+        self.store = SelfModelStore(self.mem / "self_model.json")
+
+    @staticmethod
+    def _json(path: Path) -> dict[str, Any]:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+            return value if isinstance(value, dict) else {}
+        except (OSError, json.JSONDecodeError):
+            return {}
+
+    @staticmethod
+    def _unique(*groups: Any) -> list[Any]:
+        result: list[Any] = []
+        for group in groups:
+            if not isinstance(group, list):
+                continue
+            for value in group:
+                if value not in result:
+                    result.append(value)
+        return result
+
+    def synchronize(self, psyche: Any | None = None) -> dict[str, Any]:
+        """Merge birth/narrative/psyche signals, then project the canonical core."""
+        model = self.store.read()
+        biography = self._json(self.mem / "biography.json")
+        narrative = self._json(self.mem / "self_narrative.json")
+        psyche_data = self._json(self.mem / "psyche.json")
+        identity = biography.get("identity", {}) if isinstance(biography.get("identity"), Mapping) else {}
+        narrative_identity = narrative.get("identity", {}) if isinstance(narrative.get("identity"), Mapping) else {}
+
+        # Birth data is authoritative when a core still contains defaults.
+        if model["name"] == "Singular":
+            model["name"] = str(identity.get("name") or narrative_identity.get("name") or model["name"])
+        if identity.get("id"):
+            model["stable_id"] = str(identity["id"])
+        summaries = biography.get("self_summaries", [])
+        if not model["biographical_summary"] and isinstance(summaries, list):
+            model["biographical_summary"] = " ".join(
+                str(item.get("text", "")).strip() for item in summaries if isinstance(item, Mapping) and item.get("text")
+            )
+        certificate = biography.get("birth_certificate")
+        if isinstance(certificate, Mapping) and not model["founding_events"]:
+            model["founding_events"] = [dict(certificate)]
+
+        commitments = psyche_data.get("identity_commitments", {})
+        if psyche is not None:
+            commitments = getattr(psyche, "identity_commitments", commitments)
+        if not isinstance(commitments, Mapping):
+            commitments = {}
+        model["cardinal_values"] = self._unique(model["cardinal_values"], commitments.get("values"))
+        model["red_lines"] = self._unique(model["red_lines"], commitments.get("red_lines"))
+        # Older psyche state had no separate commitments list; values remain
+        # values and are not silently promoted to promises.
+        wounds = getattr(psyche, "identity_wounds", psyche_data.get("identity_wounds", 0.0))
+        try:
+            wound_score = float(wounds)
+        except (TypeError, ValueError):
+            wound_score = 0.0
+        if wound_score > 0 and not model["identity_wounds"]:
+            model["identity_wounds"].append({"kind": "legacy_psyche_wound", "severity": wound_score})
+
+        # Psyche traits are observations, not ownership of identity.
+        trait_source = psyche if psyche is not None else psyche_data
+        for trait in ("curiosity", "patience", "playfulness", "optimism", "resilience"):
+            value = getattr(trait_source, trait, None) if psyche is not None else trait_source.get(trait)
+            if value is not None:
+                self._merge_trait(model, trait, value)
+        model["updated_at"] = _now()
+        self.store.write(model)
+        self._project(model, psyche)
+        return model
+
+    def _merge_trait(self, model: dict[str, Any], name: str, value: Any) -> None:
+        now = _now()
+        old = model["traits"].get(name, {})
+        model["traits"][name] = {"value": str(value), "source": "psyche",
+                                  "confidence": float(old.get("confidence", 1.0)),
+                                  "observed_at": old.get("observed_at", now), "last_confirmed_at": now}
+
+    def _project(self, model: dict[str, Any], psyche: Any | None) -> None:
+        """Update compatibility projections without giving them ownership."""
+        if psyche is not None:
+            psyche.identity_commitments = {"values": list(model["cardinal_values"]),
+                                           "red_lines": list(model["red_lines"])}
+            psyche.identity_wounds = max(
+                (float(w.get("severity", 0.0)) for w in model["identity_wounds"] if isinstance(w, Mapping)),
+                default=0.0,
+            )
+        narrative_path = self.mem / "self_narrative.json"
+        if narrative_path.exists():
+            from ..self_narrative import load, save
+            story = load(narrative_path)
+            story.identity.name = model["name"]
+            save(story, narrative_path)
+
+    def coherence_invariants(self) -> IdentityInvariants:
+        """Build the coherence guard input directly from the canonical core."""
+        model = self.store.read()
+        return IdentityInvariants(
+            life_name=model["name"], cardinal_values=tuple(model["cardinal_values"]),
+            long_term_commitments=tuple(model["commitments"]),
+        )
+
+
+# Less domain-specific alias for callers looking for an aggregation service.
+IdentityAggregationService = IdentityCoreService

--- a/src/singular/identity/self_model.py
+++ b/src/singular/identity/self_model.py
@@ -1,13 +1,20 @@
-"""Stable self-model storage preserving identity invariants."""
+"""Versioned, authoritative storage for the persistent identity core."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
+from uuid import uuid4
 
 from ..io_utils import atomic_write_text
+
+SCHEMA_VERSION = 2
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
 class IdentityInvariantError(ValueError):
@@ -15,73 +22,143 @@ class IdentityInvariantError(ValueError):
 
 
 class SelfModelStore:
-    """Persistent self-model for traits, preferences, and constraints."""
+    """Persistent identity core.
 
-    _REQUIRED_ROOT_KEYS = {"traits", "preferences", "constraints"}
+    Version 2 deliberately keeps autobiographical facts apart from personality
+    traits.  Evidence-bearing sections contain records rather than bare scores,
+    so their provenance survives restarts and consolidation.
+    """
+
+    _EVIDENCE_SECTIONS = ("autobiographical_facts", "traits", "preferences", "constraints")
+    _REQUIRED_ROOT_KEYS = set(_EVIDENCE_SECTIONS)
 
     def __init__(self, path: Path | str) -> None:
         self.path = Path(path)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         if not self.path.exists():
             self.write(self._default_model())
+        else:
+            # Reading is also the on-disk migration boundary.
+            model, migrated = self._read_and_migrate()
+            if migrated:
+                self.write(model)
 
     def _default_model(self) -> dict[str, Any]:
+        now = _now()
         return {
+            "schema_version": SCHEMA_VERSION,
+            "stable_id": str(uuid4()),
+            "name": "Singular",
+            "biographical_summary": "",
+            "founding_events": [],
+            "autobiographical_facts": {},
             "traits": {},
             "preferences": {},
+            "cardinal_values": [],
+            "commitments": [],
+            "red_lines": [],
+            "identity_wounds": [],
             "constraints": {},
-            "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "created_at": now,
+            "updated_at": now,
         }
 
-    def read(self) -> dict[str, Any]:
+    @staticmethod
+    def _record(value: str, raw: Any, now: str) -> dict[str, Any]:
+        if isinstance(raw, Mapping):
+            observed = str(raw.get("observed_at") or raw.get("observation_date") or now)
+            return {
+                "value": str(raw.get("value", value)),
+                "source": str(raw.get("source") or "legacy:self_model"),
+                "confidence": float(raw.get("confidence", 0.5) or 0.5),
+                "observed_at": observed,
+                "last_confirmed_at": str(raw.get("last_confirmed_at") or observed),
+            }
         try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
+            confidence = float(raw)
+        except (TypeError, ValueError):
+            confidence = 0.5
+        return {"value": value, "source": "legacy:self_model", "confidence": confidence,
+                "observed_at": now, "last_confirmed_at": now}
+
+    def _read_and_migrate(self) -> tuple[dict[str, Any], bool]:
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            payload = self._default_model()
-        if not isinstance(payload, dict):
-            payload = self._default_model()
-        for key in self._REQUIRED_ROOT_KEYS:
-            if not isinstance(payload.get(key), dict):
-                payload[key] = {}
-        payload.setdefault("updated_at", datetime.now(timezone.utc).isoformat(timespec="seconds"))
-        return payload
+            return self._default_model(), True
+        if not isinstance(raw, dict):
+            return self._default_model(), True
+        migrated = raw.get("schema_version") != SCHEMA_VERSION
+        defaults = self._default_model()
+        model = dict(raw)
+        for key, value in defaults.items():
+            if key not in model:
+                model[key] = value
+                migrated = True
+        now = str(model.get("updated_at") or _now())
+        for section in self._EVIDENCE_SECTIONS:
+            values = model.get(section)
+            if not isinstance(values, dict):
+                model[section] = {}
+                migrated = True
+                continue
+            normalized = {str(key): self._record(str(key), value, now) for key, value in values.items()}
+            if normalized != values:
+                model[section] = normalized
+                migrated = True
+        for section in ("founding_events", "cardinal_values", "commitments", "red_lines", "identity_wounds"):
+            if not isinstance(model.get(section), list):
+                model[section] = []
+                migrated = True
+        model["schema_version"] = SCHEMA_VERSION
+        return model, migrated
+
+    def read(self) -> dict[str, Any]:
+        model, migrated = self._read_and_migrate()
+        if migrated:
+            self.write(model)
+        return model
 
     def write(self, model: dict[str, Any]) -> None:
         missing = self._REQUIRED_ROOT_KEYS.difference(model)
         if missing:
             raise IdentityInvariantError(f"Missing invariant sections in self model: {sorted(missing)}")
+        model["schema_version"] = SCHEMA_VERSION
         atomic_write_text(self.path, json.dumps(model, ensure_ascii=False, indent=2) + "\n")
 
     def apply_facts(self, facts: list[dict[str, Any]]) -> dict[str, Any]:
+        """Merge extracted evidence without confusing biography and character."""
         model = self.read()
+        now = _now()
+        section_for_kind = {
+            "user_fact": "autobiographical_facts", "autobiographical_fact": "autobiographical_facts",
+            "trait": "traits", "preference": "preferences", "constraint": "constraints",
+        }
         for fact in facts:
-            kind = str(fact.get("kind", ""))
+            section = section_for_kind.get(str(fact.get("kind", "")))
             value = str(fact.get("value", "")).strip()
-            confidence = float(fact.get("confidence", 0.5) or 0.5)
-            if not value:
+            if not section or not value:
                 continue
-            if kind == "user_fact":
-                model["traits"][value] = confidence
-            elif kind == "preference":
-                model["preferences"][value] = confidence
-            elif kind == "constraint":
-                model["constraints"][value] = confidence
-        model["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            previous = model[section].get(value, {})
+            observed = str(fact.get("observed_at") or fact.get("observation_date") or now)
+            model[section][value] = {
+                "value": value,
+                "source": str(fact.get("source") or previous.get("source") or "unknown"),
+                "confidence": float(fact.get("confidence", previous.get("confidence", 0.5)) or 0.5),
+                "observed_at": str(previous.get("observed_at") or observed),
+                "last_confirmed_at": str(fact.get("last_confirmed_at") or observed),
+            }
+        model["updated_at"] = now
         self.write(model)
         return model
 
     def compact(self, keep_top_n_per_section: int = 50) -> dict[str, Any]:
-        """Compact model while keeping invariant root sections."""
-
+        """Compact evidence only; never discard the durable identity fields."""
         model = self.read()
         keep_n = max(1, keep_top_n_per_section)
-        for section in self._REQUIRED_ROOT_KEYS:
-            values = model.get(section, {})
-            if not isinstance(values, dict):
-                model[section] = {}
-                continue
-            top_items = sorted(values.items(), key=lambda item: float(item[1]), reverse=True)[:keep_n]
-            model[section] = dict(top_items)
-        model["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        for section in self._EVIDENCE_SECTIONS:
+            values = model[section]
+            model[section] = dict(sorted(values.items(), key=lambda item: float(item[1].get("confidence", 0.0)), reverse=True)[:keep_n])
+        model["updated_at"] = _now()
         self.write(model)
         return model

--- a/tests/test_identity_core.py
+++ b/tests/test_identity_core.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from singular.identity.core import IdentityCoreService
+from singular.identity.self_model import SCHEMA_VERSION, SelfModelStore
+from singular.psyche import Psyche
+
+
+def test_legacy_migration_separates_facts_and_preserves_evidence(tmp_path: Path) -> None:
+    path = tmp_path / "self_model.json"
+    path.write_text(json.dumps({"traits": {"patient": .8}, "preferences": {},
+                                "constraints": {}, "updated_at": "2020-01-01T00:00:00+00:00"}))
+    store = SelfModelStore(path)
+    migrated = store.apply_facts([{"kind": "user_fact", "value": "born in Paris",
+                                   "source": "conversation:42", "confidence": .9,
+                                   "observed_at": "2024-01-01T00:00:00+00:00"}])
+
+    assert migrated["schema_version"] == SCHEMA_VERSION
+    assert migrated["stable_id"]
+    assert "born in Paris" not in migrated["traits"]
+    fact = migrated["autobiographical_facts"]["born in Paris"]
+    assert (fact["source"], fact["confidence"], fact["observed_at"], fact["last_confirmed_at"]) == (
+        "conversation:42", .9, "2024-01-01T00:00:00+00:00", "2024-01-01T00:00:00+00:00")
+    assert SelfModelStore(path).read()["stable_id"] == migrated["stable_id"]
+
+
+def test_restart_and_consolidation_keep_durable_identity(tmp_path: Path) -> None:
+    mem = tmp_path / "life" / "mem"
+    mem.mkdir(parents=True)
+    (mem / "biography.json").write_text(json.dumps({
+        "identity": {"id": "stable-1", "name": "Ariane"},
+        "birth_certificate": {"event_type": "birth_certificate", "issued_at": "2024-01-01"},
+        "self_summaries": [{"text": "Née pour apprendre."}],
+    }))
+    psyche = Psyche(identity_commitments={"values": ["truth"], "red_lines": ["harm"]},
+                    identity_wounds=.7)
+    service = IdentityCoreService(tmp_path / "life")
+    first = service.synchronize(psyche)
+    first["commitments"] = ["keep promises"]
+    service.store.write(first)
+
+    # Several sessions and evidence compactions must not compact invariants.
+    for _ in range(3):
+        restarted = IdentityCoreService(tmp_path / "life")
+        restarted.store.compact(1)
+        current = restarted.synchronize(Psyche())
+
+    assert current["name"] == "Ariane"
+    assert current["biographical_summary"] == "Née pour apprendre."
+    assert current["commitments"] == ["keep promises"]
+    assert current["identity_wounds"] == [{"kind": "legacy_psyche_wound", "severity": .7}]
+    assert restarted.coherence_invariants().long_term_commitments == ("keep promises",)

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -94,7 +94,7 @@ def test_orchestrator_sleep_consolidates_identity_memory(
         (life / "mem" / "self_model.json").read_text(encoding="utf-8")
     )
     assert {fact["value"] for fact in semantic} == {"user_name:Alice", "likes:tea"}
-    assert "user_name:Alice" in self_model["traits"]
+    assert "user_name:Alice" in self_model["autobiographical_facts"]
     assert "likes:tea" in self_model["preferences"]
     event = next(
         item


### PR DESCRIPTION
### Motivation

- Centraliser l’identité durable dans un schéma versionné pour éviter que plusieurs composants conservent des vues divergentes de la personnalité et des faits de naissance.
- Préserver la provenance et les métadonnées d’observation pour chaque fait autobiographique afin de rendre les consolidations et migrations sans perte d’information.
- Synchroniser automatiquement ce noyau avec la psyché, le récit de soi et les artefacts de naissance pour garantir la cohérence longitudinale.

### Description

- Réécriture de `src/singular/identity/self_model.py` en un schéma versionné (SCHEMA_VERSION = 2) qui expose un noyau canonique contenant `stable_id`, `name`, `biographical_summary`, `founding_events`, `autobiographical_facts`, `traits`, `preferences`, `cardinal_values`, `commitments`, `red_lines`, `identity_wounds`, `created_at` et `updated_at`, et une migration automatique des anciens fichiers `self_model.json`.
- Séparation explicite des faits autobiographiques et des traits dans `SelfModelStore.apply_facts()`, chaque entrée gardant `source`, `confidence`, `observed_at` et `last_confirmed_at`.
- Nouveau service d’agrégation `src/singular/identity/core.py::IdentityCoreService` qui lit `biography.json`, `self_narrative.json` et `psyche.json`, fusionne les signaux pertinents dans le noyau canonique et projette les invariants vers la psyché et le récit sans leur donner la propriété des données.
- Modification de la pipeline de consolidation `src/singular/identity/consolidation.py` pour appeler `IdentityCoreService.synchronize()` après chaque consolidation afin d’aligner récit, psyché et artefacts de naissance sur le même noyau d’identité.
- Ajout/modification de tests dans `tests/test_identity_core.py` et ajustement d’un attendu dans `tests/test_orchestrator_service.py` pour valider la migration, la séparation faits/traits et la stabilité des champs durables après redémarrages et compactages.

### Testing

- `pytest -q tests/test_identity_core.py tests/test_orchestrator_service.py tests/test_identity_coherence.py` — tests exécutés et réussis (suite ciblée : all checks passed; final run: 22 passed, with warnings).
- Tests d’intégration de la consolidation validant que les faits extraits sont écrits dans `self_model.json` au bon emplacement (`autobiographical_facts` / `preferences`), et que les invariants d’identité (nom, biographie, engagements, blessures) survivent à plusieurs redémarrages et compactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a753eb4eb18832aa1b5500fea11485d)