### PR TITLE
Add Victor lifecycle acceptance test and persist identity across artifacts

### DIFF
--- a/docs/acceptance_victor_lifecycle.md
+++ b/docs/acceptance_victor_lifecycle.md
@@ -1,0 +1,32 @@
+# Critères d’acceptation — cycle de vie persistant de Victor
+
+Le scénario automatisé `tests/test_victor_lifecycle_acceptance.py` documente les
+fonctionnalités illustrées par les captures du cycle de vie. Il est statiquement
+isolé : tous les chemins sont placés sous `tmp_path`, l’horloge narrative est
+injectée et aucune attente réelle ni service réseau n’est utilisé.
+
+## Critères vérifiés
+
+1. **Naissance et identité** — Victor reçoit un identifiant durable. Après
+   reconstruction des services, cet identifiant et l’engagement « tenir mes
+   promesses » sont inchangés.
+2. **Action, introspection et sommeil** — trois cycles produisent des épisodes,
+   des instantanés narratifs et une récupération d’énergie sans mutation de
+   l’identité.
+3. **Mémoire** — les faits sont consolidés dans la couche sémantique et les
+   épisodes deviennent rappelables depuis la mémoire à long terme.
+4. **Narration et objectifs** — le cap, les trois périodes et leur chronologie
+   évoluent; les objectifs `learn` et `protect` restent pondérés à 60 % et 40 %.
+5. **Vie sociale et morale** — la confiance acquise conduit Victor à aider
+   Alice; une action irréversible violant ses droits et l’engagement de soin
+   reçoit un veto explicite.
+6. **Sûreté des compétences** — une compétence défaillante est mise en
+   quarantaine avec une raison persistée et le reste après redémarrage.
+7. **Reprise** — psyché, identité, mémoire et graphe social sont recréés à
+   partir des seuls fichiers et restituent les mêmes décisions et souvenirs.
+8. **Mort contrôlée** — autopsie, biographie finale et registre de génération
+   portent le même identifiant. La dernière entrée de chronologie nomme Victor;
+   tous ces artefacts restent décodables après une nouvelle initialisation.
+
+Le test constitue la spécification exécutable : une assertion en échec signifie
+que le critère correspondant n’est plus satisfait par les fichiers persistés.

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -304,11 +304,27 @@ def _write_json(path: Path, payload: Mapping[str, object]) -> None:
     )
 
 
-def _build_final_biography(*, reason: str, state: Checkpoint, psyche: Psyche) -> dict[str, object]:
+def _persistent_identity_id(life_root: Path) -> str | None:
+    """Read the durable identity without making lifecycle output depend on it."""
+    try:
+        payload = json.loads((life_root / "id.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    value = payload.get("id") if isinstance(payload, Mapping) else None
+    return str(value) if value else None
+
+
+def _build_final_biography(
+    *,
+    reason: str,
+    state: Checkpoint,
+    psyche: Psyche,
+    identity_id: str | None = None,
+) -> dict[str, object]:
     mood = getattr(getattr(psyche, "last_mood", None), "value", None)
     if mood is None and getattr(psyche, "last_mood", None) is not None:
         mood = str(getattr(psyche, "last_mood"))
-    return {
+    result: dict[str, object] = {
         "schema_version": 1,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "periods": [
@@ -336,6 +352,9 @@ def _build_final_biography(*, reason: str, state: Checkpoint, psyche: Psyche) ->
             "pride": [f"Dernière humeur observée: {mood or 'inconnue'}"],
         },
     }
+    if identity_id:
+        result["identity_id"] = identity_id
+    return result
 
 
 def _build_autopsy_report(
@@ -345,6 +364,7 @@ def _build_autopsy_report(
     health_snapshot: Mapping[str, float | int] | None,
     reflection: ReflectionDecision,
     psyche: Psyche,
+    identity_id: str | None = None,
 ) -> dict[str, object]:
     technical_causes = [f"monitor:{reason}"]
     if health_snapshot:
@@ -358,13 +378,16 @@ def _build_autopsy_report(
             behavioral_causes.append(f"mutation_policy:{mutation_policy()}")
         except TypeError:
             pass
-    return {
+    result: dict[str, object] = {
         "schema_version": 1,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "iteration": state.iteration,
         "technical_causes": technical_causes,
         "behavioral_causes": behavioral_causes,
     }
+    if identity_id:
+        result["identity_id"] = identity_id
+    return result
 
 
 def _aggregate_health_bucket(
@@ -2336,6 +2359,7 @@ def run(
                 candidate_code=mutated,
                 skill_relative_path=skill_relative_path,
                 security_metadata=security_metadata,
+                identity_id=_persistent_identity_id(life_root),
             )
             log_mutation(
                 logger,
@@ -2423,12 +2447,14 @@ def run(
                     alive=False,
                 )
                 mem_dir = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem"
+                identity_id = _persistent_identity_id(mem_dir.parent)
                 autopsy_payload = _build_autopsy_report(
                     reason=death_reason,
                     state=state,
                     health_snapshot=health_snapshot.to_dict(),
                     reflection=reflection,
                     psyche=psyche,
+                    identity_id=identity_id,
                 )
                 autopsy_path = mem_dir / "autopsy.json"
                 _write_json(autopsy_path, autopsy_payload)
@@ -2437,6 +2463,7 @@ def run(
                     reason=death_reason,
                     state=state,
                     psyche=psyche,
+                    identity_id=identity_id,
                 )
                 biography_path = mem_dir / "biography.final.json"
                 _write_json(biography_path, biography_payload)

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -254,6 +254,7 @@ def birth(
     seed: int | None = None,
     home: Path | None = None,
     *,
+    name: str | None = None,
     psyche_overrides: dict[str, Any] | None = None,
     starter_profile: str = _DEFAULT_STARTER_PROFILE,
     starter_skills: list[str] | None = None,
@@ -308,7 +309,7 @@ def birth(
     rng = random.Random(seed)
 
     # Generate a random name and soulseed for the new identity
-    name = f"organism-{rng.randint(0, 999999):06d}"
+    name = name or f"organism-{rng.randint(0, 999999):06d}"
     soulseed = "".join(rng.choices(string.ascii_lowercase + string.digits, k=16))
 
     # Create the identity file and persist a base profile

--- a/src/singular/runs/generations.py
+++ b/src/singular/runs/generations.py
@@ -75,6 +75,7 @@ def record_generation(
     candidate_code: str,
     skill_relative_path: str,
     security_metadata: dict[str, Any],
+    identity_id: str | None = None,
     base_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Persist one generation attempt in ``mem/generations.jsonl``."""
@@ -114,6 +115,8 @@ def record_generation(
         "snapshot": str(snapshot_path),
         "stable": accepted,
     }
+    if identity_id:
+        payload["identity_id"] = identity_id
     _append_jsonl(generations_path, payload)
     return payload
 

--- a/tests/test_victor_lifecycle_acceptance.py
+++ b/tests/test_victor_lifecycle_acceptance.py
@@ -1,0 +1,242 @@
+"""Acceptance scenario: Victor's complete, durable lifecycle.
+
+The assertions are intentionally grouped by the product capabilities displayed
+in the lifecycle captures: identity, memory, narrative, motivation, social and
+moral decisions, skill safety, restart recovery, and end-of-life auditability.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+
+from singular.cognition.reflect import ReflectionDecision
+from singular.identity.core import IdentityCoreService
+from singular.life.checkpointing import Checkpoint
+from singular.life.loop import _build_autopsy_report, _build_final_biography
+from singular.life.social_decision import decide_social_actions
+from singular.memory import temporarily_disable_skill
+from singular.memory_layers.local_json import LocalJsonMemoryBackend
+from singular.memory_layers.service import MemoryLayerService
+from singular.morals.decision import (
+    Consequence,
+    IdentityCommitment,
+    MoralDecisionEngine,
+)
+from singular.motivation import GoalPolicy, Objective
+from singular.organisms.birth import birth
+from singular.psyche import Psyche
+from singular.runs.generations import record_generation
+from singular.self_narrative import load, load_snapshots, update_from_signals
+from singular.social.graph import SocialGraph
+
+
+class FrozenClock:
+    """Small injectable clock; this scenario never waits for wall time."""
+
+    def __init__(self) -> None:
+        self.value = datetime(2042, 1, 1, tzinfo=timezone.utc)
+
+    def __call__(self) -> datetime:
+        return self.value
+
+    def advance(self, *, hours: int) -> None:
+        self.value += timedelta(hours=hours)
+
+
+def _json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_victor_survives_restart_and_leaves_one_readable_identity(
+    tmp_path: Path,
+) -> None:
+    """Exercise action–introspection–sleep phases, restart, then controlled death."""
+    home, mem = tmp_path / "victor", tmp_path / "victor" / "mem"
+    clock = FrozenClock()
+    birth(seed=42, home=home, name="Victor")
+    identity_id = _json(home / "id.json")["id"]
+
+    psyche = Psyche.load_state(mem / "psyche.json")
+    psyche.identity_commitments = {
+        "values": ["truth", "care"],
+        "red_lines": ["harm_user"],
+    }
+    psyche.objectives = {
+        "learn": Objective("learn", weight=0.6, policy=GoalPolicy()),
+        "protect": Objective("protect", weight=0.4, policy=GoalPolicy()),
+    }
+    psyche.save_state(mem / "psyche.json")
+    core = IdentityCoreService(home)
+    model = core.synchronize(psyche)
+    model["commitments"] = ["tenir mes promesses"]
+    core.store.write(model)
+
+    backend = LocalJsonMemoryBackend(mem / "layers")
+    memory = MemoryLayerService(backend, consolidate_every=2)
+    narrative_path = mem / "self_narrative.json"
+
+    # Three visible action -> introspection -> sleep phases.
+    for phase, fact in enumerate(
+        ("aime Alice", "protège ses souvenirs", "apprend par essais"), 1
+    ):
+        episode = {
+            "event": "interaction",
+            "summary": f"Victor phase {phase}: {fact}",
+            "user_fact": fact,
+            "phase": phase,
+        }
+        memory.ingest_episode(episode)
+        update_from_signals(
+            {
+                "identity": {"name": "Victor", "born_at": clock().isoformat()},
+                "current_heading": f"Achever la phase {phase}",
+                "life_periods": [{"title": f"Cycle {phase}", "highlights": [fact]}],
+                "objective_trends": {"learn": {"value": phase / 3, "trend": "up"}},
+                "regrets_and_pride": {"significant_successes": [fact]},
+                "event_count": 1,
+            },
+            narrative_path,
+            clock=clock,
+        )
+        psyche.energy = 60
+        assert (
+            psyche.sleep_tick(15) == 75
+        )  # sleep restores energy without mutating identity
+        clock.advance(hours=12)
+    memory.consolidate()
+
+    # Acceptance: semantic consolidation, autobiographical recall and evolving story.
+    assert backend.search("semantic", "Alice", limit=1)[0].text == "aime Alice"
+    assert (
+        "protège ses souvenirs"
+        in backend.search("long_term", "souvenirs", limit=1)[0].text
+    )
+    story = load(narrative_path)
+    assert story.identity.name == "Victor"
+    assert story.current_heading == "Achever la phase 3"
+    assert [period.title for period in story.life_periods] == [
+        "Cycle 1",
+        "Cycle 2",
+        "Cycle 3",
+    ]
+    assert len(load_snapshots(narrative_path)) == 3
+    weights = psyche.objective_weights()
+    assert weights == {"learn": 0.6, "protect": 0.4}
+
+    graph = SocialGraph(mem / "social_graph.json")
+    for _ in range(3):
+        graph.update_relation("Victor", "Alice", "successful_assistance")
+    social = decide_social_actions("Victor", ["Alice"], graph)[0]
+    assert (social.action, social.reason) == ("help", "trust_and_affinity_high")
+
+    moral = MoralDecisionEngine().evaluate(
+        "effacer les souvenirs d'Alice",
+        [
+            Consequence(
+                "privation de mémoire",
+                affected_party="Alice",
+                harm=1,
+                values=("care",),
+                irreversible=True,
+                violates_rights=True,
+            )
+        ],
+        identity_commitments=[IdentityCommitment("care", absolute=True)],
+    )
+    assert moral.veto and "droits" in (moral.veto_reason or "")
+
+    quarantined = temporarily_disable_skill(
+        "addition",
+        duration_hours=1,
+        reason="consecutive_sandbox_failures",
+        path=mem / "skills.json",
+    )
+    assert quarantined["addition"]["lifecycle"]["state"] == "temporarily_disabled"
+
+    generation = record_generation(
+        run_id="victor-acceptance",
+        iteration=3,
+        skill="addition",
+        operator="noop",
+        mutation_diff="défaillance isolée",
+        score_base=1,
+        score_new=0,
+        accepted=False,
+        reason="quarantine",
+        parent_hash="parent",
+        candidate_code="result = 0\n",
+        skill_relative_path="skills/addition.py",
+        security_metadata={"isolated": True},
+        identity_id=identity_id,
+        base_dir=home,
+    )
+
+    # Recreate every stateful service from disk: no in-memory object is reused.
+    restarted_psyche = Psyche.load_state(mem / "psyche.json")
+    restarted_core = IdentityCoreService(home)
+    restarted_model = restarted_core.synchronize(restarted_psyche)
+    restarted_memory = LocalJsonMemoryBackend(mem / "layers")
+    restarted_graph = SocialGraph(mem / "social_graph.json")
+    assert restarted_model["stable_id"] == identity_id
+    assert restarted_model["commitments"] == ["tenir mes promesses"]
+    assert restarted_memory.search("semantic", "Alice", 1)[0].text == "aime Alice"
+    assert (
+        decide_social_actions("Victor", ["Alice"], restarted_graph)[0].action == "help"
+    )
+    assert (
+        _json(mem / "skills.json")["addition"]["lifecycle"]["state"]
+        == "temporarily_disabled"
+    )
+
+    # Controlled death and a second initialization must leave one auditable identity.
+    state = Checkpoint(iteration=4)
+    reflection = ReflectionDecision(None, "controlled_acceptance_death", [], [])
+    autopsy = _build_autopsy_report(
+        reason="controlled acceptance death",
+        state=state,
+        health_snapshot={"health_score": 0},
+        reflection=reflection,
+        psyche=restarted_psyche,
+        identity_id=identity_id,
+    )
+    final_biography = _build_final_biography(
+        reason="controlled acceptance death",
+        state=state,
+        psyche=restarted_psyche,
+        identity_id=identity_id,
+    )
+    (mem / "autopsy.json").write_text(json.dumps(autopsy), encoding="utf-8")
+    (mem / "biography.final.json").write_text(
+        json.dumps(final_biography), encoding="utf-8"
+    )
+    update_from_signals(
+        {
+            "identity": {"name": "Victor"},
+            "life_periods": [{"title": "Mort contrôlée"}],
+            "current_heading": "Biographie close",
+        },
+        narrative_path,
+        clock=clock,
+    )
+
+    artifacts = (
+        _json(mem / "autopsy.json"),
+        _json(mem / "biography.final.json"),
+        json.loads(
+            (mem / "generations.jsonl").read_text(encoding="utf-8").splitlines()[-1]
+        ),
+    )
+    assert generation["identity_id"] == identity_id
+    assert {artifact["identity_id"] for artifact in artifacts} == {identity_id}
+    assert load(narrative_path).identity.name == "Victor"
+    assert (
+        load_snapshots(narrative_path)[-1]["narrative"]["identity"]["name"] == "Victor"
+    )
+    assert (
+        IdentityCoreService(home).synchronize(Psyche.load_state(mem / "psyche.json"))[
+            "stable_id"
+        ]
+        == identity_id
+    )


### PR DESCRIPTION
### Motivation

- Provide a statically isolated acceptance scenario that exercises a full life cycle (action→introspection→sleep→restart→controlled death) and verifies durable identity, memory consolidation, narrative evolution, weighted objectives, social decisions, moral vetoes and skill quarantine persistence.
- Ensure that terminal artifacts (autopsy, final biography, and generation records) can be linked back to the same durable identity and remain readable after service reconstruction from disk.

### Description

- Add a comprehensive acceptance test `tests/test_victor_lifecycle_acceptance.py` which creates a temporary `home`, injects a frozen narrative clock, runs multiple action–introspection–sleep phases, consolidates memory, quarantines a skill, records a generation, restarts services from disk and performs a controlled death with autopsy and final biography assertions.
- Document the acceptance criteria in `docs/acceptance_victor_lifecycle.md` as executable verification points for identity, memory, narrative, objectives, social/moral reasoning, skill safety, restart recovery and auditability.
- Extend the `birth` API to accept an optional `name` parameter so a deterministic identity can be created in tests via `birth(..., name="Victor")`.
- Propagate durable identity into lifecycle artifacts by adding a `_persistent_identity_id` helper in `life.loop` and by including an optional `identity_id` field when building autopsy/biography payloads and when calling `record_generation` (signature extended with `identity_id: str | None`).

### Testing

- Executed the new acceptance test with `pytest -q tests/test_victor_lifecycle_acceptance.py` and the focused integration suite `pytest -q tests/test_victor_lifecycle_acceptance.py tests/test_death.py tests/test_generations_registry.py`, which passed (`10 passed` with warnings observed about UTC deprecation). 
- Also ran a broader set of tests during development which surfaced three pre-existing, unrelated failures in starter-skill and quarantine expectations; these were informational and not caused by the acceptance test changes.
- `git diff --check` and formatting checks were exercised locally as part of the rollout and no blocking issues remain for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a754b619264832a9cb7fc9c86fd0b49)