### PR TITLE
feat: add event-driven self-narrative projector with append-only timeline and provenance

### DIFF
--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -7,8 +7,12 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 import json
+import hashlib
 
-SCHEMA_VERSION = 2
+from singular.identity.coherence import detect_contradictions
+from singular.io_utils import append_jsonl_line, atomic_write_text
+
+SCHEMA_VERSION = 3
 TIMELINE_SUFFIX = ".timeline.jsonl"
 
 _TRAIT_KEYS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
@@ -52,6 +56,25 @@ class RegretsAndPride:
 
 
 @dataclass
+class NarrativeEntry:
+    """One attributable, causal and explicitly qualified story statement."""
+
+    entry_id: str
+    life_id: str
+    event_type: str
+    occurred_at: str
+    summary: str
+    source_event_ids: list[str] = field(default_factory=list)
+    objective_ids: list[str] = field(default_factory=list)
+    participants: list[str] = field(default_factory=list)
+    confidence: float = 1.0
+    change_type: str = "observation"
+    causal_links: list[dict[str, str]] = field(default_factory=list)
+    certainty: str = "certain"
+    contradictions: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass
 class SelfNarrative:
     """Persistent self narrative with explicit schema version."""
 
@@ -62,6 +85,8 @@ class SelfNarrative:
     regrets_and_pride: RegretsAndPride
     current_heading: str
     objective_trends: dict[str, TraitTrend] = field(default_factory=dict)
+    life_id: str = "default"
+    entries: list[NarrativeEntry] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
@@ -71,6 +96,7 @@ class SelfNarrative:
         payload["objective_trends"] = {
             key: asdict(value) for key, value in self.objective_trends.items()
         }
+        payload["entries"] = [asdict(entry) for entry in self.entries]
         return payload
 
 
@@ -131,6 +157,8 @@ def _default_narrative() -> SelfNarrative:
         regrets_and_pride=RegretsAndPride(),
         current_heading="Clarifier ma prochaine étape utile.",
         objective_trends={},
+        life_id="default",
+        entries=[],
     )
 
 
@@ -190,6 +218,14 @@ def timeline_path(path: Path | str | None = None) -> Path:
 def load_snapshots(path: Path | str | None = None) -> list[dict[str, Any]]:
     """Read valid snapshots without letting a damaged line hide later history."""
 
+    return sorted(
+        _load_timeline_records(path), key=lambda item: str(item["recorded_at"])
+    )
+
+
+def _load_timeline_records(path: Path | str | None = None) -> list[dict[str, Any]]:
+    """Read timeline records in append order, independently of wall-clock drift."""
+
     snapshots: list[dict[str, Any]] = []
     try:
         lines = timeline_path(path).read_text(encoding="utf-8").splitlines()
@@ -202,7 +238,7 @@ def load_snapshots(path: Path | str | None = None) -> list[dict[str, Any]]:
             continue
         if isinstance(item, dict) and _parse_iso(item.get("recorded_at")):
             snapshots.append(item)
-    return sorted(snapshots, key=lambda item: str(item["recorded_at"]))
+    return snapshots
 
 
 def infer_trend(
@@ -317,6 +353,46 @@ def _materialize(payload: Mapping[str, Any]) -> SelfNarrative:
         ],
     )
 
+    entries: list[NarrativeEntry] = []
+    raw_entries = payload.get("entries")
+    if isinstance(raw_entries, list):
+        for item in raw_entries:
+            if not isinstance(item, Mapping):
+                continue
+            entries.append(
+                NarrativeEntry(
+                    entry_id=str(item.get("entry_id", "")),
+                    life_id=str(item.get("life_id", payload.get("life_id", "default"))),
+                    event_type=str(item.get("event_type", "unknown")),
+                    occurred_at=str(item.get("occurred_at", "")),
+                    summary=str(item.get("summary", "")),
+                    source_event_ids=_string_list(item.get("source_event_ids")),
+                    objective_ids=_string_list(item.get("objective_ids")),
+                    participants=_string_list(item.get("participants")),
+                    confidence=_coerce_float(item.get("confidence"), 1.0),
+                    change_type=str(item.get("change_type", "observation")),
+                    causal_links=(
+                        [
+                            {str(k): str(v) for k, v in link.items()}
+                            for link in item.get("causal_links", [])
+                            if isinstance(link, Mapping)
+                        ]
+                        if isinstance(item.get("causal_links"), list)
+                        else []
+                    ),
+                    certainty=str(item.get("certainty", "certain")),
+                    contradictions=(
+                        [
+                            dict(value)
+                            for value in item.get("contradictions", [])
+                            if isinstance(value, Mapping)
+                        ]
+                        if isinstance(item.get("contradictions"), list)
+                        else []
+                    ),
+                )
+            )
+
     narrative = SelfNarrative(
         schema_version=max(schema_version, SCHEMA_VERSION),
         identity=identity,
@@ -338,6 +414,8 @@ def _materialize(payload: Mapping[str, Any]) -> SelfNarrative:
             )
             if isinstance(value, Mapping)
         },
+        life_id=str(payload.get("life_id", "default")),
+        entries=entries,
     )
     narrative.identity.logical_age = _compute_logical_age(narrative.identity.born_at)
     return narrative
@@ -371,7 +449,7 @@ def load(path: Path | str | None = None) -> SelfNarrative:
             file_path.rename(backup)
         except OSError:
             pass
-        narrative = _default_narrative()
+        narrative = rebuild_from_timeline(file_path, persist=False)
         save(narrative, file_path, record_snapshot=False)
         return narrative
 
@@ -399,9 +477,9 @@ def save(
     file_path.parent.mkdir(parents=True, exist_ok=True)
     narrative.schema_version = SCHEMA_VERSION
     narrative.identity.logical_age = _compute_logical_age(narrative.identity.born_at)
-    file_path.write_text(
+    atomic_write_text(
+        file_path,
         json.dumps(narrative.to_dict(), ensure_ascii=False, indent=2),
-        encoding="utf-8",
     )
     if record_snapshot:
         now = (clock or (lambda: datetime.now(timezone.utc)))()
@@ -427,6 +505,231 @@ def _extend_unique(target: list[str], values: Any) -> None:
         text = str(value).strip()
         if text and text not in target:
             target.append(text)
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+SIGNIFICANT_EVENT_TYPES = frozenset(
+    {
+        "birth",
+        "goal",
+        "conversation",
+        "learning",
+        "moral_decision",
+        "relationship",
+        "mutation",
+        "incident",
+        "life_transition",
+    }
+)
+_EVENT_TYPE_ALIASES = {
+    "born": "birth",
+    "life.birth": "birth",
+    "goal.created": "goal",
+    "goal.updated": "goal",
+    "conversation.message": "conversation",
+    "learning.completed": "learning",
+    "action.moral.decision": "moral_decision",
+    "relationship.changed": "relationship",
+    "mutation.applied": "mutation",
+    "mutation.rejected": "mutation",
+    "incident.detected": "incident",
+    "life.transition": "life_transition",
+    "vital.transition": "life_transition",
+}
+
+
+def _normalize_event_type(value: Any) -> str:
+    raw = str(value or "").strip()
+    return _EVENT_TYPE_ALIASES.get(raw, raw)
+
+
+def _event_identifier(event: Mapping[str, Any]) -> str:
+    explicit = event.get("event_id") or event.get("id")
+    if explicit:
+        return str(explicit)
+    canonical = json.dumps(dict(event), ensure_ascii=False, sort_keys=True, default=str)
+    return "event-" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:20]
+
+
+def _apply_entry(narrative: SelfNarrative, entry: NarrativeEntry) -> bool:
+    if entry.life_id != narrative.life_id:
+        return False
+    if any(current.entry_id == entry.entry_id for current in narrative.entries):
+        return False
+    narrative.entries.append(entry)
+    return True
+
+
+def rebuild_from_timeline(
+    path: Path | str | None = None,
+    *,
+    life_id: str | None = None,
+    persist: bool = True,
+) -> SelfNarrative:
+    """Rebuild a projection from valid append-only records, skipping damage."""
+
+    wanted_life = life_id
+    narrative = _default_narrative()
+    if wanted_life is not None:
+        narrative.life_id = wanted_life
+    for record in _load_timeline_records(path):
+        projection = record.get("narrative")
+        if isinstance(projection, Mapping) and not record.get("entry"):
+            candidate = _migrate(projection)
+            if wanted_life is None or candidate.life_id == wanted_life:
+                narrative = candidate
+            continue
+        raw_entry = record.get("entry")
+        if not isinstance(raw_entry, Mapping):
+            continue
+        record_life = str(raw_entry.get("life_id", "default"))
+        if wanted_life is None and not narrative.entries:
+            narrative.life_id = record_life
+        if record_life != narrative.life_id:
+            continue
+        entry_payload = dict(raw_entry)
+        temp = _materialize({"life_id": record_life, "entries": [entry_payload]})
+        if temp.entries:
+            _apply_entry(narrative, temp.entries[0])
+        resulting = record.get("resulting_narrative")
+        if isinstance(resulting, Mapping):
+            candidate = _migrate(resulting)
+            if candidate.life_id == narrative.life_id:
+                narrative = candidate
+    if persist:
+        save(narrative, path, record_snapshot=False)
+    return narrative
+
+
+def project_event(
+    event: Mapping[str, Any],
+    path: Path | str | None = None,
+    *,
+    life_id: str = "default",
+    autobiographical_facts: Sequence[Mapping[str, Any]] = (),
+    commitments: Sequence[Mapping[str, Any]] = (),
+    history: Sequence[Mapping[str, Any]] = (),
+    clock: Callable[[], datetime] | None = None,
+) -> SelfNarrative:
+    """Incrementally project one significant event with provenance and coherence."""
+
+    event_type = _normalize_event_type(event.get("event_type") or event.get("type"))
+    if event_type not in SIGNIFICANT_EVENT_TYPES:
+        raise ValueError(f"unsupported narrative event type: {event_type or 'missing'}")
+    file_path = _path_or_default(path)
+    projected = load(file_path)
+    if projected.entries and projected.life_id != life_id:
+        # A path is the storage boundary of one life; never mix identities.
+        raise ValueError("narrative path belongs to a different life")
+    narrative = (
+        rebuild_from_timeline(file_path, life_id=life_id, persist=False)
+        if timeline_path(file_path).exists()
+        else projected
+    )
+    if narrative.entries and narrative.life_id != life_id:
+        raise ValueError("narrative path belongs to a different life")
+    narrative.life_id = life_id
+    event_id = _event_identifier(event)
+    if any(event_id in entry.source_event_ids for entry in narrative.entries):
+        return narrative
+
+    now = (clock or (lambda: datetime.now(timezone.utc)))()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    summary = str(event.get("summary") or event.get("statement") or event_type).strip()
+    contradictions = detect_contradictions(
+        beliefs=[
+            {"statement": summary},
+            *[dict(item) for item in autobiographical_facts],
+        ],
+        goals=[dict(item) for item in commitments],
+        history=[
+            *[{"summary": entry.summary} for entry in narrative.entries],
+            *[dict(item) for item in history],
+        ],
+    )
+    certainty = (
+        "uncertain" if contradictions else str(event.get("certainty", "certain"))
+    )
+    entry = NarrativeEntry(
+        entry_id=str(event.get("entry_id") or f"narrative-{event_id}"),
+        life_id=life_id,
+        event_type=event_type,
+        occurred_at=str(
+            event.get("occurred_at") or now.astimezone(timezone.utc).isoformat()
+        ),
+        summary=summary,
+        source_event_ids=list(
+            dict.fromkeys([event_id, *_string_list(event.get("source_event_ids"))])
+        ),
+        objective_ids=_string_list(event.get("objective_ids") or event.get("goals")),
+        participants=_string_list(event.get("participants")),
+        confidence=_coerce_float(event.get("confidence"), 1.0),
+        change_type=str(event.get("change_type", event_type)),
+        causal_links=(
+            [
+                dict(link)
+                for link in event.get("causal_links", [])
+                if isinstance(link, Mapping)
+            ]
+            if isinstance(event.get("causal_links"), list)
+            else []
+        ),
+        certainty=certainty,
+        contradictions=contradictions,
+    )
+    _apply_entry(narrative, entry)
+
+    # Contradictory claims remain visible evidence but cannot replace prior state.
+    if not contradictions:
+        if event_type == "birth":
+            narrative.identity.name = str(event.get("name") or narrative.identity.name)
+            narrative.identity.born_at = str(event.get("born_at") or entry.occurred_at)
+        heading = event.get("current_heading")
+        if isinstance(heading, str) and heading.strip():
+            narrative.current_heading = heading.strip()
+
+    record = {
+        "recorded_at": now.astimezone(timezone.utc).isoformat(),
+        "schema_version": SCHEMA_VERSION,
+        "record_type": "narrative_event",
+        "life_id": life_id,
+        "entry": asdict(entry),
+        "resulting_narrative": narrative.to_dict(),
+    }
+    append_jsonl_line(timeline_path(file_path), record)
+    save(narrative, file_path, record_snapshot=False)
+    return narrative
+
+
+class NarrativeProjector:
+    """Small event-consumer facade suitable for synchronous event buses."""
+
+    def __init__(self, path: Path | str, *, life_id: str) -> None:
+        self.path = Path(path)
+        self.life_id = life_id
+
+    def consume(self, event: Any) -> SelfNarrative:
+        payload = dict(getattr(event, "payload", event))
+        if getattr(event, "event_type", None):
+            payload.setdefault("event_type", _normalize_event_type(event.event_type))
+            payload.setdefault(
+                "event_id",
+                payload.get("event_id")
+                or f"{event.event_type}:{getattr(event, 'emitted_at', '')}",
+            )
+        return project_event(payload, self.path, life_id=self.life_id)
+
+    def subscribe(self, bus: Any) -> None:
+        """Subscribe incremental projection to every known major bus event."""
+
+        for event_type in _EVENT_TYPE_ALIASES:
+            bus.subscribe(event_type, self.consume)
 
 
 def update_from_signals(

--- a/tests/test_narrative_projector.py
+++ b/tests/test_narrative_projector.py
@@ -1,0 +1,142 @@
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from singular.self_narrative import (
+    NarrativeProjector,
+    load,
+    project_event,
+    rebuild_from_timeline,
+    timeline_path,
+)
+
+
+def _event(event_id: str, summary: str = "Je protège mes engagements.") -> dict:
+    return {
+        "event_id": event_id,
+        "event_type": "moral_decision",
+        "summary": summary,
+        "objective_ids": ["coherence"],
+        "participants": ["Nova", "Ada"],
+        "confidence": 0.91,
+        "change_type": "commitment_reinforced",
+        "causal_links": [{"cause_event_id": "birth-1", "relation": "enabled"}],
+    }
+
+
+def test_reconstruction_preserves_provenance_across_restarts(tmp_path: Path) -> None:
+    path = tmp_path / "nova" / "mem" / "self_narrative.json"
+    project_event(_event("decision-1"), path, life_id="nova")
+    restarted = NarrativeProjector(path, life_id="nova")
+    restarted.consume(
+        {
+            "event_id": "learn-1",
+            "event_type": "learning",
+            "summary": "J'ai appris à vérifier.",
+        }
+    )
+
+    rebuilt = rebuild_from_timeline(path, life_id="nova", persist=False)
+
+    assert [entry.source_event_ids[0] for entry in rebuilt.entries] == [
+        "decision-1",
+        "learn-1",
+    ]
+    first = rebuilt.entries[0]
+    assert first.objective_ids == ["coherence"]
+    assert first.participants == ["Nova", "Ada"]
+    assert first.confidence == 0.91
+    assert first.change_type == "commitment_reinforced"
+    assert first.causal_links[0]["cause_event_id"] == "birth-1"
+
+
+def test_projection_is_idempotent_for_a_source_event(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "self_narrative.json"
+    project_event(_event("same"), path, life_id="nova")
+    before = timeline_path(path).read_bytes()
+    result = project_event(_event("same"), path, life_id="nova")
+
+    assert len(result.entries) == 1
+    assert timeline_path(path).read_bytes() == before
+
+
+def test_contradiction_stays_uncertain_and_does_not_replace_heading(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "mem" / "self_narrative.json"
+    project_event(
+        {
+            "event_id": "goal-1",
+            "event_type": "goal",
+            "summary": "protect users",
+            "current_heading": "Protect users",
+        },
+        path,
+        life_id="nova",
+    )
+    result = project_event(
+        {
+            "event_id": "goal-2",
+            "event_type": "goal",
+            "summary": "not protect users",
+            "current_heading": "Ignore users",
+        },
+        path,
+        life_id="nova",
+        commitments=[{"name": "protect users"}],
+    )
+
+    assert result.current_heading == "Protect users"
+    assert result.entries[-1].certainty == "uncertain"
+    assert result.entries[-1].contradictions
+
+
+def test_corrupt_projection_and_timeline_line_are_recoverable(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "self_narrative.json"
+    project_event(_event("safe"), path, life_id="nova")
+    with timeline_path(path).open("a", encoding="utf-8") as handle:
+        handle.write("{broken\n")
+    path.write_text("{broken", encoding="utf-8")
+
+    recovered = load(path)
+
+    assert recovered.life_id == "nova"
+    assert recovered.entries[0].source_event_ids == ["safe"]
+    assert json.loads(path.read_text(encoding="utf-8"))["entries"]
+
+
+def test_lives_are_separated_even_when_timeline_is_copied(tmp_path: Path) -> None:
+    nova = tmp_path / "nova" / "self_narrative.json"
+    ada = tmp_path / "ada" / "self_narrative.json"
+    project_event(_event("nova-event"), nova, life_id="nova")
+    ada.parent.mkdir(parents=True)
+    timeline_path(ada).write_bytes(timeline_path(nova).read_bytes())
+
+    rebuilt = rebuild_from_timeline(ada, life_id="ada", persist=False)
+
+    assert rebuilt.life_id == "ada"
+    assert rebuilt.entries == []
+    with pytest.raises(ValueError, match="different life"):
+        project_event(_event("ada-event"), nova, life_id="ada")
+
+
+def test_continuity_over_multiple_restart_instances(tmp_path: Path) -> None:
+    path = tmp_path / "mem" / "self_narrative.json"
+    start = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    for index in range(4):
+        projector = NarrativeProjector(path, life_id="nova")
+        project_event(
+            {
+                "event_id": f"transition-{index}",
+                "event_type": "life_transition",
+                "summary": f"cycle {index}",
+            },
+            projector.path,
+            life_id=projector.life_id,
+            clock=lambda index=index: start + timedelta(days=index),
+        )
+
+    assert len(load(path).entries) == 4
+    assert len(rebuild_from_timeline(path, life_id="nova", persist=False).entries) == 4


### PR DESCRIPTION
### Motivation

- Provide an event-driven, reconstructable self-narrative projection that consumes major life events (birth, goals, conversations, learnings, moral decisions, relationships, mutations, incidents, transitions) and preserves provenance and causal links. 
- Ensure contradictions with autobiographical facts, commitments or history are detected and kept explicitly uncertain rather than overwriting prior state.

### Description

- Add a first-class `NarrativeEntry` and attach `life_id` + `entries` to the `SelfNarrative` schema and bump `SCHEMA_VERSION` to `3` in `src/singular/self_narrative.py`. 
- Implement append-only timeline handling with `_load_timeline_records`, `timeline_path`, `rebuild_from_timeline`, `project_event` and `NarrativeProjector` to atomically project events, persist snapshots and keep per-life isolation. 
- Integrate identity coherence checks via `detect_contradictions` so contradictory claims remain `uncertain` and do not replace existing headings; add idempotence by event identifier and event-type normalization/aliases. 
- Make persistence atomic using `atomic_write_text`, add timeline append (`append_jsonl_line`) for reconstructability, and add helpers for provenance (`_event_identifier`, `_apply_entry`, `_string_list`). 
- Add `tests/test_narrative_projector.py` covering reconstruction, provenance, idempotence, contradiction behavior, corruption recovery, life separation and multi-restart continuity.

### Testing

- Ran `pytest` for narrative tests: `tests/test_self_narrative.py` passed (`7 passed`).
- Ran new projector tests together: `python -m pytest tests/test_self_narrative.py tests/test_narrative_projector.py` which passed (`13 passed`).
- Ran broader orchestrator-related suite including `tests/test_orchestrator_service.py` with the narrative tests and formatting checks, which passed (`30 passed`, with warnings about unrelated deprecations).
- A full run of the entire repository test collection initially surfaced an unrelated, pre-existing import error in `tests/test_targeted_lifecycle_narrative_trajectory.py` (missing `CHECKPOINT_VERSION` from `singular.life.loop`); this error is external to the changes in this PR and did not affect the targeted narrative projector tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a760deff2dc832a8684731af4004378)