### PR TITLE
Add MemoryRetrievalService, embedding-capable MemoryBackend and integrate into talk

### DIFF
--- a/src/singular/memory_layers/__init__.py
+++ b/src/singular/memory_layers/__init__.py
@@ -1,6 +1,7 @@
 from .base import MemoryBackend, MemoryRecord
 from .local_json import LocalJsonMemoryBackend
 from .service import MemoryLayerService
+from .retrieval import MemoryRetrievalService, RetrievalResult
 from .vector_adapter import build_backend
 
 __all__ = [
@@ -8,5 +9,7 @@ __all__ = [
     "MemoryRecord",
     "LocalJsonMemoryBackend",
     "MemoryLayerService",
+    "MemoryRetrievalService",
+    "RetrievalResult",
     "build_backend",
 ]

--- a/src/singular/memory_layers/base.py
+++ b/src/singular/memory_layers/base.py
@@ -25,3 +25,6 @@ class MemoryBackend(Protocol):
 
     def delete(self, layer: str, record_id: str) -> bool:
         """Delete one record by id and return whether it existed."""
+
+    def similarity(self, query: str, text: str) -> float:
+        """Return lexical or embedding similarity without requiring a remote service."""

--- a/src/singular/memory_layers/local_json.py
+++ b/src/singular/memory_layers/local_json.py
@@ -7,6 +7,7 @@ import math
 import os
 import re
 import tempfile
+from typing import Callable
 
 from .base import MemoryBackend, MemoryRecord
 
@@ -16,8 +17,11 @@ _TOKEN_RE = re.compile(r"[a-zA-Z0-9_]+")
 class LocalJsonMemoryBackend(MemoryBackend):
     """Simple local backend based on JSONL files and lexical similarity."""
 
-    def __init__(self, root: Path) -> None:
+    def __init__(
+        self, root: Path, *, embed: Callable[[str], list[float]] | None = None
+    ) -> None:
         self.root = Path(root)
+        self.embed = embed
         self.root.mkdir(parents=True, exist_ok=True)
 
     def _layer_path(self, layer: str) -> Path:
@@ -78,10 +82,9 @@ class LocalJsonMemoryBackend(MemoryBackend):
         self._write_layer(layer, records)
 
     def search(self, layer: str, query: str, limit: int = 5) -> list[MemoryRecord]:
-        query_vec = _vectorize(query)
         scored: list[MemoryRecord] = []
         for rec in self._read_layer(layer):
-            rec.score = _cosine(query_vec, _vectorize(rec.text))
+            rec.score = self.similarity(query, rec.text)
             scored.append(rec)
         scored.sort(key=lambda item: item.score, reverse=True)
         return scored[: max(0, limit)]
@@ -91,6 +94,15 @@ class LocalJsonMemoryBackend(MemoryBackend):
         filtered = [rec for rec in records if rec.id != record_id]
         self._write_layer(layer, filtered)
         return len(filtered) != len(records)
+
+    def similarity(self, query: str, text: str) -> float:
+        """Use configured embeddings, falling back safely to local token vectors."""
+        if self.embed is not None:
+            try:
+                return _dense_cosine(self.embed(query), self.embed(text))
+            except (OSError, RuntimeError, TypeError, ValueError):
+                pass
+        return _cosine(_vectorize(query), _vectorize(text))
 
 
 def _vectorize(text: str) -> Counter[str]:
@@ -106,3 +118,13 @@ def _cosine(a: Counter[str], b: Counter[str]) -> float:
     if norm_a == 0.0 or norm_b == 0.0:
         return 0.0
     return dot / (norm_a * norm_b)
+
+
+def _dense_cosine(a: list[float], b: list[float]) -> float:
+    if not a or len(a) != len(b):
+        return 0.0
+    norm_a = math.sqrt(sum(value * value for value in a))
+    norm_b = math.sqrt(sum(value * value for value in b))
+    if not norm_a or not norm_b:
+        return 0.0
+    return sum(left * right for left, right in zip(a, b)) / (norm_a * norm_b)

--- a/src/singular/memory_layers/retrieval.py
+++ b/src/singular/memory_layers/retrieval.py
@@ -1,0 +1,245 @@
+"""Life-scoped retrieval across autobiographical memory sources."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .base import MemoryBackend
+
+
+@dataclass(frozen=True)
+class RetrievalResult:
+    source: str
+    id: str
+    date: str | None
+    score: float
+    confidence: float
+    excerpt: str
+
+    def as_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value.update({"ts": self.date, "summary": self.excerpt})
+        return value
+
+
+class MemoryRetrievalService:
+    """Rank persisted memories belonging exclusively to one life directory."""
+
+    def __init__(self, life_root: Path | str, backend: MemoryBackend) -> None:
+        self.life_root = Path(life_root).resolve()
+        self.mem = self.life_root / "mem"
+        self.backend = backend
+
+    def retrieve(
+        self,
+        user_query: str,
+        *,
+        active_objectives: Iterable[str] = (),
+        current_context: Mapping[str, Any] | str | None = None,
+        limit: int = 8,
+    ) -> list[dict[str, Any]]:
+        context = (
+            json.dumps(current_context, ensure_ascii=False, sort_keys=True)
+            if isinstance(current_context, Mapping)
+            else str(current_context or "")
+        )
+        query = " ".join(
+            part for part in (user_query, " ".join(active_objectives), context) if part
+        )
+        now = datetime.now(timezone.utc)
+        ranked: list[tuple[float, dict[str, Any]]] = []
+        for item in self._file_candidates() + self._layer_candidates(query):
+            relevance = max(0.0, float(self.backend.similarity(query, item["excerpt"])))
+            # Importance and recency rerank matches; they cannot create one.
+            if relevance <= 0.0:
+                continue
+            confidence = max(0.0, min(1.0, float(item.get("confidence", 0.7))))
+            score = (
+                0.62 * relevance
+                + 0.14 * _recency(item.get("date"), now)
+                + 0.14 * float(item.get("importance", 0.5))
+                + 0.10 * confidence
+            )
+            ranked.append((score, item))
+
+        seen: set[str] = set()
+        results: list[RetrievalResult] = []
+        source_counts: dict[str, int] = {}
+        for score, item in sorted(ranked, key=lambda pair: pair[0], reverse=True):
+            fingerprint = _fingerprint(item["excerpt"])
+            if fingerprint in seen:
+                continue
+            seen.add(fingerprint)
+            source = item["source"]
+            score *= 0.82 ** source_counts.get(source, 0)
+            results.append(
+                RetrievalResult(
+                    source,
+                    item["id"],
+                    item.get("date"),
+                    round(score, 6),
+                    round(float(item.get("confidence", 0.7)), 4),
+                    item["excerpt"][:360],
+                )
+            )
+            source_counts[source] = source_counts.get(source, 0) + 1
+        results.sort(key=lambda result: result.score, reverse=True)
+        return [result.as_dict() for result in results[: max(0, limit)]]
+
+    @staticmethod
+    def within_budget(
+        results: Iterable[Mapping[str, Any]], budget_chars: int
+    ) -> list[dict[str, Any]]:
+        """Select complete ranked excerpts without exceeding the context budget."""
+        selected, used = [], 0
+        for result in results:
+            cost = len(str(result.get("excerpt") or result.get("summary") or ""))
+            if used + cost <= max(0, budget_chars):
+                selected.append(dict(result))
+                used += cost
+        return selected
+
+    def _file_candidates(self) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for index, payload in enumerate(_read_jsonl(self.mem / "episodic.jsonl")):
+            if str(payload.get("event", "")).startswith("memory."):
+                continue
+            text = _best_text(payload)
+            if text:
+                rows.append(_candidate("episode", payload, text, str(index)))
+        for filename, source in (
+            ("semantic_memory.json", "semantic_fact"),
+            ("self_model.json", "self_model"),
+            ("self_narrative.json", "self_narrative"),
+        ):
+            for index, (trail, value, metadata) in enumerate(
+                _leaves(_read_json(self.mem / filename))
+            ):
+                # Structured fact objects already carry their own provenance;
+                # avoid diluting their semantic text with JSON field paths.
+                excerpt = (
+                    value if metadata else (f"{trail}: {value}" if trail else value)
+                )
+                rows.append(
+                    _candidate(
+                        source,
+                        metadata,
+                        excerpt,
+                        str(index),
+                    )
+                )
+        return rows
+
+    def _layer_candidates(self, query: str) -> list[dict[str, Any]]:
+        rows = []
+        for layer, source in (
+            ("semantic", "semantic_fact"),
+            ("long_term", "long_term"),
+        ):
+            for record in self.backend.search(layer, query, limit=50):
+                metadata = record.metadata
+                rows.append(
+                    {
+                        "source": source,
+                        "id": record.id,
+                        "date": metadata.get("ts") or metadata.get("date"),
+                        "confidence": metadata.get("confidence", 0.75),
+                        "importance": metadata.get(
+                            "importance", 0.65 if source == "long_term" else 0.55
+                        ),
+                        "excerpt": record.text,
+                    }
+                )
+        return rows
+
+
+def _candidate(
+    source: str, metadata: Mapping[str, Any], text: str, fallback: str
+) -> dict[str, Any]:
+    return {
+        "source": source,
+        "id": str(
+            metadata.get("id") or metadata.get("episode_id") or f"{source}-{fallback}"
+        ),
+        "date": metadata.get("ts")
+        or metadata.get("date")
+        or metadata.get("updated_at"),
+        "confidence": metadata.get(
+            "confidence", 0.8 if source.startswith("self_") else 0.7
+        ),
+        "importance": metadata.get(
+            "importance", 0.85 if source in {"self_model", "self_narrative"} else 0.5
+        ),
+        "excerpt": " ".join(text.split()),
+    }
+
+
+def _best_text(payload: Mapping[str, Any]) -> str:
+    return next(
+        (
+            payload[key]
+            for key in ("text", "summary", "message", "human_summary", "event")
+            if isinstance(payload.get(key), str) and payload[key].strip()
+        ),
+        "",
+    )
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    try:
+        return [
+            value
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if isinstance((value := json.loads(line)), dict)
+        ]
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def _leaves(
+    value: Any, trail: str = ""
+) -> Iterable[tuple[str, str, Mapping[str, Any]]]:
+    if isinstance(value, dict):
+        if isinstance(value.get("value"), (str, int, float, bool)):
+            yield trail, str(value["value"]), value
+            return
+        for key, child in value.items():
+            yield from _leaves(child, f"{trail}.{key}".strip("."))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from _leaves(child, f"{trail}[{index}]")
+    elif isinstance(value, (str, int, float, bool)) and str(value).strip():
+        yield trail, str(value), {}
+
+
+def _fingerprint(text: str) -> str:
+    # File-backed scalar leaves may be prefixed by their JSON path.  The value
+    # remains the same memory and should deduplicate against a structured fact.
+    if ": " in text:
+        text = text.rsplit(": ", 1)[-1]
+    normalized = " ".join(
+        "".join(char.lower() if char.isalnum() else " " for char in text).split()
+    )
+    return hashlib.sha1(normalized.encode()).hexdigest()
+
+
+def _recency(value: Any, now: datetime) -> float:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return 1 / (1 + max(0.0, (now - parsed).total_seconds() / 86400) / 30)
+    except (TypeError, ValueError):
+        return 0.35

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -15,8 +15,8 @@ from ..memory import (
     ensure_memory_structure,
     format_recalled_memories,
     read_episodes,
-    recall_relevant_episodes,
 )
+from ..memory_layers import MemoryRetrievalService, build_backend
 from ..perception import capture_signals
 from ..psyche import Mood, Psyche
 from ..self_narrative import load as load_self_narrative, summarize_short
@@ -205,9 +205,9 @@ def talk(
 
     psyche = Psyche.load_state()
 
-    def gather_context() -> tuple[
-        str | None, dict | None, dict | None, str | None, str | None
-    ]:
+    def gather_context() -> (
+        tuple[str | None, dict | None, dict | None, str | None, str | None]
+    ):
         signals = capture_signals()
         add_episode({"event": "perception", **signals})
         psyche.consume()
@@ -272,14 +272,25 @@ def talk(
     ) -> None:
         user_signals = _extract_structured_signals(user_input)
         theme = str(user_signals.get("theme", "general"))
-        recall_terms = [theme] if theme != "general" else []
-        recalled_memories = recall_relevant_episodes(
-            themes=recall_terms,
-            objectives=[f"user_dialogue:{theme}"] if theme != "general" else [],
-            limit=3,
+        life_root = os.environ.get("SINGULAR_HOME", ".")
+        retrieval = MemoryRetrievalService(
+            life_root, build_backend(root=os.path.join(life_root, "mem", "layers"))
         )
+        recalled_memories = retrieval.retrieve(
+            user_input,
+            active_objectives=[f"user_dialogue:{theme}"],
+            current_context={
+                "theme": theme,
+                "last_event": last_event,
+                "mood": mood_event,
+            },
+            limit=8,
+        )
+        recalled_memories = retrieval.within_budget(recalled_memories, 120)
         recall_summary = format_recalled_memories(recalled_memories)
-        if recalled_memories:
+        # General small-talk may reuse immediate context without creating two
+        # self-referential audit episodes on every turn.
+        if recalled_memories and theme != "general":
             add_episode(
                 {
                     "event": "memory.recalled",

--- a/tests/test_memory_retrieval.py
+++ b/tests/test_memory_retrieval.py
@@ -1,0 +1,86 @@
+import json
+from pathlib import Path
+
+from singular.memory_layers import (
+    LocalJsonMemoryBackend,
+    MemoryRecord,
+    MemoryRetrievalService,
+)
+
+
+def _write(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, ensure_ascii=False), encoding="utf-8")
+
+
+def test_embedding_paraphrase_and_restart(tmp_path: Path) -> None:
+    def embed(text: str) -> list[float]:
+        return [1.0, 0.0] if "félin" in text or "chat" in text else [0.0, 1.0]
+
+    layers = tmp_path / "mem" / "layers"
+    backend = LocalJsonMemoryBackend(layers, embed=embed)
+    backend.put(
+        "long_term", MemoryRecord("pet", "Mon chat s'appelle Moka", {"confidence": 0.9})
+    )
+
+    # A freshly constructed service/backend proves persistence across restart.
+    restarted = MemoryRetrievalService(
+        tmp_path, LocalJsonMemoryBackend(layers, embed=embed)
+    )
+    result = restarted.retrieve("Quel est le nom de mon félin ?", limit=1)[0]
+    assert result["id"] == "pet"
+    assert (
+        set(("source", "id", "date", "score", "confidence", "excerpt")) <= result.keys()
+    )
+
+
+def test_general_query_mixes_sources_and_respects_budget(tmp_path: Path) -> None:
+    mem = tmp_path / "mem"
+    mem.mkdir()
+    (mem / "episodic.jsonl").write_text(
+        json.dumps(
+            {"id": "trip", "text": "souvenir important de voyage", "importance": 1.0}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write(
+        mem / "semantic_memory.json",
+        [{"id": "fact", "value": "souvenir de thé", "confidence": 0.8}],
+    )
+    _write(mem / "self_narrative.json", {"current_heading": "préserver mes souvenirs"})
+    backend = LocalJsonMemoryBackend(mem / "layers")
+    backend.put("long_term", MemoryRecord("long", "souvenir consolidé", {}))
+
+    service = MemoryRetrievalService(tmp_path, backend)
+    results = service.retrieve(
+        "Quels souvenirs as-tu en général ?",
+        active_objectives=["préserver mes souvenirs"],
+        current_context={"topic": "souvenir"},
+    )
+    assert {item["source"] for item in results} >= {
+        "episode",
+        "semantic_fact",
+        "self_narrative",
+        "long_term",
+    }
+    selected = service.within_budget(results, 25)
+    assert sum(len(item["excerpt"]) for item in selected) <= 25
+
+
+def test_ranking_deduplication_and_life_isolation(tmp_path: Path) -> None:
+    first, second = tmp_path / "first", tmp_path / "second"
+    _write(
+        first / "mem" / "self_model.json",
+        {"facts": [{"id": "a", "value": "Alice aime le thé", "importance": 1.0}]},
+    )
+    _write(first / "mem" / "self_narrative.json", {"duplicate": "Alice aime le thé"})
+    _write(second / "mem" / "self_model.json", {"secret": "Bob aime le café"})
+    service = MemoryRetrievalService(
+        first, LocalJsonMemoryBackend(first / "mem" / "layers")
+    )
+
+    results = service.retrieve("Qui aime le thé ?")
+    assert results[0]["id"] == "a"
+    assert sum("Alice aime le thé" in item["excerpt"] for item in results) == 1
+    assert all("Bob" not in item["excerpt"] for item in results)


### PR DESCRIPTION
### Motivation
- Unifier la récupération autobiographique en interrogeant conjointement épisodes, faits sémantiques, `self_model.json`, `self_narrative.json` et la couche long terme pour produire des souvenirs pertinents et auditables.
- Fournir une interface d’embeddings configurable tout en conservant la backend lexical local comme repli sûr.
- Remplacer les appels ad-hoc à `recall_relevant_episodes()` pour centraliser le classement (récence, pertinence, importance autobiographique, confiance), la déduplication et la diversité des sources.

### Description
- Ajouté `MemoryRetrievalService` et `RetrievalResult` dans `src/singular/memory_layers/retrieval.py` pour agréger et classer les candidats issus des fichiers de vie et des couches de vecteurs, avec déduplication et pénalité MMR-like par source, et méthode `within_budget()` pour respecter un budget de contexte.
- Étendu le protocole `MemoryBackend` avec une méthode `similarity(query, text)` dans `src/singular/memory_layers/base.py`.
- Étendu `LocalJsonMemoryBackend` (`src/singular/memory_layers/local_json.py`) pour accepter un paramètre optionnel `embed` (callable) et utiliser des similarités d’embeddings (`_dense_cosine`) quand fourni, en retombant sur la similarité lexicale locale sinon.
- Remplacé l’appel à `recall_relevant_episodes()` dans `src/singular/organisms/talk.py` par `MemoryRetrievalService` construit via `build_backend()`, en lui passant la requête complète, les objectifs actifs et le contexte courant, et en n’injectant que les résultats qui respectent le budget de contexte.
- Ajouté tests ciblés `tests/test_memory_retrieval.py` couvrant paraphrase par embeddings, requête générale mélangeant sources, persistance après redémarrage, déduplication et isolement entre vies.

### Testing
- Exécutés les tests ciblés: `tests/test_memory_retrieval.py`, `tests/test_memory_layers.py`, `tests/test_memory_layers_service_targeted.py` et scénarios de `tests/test_talk.py` (sélection de cas pertinents); ces suites ciblées se sont toutes bien passées (total: 15 tests verts dans les runs ciblés).
- Réformatage avec `black` appliqué aux fichiers modifiés sans erreur de style.
- Tentative d’exécution du jeu de tests complet a échoué en collecte à cause d’une erreur préexistante non liée (import manquant de `CHECKPOINT_VERSION` dans `singular.life.loop`), qui bloque la collecte globale mais n’est pas introduite par cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75fab19498832ab28e34902cc20b62)