### PR TITLE
Construire des contextes moraux persistants avant la délibération

### DIFF
--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -13,6 +13,8 @@ from singular.memory import add_causal_trace, add_episode, get_mem_dir
 from singular.cognition.self_observation import SelfObservationService
 from singular.embodiment import Acknowledgement, Command, EmergencyStop, Observation
 from singular.morals import MoralAction, MoralDecisionEngine
+from singular.morals import MoralContextBuilder
+from singular.identity.core import IdentityCoreService
 
 DEFAULT_SCHEMA_VERSION = "1.0"
 
@@ -152,6 +154,9 @@ class AgentRuntime:
         self.event_bus = event_bus or RuntimeEventBus(schema_version=schema_version)
         self.policy_engine = policy_engine or ActionPolicyEngine()
         self.moral_engine = moral_engine or MoralDecisionEngine(journal=add_episode)
+        self.moral_context_builder = MoralContextBuilder(
+            IdentityCoreService(get_mem_dir()), journal=add_episode
+        )
         self.resource_gate = resource_gate
         self.emergency_stop = emergency_stop or EmergencyStop()
         self.safety = safety or RuntimeSafetyConfig()
@@ -224,15 +229,16 @@ class AgentRuntime:
             self._ensure_schema_version(request.schema_version)
             self.event_bus.publish("action.requested", request)
 
-            moral_context = request.parameters.get("moral_context", {})
-            if not isinstance(moral_context, dict):
-                moral_context = {}
+            action = MoralAction(request.action_type, request.parameters, intent.rationale)
+            moral_context = self.moral_context_builder.build(
+                action, request.parameters.get("moral_context", {})
+            )
             moral_decision = self.moral_engine.evaluate(
-                MoralAction(request.action_type, request.parameters, intent.rationale),
-                moral_context.get("consequences", ()),
-                moral_context.get("affected_parties", ()),
-                moral_context.get("identity_commitments", ()),
-                moral_context.get("uncertainty", 0.0),
+                action,
+                moral_context.consequences,
+                moral_context.affected_parties,
+                moral_context.identity_commitments,
+                moral_context.uncertainty,
             )
             self.event_bus.publish("action.moral.decision", moral_decision)
 

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -32,6 +32,7 @@ from singular.memory import (
     temporarily_disable_skill,
     update_score,
     add_episode,
+    get_mem_dir,
     format_recalled_memories,
     recall_relevant_episodes,
 )
@@ -69,7 +70,8 @@ from singular.governance.policy import (
     classify_sandbox_error_type,
 )
 from singular.governance.values import load_value_weights
-from singular.morals import MoralAction, MoralDecision, MoralDecisionEngine
+from singular.morals import MoralAction, MoralContextBuilder, MoralDecision, MoralDecisionEngine
+from singular.identity.core import IdentityCoreService
 
 from .checkpointing import Checkpoint, load_checkpoint, save_checkpoint
 from .sandbox_scoring import SandboxScore, score_code_with_error, score_code, _sandbox_failure_category
@@ -104,15 +106,23 @@ def _deliberate_life_action(
 ) -> MoralDecision:
     """Run and journal the moral gate independently of technical safety gates."""
 
-    decision = MoralDecisionEngine(journal=add_episode).evaluate(
-        MoralAction(action_type, parameters=dict(relational_context or {})),
-        consequences,
-        ({"identifier": organism, "vulnerability": 0.0}, *affected_parties),
-        (
+    action = MoralAction(action_type, parameters=dict(relational_context or {}))
+    supplied = {
+        "consequences": consequences,
+        "affected_parties": ({"identifier": organism, "vulnerability": 0.0}, *affected_parties),
+        "identity_commitments": (
             {"value": "non_maleficence", "weight": 1.0},
             {"value": "identity_coherence", "weight": 0.8},
         ),
-        uncertainty,
+        "uncertainty": uncertainty,
+        "social_model": dict(relational_context or {}),
+    }
+    context = MoralContextBuilder(
+        IdentityCoreService(get_mem_dir()), journal=add_episode
+    ).build(action, supplied)
+    decision = MoralDecisionEngine(journal=add_episode).evaluate(
+        action, context.consequences, context.affected_parties,
+        context.identity_commitments, context.uncertainty,
     )
     return decision
 

--- a/src/singular/morals/__init__.py
+++ b/src/singular/morals/__init__.py
@@ -9,8 +9,9 @@ from .decision import (
     MoralDecisionEngine,
     evaluate_action,
 )
+from .context import MoralContext, MoralContextBuilder
 
 __all__ = [
     "AffectedParty", "Consequence", "IdentityCommitment", "MoralAction",
-    "MoralDecision", "MoralDecisionEngine", "evaluate_action",
+    "MoralDecision", "MoralDecisionEngine", "MoralContext", "MoralContextBuilder", "evaluate_action",
 ]

--- a/src/singular/morals/context.py
+++ b/src/singular/morals/context.py
@@ -1,0 +1,82 @@
+"""Construction of complete, provenance-aware moral deliberation contexts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Callable, Mapping
+
+from singular.identity.core import IdentityCoreService
+
+from .decision import MoralAction
+from .moral_rules import is_high_impact, rule_for
+
+
+@dataclass(frozen=True)
+class MoralContext:
+    consequences: tuple[Mapping[str, Any], ...]
+    affected_parties: tuple[Mapping[str, Any], ...]
+    identity_commitments: tuple[Mapping[str, Any], ...]
+    uncertainty: float
+    permissions: tuple[str, ...]
+    social_model: Mapping[str, Any]
+    provenance: tuple[Mapping[str, Any], ...]
+    acceptable_alternative_conditions: tuple[str, ...]
+
+
+class MoralContextBuilder:
+    """Enrich proposals; caller context can add facts but cannot erase identity."""
+
+    def __init__(self, identity: IdentityCoreService, *, journal: Callable[[dict[str, Any]], Any] | None = None) -> None:
+        self.identity = identity
+        self.journal = journal
+
+    def build(self, action: MoralAction, supplied: Mapping[str, Any] | None = None) -> MoralContext:
+        supplied = supplied if isinstance(supplied, Mapping) else {}
+        model = self.identity.synchronize()
+        rule = rule_for(action.action_type)
+        consequences = list(_mappings(supplied.get("consequences")))
+        parties = list(_mappings(supplied.get("affected_parties")))
+        provenance: list[Mapping[str, Any]] = []
+        commitments: list[Mapping[str, Any]] = []
+        for item in _mappings(supplied.get("identity_commitments")):
+            commitments.append(item)
+            provenance.append({"kind": "commitment", "value": item.get("value"), "source": "action.moral_context"})
+        for value in model.get("cardinal_values", ()): 
+            commitments.append({"value": str(value), "weight": 1.0, "absolute": False, "description": "valeur persistante"})
+            provenance.append({"kind": "commitment", "value": str(value), "source": "IdentityCoreService.cardinal_values"})
+        for value in model.get("commitments", ()):
+            name = value.get("value") if isinstance(value, Mapping) else value
+            commitments.append({"value": str(name), "weight": 1.0, "absolute": False, "description": "engagement persistant"})
+            provenance.append({"kind": "commitment", "value": str(name), "source": "IdentityCoreService.commitments"})
+        for value in model.get("red_lines", ()):
+            commitments.append({"value": str(value), "weight": 1.0, "absolute": True, "description": "ligne rouge persistante"})
+            provenance.append({"kind": "commitment", "value": str(value), "source": "IdentityCoreService.red_lines"})
+
+        insufficient = rule is not None and (not consequences or not parties)
+        unknown_high = rule is None and is_high_impact(dict(action.parameters))
+        alternatives = list(supplied.get("acceptable_alternative_conditions", ()))
+        if insufficient or unknown_high:
+            family = rule.family if rule else "unknown_high_impact"
+            party = rule.affected_party if rule else "potentially_affected_parties"
+            values = rule.values if rule else ("non_maleficence", "rights")
+            description = rule.consequence if rule else "Impact élevé insuffisamment décrit; les dommages ne peuvent pas être exclus."
+            consequences.append({"description": description, "affected_party": party, "harm": 0.9, "probability": 1.0, "values": values, "irreversible": True})
+            parties.append({"identifier": party, "vulnerability": 0.5, "consent": None})
+            provenance.extend(({"kind": "consequence", "value": description, "source": f"moral_rules.{family}"}, {"kind": "affected_party", "value": party, "source": f"moral_rules.{family}"}))
+            alternatives.extend(("suspendre et documenter précisément la portée et les parties affectées", "obtenir les permissions et consentements requis", "rendre l'action réversible ou l'escalader à un responsable"))
+        for item in consequences[: len(_mappings(supplied.get("consequences")))]:
+            provenance.append({"kind": "consequence", "value": item.get("description"), "source": "action.moral_context"})
+        for item in parties[: len(_mappings(supplied.get("affected_parties")))]:
+            provenance.append({"kind": "affected_party", "value": item.get("identifier"), "source": "action.moral_context"})
+        permissions = tuple(dict.fromkeys((*(() if rule is None else rule.permissions), *map(str, supplied.get("permissions", ())))))
+        social = dict(supplied.get("social_model", {})) if isinstance(supplied.get("social_model"), Mapping) else {}
+        context = MoralContext(tuple(consequences), tuple(parties), tuple(commitments), max(float(supplied.get("uncertainty", 0.0)), 0.8 if insufficient or unknown_high else 0.0), permissions, social, tuple(provenance), tuple(dict.fromkeys(map(str, alternatives))))
+        if self.journal:
+            self.journal({"event": "moral.context.constructed", "action_type": action.action_type, **asdict(context)})
+        return context
+
+
+def _mappings(value: Any) -> tuple[Mapping[str, Any], ...]:
+    if isinstance(value, (str, bytes, Mapping)) or value is None:
+        return ()
+    return tuple(item for item in value if isinstance(item, Mapping))

--- a/src/singular/morals/moral_rules.py
+++ b/src/singular/morals/moral_rules.py
@@ -1,18 +1,42 @@
-"""Utility functions to evaluate the moral value of actions."""
+"""Minimum context requirements for morally sensitive action families."""
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any
 
 
-def score_action(action: str, context: Dict[str, Any] | None = None) -> float:
-    """Return a moral score for *action* based on *context*.
+@dataclass(frozen=True)
+class MoralRule:
+    family: str
+    prefixes: tuple[str, ...]
+    affected_party: str
+    consequence: str
+    values: tuple[str, ...]
+    permissions: tuple[str, ...] = ()
 
-    Negative values indicate morally objectionable actions while positive
-    values correspond to morally favourable ones. ``context`` may contain a
-    mapping ``moral_weights`` associating actions to moral scores.
-    """
 
-    context = context or {}
-    weights = context.get("moral_weights", {})
+SENSITIVE_ACTION_RULES = (
+    MoralRule("mutation", ("mutation", "code.", "file."), "maintainers", "Une modification peut altérer durablement le programme ou ses données.", ("integrity", "non_maleficence"), ("write",)),
+    MoralRule("social", ("social.", "message", "share", "steal", "resource."), "other_agents", "L'action peut affecter l'autonomie, les ressources ou la réputation d'autrui.", ("consent", "fairness")),
+    MoralRule("reproduction", ("reproduction", "crossover"), "future_organism", "La création engage un nouvel organisme et des ressources partagées.", ("care", "non_maleficence"), ("create",)),
+    MoralRule("external", ("network.", "shell.", "system."), "external_users", "Une action externe peut produire des effets non autorisés ou irréversibles.", ("rights", "non_maleficence"), ("external_effect",)),
+)
+
+
+def rule_for(action_type: str) -> MoralRule | None:
+    normalized = action_type.lower()
+    return next((rule for rule in SENSITIVE_ACTION_RULES if normalized.startswith(rule.prefixes)), None)
+
+
+def is_high_impact(parameters: object) -> bool:
+    """Recognize explicit high-impact declarations without assuming missing means safe."""
+    if not isinstance(parameters, dict):
+        return False
+    return bool(parameters.get("high_impact") or parameters.get("irreversible") or str(parameters.get("risk_level", "")).lower() in {"high", "critical"})
+
+
+def score_action(action: str, context: dict[str, Any] | None = None) -> float:
+    """Keep the historical lightweight reputation/motivation scoring API."""
+    weights = (context or {}).get("moral_weights", {})
     return float(weights.get(action, 0.0))

--- a/tests/test_core_agent_runtime.py
+++ b/tests/test_core_agent_runtime.py
@@ -116,10 +116,15 @@ def test_agent_runtime_rejects_schema_version_mismatch() -> None:
 
 def test_agent_runtime_blocks_action_not_allowlisted() -> None:
     decisions: list[dict[str, object]] = []
+    gate_topics: list[str] = []
+    bus = RuntimeEventBus()
+    bus.subscribe("action.moral.decision", lambda event: gate_topics.append(event.topic))
+    bus.subscribe("action.policy.decision", lambda event: gate_topics.append(event.topic))
     runtime = AgentRuntime(
         perception=_PerceptionStub(),
         mind=_MindStub(),
         action=_ActionStub(),
+        event_bus=bus,
         policy_engine=ActionPolicyEngine(
             rules=[
                 PolicyRule(
@@ -141,6 +146,8 @@ def test_agent_runtime_blocks_action_not_allowlisted() -> None:
     assert results[0].error == "action_not_allowlisted"
     assert decisions[-1]["blocked"] is True
     assert decisions[-1]["reason"] == "action_not_allowlisted"
+    # Technical safety remains an independently observable guard after moral review.
+    assert gate_topics == ["action.moral.decision", "action.policy.decision"]
 
 
 

--- a/tests/test_moral_context.py
+++ b/tests/test_moral_context.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from singular.identity.core import IdentityCoreService
+from singular.morals import MoralAction, MoralContextBuilder, MoralDecisionEngine
+
+
+def _evaluate(builder: MoralContextBuilder, action: MoralAction):
+    context = builder.build(action)
+    return MoralDecisionEngine().evaluate(
+        action,
+        context.consequences,
+        context.affected_parties,
+        context.identity_commitments,
+        context.uncertainty,
+    )
+
+
+def test_sensitive_action_without_context_cannot_bypass_veto(tmp_path):
+    action = MoralAction("mutation.applied")
+    decision = _evaluate(MoralContextBuilder(IdentityCoreService(tmp_path)), action)
+
+    assert decision.veto
+    assert "préjudice grave et irréversible" in decision.veto_reason
+    assert decision.acceptable_alternative_conditions
+
+
+def test_persistent_red_line_survives_restart_and_action_context_cannot_erase_it(tmp_path):
+    service = IdentityCoreService(tmp_path)
+    model = service.synchronize()
+    model["red_lines"] = ["human_dignity"]
+    service.store.write(model)
+
+    restarted = IdentityCoreService(tmp_path)
+    supplied = {
+        "identity_commitments": [
+            {"value": "human_dignity", "absolute": False, "weight": 0.0}
+        ],
+        "consequences": [{
+            "description": "humiliation",
+            "affected_party": "person",
+            "harm": 0.5,
+            "values": ["human_dignity"],
+        }],
+        "affected_parties": [{"identifier": "person"}],
+    }
+    context = MoralContextBuilder(restarted).build(MoralAction("message.send"), supplied)
+    decision = MoralDecisionEngine().evaluate(
+        MoralAction("message.send"), context.consequences,
+        context.affected_parties, context.identity_commitments, context.uncertainty
+    )
+
+    assert any(item["absolute"] and item["value"] == "human_dignity" for item in context.identity_commitments)
+    assert decision.veto_reason == "engagement identitaire absolu menacé: human_dignity"
+
+
+def test_context_journal_records_provenance_and_alternative_conditions(tmp_path):
+    events = []
+    builder = MoralContextBuilder(IdentityCoreService(tmp_path), journal=events.append)
+
+    context = builder.build(MoralAction("network.publish"))
+
+    assert context.permissions == ("external_effect",)
+    assert {entry["kind"] for entry in context.provenance} >= {"consequence", "affected_party"}
+    assert events[0]["event"] == "moral.context.constructed"
+    assert events[0]["acceptable_alternative_conditions"]


### PR DESCRIPTION
### Motivation
- Garantir que toute proposition d’action reçoit un contexte moral complet enrichi par les engagements et lignes rouges persistantes stockés dans `IdentityCoreService`. 
- Éviter qu’une action fournie avec un `moral_context` puisse effacer ou affaiblir des contraintes identitaires persistantes.
- Faire en sorte que les actions sensibles insuffisamment décrites ou inconnues mais déclarées à fort impact soient traitées de façon précautionnaire (suspension, réversibilité, escalade).

### Description
- Ajout de `MoralContext` et `MoralContextBuilder` dans `src/singular/morals/context.py` qui construisent un contexte enrichi (conséquences, parties affectées, engagements identitaires, permissions, modèle social, incertitude) et enregistrent la provenance de chaque élément.
- Définition de règles minimales pour familles d’actions sensibles dans `src/singular/morals/moral_rules.py`, avec heuristique `is_high_impact` et fonction rétrocompatible `score_action` pour préserver l’API existante.
- Intégration du constructeur de contexte avant `MoralDecisionEngine.evaluate()` dans le runtime central `src/singular/core/agent_runtime.py` et dans la voie de délibération de la boucle de vie `src/singular/life/loop.py` afin que toutes les évaluations morales utilisent le contexte enrichi.
- Comportement conservateur : si une action sensible est insuffisamment décrite (ou inconnue mais marquée à fort impact), le builder injecte une conséquence à fort risque, augmente l’incertitude et propose conditions alternatives (suspendre, obtenir consentement, rendre réversible ou escalader).
- Le contexte fourni par l’action est fusionné mais ne peut supprimer les `cardinal_values`, `commitments` ou `red_lines` provenant de `IdentityCoreService`.
- Ajout de tests unitaires `tests/test_moral_context.py` et mise à jour de `tests/test_core_agent_runtime.py` pour vérifier l’ordre observable des décisions (`action.moral.decision` puis `action.policy.decision`).

### Testing
- Compilation rapide du code modifié avec `python -m compileall` a réussi.
- Linter `ruff` sur les fichiers modifiés a été exécuté avec succès.
- Exécution ciblée des tests unitaires pertinents avec `pytest -q tests/test_moral_context.py tests/test_moral_decision.py tests/test_identity_core.py tests/test_core_agent_runtime.py tests/test_agent_motivation.py` a abouti à `20 passed` et les tests mis à jour sont verts.
- Une exécution initiale complète de la suite avait échoué pendant la collecte à cause d’une API supprimée, l’API historique `score_action` a été restaurée et les tests ciblés ont ensuite réussi.
- Les changements ont été contrôés par des vérifications automatiques (`git diff --check` et les checks locaux) et les tests ciblés passent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a760c664690832a8cb0dee185763354)