### PR TITLE
Add budgeted learning: imitation engine and curiosity scoring with lifecycle integration

### DIFF
--- a/src/singular/learning/__init__.py
+++ b/src/singular/learning/__init__.py
@@ -1,0 +1,12 @@
+"""Budgeted, persistent learning primitives."""
+
+from .curiosity import CuriosityEngine, CuriosityWeights
+from .imitation import Demonstration, ImitationEngine, LearningOutcome
+
+__all__ = [
+    "CuriosityEngine",
+    "CuriosityWeights",
+    "Demonstration",
+    "ImitationEngine",
+    "LearningOutcome",
+]

--- a/src/singular/learning/curiosity.py
+++ b/src/singular/learning/curiosity.py
@@ -1,0 +1,92 @@
+"""Goal-aware intrinsic motivation with an explicit exploration budget."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+def _unit(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass(frozen=True)
+class CuriosityWeights:
+    novelty: float = 1.0
+    prediction_error: float = 1.0
+    information_gain: float = 1.0
+    cost: float = 1.0
+    risk: float = 2.0
+    relevance: float = 1.0
+
+
+class CuriosityEngine:
+    """Ranks experiments and stops spending after unproductive attempts."""
+
+    def __init__(
+        self,
+        weights: CuriosityWeights | None = None,
+        *,
+        budget: float = 3.0,
+        min_score: float = 0.05,
+        max_unproductive: int = 2,
+    ) -> None:
+        self.weights = weights or CuriosityWeights()
+        self.remaining_budget = max(0.0, float(budget))
+        self.min_score = float(min_score)
+        self.max_unproductive = max(1, int(max_unproductive))
+        self.unproductive_attempts = 0
+
+    def score(
+        self,
+        *,
+        novelty: float,
+        prediction_error: float,
+        expected_information_gain: float,
+        cost: float,
+        risk: float,
+        goal_relevance: float | Mapping[str, float],
+        goal_weights: Mapping[str, float] | None = None,
+    ) -> float:
+        """Return the weighted utility; inputs are clipped to comparable units."""
+
+        if isinstance(goal_relevance, Mapping):
+            weights = goal_weights or {}
+            denominator = sum(
+                max(0.0, float(weights.get(k, 1.0))) for k in goal_relevance
+            )
+            relevance = (
+                sum(
+                    _unit(v) * max(0.0, float(weights.get(k, 1.0)))
+                    for k, v in goal_relevance.items()
+                )
+                / denominator
+                if denominator
+                else 0.0
+            )
+        else:
+            relevance = _unit(goal_relevance)
+        w = self.weights
+        return (
+            w.novelty * _unit(novelty)
+            + w.prediction_error * _unit(prediction_error)
+            + w.information_gain * _unit(expected_information_gain)
+            + w.relevance * relevance
+            - w.cost * _unit(cost)
+            - w.risk * _unit(risk)
+        )
+
+    def authorize(self, score: float, *, cost: float = 1.0) -> bool:
+        charge = max(0.0, float(cost))
+        return (
+            score >= self.min_score
+            and charge <= self.remaining_budget
+            and self.unproductive_attempts < self.max_unproductive
+        )
+
+    def record_result(self, *, information_gain: float, cost: float = 1.0) -> None:
+        self.remaining_budget = max(0.0, self.remaining_budget - max(0.0, float(cost)))
+        if information_gain <= 0.0:
+            self.unproductive_attempts += 1
+        else:
+            self.unproductive_attempts = 0

--- a/src/singular/learning/imitation.py
+++ b/src/singular/learning/imitation.py
@@ -1,0 +1,275 @@
+"""Safe imitation learning and durable experiment history."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from singular.io_utils import append_jsonl_line, atomic_write_text
+from singular.life.sandbox import SandboxError, run as sandbox_run
+from singular.life.skill_catalog import refresh_skill_catalog
+
+
+@dataclass(frozen=True)
+class Demonstration:
+    observations: Sequence[Any]
+    actions: Sequence[Any]
+    name: str = "imitated_skill"
+    metadata: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class LearningOutcome:
+    status: str
+    skill: str
+    candidate_score: float = 0.0
+    baseline_score: float = 0.0
+    reason: str = ""
+    active_path: Path | None = None
+
+
+class ImitationEngine:
+    """Learns a deterministic observation/action policy behind safety gates."""
+
+    def __init__(self, root: Path, *, min_improvement: float = 0.01) -> None:
+        self.root = Path(root)
+        self.store = self.root / "mem" / "learning"
+        self.skills_dir = self.root / "skills"
+        self.min_improvement = float(min_improvement)
+        self.pending: list[Demonstration] = []
+        self.store.mkdir(parents=True, exist_ok=True)
+        self._load_pending()
+
+    @staticmethod
+    def extract_sequences(
+        payload: Demonstration | Mapping[str, Any],
+    ) -> list[tuple[Any, Any]]:
+        """Normalize either parallel arrays or structured ``steps``."""
+
+        if isinstance(payload, Demonstration):
+            observations, actions = payload.observations, payload.actions
+        elif "steps" in payload:
+            steps = payload.get("steps", [])
+            return [
+                (step["observation"], step["action"])
+                for step in steps
+                if isinstance(step, Mapping)
+                and "observation" in step
+                and "action" in step
+            ]
+        else:
+            observations = payload.get("observations", [])
+            actions = payload.get("actions", [])
+        if len(observations) != len(actions):
+            raise ValueError("observations and actions must have the same length")
+        return list(zip(observations, actions))
+
+    def ingest(self, payload: Demonstration | Mapping[str, Any]) -> Demonstration:
+        pairs = self.extract_sequences(payload)
+        name = (
+            payload.name
+            if isinstance(payload, Demonstration)
+            else str(payload.get("name", "imitated_skill"))
+        )
+        metadata = (
+            payload.metadata
+            if isinstance(payload, Demonstration)
+            else payload.get("metadata")
+        )
+        demonstration = Demonstration(
+            [p[0] for p in pairs], [p[1] for p in pairs], name, metadata
+        )
+        if not pairs:
+            raise ValueError(
+                "a demonstration must contain at least one observation-action pair"
+            )
+        self.pending.append(demonstration)
+        self._event(
+            "demonstrations", {"type": "demonstration", **asdict(demonstration)}
+        )
+        self._save_pending()
+        return demonstration
+
+    ingest_demonstration = ingest
+
+    def propose_candidate(self, demonstration: Demonstration) -> str:
+        pairs = self.extract_sequences(demonstration)
+        default = max(
+            set(map(repr, demonstration.actions)),
+            key=list(map(repr, demonstration.actions)).count,
+        )
+        source = (
+            '"""Capability_tags: imitation, learned\nReliability: 0.5\nEstimated_cost: 0.1\n"""\n'
+            f"_POLICY = {pairs!r}\n_DEFAULT = {default}\n\n"
+            "def run(observation):\n"
+            "    for seen, action in _POLICY:\n"
+            "        if seen == observation:\n"
+            "            return action\n"
+            "    return _DEFAULT\n"
+        )
+        self._event(
+            "hypotheses",
+            {
+                "type": "candidate",
+                "skill": demonstration.name,
+                "sha256": hashlib.sha256(source.encode()).hexdigest(),
+                "source": source,
+            },
+        )
+        return source
+
+    propose_skill = propose_candidate
+
+    def learn_next(self) -> LearningOutcome | None:
+        if not self.pending:
+            return None
+        demo = self.pending.pop(0)
+        try:
+            outcome = self.evaluate_and_publish(demo, self.propose_candidate(demo))
+        finally:
+            self._save_pending()
+        return outcome
+
+    def evaluate_and_publish(self, demo: Demonstration, source: str) -> LearningOutcome:
+        name = self._safe_name(demo.name)
+        pairs = self.extract_sequences(demo)
+        baseline = self._baseline_accuracy([a for _, a in pairs])
+        reason = self._static_safety_reason(source)
+        score = 0.0
+        if reason is None:
+            correct = 0
+            try:
+                for observation, action in pairs:
+                    observed = sandbox_run(f"{source}\nresult = run({observation!r})")
+                    correct += observed == action
+                score = correct / len(pairs)
+            except (Exception, SandboxError) as exc:
+                reason = f"sandbox rejected candidate: {exc}"
+        accepted = reason is None and score >= baseline + self.min_improvement
+        result = {
+            "type": "evaluation",
+            "skill": name,
+            "score": score,
+            "baseline": baseline,
+            "accepted": accepted,
+            "reason": reason
+            or ("improves baseline" if accepted else "does not improve baseline"),
+            "timestamp": time.time(),
+        }
+        self._event("trials", {"type": "sandbox_trial", **result})
+        self._event("results", result)
+        self._event(
+            "learning_curves",
+            {
+                "skill": name,
+                "episode": self._result_count(name),
+                "score": score,
+                "baseline": baseline,
+            },
+        )
+        if not accepted:
+            quarantine = (
+                self.store / "quarantine" / f"{name}-{int(time.time() * 1000)}.py"
+            )
+            quarantine.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_text(quarantine, source)
+            return LearningOutcome(
+                "quarantined", name, score, baseline, result["reason"]
+            )
+
+        target = self.skills_dir / f"{name}.py"
+        self.skills_dir.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            rollback = self.store / "rollback" / f"{name}-{int(time.time() * 1000)}.py"
+            rollback.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write_text(rollback, target.read_text(encoding="utf-8"))
+        atomic_write_text(target, source)
+        try:
+            refresh_skill_catalog(skills_dir=self.skills_dir, mem_dir=self.root / "mem")
+        except Exception:
+            target.unlink(missing_ok=True)
+            raise
+        return LearningOutcome("active", name, score, baseline, "validated", target)
+
+    def _static_safety_reason(self, source: str) -> str | None:
+        try:
+            tree = ast.parse(source)
+        except SyntaxError as exc:
+            return f"invalid syntax: {exc.msg}"
+        forbidden = (
+            ast.Import,
+            ast.ImportFrom,
+            ast.With,
+            ast.AsyncWith,
+            ast.Global,
+            ast.Nonlocal,
+        )
+        dangerous = {
+            "open",
+            "exec",
+            "eval",
+            "compile",
+            "__import__",
+            "os",
+            "sys",
+            "subprocess",
+            "socket",
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, forbidden):
+                return "governance rejected forbidden syntax"
+            if isinstance(node, ast.Name) and node.id in dangerous:
+                return f"governance rejected dangerous name: {node.id}"
+        return None
+
+    @staticmethod
+    def _baseline_accuracy(actions: Sequence[Any]) -> float:
+        representations = [repr(action) for action in actions]
+        return max(representations.count(item) for item in set(representations)) / len(
+            actions
+        )
+
+    @staticmethod
+    def _safe_name(name: str) -> str:
+        safe = "".join(c if c.isalnum() or c == "_" else "_" for c in name).strip("_")
+        return safe or "imitated_skill"
+
+    def _event(self, stream: str, payload: dict[str, Any]) -> None:
+        append_jsonl_line(self.store / f"{stream}.jsonl", payload)
+
+    def _result_count(self, skill: str) -> int:
+        path = self.store / "results.jsonl"
+        if not path.exists():
+            return 1
+        return sum(
+            1
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if f'"skill": "{skill}"' in line
+        )
+
+    def _save_pending(self) -> None:
+        atomic_write_text(
+            self.store / "state.json",
+            json.dumps(
+                {"pending": [asdict(item) for item in self.pending]},
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )
+
+    def _load_pending(self) -> None:
+        path = self.store / "state.json"
+        if not path.exists():
+            return
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            self.pending = [
+                Demonstration(**item) for item in payload.get("pending", [])
+            ]
+        except (ValueError, TypeError, json.JSONDecodeError):
+            self.pending = []

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -85,6 +85,7 @@ from .coevolution_flow import CoevolutionConfig, CoevolutionFlow, MapElites, Liv
 from .skill_genesis import create_skill
 from .social_decision import decide_social_actions
 from .profiling import LifeLoopProfiler
+from singular.learning.imitation import ImitationEngine
 
 # mypy: ignore-errors
 
@@ -832,6 +833,8 @@ def run(
     ecosystem_rules: EcosystemRules | None = None,
     ecosystem_mode: str = "production",
     social_graph: SocialGraph | None = None,
+    imitation_engine: ImitationEngine | None = None,
+    learning_budget: int = 1,
 ) -> Checkpoint:
     """Run the evolutionary loop for at most ``budget_seconds`` seconds.
 
@@ -894,6 +897,7 @@ def run(
     social_graph = social_graph or SocialGraph()
     register_memory_event_handlers(event_bus)
     start = time.time()
+    learning_attempts = 0
     last_post = 0.0
     initial_freq = max(
         1,
@@ -969,6 +973,11 @@ def run(
         while time.time() - start < budget_seconds:
             if max_iterations is not None and tick_count >= max_iterations:
                 break
+            # Learning is metered separately and remains inactive until every
+            # sandbox, baseline, governance, and publication gate has passed.
+            if imitation_engine is not None and learning_attempts < max(0, learning_budget):
+                imitation_engine.learn_next()
+                learning_attempts += 1
             if getattr(psyche, "sleeping", False) or (
                 hasattr(psyche, "energy")
                 and getattr(psyche, "energy") < SLEEP_THRESHOLD
@@ -2666,6 +2675,8 @@ def run_tick(
     multiagent_runtime: MultiAgentRuntime | None = None,
     tick_budget_seconds: float = 0.2,
     ecosystem_rules: EcosystemRules | None = None,
+    imitation_engine: ImitationEngine | None = None,
+    learning_budget: int = 1,
 ) -> Checkpoint:
     """Execute one mutation tick and persist checkpoint state."""
 
@@ -2691,6 +2702,8 @@ def run_tick(
         multiagent_runtime=multiagent_runtime,
         max_iterations=1,
         ecosystem_rules=ecosystem_rules,
+        imitation_engine=imitation_engine,
+        learning_budget=learning_budget,
     )
 
 

--- a/tests/test_learning_engines.py
+++ b/tests/test_learning_engines.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from singular.learning.curiosity import CuriosityEngine
+from singular.learning.imitation import Demonstration, ImitationEngine
+
+
+def _demo(name: str = "traffic") -> Demonstration:
+    return Demonstration(
+        observations=[{"light": "red"}, {"light": "green"}, {"light": "amber"}],
+        actions=["stop", "go", "wait"],
+        name=name,
+    )
+
+
+def test_imitation_improves_over_baseline_and_persists_curve(tmp_path: Path) -> None:
+    engine = ImitationEngine(tmp_path)
+    engine.ingest(_demo())
+    outcome = engine.learn_next()
+    engine.ingest(_demo())
+    second_outcome = engine.learn_next()
+
+    assert outcome is not None and outcome.status == "active"
+    assert second_outcome is not None and second_outcome.status == "active"
+    assert outcome.candidate_score > outcome.baseline_score
+    curve = (tmp_path / "mem/learning/learning_curves.jsonl").read_text()
+    assert '"score": 1.0' in curve
+    assert '"episode": 2' in curve
+    assert (tmp_path / "mem/skill_catalog.json").exists()
+
+
+def test_dangerous_imitation_is_quarantined(tmp_path: Path) -> None:
+    engine = ImitationEngine(tmp_path)
+    outcome = engine.evaluate_and_publish(
+        _demo("unsafe"),
+        "import os\ndef run(observation):\n    return os.system('echo unsafe')\n",
+    )
+
+    assert outcome.status == "quarantined"
+    assert not (tmp_path / "skills/unsafe.py").exists()
+    assert list((tmp_path / "mem/learning/quarantine").glob("unsafe-*.py"))
+
+
+def test_curiosity_limits_unproductive_exploration() -> None:
+    curiosity = CuriosityEngine(budget=10, max_unproductive=2)
+    score = curiosity.score(
+        novelty=1,
+        prediction_error=1,
+        expected_information_gain=1,
+        cost=0.1,
+        risk=0,
+        goal_relevance=1,
+    )
+    assert curiosity.authorize(score)
+    curiosity.record_result(information_gain=0)
+    curiosity.record_result(information_gain=0)
+    assert not curiosity.authorize(score)
+
+
+def test_pending_learning_resumes_after_restart(tmp_path: Path) -> None:
+    first = ImitationEngine(tmp_path)
+    first.ingest(_demo("resumed"))
+
+    restarted = ImitationEngine(tmp_path)
+    outcome = restarted.learn_next()
+
+    assert outcome is not None and outcome.status == "active"
+    state = json.loads((tmp_path / "mem/learning/state.json").read_text())
+    assert state["pending"] == []


### PR DESCRIPTION
### Motivation

- Introduce safe, persistent learning primitives so the life loop can autonomously ingest demonstrations, propose candidate skills, evaluate them under existing sandbox/governance, and only activate improvements after validation and rollback/quarantine options.
- Provide an intrinsic motivation engine to prioritize experiments while enforcing an explicit exploration budget and stopping unproductive exploration.

### Description

- Add a new learning package with a public API: `src/singular/learning/__init__.py` exposing `CuriosityEngine`, `CuriosityWeights`, `Demonstration`, `ImitationEngine`, and `LearningOutcome`.
- Implement `CuriosityEngine` in `src/singular/learning/curiosity.py` with weighted scoring over novelty, prediction error, information gain, cost, risk and relevance, plus budget, minimum score and unproductive-attempt limits (`authorize`, `score`, `record_result`).
- Implement `ImitationEngine` in `src/singular/learning/imitation.py` to ingest structured demonstrations, normalize observation-action sequences, propose deterministic candidate skills (source scaffolds), run static safety checks, execute candidates in the sandbox, compare to a baseline, quarantine unsafe candidates, persist rollback copies and update the skill catalog only after successful validation, and persist events/curves/state (`mem/learning/*`).
- Integrate learning into the life loop by adding optional `imitation_engine` and `learning_budget` parameters to `run` and `run_tick` in `src/singular/life/loop.py`, and budgeted invocation of `imitation_engine.learn_next()` so learning is metered separately and does not make candidates visible until all gates pass.
- Add tests in `tests/test_learning_engines.py` covering: improvement over baseline across multiple episodes, quarantine of dangerous candidates, curiosity limits on unproductive exploration, and resume-of-pending-learning after restart.

### Testing

- Ran targeted unit tests: `pytest -q tests/test_learning_engines.py tests/test_skill_catalog.py` — all tests passed (`5 passed`).
- Ran `python -m compileall` on new modules to ensure they compile cleanly — succeeded.
- Ran repository-wide test collection: this run hit a preexisting upstream test collection error (an `ImportError` from a test expecting `CHECKPOINT_VERSION` in `singular.life.loop`) that is unrelated to these changes and prevented a full-suite green run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7547b9a040832ab343ce78522e1cac)