### PR TITLE
Versionner la trajectoire de la narration de soi et calculer tendances historiques

### DIFF
--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -203,7 +203,12 @@ def _event_text(row: Mapping[str, Any]) -> str:
 REQUIRED_CYCLE_PHASES = ("veille", "action", "introspection", "sommeil")
 TERMINAL_PHASE_TOKENS = ("extinct", "extinction", "death", "terminal", "dying", "stop")
 BUDGET_EXHAUSTED_EVENTS = {"loop.budget_exhausted", "daemon.budget_exhausted"}
-MUTATION_PAUSED_TOKENS = ("mutation_paused", "mutation.paused", "safe_mode", "quota_exhausted")
+MUTATION_PAUSED_TOKENS = (
+    "mutation_paused",
+    "mutation.paused",
+    "safe_mode",
+    "quota_exhausted",
+)
 
 
 def _row_phase(row: Mapping[str, Any]) -> str | None:
@@ -405,8 +410,73 @@ def _extract_identity_signal(self_narrative: dict) -> dict:
 
 
 def _extract_narrative_continuity_signal(
-    self_narrative: dict, threshold_days: int
+    self_narrative: dict,
+    threshold_days: int,
+    *,
+    snapshots: Sequence[Mapping[str, Any]] = (),
+    now: datetime | None = None,
+    minimum_events_per_day: float = 1.0,
 ) -> dict:
+    current_time = now or datetime.now(UTC)
+    valid_snapshots = [
+        (timestamp, item)
+        for item in snapshots
+        if (timestamp := _parse_dt(item.get("recorded_at"))) is not None
+        and timestamp <= current_time
+    ]
+    if valid_snapshots:
+        valid_snapshots.sort(key=lambda pair: pair[0])
+        distinct_days = sorted({timestamp.date() for timestamp, _ in valid_snapshots})
+        recent_days = set(distinct_days[-max(0, threshold_days) :])
+        recent = [pair for pair in valid_snapshots if pair[0].date() in recent_days]
+        event_count = sum(
+            max(0, int(item.get("metadata", {}).get("event_count", 0) or 0))
+            for _, item in recent
+            if isinstance(item.get("metadata"), Mapping)
+        )
+        density = event_count / max(1, len(recent_days))
+        ruptures: list[dict[str, Any]] = []
+        previous_name = ""
+        for timestamp, item in recent:
+            narrative = item.get("narrative", {})
+            identity = (
+                narrative.get("identity", {}) if isinstance(narrative, Mapping) else {}
+            )
+            name = (
+                str(identity.get("name", "")).strip()
+                if isinstance(identity, Mapping)
+                else ""
+            )
+            metadata = item.get("metadata", {})
+            explained = bool(
+                isinstance(metadata, Mapping) and metadata.get("identity_transition")
+            )
+            if previous_name and name and name != previous_name and not explained:
+                ruptures.append(
+                    {"at": timestamp.isoformat(), "from": previous_name, "to": name}
+                )
+            if name:
+                previous_name = name
+        enough_days = len(recent_days) >= threshold_days
+        ok = enough_days and density >= minimum_events_per_day and not ruptures
+        return _signal(
+            ok,
+            1.0 if ok else 0.0,
+            (
+                "versioned narrative trajectory is continuous"
+                if ok
+                else "versioned narrative trajectory is insufficient or incoherent"
+            ),
+            {
+                "distinct_days": len(recent_days),
+                "threshold_days": threshold_days,
+                "event_count": event_count,
+                "events_per_day": density,
+                "minimum_events_per_day": minimum_events_per_day,
+                "unexplained_identity_ruptures": ruptures,
+            },
+        )
+
     period_dates: list[Any] = []
     identity = (
         self_narrative.get("identity")
@@ -424,7 +494,7 @@ def _extract_narrative_continuity_signal(
         if isinstance(period, Mapping):
             period_dates.extend([period.get("start_at"), period.get("end_at")])
     first_seen = _first_timestamp(period_dates)
-    age_days = (datetime.now(UTC) - first_seen).days if first_seen else 0
+    age_days = (current_time - first_seen).days if first_seen else 0
     has_content = bool(
         self_narrative.get("current_heading")
         or _list_count(self_narrative.get("life_periods"))
@@ -626,6 +696,7 @@ def compute_life_status(
     registry_entry: object | None = None,
     runs: list[dict[str, Any]] | None = None,
     config: "LifeDefinitionConfig | None" = None,
+    now: datetime | None = None,
 ) -> LifeStatusResult:
     """Compute the philosophical-operational life status for one life home.
 
@@ -644,12 +715,14 @@ def compute_life_status(
         "world_state": mem / "world_state.json",
         "autopsy": mem / "autopsy.json",
         "self_narrative": mem / "self_narrative.json",
+        "self_narrative_timeline": mem / "self_narrative.timeline.jsonl",
         "goals": mem / "goals.json",
         "quests_state": mem / "quests_state.json",
         "generations": mem / "generations.jsonl",
     }
     autopsy = _read_json(paths["autopsy"])
     narrative = _read_json(paths["self_narrative"])
+    narrative_snapshots = _read_jsonl(paths["self_narrative_timeline"])
     goals = _read_json(paths["goals"])
     quests = _read_json(paths["quests_state"])
     generation_rows = _read_jsonl(paths["generations"])
@@ -660,7 +733,7 @@ def compute_life_status(
         else _find_registry_entry(life_home)
     )
 
-    optional_files = {"goals", "generations"}
+    optional_files = {"goals", "generations", "self_narrative_timeline"}
     missing = [
         name
         for name, path in paths.items()
@@ -758,18 +831,18 @@ def compute_life_status(
         row.get("ts") or row.get("time") or row.get("timestamp") for row in run_rows
     )
     first_seen = _first_timestamp(period_dates)
-    age_days = (datetime.now(UTC) - first_seen).days if first_seen else 0
+    current_time = now or datetime.now(UTC)
+    age_days = (current_time - first_seen).days if first_seen else 0
     narrative_has_content = bool(
         narrative.get("current_heading") or _list_count(narrative.get("life_periods"))
     )
     narrative_continuity_signal = _extract_narrative_continuity_signal(
         narrative_with_registry_identity,
         cfg.thresholds.minimum_narrative_trajectory_days,
+        snapshots=narrative_snapshots,
+        now=current_time,
     )
-    narrative_continuity = bool(
-        narrative_has_content
-        and age_days >= cfg.thresholds.minimum_narrative_trajectory_days
-    ) or bool(narrative_continuity_signal["ok"])
+    narrative_continuity = bool(narrative_continuity_signal["ok"])
 
     registry_status = str(registry.get("status", "")).lower()
     extinction_signal = _extract_extinction_signal(
@@ -797,9 +870,15 @@ def compute_life_status(
         registry_status=registry_status or None,
     )
     vital_state = str(vital_timeline.get("state", ""))
-    latest_event = str(run_rows[-1].get("event", "")).strip().lower() if run_rows else ""
+    latest_event = (
+        str(run_rows[-1].get("event", "")).strip().lower() if run_rows else ""
+    )
     budget_exhausted = latest_event in BUDGET_EXHAUSTED_EVENTS
-    mutation_paused = any(token in _event_text(row) for row in run_rows[-10:] for token in MUTATION_PAUSED_TOKENS)
+    mutation_paused = any(
+        token in _event_text(row)
+        for row in run_rows[-10:]
+        for token in MUTATION_PAUSED_TOKENS
+    )
     terminal = vital_state in {"terminal", "extinct"}
     reproduction_eligible = vital_timeline.get("reproduction_eligible") is True
     reproduction_capability = bool(

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -11,7 +11,7 @@ import logging
 import signal
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from singular.events import (
     Event,
@@ -39,7 +39,13 @@ from singular.orchestrator.lifecycle_clock import (
 )
 from singular.perception import capture_signals
 from singular.psyche import Psyche
-from singular.self_narrative import summarize_long, summarize_short, update_from_signals
+from singular.self_narrative import (
+    infer_trend,
+    load_snapshots,
+    summarize_long,
+    summarize_short,
+    update_from_signals,
+)
 from singular.resource_manager import ResourceManager
 from singular.quests import QuestRuntime
 from singular.sensors import load_host_sensor_thresholds
@@ -123,10 +129,12 @@ class OrchestratorService:
         config: OrchestratorConfig,
         bus: EventBus | None = None,
         base_dir: Path | None = None,
+        clock: Callable[[], datetime] | None = None,
     ) -> None:
         self.config = config
         self.bus = bus or get_global_event_bus()
         self.base_dir = base_dir or get_base_dir()
+        self.clock = clock or (lambda: datetime.now(timezone.utc))
         self.mem_dir = get_mem_dir()
         self.state_path = self.mem_dir / "orchestrator_state.json"
         self.stop_signal_path = self.mem_dir / "orchestrator.stop.json"
@@ -415,25 +423,66 @@ class OrchestratorService:
             except (TypeError, ValueError):
                 return 0.5
 
+        now = self.clock()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        snapshots = load_snapshots(self.mem_dir / "self_narrative.json")
+
+        def _history_values(
+            group: str, name: str, current: float
+        ) -> list[tuple[datetime, float]]:
+            values: list[tuple[datetime, float]] = []
+            for snapshot in snapshots:
+                try:
+                    at = datetime.fromisoformat(str(snapshot["recorded_at"]))
+                    entry = snapshot["narrative"][group][name]
+                    values.append((at, float(entry["value"])))
+                except (KeyError, TypeError, ValueError):
+                    continue
+            values.append((now, current))
+            return values
+
+        trait_values = {
+            name: _trait_value(name)
+            for name in (
+                "curiosity",
+                "patience",
+                "playfulness",
+                "optimism",
+                "resilience",
+            )
+        }
+        objective_trends = (
+            {
+                str(name): {
+                    "value": float(value),
+                    "trend": infer_trend(
+                        _history_values("objective_trends", str(name), float(value)),
+                        now=now,
+                    ),
+                }
+                for name, value in latest_weights.items()
+            }
+            if isinstance(latest_weights, dict)
+            else {}
+        )
+
         narrative = update_from_signals(
             {
                 "current_heading": current_heading,
                 "trait_trends": {
-                    "curiosity": {
-                        "value": _trait_value("curiosity"),
-                        "trend": "stable",
-                    },
-                    "patience": {"value": _trait_value("patience"), "trend": "stable"},
-                    "playfulness": {
-                        "value": _trait_value("playfulness"),
-                        "trend": "stable",
-                    },
-                    "optimism": {"value": _trait_value("optimism"), "trend": "stable"},
-                    "resilience": {
-                        "value": _trait_value("resilience"),
-                        "trend": "stable",
-                    },
+                    name: {
+                        "value": value,
+                        "trend": infer_trend(
+                            _history_values("trait_trends", name, value), now=now
+                        ),
+                    }
+                    for name, value in trait_values.items()
                 },
+                "objective_trends": objective_trends,
+                "event_count": len(recent_episodes)
+                + len(run_events)
+                + len(last_events),
                 "regrets_and_pride": {
                     "significant_successes": successes[-3:],
                     "significant_failures": failures[-3:],
@@ -443,6 +492,7 @@ class OrchestratorService:
                 },
             },
             self.mem_dir / "self_narrative.json",
+            clock=self.clock,
         )
         summary_short = summarize_short(narrative=narrative)
         summary_long = summarize_long(narrative=narrative)

--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping, Sequence
 import json
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+TIMELINE_SUFFIX = ".timeline.jsonl"
 
 _TRAIT_KEYS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
 
@@ -60,11 +61,15 @@ class SelfNarrative:
     trait_trends: dict[str, TraitTrend]
     regrets_and_pride: RegretsAndPride
     current_heading: str
+    objective_trends: dict[str, TraitTrend] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
         payload["trait_trends"] = {
             key: asdict(value) for key, value in self.trait_trends.items()
+        }
+        payload["objective_trends"] = {
+            key: asdict(value) for key, value in self.objective_trends.items()
         }
         return payload
 
@@ -78,12 +83,26 @@ def extract_planner_signals(narrative: SelfNarrative | None = None) -> dict[str,
     incidents = len(regrets.costly_incidents)
     successes = len(regrets.significant_successes)
     abandoned = len(regrets.abandoned_skills)
-    drift = sum(1 for trend in current.trait_trends.values() if trend.trend in {"up", "down"})
-    coherence = max(0.0, min(1.0, 1.0 - ((failures + incidents + abandoned) / max(1.0, successes + failures + 1.0))))
+    drift = sum(
+        1 for trend in current.trait_trends.values() if trend.trend in {"up", "down"}
+    )
+    coherence = max(
+        0.0,
+        min(
+            1.0,
+            1.0
+            - (
+                (failures + incidents + abandoned)
+                / max(1.0, successes + failures + 1.0)
+            ),
+        ),
+    )
     regret_pressure = max(0.0, min(1.0, (failures + incidents + abandoned) / 12.0))
     pride_drive = max(0.0, min(1.0, successes / 12.0))
     identity_drift = max(0.0, min(1.0, drift / max(1.0, len(current.trait_trends))))
-    dissonance = max(0.0, min(1.0, regret_pressure * 0.6 + identity_drift * 0.4 - pride_drive * 0.3))
+    dissonance = max(
+        0.0, min(1.0, regret_pressure * 0.6 + identity_drift * 0.4 - pride_drive * 0.3)
+    )
     return {
         "coherence_signal": coherence,
         "regret_pressure": regret_pressure,
@@ -111,6 +130,7 @@ def _default_narrative() -> SelfNarrative:
         trait_trends=_default_trait_trends(),
         regrets_and_pride=RegretsAndPride(),
         current_heading="Clarifier ma prochaine étape utile.",
+        objective_trends={},
     )
 
 
@@ -160,9 +180,70 @@ def _path_or_default(path: Path | str | None) -> Path:
     return Path("mem") / "self_narrative.json"
 
 
+def timeline_path(path: Path | str | None = None) -> Path:
+    """Return the append-only timeline belonging to a narrative projection."""
+
+    current = _path_or_default(path)
+    return current.with_name(current.stem + TIMELINE_SUFFIX)
+
+
+def load_snapshots(path: Path | str | None = None) -> list[dict[str, Any]]:
+    """Read valid snapshots without letting a damaged line hide later history."""
+
+    snapshots: list[dict[str, Any]] = []
+    try:
+        lines = timeline_path(path).read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return snapshots
+    for line in lines:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict) and _parse_iso(item.get("recorded_at")):
+            snapshots.append(item)
+    return sorted(snapshots, key=lambda item: str(item["recorded_at"]))
+
+
+def infer_trend(
+    observations: Sequence[tuple[datetime, float]],
+    *,
+    now: datetime,
+    window: timedelta = timedelta(days=7),
+    minimum_observations: int = 3,
+    minimum_delta: float = 0.03,
+) -> str:
+    """Infer a bounded linear trend from sufficiently dense recent evidence."""
+
+    recent = sorted(
+        ((at, value) for at, value in observations if now - window <= at <= now),
+        key=lambda item: item[0],
+    )
+    if len(recent) < minimum_observations:
+        return "stable"
+    xs = [(at - recent[0][0]).total_seconds() / 86400 for at, _ in recent]
+    ys = [value for _, value in recent]
+    mean_x, mean_y = sum(xs) / len(xs), sum(ys) / len(ys)
+    denominator = sum((x - mean_x) ** 2 for x in xs)
+    if denominator == 0:
+        return "stable"
+    projected_delta = (
+        sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+        / denominator
+        * max(xs[-1] - xs[0], 1.0)
+    )
+    return (
+        "up"
+        if projected_delta >= minimum_delta
+        else "down" if projected_delta <= -minimum_delta else "stable"
+    )
+
+
 def _materialize(payload: Mapping[str, Any]) -> SelfNarrative:
     schema_version = int(payload.get("schema_version", 0) or 0)
-    identity_payload = payload.get("identity") if isinstance(payload.get("identity"), Mapping) else {}
+    identity_payload = (
+        payload.get("identity") if isinstance(payload.get("identity"), Mapping) else {}
+    )
     born_at = identity_payload.get("born_at")
 
     identity = IdentitySummary(
@@ -181,9 +262,15 @@ def _materialize(payload: Mapping[str, Any]) -> SelfNarrative:
             life_periods.append(
                 LifePeriod(
                     title=str(item.get("title", "Période")),
-                    start_at=str(item.get("start_at")) if item.get("start_at") else None,
+                    start_at=(
+                        str(item.get("start_at")) if item.get("start_at") else None
+                    ),
                     end_at=str(item.get("end_at")) if item.get("end_at") else None,
-                    highlights=[str(h) for h in highlights] if isinstance(highlights, list) else [],
+                    highlights=(
+                        [str(h) for h in highlights]
+                        if isinstance(highlights, list)
+                        else []
+                    ),
                 )
             )
 
@@ -194,8 +281,12 @@ def _materialize(payload: Mapping[str, Any]) -> SelfNarrative:
             current = raw_traits.get(key)
             if isinstance(current, Mapping):
                 trait_trends[key] = TraitTrend(
-                    value=_coerce_float(current.get("value"), default=trait_trends[key].value),
-                    trend=_coerce_trend(current.get("trend") if isinstance(current, Mapping) else None),
+                    value=_coerce_float(
+                        current.get("value"), default=trait_trends[key].value
+                    ),
+                    trend=_coerce_trend(
+                        current.get("trend") if isinstance(current, Mapping) else None
+                    ),
                 )
 
     regrets_payload = (
@@ -232,7 +323,21 @@ def _materialize(payload: Mapping[str, Any]) -> SelfNarrative:
         life_periods=life_periods,
         trait_trends=trait_trends,
         regrets_and_pride=regrets,
-        current_heading=str(payload.get("current_heading", "Clarifier ma prochaine étape utile.")),
+        current_heading=str(
+            payload.get("current_heading", "Clarifier ma prochaine étape utile.")
+        ),
+        objective_trends={
+            str(key): TraitTrend(
+                value=_coerce_float(value.get("value")),
+                trend=_coerce_trend(value.get("trend")),
+            )
+            for key, value in (
+                payload.get("objective_trends", {}).items()
+                if isinstance(payload.get("objective_trends"), Mapping)
+                else []
+            )
+            if isinstance(value, Mapping)
+        },
     )
     narrative.identity.logical_age = _compute_logical_age(narrative.identity.born_at)
     return narrative
@@ -253,32 +358,41 @@ def load(path: Path | str | None = None) -> SelfNarrative:
     file_path = _path_or_default(path)
     if not file_path.exists():
         narrative = _default_narrative()
-        save(narrative, file_path)
+        save(narrative, file_path, record_snapshot=False)
         return narrative
 
     try:
         payload = json.loads(file_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        backup = file_path.with_suffix(file_path.suffix + f".corrupt-{int(datetime.now(timezone.utc).timestamp())}")
+        backup = file_path.with_suffix(
+            file_path.suffix + f".corrupt-{int(datetime.now(timezone.utc).timestamp())}"
+        )
         try:
             file_path.rename(backup)
         except OSError:
             pass
         narrative = _default_narrative()
-        save(narrative, file_path)
+        save(narrative, file_path, record_snapshot=False)
         return narrative
 
     if not isinstance(payload, Mapping):
         narrative = _default_narrative()
-        save(narrative, file_path)
+        save(narrative, file_path, record_snapshot=False)
         return narrative
 
     narrative = _migrate(payload)
-    save(narrative, file_path)
+    save(narrative, file_path, record_snapshot=False)
     return narrative
 
 
-def save(narrative: SelfNarrative, path: Path | str | None = None) -> SelfNarrative:
+def save(
+    narrative: SelfNarrative,
+    path: Path | str | None = None,
+    *,
+    clock: Callable[[], datetime] | None = None,
+    record_snapshot: bool = True,
+    snapshot_metadata: Mapping[str, Any] | None = None,
+) -> SelfNarrative:
     """Persist narrative JSON and return canonicalized object."""
 
     file_path = _path_or_default(path)
@@ -289,6 +403,20 @@ def save(narrative: SelfNarrative, path: Path | str | None = None) -> SelfNarrat
         json.dumps(narrative.to_dict(), ensure_ascii=False, indent=2),
         encoding="utf-8",
     )
+    if record_snapshot:
+        now = (clock or (lambda: datetime.now(timezone.utc)))()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        snapshot = {
+            "recorded_at": now.astimezone(timezone.utc).isoformat(),
+            "schema_version": SCHEMA_VERSION,
+            "narrative": narrative.to_dict(),
+            "metadata": dict(snapshot_metadata or {}),
+        }
+        history = timeline_path(file_path)
+        history.parent.mkdir(parents=True, exist_ok=True)
+        with history.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(snapshot, ensure_ascii=False) + "\n")
     return narrative
 
 
@@ -302,7 +430,10 @@ def _extend_unique(target: list[str], values: Any) -> None:
 
 
 def update_from_signals(
-    signals: Mapping[str, Any], path: Path | str | None = None
+    signals: Mapping[str, Any],
+    path: Path | str | None = None,
+    *,
+    clock: Callable[[], datetime] | None = None,
 ) -> SelfNarrative:
     """Update persisted narrative from external signals and return it."""
 
@@ -311,7 +442,9 @@ def update_from_signals(
     identity_patch = signals.get("identity")
     if isinstance(identity_patch, Mapping):
         if "name" in identity_patch:
-            narrative.identity.name = str(identity_patch.get("name") or narrative.identity.name)
+            narrative.identity.name = str(
+                identity_patch.get("name") or narrative.identity.name
+            )
         if "born_at" in identity_patch:
             narrative.identity.born_at = str(identity_patch.get("born_at") or "")
 
@@ -327,11 +460,15 @@ def update_from_signals(
             narrative.life_periods.append(
                 LifePeriod(
                     title=str(period.get("title", "Période")),
-                    start_at=str(period.get("start_at")) if period.get("start_at") else None,
+                    start_at=(
+                        str(period.get("start_at")) if period.get("start_at") else None
+                    ),
                     end_at=str(period.get("end_at")) if period.get("end_at") else None,
-                    highlights=[str(x) for x in period.get("highlights", [])]
-                    if isinstance(period.get("highlights"), list)
-                    else [],
+                    highlights=(
+                        [str(x) for x in period.get("highlights", [])]
+                        if isinstance(period.get("highlights"), list)
+                        else []
+                    ),
                 )
             )
 
@@ -344,6 +481,17 @@ def update_from_signals(
             baseline = narrative.trait_trends[trait]
             baseline.value = _coerce_float(patch.get("value"), baseline.value)
             baseline.trend = _coerce_trend(patch.get("trend"))
+
+    objective_signals = signals.get("objective_trends")
+    if isinstance(objective_signals, Mapping):
+        narrative.objective_trends = {
+            str(name): TraitTrend(
+                value=_coerce_float(patch.get("value")),
+                trend=_coerce_trend(patch.get("trend")),
+            )
+            for name, patch in objective_signals.items()
+            if isinstance(patch, Mapping)
+        }
 
     regrets_signals = signals.get("regrets_and_pride")
     if isinstance(regrets_signals, Mapping):
@@ -364,11 +512,21 @@ def update_from_signals(
             regrets_signals.get("costly_incidents"),
         )
 
-    save(narrative, path)
+    save(
+        narrative,
+        path,
+        clock=clock,
+        snapshot_metadata={
+            "event_count": max(0, int(signals.get("event_count", 1))),
+            "identity_transition": signals.get("identity_transition"),
+        },
+    )
     return narrative
 
 
-def summarize_short(narrative: SelfNarrative | None = None, path: Path | str | None = None) -> str:
+def summarize_short(
+    narrative: SelfNarrative | None = None, path: Path | str | None = None
+) -> str:
     """Return a compact one-line summary."""
 
     current = narrative or load(path)
@@ -378,7 +536,9 @@ def summarize_short(narrative: SelfNarrative | None = None, path: Path | str | N
     )
 
 
-def summarize_long(narrative: SelfNarrative | None = None, path: Path | str | None = None) -> str:
+def summarize_long(
+    narrative: SelfNarrative | None = None, path: Path | str | None = None
+) -> str:
     """Return a richer human-readable summary."""
 
     current = narrative or load(path)
@@ -386,7 +546,10 @@ def summarize_long(narrative: SelfNarrative | None = None, path: Path | str | No
         f"{name}={trend.value:.2f} ({trend.trend})"
         for name, trend in current.trait_trends.items()
     )
-    periods = "; ".join(period.title for period in current.life_periods[-3:]) or "aucune période marquante"
+    periods = (
+        "; ".join(period.title for period in current.life_periods[-3:])
+        or "aucune période marquante"
+    )
 
     wins = ", ".join(current.regrets_and_pride.significant_successes[-3:]) or "aucune"
     losses = ", ".join(current.regrets_and_pride.significant_failures[-3:]) or "aucune"

--- a/tests/test_self_narrative.py
+++ b/tests/test_self_narrative.py
@@ -86,3 +86,97 @@ def test_summaries_include_current_heading(tmp_path: Path) -> None:
     assert "Mieux décider." in short
     assert "Cap actuel" in long
     assert "Mieux décider." in long
+
+
+def test_versioned_timeline_keeps_seven_injected_clock_days(tmp_path: Path) -> None:
+    from singular.life.life_status import _extract_narrative_continuity_signal
+    from singular.self_narrative import load_snapshots
+
+    path = tmp_path / "mem" / "self_narrative.json"
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    for offset in range(7):
+        instant = start + timedelta(days=offset)
+        update_from_signals(
+            {
+                "identity": {"name": "Nova"},
+                "current_heading": "Continuer",
+                "event_count": 2,
+            },
+            path,
+            clock=lambda instant=instant: instant,
+        )
+
+    snapshots = load_snapshots(path)
+    signal = _extract_narrative_continuity_signal(
+        {}, 7, snapshots=snapshots, now=start + timedelta(days=6, hours=1)
+    )
+    assert signal["ok"] is True
+    assert signal["evidence"]["distinct_days"] == 7
+
+
+def test_timeline_detects_missing_day_and_unexplained_identity_drift(
+    tmp_path: Path,
+) -> None:
+    from singular.life.life_status import _extract_narrative_continuity_signal
+    from singular.self_narrative import load_snapshots
+
+    path = tmp_path / "mem" / "self_narrative.json"
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    for offset in (0, 1, 2, 4, 5, 6):
+        update_from_signals(
+            {"identity": {"name": "Nova"}, "current_heading": "Continuer"},
+            path,
+            clock=lambda offset=offset: start + timedelta(days=offset),
+        )
+    missing = _extract_narrative_continuity_signal(
+        {}, 7, snapshots=load_snapshots(path), now=start + timedelta(days=6, hours=1)
+    )
+    assert missing["ok"] is False
+    assert missing["evidence"]["distinct_days"] == 6
+
+    update_from_signals(
+        {"identity": {"name": "Autre"}, "current_heading": "Continuer"},
+        path,
+        clock=lambda: start + timedelta(days=7),
+    )
+    drift = _extract_narrative_continuity_signal(
+        {}, 7, snapshots=load_snapshots(path), now=start + timedelta(days=7, hours=1)
+    )
+    assert drift["ok"] is False
+    assert drift["evidence"]["unexplained_identity_ruptures"]
+
+
+def test_trajectory_recovers_after_interruption_and_retention_preserves_it(
+    tmp_path: Path,
+) -> None:
+    from singular.life.life_status import _extract_narrative_continuity_signal
+    from singular.self_narrative import load_snapshots, timeline_path
+    from singular.storage_retention import RetentionConfig, apply_runs_retention
+
+    path = tmp_path / "mem" / "self_narrative.json"
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    for offset in (*range(3), *range(10, 17)):
+        update_from_signals(
+            {
+                "identity": {"name": "Nova"},
+                "current_heading": "Reprendre",
+                "event_count": 1,
+            },
+            path,
+            clock=lambda offset=offset: start + timedelta(days=offset),
+        )
+    signal = _extract_narrative_continuity_signal(
+        {}, 7, snapshots=load_snapshots(path), now=start + timedelta(days=16, hours=1)
+    )
+    assert signal["ok"] is True
+
+    before = timeline_path(path).read_bytes()
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    (runs / "old.jsonl").write_text("{}\n", encoding="utf-8")
+    apply_runs_retention(
+        runs_dir=runs,
+        config=RetentionConfig(max_runs=1, max_run_age_days=1),
+        now=start + timedelta(days=30),
+    )
+    assert timeline_path(path).read_bytes() == before


### PR DESCRIPTION
### Motivation

* Permettre la conservation append-only des mises à jour de `self_narrative` pour raisonner sur une trajectoire temporelle plutôt que d’utiliser uniquement le dernier état.
* Calculer de véritables tendances de traits et d’objectifs à partir d’observations historiques plutôt que de remplir automatiquement `trend: stable`.
* Faire en sorte que le critère de continuité narrative tienne compte de jours distincts, d’une densité minimale d’événements et d’éventuelles ruptures d’identité non expliquées.

### Description

* Bump du schéma narratif à `SCHEMA_VERSION = 2` et ajout d’un fichier de chronologie append-only `self_narrative.timeline.jsonl`, plus fonctions utilitaires `timeline_path()` et `load_snapshots()` pour lire des snapshots valides. (modifications dans `src/singular/self_narrative.py`).
* Ajout de `infer_trend()` qui infère une tendance (“up”, “down”, “stable”) sur une fenêtre glissante (par défaut 7 jours) avec un seuil minimal d’observations et delta significatif. (dans `src/singular/self_narrative.py`).
* `save()` enregistre désormais des snapshots horodatés dans la chronologie (option `record_snapshot` et horloge injectable `clock`), et `update_from_signals()` accepte une `clock` injectable et enrichit les métadonnées de snapshot (`event_count`, `identity_transition`). (dans `src/singular/self_narrative.py`).
* L’orchestrateur reconstruit les séries historiques depuis la chronologie et calcule des tendances réelles pour traits et objectifs en appelant `infer_trend()` avant de mettre à jour la narration; il passe l’horloge au `save()` pour snapshots reproductibles. (dans `src/singular/orchestrator/service.py`).
* Le calcul du statut de vie lit la chronologie et remplace la logique fragile de seuil par `_extract_narrative_continuity_signal()` qui vérifie les jours distincts, la densité minimale d’événements et détecte les ruptures d’identité non expliquées via les snapshots versionnés. (dans `src/singular/life/life_status.py`).
* Ajout de tests à horloge injectée couvrant: sept jours consécutifs, détection d’un jour manquant, détection d’une dérive d’identité inexpliquée, reprise après interruption et vérification que les politiques de rétention de runs n’altèrent pas la chronologie. (dans `tests/test_self_narrative.py`).

### Testing

* `python -m pytest tests/test_self_narrative.py tests/test_orchestrator_service.py tests/test_life_status.py tests/test_retention.py -q` — suite ciblée exécutée sur les fichiers modifiés et dépendances pertinentes: allégée et réussie (`55 passed`, warnings non bloquants).
* `python -m pytest tests/test_self_narrative.py -q` — tests ajoutés pour la timeline avec horloge injectée: réussis (`7 passed`).
* Formatage et vérifications statiques: `python -m black --check ...` et `python -m compileall -q src/singular` ont été exécutés et n’ont laissé aucune erreur bloquante après reformattage; la base s’est compilée correctement.
* Note: une exécution de collecte globale initiale a échoué pour un import non lié (`CHECKPOINT_VERSION` manquant dans `singular.life.loop`) provenant d’un test non modifié; les suites ciblées touchant les modifications ont toutes réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7549404d30832aa5f9b24dc824c005)