### PR TITLE
Ajouter une passerelle décisionnelle morale structurée

### DIFF
--- a/src/singular/agents/agent.py
+++ b/src/singular/agents/agent.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional
 from singular.cognition.reflect import ActionHypothesis, reflect_action
 from singular.memory import add_episode
 from singular.morals.moral_rules import score_action
+from singular.morals import MoralAction, MoralDecisionEngine
 
 from singular.models.agents.motivation import Motivation
 
@@ -62,10 +63,24 @@ class Agent:
 
         context = context or {}
         action_costs = context.get("action_costs", {})
+        moral_engine = MoralDecisionEngine(journal=add_episode)
+        moral_decisions = {
+            act: moral_engine.evaluate(
+                MoralAction(act, context.get("action_parameters", {}).get(act, {})),
+                context.get("consequences", {}).get(act, ()),
+                context.get("affected_parties", ()),
+                context.get("identity_commitments", ()),
+                context.get("uncertainty", {}).get(act, 0.0)
+                if isinstance(context.get("uncertainty", 0.0), dict)
+                else context.get("uncertainty", 0.0),
+            )
+            for act in actions
+        }
         allowed_actions = {
             act: val
             for act, val in actions.items()
             if score_action(act, context) >= -self.moral_tolerance
+            and not moral_decisions[act].veto
         }
 
         if not allowed_actions:
@@ -75,7 +90,7 @@ class Agent:
         hypotheses = [
             ActionHypothesis(
                 action=action,
-                long_term=value / max_value,
+                long_term=(value / max_value) + moral_decisions[action].scores["overall"],
                 sandbox_risk=max(0.0, -score_action(action, context)),
                 resource_cost=float(action_costs.get(action, 0.0)),
                 metadata={"raw_value": value},

--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -9,6 +9,8 @@ from typing import Any, Callable, Protocol
 
 from security.policy_engine import ActionPolicyEngine
 from uuid import uuid4
+from singular.memory import add_episode
+from singular.morals import MoralAction, MoralDecisionEngine
 
 DEFAULT_SCHEMA_VERSION = "1.0"
 
@@ -165,6 +167,7 @@ class AgentRuntime:
         schema_version: str = DEFAULT_SCHEMA_VERSION,
         safety: RuntimeSafetyConfig | None = None,
         stop_signal: Callable[[], bool] | None = None,
+        moral_engine: MoralDecisionEngine | None = None,
     ) -> None:
         self.perception = perception
         self.mind = mind
@@ -172,6 +175,7 @@ class AgentRuntime:
         self.schema_version = schema_version
         self.event_bus = event_bus or RuntimeEventBus(schema_version=schema_version)
         self.policy_engine = policy_engine or ActionPolicyEngine()
+        self.moral_engine = moral_engine or MoralDecisionEngine(journal=add_episode)
         self.safety = safety or RuntimeSafetyConfig()
         self._stop_signal = stop_signal
         self._global_stop_requested = False
@@ -232,6 +236,29 @@ class AgentRuntime:
                 continue
             self._ensure_schema_version(request.schema_version)
             self.event_bus.publish("action.requested", request)
+
+            moral_context = request.parameters.get("moral_context", {})
+            if not isinstance(moral_context, dict):
+                moral_context = {}
+            moral_decision = self.moral_engine.evaluate(
+                MoralAction(request.action_type, request.parameters, intent.rationale),
+                moral_context.get("consequences", ()),
+                moral_context.get("affected_parties", ()),
+                moral_context.get("identity_commitments", ()),
+                moral_context.get("uncertainty", 0.0),
+            )
+            self.event_bus.publish("action.moral.decision", moral_decision)
+            if moral_decision.veto:
+                result = ActionResult(
+                    action_type=request.action_type,
+                    success=False,
+                    message="blocked by moral veto",
+                    error=moral_decision.veto_reason,
+                    audit={"moral": moral_decision.to_dict()},
+                )
+                self.event_bus.publish("action.moral.vetoed", result)
+                results.append(result)
+                continue
 
             if self._stop_requested():
                 self.event_bus.publish(
@@ -375,6 +402,7 @@ class AgentRuntime:
             self._ensure_schema_version(result.schema_version)
             self._register_action(request.action_type)
             enriched_audit = dict(result.audit)
+            enriched_audit["moral"] = moral_decision.to_dict()
             enriched_audit["policy"] = {
                 "allowed": decision.allowed,
                 "blocked": decision.blocked,

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -68,6 +68,7 @@ from singular.governance.policy import (
     classify_sandbox_error_type,
 )
 from singular.governance.values import load_value_weights
+from singular.morals import MoralAction, MoralDecision, MoralDecisionEngine
 
 from .checkpointing import Checkpoint, load_checkpoint, save_checkpoint
 from .sandbox_scoring import SandboxScore, score_code_with_error, score_code, _sandbox_failure_category
@@ -88,6 +89,28 @@ from .profiling import LifeLoopProfiler
 # mypy: ignore-errors
 
 log = logging.getLogger(__name__)
+
+
+def _deliberate_life_action(
+    action_type: str,
+    *,
+    consequences: Iterable[Mapping[str, object]] = (),
+    uncertainty: float = 0.0,
+    organism: str = "self",
+) -> MoralDecision:
+    """Run and journal the moral gate independently of technical safety gates."""
+
+    decision = MoralDecisionEngine(journal=add_episode).evaluate(
+        MoralAction(action_type),
+        consequences,
+        ({"identifier": organism, "vulnerability": 0.0},),
+        (
+            {"value": "non_maleficence", "weight": 1.0},
+            {"value": "identity_coherence", "weight": 0.8},
+        ),
+        uncertainty,
+    )
+    return decision
 
 _DEFAULT_RUN_LOGGER = RunLogger
 
@@ -1379,6 +1402,33 @@ def run(
                 )
             # Graine constrains the operator family. Singular still materializes
             # the concrete source mutation, then sends it to sandbox/governance.
+            mutation_moral_decision = _deliberate_life_action(
+                f"mutation:{op_name}",
+                consequences=(
+                    {
+                        "description": "risque de régression du comportement",
+                        "affected_party": org_name,
+                        "harm": baseline_failure_risk,
+                        "probability": baseline_failure_risk,
+                        "values": ("identity_coherence",),
+                    },
+                ),
+                uncertainty=baseline_failure_risk,
+                organism=org_name,
+            )
+            logger.log_interaction(
+                "moral.deliberation",
+                **mutation_moral_decision.to_dict(),
+                alive=True,
+            )
+            if mutation_moral_decision.veto:
+                logger.log_interaction(
+                    "mutation.moral_veto",
+                    operator=op_name,
+                    reason=mutation_moral_decision.veto_reason,
+                    alive=True,
+                )
+                continue
             with tick_profiler.phase("mutation"):
                 mutated = apply_mutation(original, eligible_operators[op_name], rng)
             org = world.organisms[org_name]
@@ -1922,6 +1972,32 @@ def run(
                     for name, score in sorted(psyche_decision.scores.items())
                 },
             )
+            action_moral_decision = _deliberate_life_action(
+                action_name,
+                consequences=(
+                    {
+                        "description": "exposition au risque du monde",
+                        "affected_party": org_name,
+                        "harm": persistent_world_state.risks,
+                        "probability": persistent_world_state.risks,
+                        "values": ("non_maleficence",),
+                    },
+                ),
+                uncertainty=persistent_world_state.risks,
+                organism=org_name,
+            )
+            logger.log_interaction(
+                "moral.deliberation", **action_moral_decision.to_dict(), alive=True
+            )
+            if action_moral_decision.veto:
+                action_name = "rest"
+                logger.log_interaction(
+                    "action.moral_alternative",
+                    rejected_action=psyche_decision.action,
+                    selected_action=action_name,
+                    conditions=action_moral_decision.acceptable_alternative_conditions,
+                    alive=True,
+                )
             effect_result = perform_action(
                 action_name,
                 {

--- a/src/singular/morals/__init__.py
+++ b/src/singular/morals/__init__.py
@@ -1,1 +1,16 @@
 """Moral evaluation utilities."""
+
+from .decision import (
+    AffectedParty,
+    Consequence,
+    IdentityCommitment,
+    MoralAction,
+    MoralDecision,
+    MoralDecisionEngine,
+    evaluate_action,
+)
+
+__all__ = [
+    "AffectedParty", "Consequence", "IdentityCommitment", "MoralAction",
+    "MoralDecision", "MoralDecisionEngine", "evaluate_action",
+]

--- a/src/singular/morals/decision.py
+++ b/src/singular/morals/decision.py
@@ -1,0 +1,218 @@
+"""Structured, explainable moral deliberation for proposed actions."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+
+def _unit(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass(frozen=True)
+class MoralAction:
+    """An action proposal, independent from its eventual execution mechanism."""
+
+    action_type: str
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+    purpose: str = ""
+
+
+@dataclass(frozen=True)
+class Consequence:
+    """A predicted positive or negative effect (magnitudes are in ``[0, 1]``)."""
+
+    description: str
+    affected_party: str = "self"
+    harm: float = 0.0
+    benefit: float = 0.0
+    probability: float = 1.0
+    values: tuple[str, ...] = ()
+    irreversible: bool = False
+    violates_rights: bool = False
+
+
+@dataclass(frozen=True)
+class AffectedParty:
+    identifier: str
+    vulnerability: float = 0.0
+    consent: bool | None = None
+
+
+@dataclass(frozen=True)
+class IdentityCommitment:
+    value: str
+    weight: float = 1.0
+    absolute: bool = False
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class MoralDecision:
+    """Serializable result of a moral deliberation."""
+
+    action: MoralAction
+    scores: Mapping[str, float]
+    conflicting_values: tuple[str, ...]
+    anticipated_harms: tuple[Mapping[str, Any], ...]
+    veto: bool
+    veto_reason: str | None
+    explanation: str
+    acceptable_alternative_conditions: tuple[str, ...]
+    uncertainty: float
+
+    @property
+    def acceptable(self) -> bool:
+        return not self.veto
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class MoralDecisionEngine:
+    """Precautionary multi-value evaluator; safety policy remains a separate gate."""
+
+    def __init__(
+        self,
+        *,
+        catastrophic_harm_threshold: float = 0.85,
+        journal: Callable[[dict[str, Any]], Any] | None = None,
+    ) -> None:
+        self.catastrophic_harm_threshold = _unit(catastrophic_harm_threshold)
+        self.journal = journal
+
+    def evaluate(
+        self,
+        action: MoralAction | Mapping[str, Any] | str,
+        consequences: Iterable[Consequence | Mapping[str, Any]] = (),
+        affected_parties: Iterable[AffectedParty | Mapping[str, Any]] = (),
+        identity_commitments: Iterable[IdentityCommitment | Mapping[str, Any]] = (),
+        uncertainty: float = 0.0,
+    ) -> MoralDecision:
+        action = _coerce_action(action)
+        consequences = tuple(_coerce(Consequence, item) for item in consequences)
+        parties = tuple(_coerce(AffectedParty, item) for item in affected_parties)
+        commitments = tuple(_coerce(IdentityCommitment, item) for item in identity_commitments)
+        uncertainty = _unit(uncertainty)
+        party_by_id = {party.identifier: party for party in parties}
+
+        harms: list[dict[str, Any]] = []
+        harm_total = benefit_total = rights_risk = 0.0
+        supported: set[str] = set()
+        threatened: set[str] = set()
+        veto_reasons: list[str] = []
+        for effect in consequences:
+            party = party_by_id.get(effect.affected_party)
+            vulnerability = _unit(party.vulnerability) if party else 0.0
+            exposure = _unit(effect.probability) * (1.0 + 0.5 * vulnerability)
+            expected_harm = _unit(effect.harm) * exposure
+            expected_benefit = _unit(effect.benefit) * exposure
+            harm_total += expected_harm
+            benefit_total += expected_benefit
+            if expected_harm:
+                threatened.update(effect.values)
+                harms.append({
+                    "description": effect.description,
+                    "affected_party": effect.affected_party,
+                    "expected_harm": round(expected_harm, 6),
+                    "irreversible": effect.irreversible,
+                    "violates_rights": effect.violates_rights,
+                })
+            if expected_benefit:
+                supported.update(effect.values)
+            if effect.violates_rights:
+                rights_risk += exposure
+                veto_reasons.append(f"violation des droits: {effect.description}")
+            if effect.irreversible and _unit(effect.harm) >= self.catastrophic_harm_threshold:
+                veto_reasons.append(f"préjudice grave et irréversible: {effect.description}")
+
+        for commitment in commitments:
+            if commitment.absolute and commitment.value in threatened:
+                veto_reasons.append(f"engagement identitaire absolu menacé: {commitment.value}")
+
+        conflicts = tuple(sorted(supported & threatened))
+        # Uncertainty is a precautionary cost rather than invented evidence of harm.
+        precaution = uncertainty * (0.25 + min(1.0, harm_total) * 0.75)
+        scores = {
+            "beneficence": round(min(1.0, benefit_total), 6),
+            "non_maleficence": round(max(0.0, 1.0 - min(1.0, harm_total)), 6),
+            "rights_and_consent": round(max(0.0, 1.0 - min(1.0, rights_risk)), 6),
+            "identity_coherence": round(_identity_score(commitments, supported, threatened), 6),
+            "certainty": round(1.0 - uncertainty, 6),
+            "overall": round(max(-1.0, min(1.0, benefit_total - harm_total - precaution)), 6),
+        }
+        veto = bool(veto_reasons)
+        conditions = _alternative_conditions(harms, uncertainty, conflicts)
+        explanation = _explain(action, scores, conflicts, harms, veto_reasons, uncertainty)
+        decision = MoralDecision(
+            action=action,
+            scores=scores,
+            conflicting_values=conflicts,
+            anticipated_harms=tuple(harms),
+            veto=veto,
+            veto_reason="; ".join(veto_reasons) or None,
+            explanation=explanation,
+            acceptable_alternative_conditions=conditions,
+            uncertainty=uncertainty,
+        )
+        if self.journal is not None:
+            self.journal({"event": "moral.deliberation", **decision.to_dict()})
+        return decision
+
+    def select_least_harmful(
+        self,
+        proposals: Sequence[Mapping[str, Any]],
+    ) -> tuple[MoralDecision | None, tuple[MoralDecision, ...]]:
+        """Evaluate candidates and choose the permitted one with the best overall score."""
+
+        decisions = tuple(self.evaluate(**proposal) for proposal in proposals)
+        permitted = [decision for decision in decisions if not decision.veto]
+        selected = max(permitted, key=lambda item: item.scores["overall"], default=None)
+        return selected, decisions
+
+
+def _coerce_action(value: MoralAction | Mapping[str, Any] | str) -> MoralAction:
+    if isinstance(value, MoralAction):
+        return value
+    if isinstance(value, str):
+        return MoralAction(value)
+    data = dict(value)
+    if "name" in data and "action_type" not in data:
+        data["action_type"] = data.pop("name")
+    return MoralAction(**data)
+
+
+def _coerce(cls: type, value: Any) -> Any:
+    return value if isinstance(value, cls) else cls(**dict(value))
+
+
+def _identity_score(commitments: tuple[IdentityCommitment, ...], supported: set[str], threatened: set[str]) -> float:
+    if not commitments:
+        return 1.0
+    total = sum(max(0.0, item.weight) for item in commitments) or 1.0
+    score = sum(max(0.0, item.weight) * (1 if item.value in supported else -1 if item.value in threatened else 0) for item in commitments)
+    return max(0.0, min(1.0, 0.5 + score / (2 * total)))
+
+
+def _alternative_conditions(harms: list[dict[str, Any]], uncertainty: float, conflicts: tuple[str, ...]) -> tuple[str, ...]:
+    conditions = [f"réduire ou obtenir le consentement de {item['affected_party']}" for item in harms]
+    if uncertainty >= 0.6:
+        conditions.append("obtenir des informations supplémentaires ou rendre l'action réversible")
+    if conflicts:
+        conditions.append("préserver explicitement les valeurs en conflit: " + ", ".join(conflicts))
+    return tuple(dict.fromkeys(conditions))
+
+
+def _explain(action: MoralAction, scores: Mapping[str, float], conflicts: tuple[str, ...], harms: list[dict[str, Any]], veto: list[str], uncertainty: float) -> str:
+    outcome = "veto" if veto else "acceptable sous réserve"
+    details = f"{len(harms)} préjudice(s) anticipé(s), incertitude {uncertainty:.2f}"
+    conflict_text = f", conflit: {', '.join(conflicts)}" if conflicts else ""
+    reason = f" ({'; '.join(veto)})" if veto else ""
+    return f"Action {action.action_type}: {outcome}; {details}{conflict_text}; score global {scores['overall']:.2f}{reason}."
+
+
+def evaluate_action(**kwargs: Any) -> MoralDecision:
+    """Convenience functional API."""
+
+    return MoralDecisionEngine().evaluate(**kwargs)

--- a/tests/test_moral_decision.py
+++ b/tests/test_moral_decision.py
@@ -1,0 +1,50 @@
+from singular.morals import MoralDecisionEngine
+
+
+def test_absolute_veto_for_rights_violation() -> None:
+    decision = MoralDecisionEngine().evaluate(
+        "publish_private_data",
+        [{"description": "privacy breach", "harm": 0.7, "violates_rights": True, "values": ("privacy",)}],
+        [{"identifier": "user", "vulnerability": 0.5}],
+        [{"value": "privacy", "absolute": True}],
+        0.1,
+    )
+
+    assert decision.veto is True
+    assert "droits" in (decision.veto_reason or "")
+
+
+def test_conflict_between_two_values_is_made_explicit() -> None:
+    decision = MoralDecisionEngine().evaluate(
+        "tell_difficult_truth",
+        [
+            {"description": "supports autonomy", "benefit": 0.8, "values": ("autonomy",)},
+            {"description": "causes distress", "harm": 0.3, "values": ("autonomy",)},
+        ],
+        identity_commitments=[{"value": "autonomy"}],
+    )
+
+    assert decision.conflicting_values == ("autonomy",)
+    assert decision.veto is False
+
+
+def test_high_uncertainty_reduces_score_and_requires_more_information() -> None:
+    engine = MoralDecisionEngine()
+    low = engine.evaluate("act", uncertainty=0.1)
+    high = engine.evaluate("act", uncertainty=0.9)
+
+    assert high.scores["overall"] < low.scores["overall"]
+    assert any("informations" in item for item in high.acceptable_alternative_conditions)
+
+
+def test_selects_less_harmful_acceptable_alternative() -> None:
+    selected, considered = MoralDecisionEngine().select_least_harmful(
+        [
+            {"action": "force", "consequences": [{"description": "injury", "harm": 0.8}]},
+            {"action": "negotiate", "consequences": [{"description": "delay", "harm": 0.1, "benefit": 0.3}]},
+        ]
+    )
+
+    assert len(considered) == 2
+    assert selected is not None
+    assert selected.action.action_type == "negotiate"


### PR DESCRIPTION
### Motivation
- Introduire une couche de délibération morale qui évalue une action proposée avec ses conséquences prévues, les parties affectées, les engagements identitaires et le degré d’incertitude avant exécution. 
- Conserver les contrôles de sécurité/policy existants comme barrière séparée et cumulative tout en journalisant les dilemmes moraux dans la mémoire épisodique pour la narration et la cohérence identitaire.

### Description
- Ajout d’un moteur de décision morale `MoralDecisionEngine` et des types structurés (`MoralAction`, `Consequence`, `AffectedParty`, `IdentityCommitment`, `MoralDecision`) dans `src/singular/morals/decision.py` et export public via `src/singular/morals/__init__.py`.
- Intégration dans le choix d’action de l’agent (`src/singular/agents/agent.py`) : évaluation morale par action, veto absolu empêche l’inclusion; le score moral influence la valeur long-term utilisée par la réflexion.
- Branchement dans le runtime central (`src/singular/core/agent_runtime.py`) : évaluation morale juste après `action.requested`, publication d’événements `action.moral.decision` et `action.moral.vetoed`, et audit moral injecté dans `ActionResult.audit` lorsque pertinent.
- Insertion de la porte morale dans la boucle de vie (`src/singular/life/loop.py`) avant application de mutations et avant exécution d’actions d’effecteur ; les décisions morales sont journalisées via `add_episode` et `logger.log_interaction`, et une action mise en veto est remplacée par une alternative moins nuisible (`rest`) avec conditions enregistrées.
- Ajout de tests couvrant : veto absolu pour violation de droits, explicitement exposer les conflits entre valeurs, effet d’une incertitude élevée sur le score et sélection d’une alternative moins nuisible (`tests/test_moral_decision.py`).

### Testing
- Exécution ciblée des tests modifiés/relatifs : `python -m pytest -q tests/test_moral_decision.py tests/test_agent_motivation.py tests/test_agent_action_noise.py tests/test_core_agent_runtime.py` — tous verts (`17 passed`).
- Vérification de la compilation des modules modifiés : `python -m compileall -q src/singular/morals src/singular/agents/agent.py src/singular/core/agent_runtime.py src/singular/life/loop.py` — OK.
- Vérification d’intégrité git : `git diff --check` — aucune erreur.
- Note: lors d’un précédent run ciblant la boucle de vie plus large (`tests/test_loop.py` / `tests/test_life_loop_targeted.py`) une exécution a échoué sur une erreur préexistante non liée aux changements introduits (AttributeError: module 'singular.life.loop' has no attribute 'CHECKPOINT_VERSION'); ceci semble être un problème de compatibilité/état antérieur et n’est pas causé par la logique morale ajoutée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7541ee70a8832ab5b6d514ed073540)