### PR TITLE
Add evidence-backed metacognitive calibration and self-observation service

### DIFF
--- a/src/singular/cognition/__init__.py
+++ b/src/singular/cognition/__init__.py
@@ -1,5 +1,11 @@
 """Cognitive helpers used by decision-making components."""
 
 from .reflect import ActionHypothesis, ReflectionDecision, reflect_action
+from .self_observation import SelfObservationService
 
-__all__ = ["ActionHypothesis", "ReflectionDecision", "reflect_action"]
+__all__ = [
+    "ActionHypothesis",
+    "ReflectionDecision",
+    "SelfObservationService",
+    "reflect_action",
+]

--- a/src/singular/cognition/reflect.py
+++ b/src/singular/cognition/reflect.py
@@ -169,6 +169,7 @@ def reflect_action(
     resource_weight: float = 0.15,
     bus: EventBus | None = None,
     event_context: Mapping[str, Any] | None = None,
+    metacognition: Mapping[str, Any] | None = None,
 ) -> ReflectionDecision:
     """Select the best action from candidate hypotheses.
 
@@ -212,11 +213,26 @@ def reflect_action(
     ranked = [action for _, action, _ in ranked_scores]
     selected = ranked_scores[0][1]
     selected_assessment = assessments_by_action[selected]
+    meta = dict(metacognition or {})
+    samples = int(meta.get("sample_count", 0) or 0)
+    calibration = _clamp(float(meta.get("calibration_score", 0.5) or 0.5))
+    uncertainty = _clamp(float(meta.get("uncertainty", 1.0) or 1.0))
+    evidence_weight = min(1.0, samples / 3.0)
+    calibrated_confidence = _clamp(
+        selected_assessment.confidence * (1.0 - evidence_weight)
+        + calibration * evidence_weight
+    )
+    recommendation = selected_assessment.action_recommended
+    limitations = _metadata_list(meta, "limitations")
+    if samples >= 3 and (calibration < 0.55 or uncertainty > 0.65):
+        recommendation = (
+            "request_information" if uncertainty > 0.65 else "simulate_or_escalate"
+        )
     reason = (
         "selected highest weighted score "
         f"(long_term={long_term_weight:.2f}, sandbox={sandbox_weight:.2f}, "
         f"resources={resource_weight:.2f}); "
-        f"confidence={selected_assessment.confidence:.2f}"
+        f"confidence={calibrated_confidence:.2f}; calibration={calibration:.2f}"
     )
     decision = ReflectionDecision(
         action=selected,
@@ -224,10 +240,10 @@ def reflect_action(
         alternative_scores=ranked_scores,
         ranked_actions=ranked,
         hypotheses=selected_assessment.hypotheses,
-        risks=selected_assessment.risks,
+        risks=selected_assessment.risks + limitations,
         benefits=selected_assessment.benefits,
-        confidence=selected_assessment.confidence,
-        action_recommended=selected_assessment.action_recommended,
+        confidence=calibrated_confidence,
+        action_recommended=recommendation,
         assessments=[assessments_by_action[action] for action in ranked],
     )
     _publish_decision(decision, bus=bus, event_context=event_context)

--- a/src/singular/cognition/self_observation.py
+++ b/src/singular/cognition/self_observation.py
@@ -1,0 +1,205 @@
+"""Evidence-bound observation and calibration of the agent's own decisions."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from singular.identity.self_model import SelfModelStore
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+class SelfObservationService:
+    """Compare predicted and actual outcomes without turning guesses into facts.
+
+    Every accepted observation has at least one durable evidence reference.  A
+    domain score remains explicitly uncertain until three independent samples
+    exist, and confidence is shrunk toward 0.5 while evidence is sparse.
+    """
+
+    MIN_EVIDENCE = 3
+    REPEATED_FAILURES = 3
+
+    def __init__(self, store: SelfModelStore | Path | str) -> None:
+        self.store = (
+            store if isinstance(store, SelfModelStore) else SelfModelStore(store)
+        )
+
+    def observe(self, observations: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+        model = self.store.read()
+        meta = model["metacognition"]
+        now = _now()
+        processed = set(str(ref) for ref in meta.get("processed_evidence_refs", ()))
+        for raw in observations:
+            refs = [str(ref) for ref in raw.get("evidence_refs", ()) if str(ref)]
+            if not refs or all(ref in processed for ref in refs):
+                continue
+            domain = str(raw.get("domain") or "general")
+            prediction = _clamp(
+                float(raw.get("prediction", raw.get("confidence", 0.5)))
+            )
+            success = bool(raw.get("success", False))
+            outcome = 1.0 if success else 0.0
+            error = abs(prediction - outcome)
+            record = meta["domains"].setdefault(
+                domain,
+                {
+                    "sample_count": 0,
+                    "success_count": 0,
+                    "mean_confidence": 0.0,
+                    "brier_score": None,
+                    "calibration_score": None,
+                    "competence": None,
+                    "limitations": [],
+                    "uncertainty": 1.0,
+                    "evidence_refs": [],
+                },
+            )
+            n = int(record["sample_count"])
+            record["sample_count"] = n + 1
+            record["success_count"] = int(record["success_count"]) + int(success)
+            record["mean_confidence"] = (
+                (float(record["mean_confidence"]) * n) + prediction
+            ) / (n + 1)
+            previous_brier = float(record["brier_score"] or 0.0)
+            brier = ((previous_brier * n) + (error * error)) / (n + 1)
+            record["brier_score"] = brier
+            # Shrink estimates toward ignorance until there is adequate evidence.
+            weight = min(1.0, (n + 1) / self.MIN_EVIDENCE)
+            record["calibration_score"] = 0.5 + ((1.0 - brier - 0.5) * weight)
+            observed_rate = int(record["success_count"]) / (n + 1)
+            record["competence"] = 0.5 + ((observed_rate - 0.5) * weight)
+            record["uncertainty"] = 1.0 / ((n + 1) ** 0.5)
+            record["evidence_refs"] = list(
+                dict.fromkeys([*record["evidence_refs"], *refs])
+            )[-100:]
+
+            failure = str(
+                raw.get("failure_condition") or raw.get("error_type") or ""
+            ).strip()
+            if not success and failure:
+                item = meta["failure_conditions"].setdefault(
+                    f"{domain}:{failure}",
+                    {"count": 0, "domains": [domain], "evidence_refs": []},
+                )
+                item["count"] += 1
+                item["evidence_refs"] = list(
+                    dict.fromkeys([*item["evidence_refs"], *refs])
+                )[-50:]
+                if item["count"] >= self.REPEATED_FAILURES:
+                    limitation = f"repeated_failure:{failure}"
+                    if limitation not in record["limitations"]:
+                        record["limitations"].append(limitation)
+                    meta["recurring_errors"][f"{domain}:{failure}"] = dict(item)
+
+            strategy = str(raw.get("strategy") or "").strip()
+            if success and strategy:
+                item = meta["effective_strategies"].setdefault(
+                    strategy, {"success_count": 0, "evidence_refs": []}
+                )
+                item["success_count"] += 1
+                item["evidence_refs"] = list(
+                    dict.fromkeys([*item["evidence_refs"], *refs])
+                )[-50:]
+            bias = str(raw.get("observed_bias") or "").strip()
+            if bias:
+                item = meta["observed_biases"].setdefault(
+                    bias, {"count": 0, "evidence_refs": []}
+                )
+                item["count"] += 1
+                item["evidence_refs"] = list(
+                    dict.fromkeys([*item["evidence_refs"], *refs])
+                )[-50:]
+
+            meta["calibration_history"].append(
+                {
+                    "observed_at": now,
+                    "domain": domain,
+                    "prediction": prediction,
+                    "outcome": outcome,
+                    "absolute_error": error,
+                    "evidence_refs": refs,
+                }
+            )
+            processed.update(refs)
+        meta["calibration_history"] = meta["calibration_history"][-500:]
+        meta["processed_evidence_refs"] = list(processed)[-1000:]
+        meta["updated_at"] = now
+        model["updated_at"] = now
+        self.store.write(model)
+        return model
+
+    def observe_trace(
+        self, trace: Mapping[str, Any], *, evidence_ref: str
+    ) -> dict[str, Any]:
+        decision = trace.get("decision", {})
+        action = trace.get("action", {})
+        result = trace.get("result", {})
+        if not all(isinstance(part, Mapping) for part in (decision, action, result)):
+            return self.store.read()
+        return self.observe(
+            [
+                {
+                    "domain": action.get("domain")
+                    or action.get("action_type")
+                    or action.get("kind")
+                    or "general",
+                    "prediction": decision.get(
+                        "confidence", decision.get("predicted_success", 0.5)
+                    ),
+                    "success": result.get(
+                        "success", float(result.get("gain_loss", 0.0)) > 0.0
+                    ),
+                    "error_type": result.get("error")
+                    or result.get("failure_condition"),
+                    "strategy": decision.get("operator") or action.get("strategy"),
+                    "evidence_refs": [evidence_ref],
+                }
+            ]
+        )
+
+    def observe_episodes(self, episodes: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+        observations = []
+        for index, episode in enumerate(episodes):
+            if not isinstance(episode.get("decision"), Mapping) or not isinstance(
+                episode.get("result"), Mapping
+            ):
+                continue
+            ref = str(
+                episode.get("trace_id") or episode.get("id") or f"episode:{index}"
+            )
+            trace = {
+                "decision": episode["decision"],
+                "action": episode.get("action", {}),
+                "result": episode["result"],
+            }
+            decision, action, result = (
+                trace["decision"],
+                trace["action"],
+                trace["result"],
+            )
+            observations.append(
+                {
+                    "domain": action.get("domain") or action.get("kind") or "general",
+                    "prediction": decision.get("confidence", 0.5),
+                    "success": result.get(
+                        "success", float(result.get("gain_loss", 0)) > 0
+                    ),
+                    "error_type": result.get("error"),
+                    "strategy": decision.get("operator"),
+                    "evidence_refs": [ref],
+                }
+            )
+        return self.observe(observations) if observations else self.store.read()
+
+    def decision_context(self, domain: str) -> dict[str, Any]:
+        record = self.store.read()["metacognition"]["domains"].get(domain, {})
+        return dict(record) if isinstance(record, Mapping) else {}

--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -9,7 +9,8 @@ from typing import Any, Callable, Protocol
 
 from security.policy_engine import ActionPolicyEngine
 from uuid import uuid4
-from singular.memory import add_causal_trace, add_episode
+from singular.memory import add_causal_trace, add_episode, get_mem_dir
+from singular.cognition.self_observation import SelfObservationService
 from singular.embodiment import Acknowledgement, Command, EmergencyStop, Observation
 from singular.morals import MoralAction, MoralDecisionEngine
 
@@ -142,6 +143,7 @@ class AgentRuntime:
         moral_engine: MoralDecisionEngine | None = None,
         resource_gate: Callable[[ActionRequest], bool | tuple[bool, str]] | None = None,
         emergency_stop: EmergencyStop | None = None,
+        self_observation: SelfObservationService | None = None,
     ) -> None:
         self.perception = perception
         self.mind = mind
@@ -162,6 +164,9 @@ class AgentRuntime:
             maxlen=max(self.safety.watchdog_window_size, 1)
         )
         self._causal_traces: deque[CausalTrace] = deque(maxlen=200)
+        self.self_observation = self_observation or SelfObservationService(
+            get_mem_dir() / "self_model.json"
+        )
 
     @property
     def disabled(self) -> bool:
@@ -612,3 +617,8 @@ class AgentRuntime:
         }
         add_causal_trace(payload)
         add_episode({"event": "embodiment.action.result", **payload})
+        # The persisted trace id is the evidence anchor; never learn from an
+        # unreferenced interpretation of an action result.
+        self.self_observation.observe_trace(
+            payload, evidence_ref=f"causal:{trace.trace_id}"
+        )

--- a/src/singular/identity/self_model.py
+++ b/src/singular/identity/self_model.py
@@ -10,7 +10,8 @@ from uuid import uuid4
 
 from ..io_utils import atomic_write_text
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
+METACOGNITION_VERSION = 1
 
 
 def _now() -> str:
@@ -31,6 +32,20 @@ class SelfModelStore:
 
     _EVIDENCE_SECTIONS = ("autobiographical_facts", "traits", "preferences", "constraints")
     _REQUIRED_ROOT_KEYS = set(_EVIDENCE_SECTIONS)
+
+    @staticmethod
+    def _default_metacognition() -> dict[str, Any]:
+        return {
+            "version": METACOGNITION_VERSION,
+            "domains": {},
+            "recurring_errors": {},
+            "observed_biases": {},
+            "effective_strategies": {},
+            "failure_conditions": {},
+            "calibration_history": [],
+            "processed_evidence_refs": [],
+            "updated_at": None,
+        }
 
     def __init__(self, path: Path | str) -> None:
         self.path = Path(path)
@@ -59,6 +74,7 @@ class SelfModelStore:
             "red_lines": [],
             "identity_wounds": [],
             "constraints": {},
+            "metacognition": self._default_metacognition(),
             "created_at": now,
             "updated_at": now,
         }
@@ -110,6 +126,16 @@ class SelfModelStore:
             if not isinstance(model.get(section), list):
                 model[section] = []
                 migrated = True
+        metacognition = model.get("metacognition")
+        if not isinstance(metacognition, dict):
+            metacognition = self._default_metacognition()
+            model["metacognition"] = metacognition
+            migrated = True
+        for key, value in self._default_metacognition().items():
+            if key not in metacognition:
+                metacognition[key] = value
+                migrated = True
+        metacognition["version"] = METACOGNITION_VERSION
         model["schema_version"] = SCHEMA_VERSION
         return model, migrated
 

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterable, Mapping
 
 from singular.cognition.reflect import ActionHypothesis, ReflectionDecision, reflect_action
+from singular.cognition.self_observation import SelfObservationService
 from singular.beliefs.store import BeliefStore
 from singular.beliefs.meta_learning import (
     extract_run_features,
@@ -940,6 +941,9 @@ def run(
     quarantined_skill_keys: set[str] = set()
     sleep_ticks_remaining = 0
     intrinsic_goals = IntrinsicGoals(value_weights=value_weights)
+    self_observation = SelfObservationService(
+        Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "self_model.json"
+    )
     coevolution_flow: CoevolutionFlow | None = None
     if coevolve_tests:
         if test_pool is None:
@@ -1369,6 +1373,7 @@ def run(
                     goal_weights.efficacite
                     + (psyche_axes.get("resource", 0.0) * 0.4)
                 ),
+                metacognition=self_observation.decision_context("mutation"),
             )
             score_by_index = {index: score for index, _, score in reflection.alternative_scores}
             belief_bias = belief_store.operator_preference_bias(eligible_operators.keys())
@@ -2298,8 +2303,7 @@ def run(
                 "skill_reputation": logger.skill_reputation().get(key, {}),
             }
             gain_loss = round(base_score - mutated_score, 6)
-            add_causal_trace(
-                {
+            causal_payload = {
                     "ts": datetime.now(timezone.utc).isoformat(),
                     "trace_id": hashlib.sha1(
                         f"{logger.run_id}:{state.iteration}:{key}:{op_name}".encode("utf-8")
@@ -2332,6 +2336,9 @@ def run(
                         },
                     },
                 }
+            add_causal_trace(causal_payload)
+            self_observation.observe_trace(
+                causal_payload, evidence_ref=causal_payload["trace_id"]
             )
             event_bus.publish(
                 "mutation.applied" if accepted else "mutation.rejected",

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -21,6 +21,7 @@ from singular.events import (
     get_global_event_bus,
 )
 from singular.goals import IntrinsicGoals
+from singular.cognition.self_observation import SelfObservationService
 from singular.identity import ConsolidationPipeline
 from singular.governance.policy import MutationGovernancePolicy
 from singular.life.coevolution_flow import LivingTestPool
@@ -163,6 +164,7 @@ class OrchestratorService:
         )
         self.goals = IntrinsicGoals(path=self.mem_dir / "goals.json")
         self.consolidation_pipeline = ConsolidationPipeline(mem_dir=self.mem_dir)
+        self.self_observation = SelfObservationService(self.mem_dir / "self_model.json")
         self._running = False
         self._wake_requested = False
         self._pending_events: list[dict[str, Any]] = []
@@ -713,6 +715,10 @@ class OrchestratorService:
             mood = self.psyche.update_from_resource_manager(self.resource_manager)
             self.psyche.save_state()
             narrative_update = self._refresh_self_narrative()
+            metacognitive_model = self.self_observation.observe_episodes(
+                read_episodes()
+            )
+            metacognition = metacognitive_model["metacognition"]
             self._push_event(
                 phase,
                 {
@@ -720,6 +726,8 @@ class OrchestratorService:
                     "energy": self.psyche.energy,
                     "self_narrative_event": narrative_update["event_type"],
                     "self_narrative_short": narrative_update["short_summary"],
+                    "metacognition_updated_at": metacognition["updated_at"],
+                    "calibrated_domains": len(metacognition["domains"]),
                 },
             )
             return

--- a/tests/test_self_observation.py
+++ b/tests/test_self_observation.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+
+from singular.cognition.reflect import ActionHypothesis, reflect_action
+from singular.cognition.self_observation import SelfObservationService
+from singular.identity.self_model import SCHEMA_VERSION, SelfModelStore
+
+
+def _observation(index: int, *, success: bool, prediction: float = 0.8):
+    return {
+        "domain": "mutation",
+        "prediction": prediction,
+        "success": success,
+        "error_type": "regression" if not success else None,
+        "strategy": "simulate",
+        "evidence_refs": [f"trace:{index}"],
+    }
+
+
+def test_schema_migration_and_metacognition_persist(tmp_path):
+    path = tmp_path / "self.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "autobiographical_facts": {},
+                "traits": {},
+                "preferences": {},
+                "constraints": {},
+            }
+        )
+    )
+    store = SelfModelStore(path)
+    service = SelfObservationService(store)
+    service.observe([_observation(1, success=True)])
+
+    reloaded = SelfModelStore(path).read()
+    assert reloaded["schema_version"] == SCHEMA_VERSION
+    assert reloaded["metacognition"]["version"] == 1
+    assert reloaded["metacognition"]["domains"]["mutation"]["evidence_refs"] == [
+        "trace:1"
+    ]
+
+
+def test_sparse_evidence_stays_uncertain_and_duplicate_reference_is_ignored(tmp_path):
+    service = SelfObservationService(tmp_path / "self.json")
+    service.observe([_observation(1, success=True, prediction=0.99)])
+    model = service.observe([_observation(1, success=True, prediction=0.99)])
+    domain = model["metacognition"]["domains"]["mutation"]
+
+    assert domain["sample_count"] == 1
+    assert domain["competence"] < 0.7
+    assert domain["uncertainty"] == 1.0
+
+
+def test_calibration_and_repeated_failures_are_evidence_backed(tmp_path):
+    service = SelfObservationService(tmp_path / "self.json")
+    model = service.observe(
+        [_observation(i, success=False, prediction=0.9) for i in range(3)]
+    )
+    meta = model["metacognition"]
+    domain = meta["domains"]["mutation"]
+
+    assert domain["calibration_score"] < 0.55
+    assert "repeated_failure:regression" in domain["limitations"]
+    assert meta["recurring_errors"]["mutation:regression"]["count"] == 3
+    assert len(meta["calibration_history"]) == 3
+
+
+def test_low_calibration_changes_later_reflection_recommendation(tmp_path):
+    service = SelfObservationService(tmp_path / "self.json")
+    service.observe([_observation(i, success=False, prediction=0.95) for i in range(3)])
+    decision = reflect_action(
+        [ActionHypothesis("rewrite", 0.9, 0.1, 0.1)],
+        metacognition=service.decision_context("mutation"),
+    )
+
+    assert decision.action == "rewrite"
+    assert decision.action_recommended == "simulate_or_escalate"
+    assert decision.confidence < 0.55
+    assert "repeated_failure:regression" in decision.risks


### PR DESCRIPTION
### Motivation

- Provide a versioned, evidence-bound metacognition section in the persistent self model to record domain competencies, limitations, recurring failures, observed biases, effective strategies, failure conditions and calibration history. 
- Collect and use only evidence-referenced observations (episodes and causal traces) so the system can update uncertainty conservatively and avoid overinterpretation from sparse data.
- Use metacognitive calibration to influence reflection and decision-making so low calibration triggers information requests, simulation or escalation instead of blind execution.

### Description

- Bump persistent identity schema and add metacognition: `SCHEMA_VERSION = 3` and `METACOGNITION_VERSION = 1`, with a default `metacognition` block and on-disk migration that fills missing keys. (`src/singular/identity/self_model.py`).
- New `SelfObservationService` implemented in `src/singular/cognition/self_observation.py` that ingests observations only when they include `evidence_refs`, deduplicates references, preserves explicit uncertainty for sparse evidence, computes Brier-style calibration/competence, records recurring failures, observed biases and effective strategies, and maintains `processed_evidence_refs` and a bounded `calibration_history`.
- Integrate observation and calibration into runtime and lifecycle flows:
  - `AgentRuntime` now calls `SelfObservationService.observe_trace(...)` after action results to anchor observations to causal trace ids (`src/singular/core/agent_runtime.py`).
  - `OrchestratorService` runs `SelfObservationService.observe_episodes(read_episodes())` during introspection and exposes `metacognition_updated_at` and `calibrated_domains` in introspection events (`src/singular/orchestrator/service.py`).
  - Life loop (`run`) loads a `SelfObservationService` and passes domain decision context into `reflect_action(...)`, and records causal traces via `SelfObservationService.observe_trace(...)` after mutation results (`src/singular/life/loop.py`).
- Reflection adjustments: `reflect_action()` accepts an optional `metacognition` context and uses domain sample counts, calibration and uncertainty to reweight the selected assessment confidence and to inject known `limitations` into risks; when calibration is low a recommendation such as `request_information` or `simulate_or_escalate` can be returned instead of `execute` (`src/singular/cognition/reflect.py`).
- Export `SelfObservationService` from cognition package (`src/singular/cognition/__init__.py`).
- Add tests covering migration and persistence of metacognition, deduplication of evidence refs, conservative behavior with sparse evidence, repeated-failure detection, calibration computation, and influence on reflection decisions (`tests/test_self_observation.py`).

### Testing

- Ran unit tests: `pytest -q tests/test_self_observation.py tests/test_identity_core.py tests/test_cognition_reflect.py tests/test_core_agent_runtime.py tests/test_orchestrator_service_targeted.py` and all targeted tests passed (24 passed).
- Static checks: `ruff check` over the modified modules completed cleanly.
- Byte-compile check: `python -m compileall -q src/singular` succeeded.
- Added test `tests/test_self_observation.py` exercises migration, persistence, sparse-evidence behavior, repeated failure detection and resulting reflection influence and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75fc84e7cc832aa49bce2d5af6ffaa)