### PR TITLE
Add persistent theory-of-mind models and use them in social & reproduction decisions

### DIFF
--- a/src/singular/life/reproduction.py
+++ b/src/singular/life/reproduction.py
@@ -124,6 +124,15 @@ def compute_reproduction_compatibility(
     trust = _clamp01(float(relation.get("trust", 0.5)))
     rivalry = _clamp01(float(relation.get("rivalry", 0.0)))
     social_score = _clamp01((0.5 * affinity) + (0.4 * trust) + (0.1 * (1.0 - rivalry)))
+    mental = graph.get_mental_state(parent_b)
+    mental_confidence = _clamp01(float(mental.get("confidence", 0.0)))
+    if int(mental.get("version", 0)):
+        # Sparse evidence makes irreversible choices conservative; stronger
+        # evidence progressively incorporates predicted reliability/reciprocity.
+        reliability = _clamp01(float(mental.get("reliability", 0.5)))
+        reciprocity = _clamp01((float(mental.get("reciprocity", 0.0)) + 1.0) / 2.0)
+        predicted = (0.7 * reliability) + (0.3 * reciprocity)
+        social_score = _clamp01((social_score * mental_confidence) + (predicted * mental_confidence)) / 2.0
     skills_score = _clamp01(_skills_complementarity(parent_a_skills, parent_b_skills))
     viability_score = _clamp01((float(parent_a_health) + float(parent_b_health)) / 2.0)
     governance_score = 1.0 if governance_allowed else 0.0
@@ -136,6 +145,7 @@ def compute_reproduction_compatibility(
     )
     components = {
         "social_affinity": round(social_score, 4),
+        "mental_state_confidence": round(mental_confidence, 4),
         "skills_complementarity": round(skills_score, 4),
         "viability": round(viability_score, 4),
         "governance": round(governance_score, 4),

--- a/src/singular/life/social_decision.py
+++ b/src/singular/life/social_decision.py
@@ -18,6 +18,7 @@ class SocialDecision:
     trust: float
     rivalry: float
     reason: str
+    mental_confidence: float = 0.0
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)
@@ -42,8 +43,19 @@ def decide_social_actions(
         affinity = _metric(relation, "affinity", 0.5)
         trust = _metric(relation, "trust", 0.5)
         rivalry = _metric(relation, "rivalry", 0.0)
+        mental = social_graph.get_mental_state(peer)
+        model_version = int(mental.get("version", 0))
+        mental_confidence = _metric(mental, "confidence", 0.0)
+        reliability = _metric(mental, "reliability", 0.5)
+        reciprocity = max(-1.0, min(1.0, float(mental.get("reciprocity", 0.0))))
 
-        if trust >= 0.7 and affinity >= 0.7 and rivalry < 0.65:
+        if model_version and mental_confidence < 0.25:
+            action = "neutral"
+            reason = "insufficient_mental_state_evidence"
+        elif model_version and mental_confidence >= 0.25 and (reliability < 0.35 or reciprocity < -0.4):
+            action = "avoid"
+            reason = "predicted_unreliable_or_nonreciprocal"
+        elif trust >= 0.7 and affinity >= 0.7 and rivalry < 0.65:
             action = "help"
             reason = "trust_and_affinity_high"
         elif rivalry >= 0.75 and trust < 0.4:
@@ -64,6 +76,7 @@ def decide_social_actions(
                 trust=trust,
                 rivalry=rivalry,
                 reason=reason,
+                mental_confidence=mental_confidence,
             )
         )
     return decisions

--- a/src/singular/social/graph.py
+++ b/src/singular/social/graph.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import json
 
 from singular.memory import _atomic_write_text, get_mem_dir
+from singular.social.theory_of_mind import TheoryOfMindStore
 
 _HISTORY_LIMIT = 20
 
@@ -39,6 +40,7 @@ class SocialGraph:
 
     def __init__(self, path: Path | None = None) -> None:
         self.path = path or (get_mem_dir() / "social_graph.json")
+        self.theory_of_mind = TheoryOfMindStore(self.path.with_name("theory_of_mind.json"))
         self._relations: dict[str, PairRelation] = {}
         self._load()
 
@@ -112,6 +114,43 @@ class SocialGraph:
         self._relations[pair_key] = relation
         self._save()
         return relation.to_dict()
+
+    def observe_mental_state(self, individual_id: str, event: str, **details: object) -> dict[str, object]:
+        """Update a peer hypothesis without changing the affective relation."""
+
+        return self.theory_of_mind.observe(individual_id, event, **details)  # type: ignore[arg-type]
+
+    def get_mental_state(self, individual_id: str) -> dict[str, object]:
+        return self.theory_of_mind.get(individual_id)
+
+    def record_interaction(
+        self,
+        observer: str,
+        individual_id: str,
+        event: str,
+        **details: object,
+    ) -> dict[str, object]:
+        """Record evidence from an interaction and, when applicable, its relation.
+
+        ``observer`` identifies whose point of view produced the hypothesis.  A
+        graph instance belongs to one life, so only the observed individual's
+        mental model is indexed; the affective pair remains independently
+        indexed by both participants.
+        """
+
+        mental = self.observe_mental_state(individual_id, event, **details)
+        relation_event = {
+            "cooperation": "successful_assistance",
+            "successful_cooperation": "successful_assistance",
+            "conflict": "resource_conflict",
+            "cooperation_failure": "cooperation_failure",
+        }.get(event.lower())
+        relation = (
+            self.update_relation(observer, individual_id, relation_event)
+            if relation_event is not None
+            else self.get_relation(observer, individual_id)
+        )
+        return {"mental_state": mental, "relation": relation}
 
 
 def _normalize_history(raw: object) -> list[dict[str, str]]:

--- a/src/singular/social/theory_of_mind.py
+++ b/src/singular/social/theory_of_mind.py
@@ -1,0 +1,187 @@
+"""Persisted, explicitly uncertain models of other individuals' mental states.
+
+The contents of this store are hypotheses derived from observations.  They are
+deliberately kept separate from :mod:`singular.social.graph`: liking somebody
+is not evidence that we know what they believe or intend to do.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import json
+import math
+from pathlib import Path
+from typing import Callable, Mapping
+
+from singular.memory import _atomic_write_text, get_mem_dir
+
+SCHEMA_VERSION = 1
+_EVIDENCE_LIMIT = 50
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass(slots=True)
+class MentalStateModel:
+    """A versioned hypothesis about one individual, never an asserted fact."""
+
+    individual_id: str
+    version: int = 0
+    supposed_goals: list[str] = field(default_factory=list)
+    intentions: dict[str, float] = field(default_factory=dict)
+    attributed_beliefs: dict[str, float] = field(default_factory=dict)
+    reliability: float = 0.5
+    confidence: float = 0.0
+    reciprocity: float = 0.0
+    evidence: list[dict[str, object]] = field(default_factory=list)
+    uncertainty: float = 1.0
+    updated_at: str = field(default_factory=lambda: _utcnow().isoformat())
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class TheoryOfMindStore:
+    """JSON-backed collection of independent, per-individual hypotheses."""
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        *,
+        clock: Callable[[], datetime] = _utcnow,
+        confidence_half_life_days: float = 30.0,
+    ) -> None:
+        self.path = path or (get_mem_dir() / "theory_of_mind.json")
+        self.clock = clock
+        self.confidence_half_life_days = max(0.001, confidence_half_life_days)
+        self._models: dict[str, MentalStateModel] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        models = raw.get("models", {}) if isinstance(raw, dict) else {}
+        if not isinstance(models, dict):
+            return
+        for individual, value in models.items():
+            if not isinstance(individual, str) or not isinstance(value, dict):
+                continue
+            try:
+                self._models[individual] = MentalStateModel(
+                    individual_id=individual,
+                    version=max(0, int(value.get("version", 0))),
+                    supposed_goals=_strings(value.get("supposed_goals")),
+                    intentions=_scores(value.get("intentions")),
+                    attributed_beliefs=_scores(value.get("attributed_beliefs")),
+                    reliability=_clamp(value.get("reliability", 0.5)),
+                    confidence=_clamp(value.get("confidence", 0.0)),
+                    reciprocity=max(-1.0, min(1.0, float(value.get("reciprocity", 0.0)))),
+                    evidence=_evidence(value.get("evidence")),
+                    uncertainty=_clamp(value.get("uncertainty", 1.0)),
+                    updated_at=str(value.get("updated_at", self.clock().isoformat())),
+                )
+            except (TypeError, ValueError):
+                continue
+
+    def _save(self) -> None:
+        _atomic_write_text(self.path, json.dumps({
+            "schema_version": SCHEMA_VERSION,
+            "models": {key: model.to_dict() for key, model in sorted(self._models.items())},
+        }, ensure_ascii=False, indent=2))
+
+    def get(self, individual_id: str, *, decayed: bool = True) -> dict[str, object]:
+        model = self._models.get(str(individual_id), MentalStateModel(str(individual_id)))
+        result = model.to_dict()
+        if decayed and model.version:
+            try:
+                then = datetime.fromisoformat(model.updated_at)
+                if then.tzinfo is None:
+                    then = then.replace(tzinfo=timezone.utc)
+                age_days = max(0.0, (self.clock() - then).total_seconds() / 86400.0)
+                factor = math.pow(0.5, age_days / self.confidence_half_life_days)
+                result["confidence"] = _clamp(model.confidence * factor)
+                result["uncertainty"] = _clamp(1.0 - (1.0 - model.uncertainty) * factor)
+            except (TypeError, ValueError):
+                result["confidence"], result["uncertainty"] = 0.0, 1.0
+        return result
+
+    def observe(
+        self,
+        individual_id: str,
+        event: str,
+        *,
+        intention: str | None = None,
+        goal: str | None = None,
+        belief: str | None = None,
+        outcome: bool | None = None,
+        note: str | None = None,
+    ) -> dict[str, object]:
+        """Revise a hypothesis from a conversation, act, promise, or outcome."""
+
+        key = str(individual_id)
+        model = self._models.get(key, MentalStateModel(key))
+        event_key = str(event).lower()
+        positive = event_key in {"conversation", "cooperation", "successful_cooperation", "promise_kept", "positive_outcome"}
+        negative = event_key in {"conflict", "cooperation_failure", "promise_broken", "negative_outcome"}
+        if outcome is not None:
+            positive, negative = outcome, not outcome
+
+        if goal and goal not in model.supposed_goals:
+            model.supposed_goals.append(goal)
+        if intention:
+            previous = model.intentions.get(intention, 0.5)
+            model.intentions[intention] = _clamp(previous + (0.25 if positive else -0.4 if negative else 0.08))
+        if belief:
+            previous = model.attributed_beliefs.get(belief, 0.5)
+            model.attributed_beliefs[belief] = _clamp(previous + (0.15 if not negative else -0.25))
+        if positive:
+            model.reliability = _clamp(model.reliability + 0.1)
+            model.reciprocity = min(1.0, model.reciprocity + 0.15)
+        elif negative:
+            model.reliability = _clamp(model.reliability - 0.18)
+            model.reciprocity = max(-1.0, model.reciprocity - 0.2)
+        evidence_strength = 0.14 if outcome is not None or "promise" in event_key else 0.08
+        model.confidence = _clamp(model.confidence + evidence_strength)
+        model.uncertainty = _clamp(1.0 - model.confidence)
+        model.version += 1
+        model.updated_at = self.clock().isoformat()
+        item: dict[str, object] = {"event": event, "at": model.updated_at}
+        for name, value in (("intention", intention), ("goal", goal), ("belief", belief), ("outcome", outcome), ("note", note)):
+            if value is not None:
+                item[name] = value
+        model.evidence = (model.evidence + [item])[-_EVIDENCE_LIMIT:]
+        self._models[key] = model
+        self._save()
+        return self.get(key)
+
+
+def _strings(value: object) -> list[str]:
+    return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
+
+
+def _scores(value: object) -> dict[str, float]:
+    if not isinstance(value, Mapping):
+        return {}
+    result: dict[str, float] = {}
+    for key, score in value.items():
+        if isinstance(key, str):
+            try:
+                result[key] = _clamp(float(score))
+            except (TypeError, ValueError):
+                pass
+    return result
+
+
+def _evidence(value: object) -> list[dict[str, object]]:
+    return [dict(item) for item in value if isinstance(item, dict)][-_EVIDENCE_LIMIT:] if isinstance(value, list) else []

--- a/tests/test_theory_of_mind.py
+++ b/tests/test_theory_of_mind.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from singular.life.social_decision import decide_social_actions
+from singular.social.graph import SocialGraph
+from singular.social.theory_of_mind import TheoryOfMindStore
+
+
+def test_model_persists_after_restart(tmp_path: Path) -> None:
+    path = tmp_path / "theory_of_mind.json"
+    store = TheoryOfMindStore(path)
+    first = store.observe("bob", "promise", intention="share", goal="cooperate")
+
+    restarted = TheoryOfMindStore(path).get("bob")
+
+    assert restarted["version"] == first["version"] == 1
+    assert restarted["intentions"] == {"share": 0.58}
+    assert restarted["supposed_goals"] == ["cooperate"]
+    assert restarted["evidence"][0]["event"] == "promise"
+
+
+def test_observed_result_revises_a_contradicted_intention(tmp_path: Path) -> None:
+    store = TheoryOfMindStore(tmp_path / "theory_of_mind.json")
+    promised = store.observe("bob", "promise", intention="share")
+    contradicted = store.observe(
+        "bob", "promise_broken", intention="share", outcome=False
+    )
+
+    assert contradicted["version"] == 2
+    assert contradicted["intentions"]["share"] < promised["intentions"]["share"]
+    assert contradicted["reliability"] < promised["reliability"]
+
+
+def test_models_for_two_individuals_do_not_leak(tmp_path: Path) -> None:
+    store = TheoryOfMindStore(tmp_path / "theory_of_mind.json")
+    store.observe("alice", "cooperation", intention="help", outcome=True)
+    store.observe("bob", "conflict", intention="compete", outcome=False)
+
+    assert "help" in store.get("alice")["intentions"]
+    assert "help" not in store.get("bob")["intentions"]
+    assert store.get("alice")["reliability"] > store.get("bob")["reliability"]
+
+
+def test_mental_model_has_measurable_effect_on_social_decision(tmp_path: Path) -> None:
+    graph = SocialGraph(tmp_path / "social_graph.json")
+    for _ in range(3):
+        graph.update_relation("me", "bob", "successful_assistance")
+    assert decide_social_actions("me", ["bob"], graph)[0].action == "help"
+
+    for _ in range(3):
+        graph.observe_mental_state(
+            "bob", "promise_broken", intention="cooperate", outcome=False
+        )
+    decision = decide_social_actions("me", ["bob"], graph)[0]
+    assert decision.action == "avoid"
+    assert decision.reason == "predicted_unreliable_or_nonreciprocal"
+
+
+def test_confidence_decays_and_sparse_evidence_is_cautious(tmp_path: Path) -> None:
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    store = TheoryOfMindStore(tmp_path / "theory_of_mind.json", clock=lambda: now)
+    observed = store.observe("bob", "conversation", intention="help")
+    later = TheoryOfMindStore(
+        tmp_path / "theory_of_mind.json",
+        clock=lambda: now + timedelta(days=30),
+    ).get("bob")
+
+    assert later["confidence"] == observed["confidence"] / 2
+    graph = SocialGraph(tmp_path / "graph.json")
+    graph.observe_mental_state("bob", "conversation", intention="help")
+    decision = decide_social_actions("me", ["bob"], graph)[0]
+    assert decision.reason == "insufficient_mental_state_evidence"


### PR DESCRIPTION
### Motivation

- Introduce an explicit, versioned store for hypotheses about other individuals' mental states that is kept separate from affective relations to avoid conflating liking with beliefs or intentions. 
- Allow the system to revise those hypotheses from conversations, cooperations, conflicts, promises and observed outcomes so decisions can reflect updated evidence. 
- Use temporally decayed confidence and conservative decision rules so irreversible choices (helping, reproduction) are cautious when evidence is sparse.

### Description

- Add `src/singular/social/theory_of_mind.py` implementing `MentalStateModel` and `TheoryOfMindStore` with fields for supposed goals, intentions, attributed beliefs, reliability, confidence, reciprocity, evidence, uncertainty, versioning and timestamped updates, and a configurable confidence half-life.
- Extend `src/singular/social/graph.py` to hold a `TheoryOfMindStore` and expose `observe_mental_state`, `get_mental_state`, and `record_interaction` to record mental-state evidence without conflating it with pairwise affective relations.
- Update social decision logic in `src/singular/life/social_decision.py` to consult the mental model and add cautious rules: return `neutral` when model exists but confidence is low, `avoid` when predicted reliability/reciprocity is poor, and expose `mental_confidence` on `SocialDecision` for auditing.
- Incorporate mental-state predictions into reproduction compatibility in `src/singular/life/reproduction.py` by factoring in mental `confidence`/`reliability` when available and adding `mental_state_confidence` to the returned compatibility `components`.
- Add tests in `tests/test_theory_of_mind.py` covering persistence across restarts, revision when an intention is contradicted by outcomes, separate models for two individuals, measurable impact of the mental model on social decisions, and confidence decay behavior.

### Testing

- Ran `python -m pytest tests/test_theory_of_mind.py tests/test_social_graph.py -q` which passed (11 tests).
- Ran static checks with `ruff` on the new and modified modules (`src/singular/social/theory_of_mind.py`, `src/singular/social/graph.py`, `src/singular/life/social_decision.py`, `src/singular/life/reproduction.py`, `tests/test_theory_of_mind.py`) with no reported issues.
- A broader run including existing reproduction tests earlier surfaced a pre-existing unrelated failure in a generated-skill signature check (`test_realistic_reproduction_keeps_inheritance_and_files_scoped`), which is not caused by the theory-of-mind changes but was noted during testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7540703328832aba112d9349e10cbd)