### PR TITLE
Ajout : service systemd, Docker/Compose, vérification des manifests et test d’intégration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: ruff check .
       - name: Black
         run: black --check --target-version py310 --fast .
+      - name: Deployment manifests
+        run: python scripts/check_deployment_manifests.py
 
   typecheck:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    SINGULAR_ROOT=/var/lib/singular
+
+RUN groupadd --system singular && useradd --system --gid singular --home /var/lib/singular singular
+WORKDIR /opt/singular
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+COPY configs /etc/singular
+RUN python -m pip install . && \
+    install -d -o singular -g singular /var/lib/singular /var/lib/singular/mem \
+      /var/lib/singular/runs /var/lib/singular/lives /etc/singular
+
+USER singular:singular
+VOLUME ["/var/lib/singular/mem", "/var/lib/singular/runs", "/var/lib/singular/lives", "/etc/singular"]
+STOPSIGNAL SIGTERM
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["python", "-c", "from pathlib import Path; import sys; c=Path('/proc/1/cmdline').read_bytes(); sys.exit(0 if b'singular' in c and b'orchestrate' in c else 1)"]
+CMD ["singular", "orchestrate", "run", "--lifecycle-config", "/etc/singular/lifecycle.yaml"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,89 @@ singular dashboard
 - [Tutorial EN — create a life, add a skill, run a tick and read logs](docs/tutorial_create_life.en.md)
 - [Guide de personnalisation de la gouvernance `policy.yaml`](docs/policy_customization.md)
 
+## 🚀 Exécution permanente (systemd ou Docker)
+
+Les deux déploiements utilisent un répertoire d'état durable et transmettent
+`SIGTERM` à l'orchestrateur afin qu'il puisse terminer proprement. Avant le
+premier démarrage, créez et sélectionnez une vie dans le même root, par exemple
+`sudo -u singular SINGULAR_ROOT=/var/lib/singular singular lives create --name Lumen`.
+
+### Service systemd
+
+Le modèle [`deploy/systemd/singular.service`](deploy/systemd/singular.service)
+suppose que le dépôt et son environnement virtuel sont installés sous
+`/opt/singular`, et utilise le compte non privilégié `singular` :
+
+```bash
+sudo useradd --system --home /var/lib/singular --create-home singular
+sudo git clone <URL_DU_DEPOT> /opt/singular
+sudo python3 -m venv /opt/singular/.venv
+sudo /opt/singular/.venv/bin/pip install /opt/singular
+sudo chown -R singular:singular /opt/singular /var/lib/singular
+sudo install -m 0644 deploy/systemd/singular.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now singular.service
+```
+
+Consultez l'état et les journaux avec `systemctl status singular` et
+`journalctl -u singular -f`. Pour mettre à niveau : arrêtez le service, faites
+une sauvegarde, mettez le dépôt à jour, réinstallez le paquet dans le venv puis
+redémarrez :
+
+```bash
+sudo systemctl stop singular
+sudo tar -C /var/lib -czf "singular-$(date +%F-%H%M).tgz" singular
+sudo git -C /opt/singular pull --ff-only
+sudo /opt/singular/.venv/bin/pip install --upgrade /opt/singular
+sudo systemctl start singular
+```
+
+Après un crash, `Restart=on-failure` relance le processus après 10 secondes et
+celui-ci reprend l'identité et la progression présentes dans
+`/var/lib/singular`. Si l'état est endommagé, arrêtez le service, déplacez le
+répertoire concerné, restaurez l'archive dans `/var/lib`, corrigez ses droits
+(`chown -R singular:singular /var/lib/singular`) puis redémarrez.
+
+### Docker Compose
+
+Docker est supporté par le `Dockerfile` et `compose.yaml`. Les volumes nommés
+conservent `mem/`, `runs/`, les vies (donc leur identité) et la configuration;
+Compose applique aussi un healthcheck et des limites CPU/mémoire.
+
+```bash
+docker compose build
+docker compose run --rm singular singular lives create --name Lumen
+docker compose up -d
+docker compose logs -f singular
+```
+
+Mise à niveau et sauvegarde (ne supprimez jamais les volumes avec `down -v`) :
+
+```bash
+docker compose down
+docker run --rm -v singular_singular-lives:/data -v "$PWD":/backup \
+  alpine tar -czf /backup/singular-lives.tgz -C /data .
+docker compose build --pull
+docker compose up -d
+```
+
+Sauvegardez de la même façon les volumes `singular-mem`, `singular-runs` et
+`singular-config`. Pour récupérer après un crash, examinez d'abord
+`docker compose logs`, laissez `restart: unless-stopped` relancer le conteneur,
+ou faites `docker compose down`, restaurez chaque archive dans son volume puis
+`docker compose up -d`. L'état persistant n'est pas réinitialisé par la
+reconstruction de l'image.
+
+Validez statiquement les manifestes avec
+`python scripts/check_deployment_manifests.py`. Le test de reprise accepte une
+commande injectable (placeholder `{root}`), utile pour tester un wrapper ou un
+superviseur réel :
+
+```bash
+SINGULAR_INTEGRATION_COMMAND='mon-wrapper --root {root}' \
+  pytest -m integration tests/test_deployment.py
+```
+
 ## 🧭 Guide d’utilisation clair (pas à pas)
 
 Si vous débutez, suivez **exactement** ces étapes :

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,32 @@
+services:
+  singular:
+    build: .
+    image: singular:local
+    restart: unless-stopped
+    init: true
+    stop_grace_period: 45s
+    volumes:
+      - singular-mem:/var/lib/singular/mem
+      - singular-runs:/var/lib/singular/runs
+      - singular-lives:/var/lib/singular/lives
+      - singular-config:/etc/singular
+    healthcheck:
+      test: ["CMD", "python", "-c", "from pathlib import Path; import sys; c=Path('/proc/1/cmdline').read_bytes(); sys.exit(0 if b'singular' in c and b'orchestrate' in c else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+        reservations:
+          cpus: "0.10"
+          memory: 128M
+
+volumes:
+  singular-mem:
+  singular-runs:
+  singular-lives:
+  singular-config:

--- a/deploy/systemd/singular.service
+++ b/deploy/systemd/singular.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Singular autonomous orchestrator
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=singular
+Group=singular
+WorkingDirectory=/opt/singular
+Environment=SINGULAR_ROOT=/var/lib/singular
+ExecStart=/opt/singular/.venv/bin/singular orchestrate run
+Restart=on-failure
+RestartSec=10s
+StateDirectory=singular
+StateDirectoryMode=0750
+KillSignal=SIGTERM
+TimeoutStopSec=45s
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
+markers =
+    integration: integration tests that may execute an injected deployment command
 testpaths = tests
 pythonpath = .

--- a/scripts/check_deployment_manifests.py
+++ b/scripts/check_deployment_manifests.py
@@ -1,0 +1,53 @@
+"""Dependency-free static validation for the deployment manifests."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def require(path: str, fragments: tuple[str, ...]) -> None:
+    content = (ROOT / path).read_text(encoding="utf-8")
+    missing = [fragment for fragment in fragments if fragment not in content]
+    if missing:
+        raise SystemExit(f"{path}: missing required values: {', '.join(missing)}")
+
+
+def main() -> int:
+    require(
+        "deploy/systemd/singular.service",
+        (
+            "User=singular",
+            "WorkingDirectory=",
+            "singular orchestrate run",
+            "Restart=on-failure",
+            "RestartSec=",
+            "StateDirectory=singular",
+            "KillSignal=SIGTERM",
+        ),
+    )
+    require(
+        "Dockerfile",
+        (
+            "USER singular:singular",
+            "STOPSIGNAL SIGTERM",
+            "HEALTHCHECK",
+            '"singular", "orchestrate", "run"',
+        ),
+    )
+    require(
+        "compose.yaml",
+        (
+            "restart: unless-stopped",
+            "singular-mem:/var/lib/singular/mem",
+            "singular-runs:/var/lib/singular/runs",
+            "singular-config:/etc/singular",
+            "healthcheck:",
+            "limits:",
+        ),
+    )
+    print("deployment manifests: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,39 @@
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.check_deployment_manifests import main as check_manifests
+from singular.cli import main
+
+
+def test_deployment_manifests_are_complete() -> None:
+    assert check_manifests() == 0
+
+
+@pytest.mark.integration
+def test_injected_restart_preserves_identity_and_progress(tmp_path: Path) -> None:
+    """Run any injected supervisor command twice against an existing data root."""
+    root = tmp_path / "state"
+    assert main(["--root", str(root), "lives", "create", "--name", "Resume"]) == 0
+    identity_path = root / "lives" / "resume" / "id.json"
+    progress_path = root / "lives" / "resume" / "mem" / "restart-progress.json"
+    progress = {"completed_steps": 7, "checkpoint": "before-restart"}
+    progress_path.write_text(json.dumps(progress), encoding="utf-8")
+    identity = identity_path.read_bytes()
+
+    template = os.environ.get(
+        "SINGULAR_INTEGRATION_COMMAND",
+        f"{shlex.quote(sys.executable)} -m singular --root {{root}} status --format json",
+    )
+    env = {**os.environ, "PYTHONPATH": str(Path(__file__).parents[1] / "src")}
+    for _ in range(2):
+        command = template.format(root=shlex.quote(str(root)))
+        subprocess.run(shlex.split(command), check=True, env=env, timeout=30)
+
+    assert identity_path.read_bytes() == identity
+    assert json.loads(progress_path.read_text(encoding="utf-8")) == progress


### PR DESCRIPTION
### Motivation
- Fournir des modèles d’exécution permanente (systemd et Docker) pour lancer l’orchestrateur `singular orchestrate run` de façon résiliente et non privilégiée.
- Prévenir les régressions de déploiement en ajoutant une validation statique minimale des manifests et un test d’intégration qui vérifie que la reprise n’écrase pas l’identité ni la progression.

### Description
- Ajout du service systemd `deploy/systemd/singular.service` exécutant `singular orchestrate run` en tant qu’utilisateur `singular` avec `Restart=on-failure`, `RestartSec`, `StateDirectory`, `KillSignal=SIGTERM`, `WorkingDirectory` et durcissements (`NoNewPrivileges`, `PrivateTmp`).
- Ajout d’un `Dockerfile` non privilégié et d’un `compose.yaml` avec `restart: unless-stopped`, volumes nommés persistants pour `mem/`, `runs/`, `lives/` et `config`, `HEALTHCHECK`, `STOPSIGNAL SIGTERM` et limites de ressources CPU/mémoire.
- Ajout d’un script de validation léger `scripts/check_deployment_manifests.py` qui vérifie la présence des fragments essentiels dans les fichiers de déploiement.
- Ajout du test `tests/test_deployment.py` contenant un test de conformité des manifests et un test d’intégration injectable (`SINGULAR_INTEGRATION_COMMAND`) qui exécute deux fois la commande fournie et vérifie que `id.json` et un fichier de progression (`restart-progress.json`) ne sont pas modifiés.
- Mise à jour de la documentation `README.md` pour décrire l’installation systemd, les procédures d’activation/upgrade, la consultation des journaux, la sauvegarde et la récupération après crash, ainsi que l’usage Docker/Compose et la validation statique.
- Intégration de la vérification des manifests dans la CI (`.github/workflows/ci.yml`) et ajout d’un marqueur pytest `integration` dans `pytest.ini`.

### Testing
- Exécution de la validation statique `python scripts/check_deployment_manifests.py` a imprimé `deployment manifests: OK`.
- Exécution des tests ajoutés avec `python -m pytest tests/test_deployment.py -q` a réussi (`2 passed`).
- Format/checks : `black --check` et `ruff check` sur les nouveaux fichiers sont passés après application du formatage automatique sur le fichier ajouté.
- Tentative de construire l’image Docker et d’exécuter `docker compose` a échoué dans l’environnement CI local car `docker` n’est pas installé (info non bloquante pour le PR).
- `systemd-analyze verify deploy/systemd/singular.service` a retourné une alerte attendue car le chemin `/opt/singular/.venv/bin/singular` est spécifique à l’installation cible et n’existe pas dans cet environnement de test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a754463b108832a9eb602e0aa5bec3a)