### PR TITLE
Add unified embodiment interfaces, deterministic simulators and optional ROS2/GPIO adapters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dashboard = [
     "websockets>=12,<16",
 ]
 viz = ["matplotlib>=3.8,<4"]
+ros2 = ["rclpy>=3.3,<4"]
+gpio = ["gpiozero>=2.0,<3"]
 
 [project.scripts]
 singular = "singular.cli:main"

--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -9,23 +9,11 @@ from typing import Any, Callable, Protocol
 
 from security.policy_engine import ActionPolicyEngine
 from uuid import uuid4
-from singular.memory import add_episode
+from singular.memory import add_causal_trace, add_episode
+from singular.embodiment import Acknowledgement, Command, EmergencyStop, Observation
 from singular.morals import MoralAction, MoralDecisionEngine
 
 DEFAULT_SCHEMA_VERSION = "1.0"
-
-
-@dataclass(frozen=True)
-class PerceptEvent:
-    """Structured perception signal captured by the runtime."""
-
-    event_type: str
-    payload: dict[str, Any]
-    source: str
-    schema_version: str = DEFAULT_SCHEMA_VERSION
-    observed_at: str = field(
-        default_factory=lambda: datetime.now(timezone.utc).isoformat()
-    )
 
 
 @dataclass(frozen=True)
@@ -40,32 +28,10 @@ class Intent:
     schema_version: str = DEFAULT_SCHEMA_VERSION
 
 
-@dataclass(frozen=True)
-class ActionRequest:
-    """Action demanded by the runtime and sent to the action port."""
-
-    action_type: str
-    parameters: dict[str, Any] = field(default_factory=dict)
-    intent_goal: str = ""
-    schema_version: str = DEFAULT_SCHEMA_VERSION
-    requested_at: str = field(
-        default_factory=lambda: datetime.now(timezone.utc).isoformat()
-    )
-
-
-@dataclass(frozen=True)
-class ActionResult:
-    """Execution result and audit metadata for an action."""
-
-    action_type: str
-    success: bool
-    message: str = ""
-    error: str | None = None
-    audit: dict[str, Any] = field(default_factory=dict)
-    schema_version: str = DEFAULT_SCHEMA_VERSION
-    completed_at: str = field(
-        default_factory=lambda: datetime.now(timezone.utc).isoformat()
-    )
+# Backwards-compatible names now point at the shared embodiment contracts.
+PerceptEvent = Observation
+ActionRequest = Command
+ActionResult = Acknowledgement
 
 
 @dataclass(frozen=True)
@@ -76,7 +42,9 @@ class RuntimeEvent:
     payload: Any
     schema_version: str = DEFAULT_SCHEMA_VERSION
     event_id: str = field(default_factory=lambda: uuid4().hex)
-    emitted_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    emitted_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
 
 
 @dataclass(frozen=True)
@@ -89,7 +57,9 @@ class CausalTrace:
     action: dict[str, Any]
     result: dict[str, Any]
     schema_version: str = DEFAULT_SCHEMA_VERSION
-    recorded_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    recorded_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
 
 
 @dataclass(frozen=True)
@@ -142,7 +112,9 @@ class MindPort(Protocol):
     def propose_intent(self, percept: PerceptEvent) -> Intent | None:
         """Propose a goal based on one percept."""
 
-    def propose_action(self, intent: Intent, percept: PerceptEvent) -> ActionRequest | None:
+    def propose_action(
+        self, intent: Intent, percept: PerceptEvent
+    ) -> ActionRequest | None:
         """Translate one intent into an executable action request."""
 
 
@@ -168,6 +140,8 @@ class AgentRuntime:
         safety: RuntimeSafetyConfig | None = None,
         stop_signal: Callable[[], bool] | None = None,
         moral_engine: MoralDecisionEngine | None = None,
+        resource_gate: Callable[[ActionRequest], bool | tuple[bool, str]] | None = None,
+        emergency_stop: EmergencyStop | None = None,
     ) -> None:
         self.perception = perception
         self.mind = mind
@@ -176,13 +150,17 @@ class AgentRuntime:
         self.event_bus = event_bus or RuntimeEventBus(schema_version=schema_version)
         self.policy_engine = policy_engine or ActionPolicyEngine()
         self.moral_engine = moral_engine or MoralDecisionEngine(journal=add_episode)
+        self.resource_gate = resource_gate
+        self.emergency_stop = emergency_stop or EmergencyStop()
         self.safety = safety or RuntimeSafetyConfig()
         self._stop_signal = stop_signal
         self._global_stop_requested = False
         self._disabled = False
         self._critical_error_count = 0
         self._action_timestamps: deque[float] = deque()
-        self._recent_actions: deque[str] = deque(maxlen=max(self.safety.watchdog_window_size, 1))
+        self._recent_actions: deque[str] = deque(
+            maxlen=max(self.safety.watchdog_window_size, 1)
+        )
         self._causal_traces: deque[CausalTrace] = deque(maxlen=200)
 
     @property
@@ -195,6 +173,10 @@ class AgentRuntime:
         """Request an immediate global stop (hotkey equivalent)."""
 
         self._global_stop_requested = True
+        self.emergency_stop.engage("runtime_global_stop")
+        stop = getattr(self.action, "emergency_stop", None)
+        if callable(stop):
+            stop("runtime_global_stop")
 
     def step(self) -> list[ActionResult]:
         """Run one full runtime step.
@@ -248,17 +230,6 @@ class AgentRuntime:
                 moral_context.get("uncertainty", 0.0),
             )
             self.event_bus.publish("action.moral.decision", moral_decision)
-            if moral_decision.veto:
-                result = ActionResult(
-                    action_type=request.action_type,
-                    success=False,
-                    message="blocked by moral veto",
-                    error=moral_decision.veto_reason,
-                    audit={"moral": moral_decision.to_dict()},
-                )
-                self.event_bus.publish("action.moral.vetoed", result)
-                results.append(result)
-                continue
 
             if self._stop_requested():
                 self.event_bus.publish(
@@ -327,6 +298,57 @@ class AgentRuntime:
                     },
                 )
                 self.event_bus.publish("action.blocked", result)
+                self._record_causal_trace(
+                    percept=percept,
+                    intent=intent,
+                    request=request,
+                    result=result,
+                    decision=decision,
+                )
+                results.append(result)
+                continue
+
+            if moral_decision.veto:
+                result = ActionResult(
+                    action_type=request.action_type,
+                    success=False,
+                    message="blocked by moral veto",
+                    error=moral_decision.veto_reason,
+                    audit={"moral": moral_decision.to_dict()},
+                    command_id=request.command_id,
+                    actual={"executed": False},
+                )
+                self.event_bus.publish("action.moral.vetoed", result)
+                self._record_causal_trace(
+                    percept=percept,
+                    intent=intent,
+                    request=request,
+                    result=result,
+                    decision=decision,
+                )
+                results.append(result)
+                continue
+
+            resource_allowed, resource_reason = self._resources_allow(request)
+            self.event_bus.publish(
+                "action.resource.decision",
+                {
+                    "request": request,
+                    "allowed": resource_allowed,
+                    "reason": resource_reason,
+                },
+            )
+            if not resource_allowed:
+                result = ActionResult(
+                    action_type=request.action_type,
+                    success=False,
+                    message="blocked by resource limits",
+                    error=resource_reason,
+                    audit={"resource": {"allowed": False, "reason": resource_reason}},
+                    command_id=request.command_id,
+                    actual={"executed": False},
+                )
+                self.event_bus.publish("action.resource.blocked", result)
                 self._record_causal_trace(
                     percept=percept,
                     intent=intent,
@@ -419,6 +441,8 @@ class AgentRuntime:
                 audit=enriched_audit,
                 schema_version=result.schema_version,
                 completed_at=result.completed_at,
+                command_id=result.command_id or request.command_id,
+                actual=dict(result.actual),
             )
             if self._is_critical_result(result):
                 self._record_critical_error("critical_action_result")
@@ -435,6 +459,14 @@ class AgentRuntime:
                 break
 
         return results
+
+    def _resources_allow(self, request: ActionRequest) -> tuple[bool, str]:
+        if self.resource_gate is None:
+            return True, "within_limits"
+        verdict = self.resource_gate(request)
+        if isinstance(verdict, tuple):
+            return bool(verdict[0]), str(verdict[1])
+        return bool(verdict), "within_limits" if verdict else "resource_limit_exceeded"
 
     def _ensure_schema_version(self, candidate: str) -> None:
         if candidate != self.schema_version:
@@ -479,7 +511,9 @@ class AgentRuntime:
         threshold = self.safety.watchdog_repeat_action_threshold
         if threshold <= 0 or len(self._recent_actions) < threshold - 1:
             return False
-        return list(self._recent_actions)[-(threshold - 1) :] == [action_type] * (threshold - 1)
+        return list(self._recent_actions)[-(threshold - 1) :] == [action_type] * (
+            threshold - 1
+        )
 
     def _is_critical_result(self, result: ActionResult) -> bool:
         if result.success:
@@ -489,7 +523,11 @@ class AgentRuntime:
             return True
         if isinstance(result.error, str) and "critical" in result.error.lower():
             return True
-        return bool(result.audit.get("critical_error", False)) if isinstance(result.audit, dict) else False
+        return (
+            bool(result.audit.get("critical_error", False))
+            if isinstance(result.audit, dict)
+            else False
+        )
 
     def _record_critical_error(self, reason: str) -> None:
         self._critical_error_count += 1
@@ -551,6 +589,8 @@ class AgentRuntime:
                 "success": result.success,
                 "message": result.message,
                 "error": result.error,
+                "command_id": result.command_id,
+                "actual": result.actual,
                 "gain_loss": gain_loss,
                 "objective_impact": {
                     "objective": intent.goal,
@@ -561,3 +601,14 @@ class AgentRuntime:
         )
         self._causal_traces.append(trace)
         self.event_bus.publish("causal.trace", trace)
+        payload = {
+            "ts": trace.recorded_at,
+            "trace_id": trace.trace_id,
+            "pipeline": "agent_runtime.embodiment",
+            "input": trace.input,
+            "decision": trace.decision,
+            "action": trace.action,
+            "result": trace.result,
+        }
+        add_causal_trace(payload)
+        add_episode({"event": "embodiment.action.result", **payload})

--- a/src/singular/embodiment/__init__.py
+++ b/src/singular/embodiment/__init__.py
@@ -1,0 +1,39 @@
+"""Stable public embodiment API with no hardware dependency."""
+
+from .contracts import (
+    Acknowledgement,
+    Actuator,
+    Command,
+    EmbodimentError,
+    EmergencyStop,
+    ErrorCode,
+    Observation,
+    Sensor,
+)
+from .simulators import (
+    ActuatorSimulator,
+    CameraSimulator,
+    DeterministicClock,
+    MicrophoneSimulator,
+    ScriptedSensor,
+)
+from .adapters import GPIOActuator, OptionalAdapterUnavailable, ROS2Sensor
+
+__all__ = [
+    "Acknowledgement",
+    "Actuator",
+    "ActuatorSimulator",
+    "CameraSimulator",
+    "Command",
+    "DeterministicClock",
+    "EmbodimentError",
+    "EmergencyStop",
+    "ErrorCode",
+    "MicrophoneSimulator",
+    "Observation",
+    "ScriptedSensor",
+    "Sensor",
+    "GPIOActuator",
+    "OptionalAdapterUnavailable",
+    "ROS2Sensor",
+]

--- a/src/singular/embodiment/adapters.py
+++ b/src/singular/embodiment/adapters.py
@@ -1,0 +1,87 @@
+"""Optional ROS2 and GPIO adapters; imports occur only when instantiated."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .contracts import Acknowledgement, Command, Observation, utc_now
+
+
+class OptionalAdapterUnavailable(RuntimeError):
+    pass
+
+
+@dataclass
+class ROS2Sensor:
+    topic: str
+    message_type: Any
+    node_name: str = "singular_sensor"
+
+    def __post_init__(self) -> None:
+        try:
+            import rclpy
+        except ImportError as exc:
+            raise OptionalAdapterUnavailable(
+                "ROS2 adapter requires the 'ros2' extra (rclpy)"
+            ) from exc
+        self._rclpy = rclpy
+        rclpy.init(args=None)
+        self._node = rclpy.create_node(self.node_name)
+        self._pending: list[Observation] = []
+        self._subscription = self._node.create_subscription(
+            self.message_type, self.topic, self._receive, 10
+        )
+
+    def _receive(self, message: Any) -> None:
+        payload = message if isinstance(message, dict) else {"message": str(message)}
+        self._pending.append(Observation("ros2", payload, f"ros2:{self.topic}"))
+
+    def collect(self) -> list[Observation]:
+        self._rclpy.spin_once(self._node, timeout_sec=0.0)
+        result, self._pending = self._pending, []
+        return result
+
+    def close(self) -> None:
+        self._node.destroy_node()
+
+
+@dataclass
+class GPIOActuator:
+    pin: int
+    transform: Callable[[Command], bool] = lambda command: bool(
+        command.parameters.get("value", True)
+    )
+
+    def __post_init__(self) -> None:
+        try:
+            from gpiozero import OutputDevice
+        except ImportError as exc:
+            raise OptionalAdapterUnavailable(
+                "GPIO adapter requires the 'gpio' extra (gpiozero)"
+            ) from exc
+        self._device = OutputDevice(self.pin)
+        self._stopped = False
+
+    def execute(self, command: Command) -> Acknowledgement:
+        if self._stopped:
+            return Acknowledgement(
+                command.action_type,
+                False,
+                "emergency stop engaged",
+                "emergency_stop",
+                command_id=command.command_id,
+            )
+        value = self.transform(command)
+        self._device.on() if value else self._device.off()
+        return Acknowledgement(
+            command.action_type,
+            True,
+            "gpio updated",
+            command_id=command.command_id,
+            actual={"pin": self.pin, "value": value, "observed_at": utc_now()},
+        )
+
+    def emergency_stop(self, reason: str = "operator_request") -> None:
+        self._stopped = True
+        self._device.off()

--- a/src/singular/embodiment/contracts.py
+++ b/src/singular/embodiment/contracts.py
@@ -1,0 +1,102 @@
+"""Dependency-free contracts shared by embodied inputs and outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping, Protocol, runtime_checkable
+from uuid import uuid4
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class ErrorCode(str, Enum):
+    UNAVAILABLE = "unavailable"
+    TIMEOUT = "timeout"
+    REFUSED = "refused"
+    EMERGENCY_STOP = "emergency_stop"
+    IO_ERROR = "io_error"
+
+
+@dataclass(frozen=True)
+class EmbodimentError:
+    code: ErrorCode
+    message: str
+    recoverable: bool = True
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Observation:
+    """A timestamped, source-identifiable sensor reading."""
+
+    event_type: str
+    payload: dict[str, Any]
+    source: str
+    schema_version: str = "1.0"
+    observed_at: str = field(default_factory=utc_now)
+    observation_id: str = field(default_factory=lambda: uuid4().hex)
+    error: EmbodimentError | None = None
+
+
+@dataclass(frozen=True)
+class Command:
+    """An actuator command. Commands are proposals until acknowledged."""
+
+    action_type: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+    intent_goal: str = ""
+    schema_version: str = "1.0"
+    requested_at: str = field(default_factory=utc_now)
+    command_id: str = field(default_factory=lambda: uuid4().hex)
+
+
+@dataclass(frozen=True)
+class Acknowledgement:
+    """The measured outcome returned by an actuator, including refusals."""
+
+    action_type: str
+    success: bool
+    message: str = ""
+    error: str | None = None
+    audit: dict[str, Any] = field(default_factory=dict)
+    schema_version: str = "1.0"
+    completed_at: str = field(default_factory=utc_now)
+    command_id: str | None = None
+    actual: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EmergencyStop:
+    """Latched emergency stop shared by a runtime and its actuators."""
+
+    engaged: bool = False
+    reason: str | None = None
+    engaged_at: str | None = None
+
+    def engage(self, reason: str = "operator_request") -> None:
+        self.engaged = True
+        self.reason = reason
+        self.engaged_at = utc_now()
+
+    def reset(self) -> None:
+        self.engaged = False
+        self.reason = None
+        self.engaged_at = None
+
+
+@runtime_checkable
+class Sensor(Protocol):
+    def collect(self) -> list[Observation]: ...
+
+    def close(self) -> None: ...
+
+
+@runtime_checkable
+class Actuator(Protocol):
+    def execute(self, command: Command) -> Acknowledgement: ...
+
+    def emergency_stop(self, reason: str = "operator_request") -> None: ...

--- a/src/singular/embodiment/simulators.py
+++ b/src/singular/embodiment/simulators.py
@@ -1,0 +1,132 @@
+"""Deterministic, hardware-free embodiment simulators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+from .contracts import (
+    Acknowledgement,
+    Command,
+    EmbodimentError,
+    EmergencyStop,
+    ErrorCode,
+    Observation,
+)
+
+
+@dataclass
+class DeterministicClock:
+    current: datetime = field(
+        default_factory=lambda: datetime(2024, 1, 1, tzinfo=timezone.utc)
+    )
+
+    def now(self) -> str:
+        return self.current.isoformat()
+
+    def advance(self, seconds: float) -> str:
+        self.current += timedelta(seconds=max(0.0, seconds))
+        return self.now()
+
+
+@dataclass
+class ScriptedSensor:
+    source: str
+    event_type: str
+    readings: Iterable[Any] = ()
+    clock: DeterministicClock = field(default_factory=DeterministicClock)
+    latency_s: float = 0.0
+    unavailable_at: frozenset[int] = frozenset()
+    _readings: list[Any] = field(init=False, repr=False)
+    _index: int = field(default=0, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._readings = list(self.readings)
+
+    def collect(self) -> list[Observation]:
+        index = self._index
+        self._index += 1
+        observed_at = self.clock.advance(self.latency_s)
+        if index in self.unavailable_at:
+            return [
+                Observation(
+                    self.event_type,
+                    {"status": "unavailable"},
+                    self.source,
+                    observed_at=observed_at,
+                    error=EmbodimentError(
+                        ErrorCode.UNAVAILABLE, f"{self.source} unavailable"
+                    ),
+                )
+            ]
+        if index >= len(self._readings):
+            return []
+        value = self._readings[index]
+        payload = value if isinstance(value, dict) else {"value": value}
+        return [
+            Observation(
+                self.event_type, dict(payload), self.source, observed_at=observed_at
+            )
+        ]
+
+    def close(self) -> None:
+        return None
+
+
+class CameraSimulator(ScriptedSensor):
+    def __init__(self, frames: Iterable[Any] = (), **kwargs: Any) -> None:
+        super().__init__(
+            source="sim.camera", event_type="vision", readings=frames, **kwargs
+        )
+
+
+class MicrophoneSimulator(ScriptedSensor):
+    def __init__(self, blocks: Iterable[Any] = (), **kwargs: Any) -> None:
+        super().__init__(
+            source="sim.microphone", event_type="audio", readings=blocks, **kwargs
+        )
+
+
+@dataclass
+class ActuatorSimulator:
+    clock: DeterministicClock = field(default_factory=DeterministicClock)
+    latency_s: float = 0.0
+    refused_actions: frozenset[str] = frozenset()
+    stop: EmergencyStop = field(default_factory=EmergencyStop)
+    commands: list[Command] = field(default_factory=list)
+
+    def execute(self, command: Command) -> Acknowledgement:
+        completed_at = self.clock.advance(self.latency_s)
+        if self.stop.engaged:
+            return Acknowledgement(
+                command.action_type,
+                False,
+                "emergency stop engaged",
+                ErrorCode.EMERGENCY_STOP.value,
+                completed_at=completed_at,
+                command_id=command.command_id,
+                actual={"executed": False},
+            )
+        if command.action_type in self.refused_actions:
+            return Acknowledgement(
+                command.action_type,
+                False,
+                "command refused",
+                ErrorCode.REFUSED.value,
+                completed_at=completed_at,
+                command_id=command.command_id,
+                actual={"executed": False},
+            )
+        self.commands.append(command)
+        return Acknowledgement(
+            command.action_type,
+            True,
+            "executed",
+            completed_at=completed_at,
+            command_id=command.command_id,
+            actual={"executed": True, "parameters": dict(command.parameters)},
+        )
+
+    def emergency_stop(self, reason: str = "operator_request") -> None:
+        self.stop.engage(reason)

--- a/src/singular/sensors/__init__.py
+++ b/src/singular/sensors/__init__.py
@@ -2,6 +2,7 @@
 
 from .config import HostSensorThresholds, load_host_sensor_thresholds
 from .host import collect_host_metrics
+from singular.embodiment import Observation
 from .host_metrics_store import (
     append_host_metrics_sample,
     compute_host_metrics_aggregates,
@@ -9,8 +10,21 @@ from .host_metrics_store import (
     summarize_environmental_impact,
 )
 
+
+class HostSensor:
+    """Adapt the legacy host-metrics function to the common sensor contract."""
+
+    def collect(self) -> list[Observation]:
+        metrics = collect_host_metrics()
+        return [Observation("host_metrics", metrics, "host.metrics")]
+
+    def close(self) -> None:
+        return None
+
+
 __all__ = [
     "HostSensorThresholds",
+    "HostSensor",
     "append_host_metrics_sample",
     "collect_host_metrics",
     "compute_host_metrics_aggregates",

--- a/tests/test_embodiment.py
+++ b/tests/test_embodiment.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from singular.core.agent_runtime import AgentRuntime, Intent
+from singular.embodiment import (
+    ActuatorSimulator,
+    CameraSimulator,
+    Command,
+    DeterministicClock,
+    EmergencyStop,
+    ErrorCode,
+    MicrophoneSimulator,
+)
+
+
+def test_deterministic_sensors_model_latency_and_unavailability() -> None:
+    clock = DeterministicClock()
+    camera = CameraSimulator(
+        [{"frame": 1}, {"frame": 2}],
+        clock=clock,
+        latency_s=0.25,
+        unavailable_at=frozenset({1}),
+    )
+    first = camera.collect()[0]
+    unavailable = camera.collect()[0]
+    assert first.observed_at == "2024-01-01T00:00:00.250000+00:00"
+    assert first.payload == {"frame": 1}
+    assert unavailable.error is not None
+    assert unavailable.error.code is ErrorCode.UNAVAILABLE
+
+    microphone = MicrophoneSimulator([{"text": "bonjour"}])
+    assert microphone.collect()[0].source == "sim.microphone"
+
+
+def test_actuator_models_refusal_and_latched_emergency_stop() -> None:
+    actuator = ActuatorSimulator(refused_actions=frozenset({"motor.reverse"}))
+    refused = actuator.execute(Command("motor.reverse"))
+    assert refused.success is False
+    assert refused.error == ErrorCode.REFUSED.value
+    actuator.emergency_stop("test")
+    stopped = actuator.execute(Command("motor.forward"))
+    assert stopped.error == ErrorCode.EMERGENCY_STOP.value
+    assert actuator.commands == []
+
+
+class _Mind:
+    def propose_intent(self, percept):
+        return Intent("move")
+
+    def propose_action(self, intent, percept):
+        return Command(
+            "motor.forward", {"value": percept.payload["frame"]}, intent.goal
+        )
+
+
+def test_runtime_full_hardware_free_loop_and_resource_refusal(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    actuator = ActuatorSimulator()
+    runtime = AgentRuntime(
+        perception=CameraSimulator([{"frame": 3}]),
+        mind=_Mind(),
+        action=actuator,
+        resource_gate=lambda command: (False, "energy_budget_exhausted"),
+    )
+    result = runtime.step()[0]
+    assert result.error == "energy_budget_exhausted"
+    assert actuator.commands == []
+
+
+def test_runtime_emergency_stop_reaches_actuator() -> None:
+    actuator = ActuatorSimulator(stop=EmergencyStop())
+    runtime = AgentRuntime(
+        perception=CameraSimulator([{"frame": 1}]), mind=_Mind(), action=actuator
+    )
+    runtime.request_global_stop()
+    assert runtime.step() == []
+    assert actuator.stop.engaged is True


### PR DESCRIPTION
### Motivation

- Fournir des contrats communs et découplés du matériel pour capteurs, actionneurs, observations horodatées, commandes, accusés, erreurs et arrêt d’urgence afin d’unifier les pipelines de perception et la boucle d’action.
- Faire transiter chaque commande d’actionneur par les contrôles techniques et moraux (policy + veto moral) et par une gate de ressources avant exécution, puis réinjecter le résultat réel dans la mémoire épisodique et la timeline causale pour traçabilité.
- Permettre des adaptateurs optionnels pour ROS2 et GPIO sans rendre ces dépendances obligatoires pour l’installation standard.
- Fournir des simulateurs déterministes pour tester une boucle complète software-only (latences, capteurs indisponibles, refus de commandes, arrêt d’urgence).

### Description

- Ajout du package `src/singular/embodiment/` contenant `contracts.py` (contrats indépendants), `simulators.py` (simulateurs déterministes) et `adapters.py` (ROS2/GPIO à chargement différé), plus un `__init__.py` public exposant l’API d’embodiment.
- Adaptation de `AgentRuntime` pour utiliser les contrats partagés (`Observation`/`Command`/`Acknowledgement`), ajout d’un `resource_gate` optionnel et d’un `emergency_stop` propagé vers l’actionneur, et persistance des résultats observés via `add_causal_trace` / `add_episode`.
- Ajout d’un adaptateur `HostSensor` dans `src/singular/sensors/__init__.py` qui transforme la sortie de `collect_host_metrics()` en `Observation` pour la compatibilité avec la nouvelle API.
- Déclaration d’options de dépendances dans `pyproject.toml` (`ros2` et `gpio`) et ajout de tests d’intégration matérielle-fake dans `tests/test_embodiment.py` couvrant la boucle complète sans matériel.

### Testing

- Exécution ciblée des tests unitaires avec `pytest -q tests/test_embodiment.py tests/test_core_agent_runtime.py tests/perception tests/test_host_sensors.py tests/test_host_sensor.py` — résultat : `29 passed, 1 warning` (tests pertinents verts).
- Vérifications de style/qualité : `ruff check` et `black --check` passés, puis `black` appliqué et re-vérifications OK.
- Isolation des adaptateurs optionnels vérifiée en instanciant `ROS2Sensor` sans `rclpy` et en confirmant que `OptionalAdapterUnavailable` est levée (comportement attendu sans extra d’installation).
- Remarque : un `pytest -q` sur l’intégralité de la suite a précédemment échoué en collecte à cause d’un test préexistant hors périmètre (ImportError lié à `CHECKPOINT_VERSION` dans `singular.life.loop`), ce qui n’est pas causé par ces changements ciblés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7545d9a08c832aa4a3d895481d2421)