### PR TITLE
feat(embodiment): add configurable ROS2 bridge and adapters

### DIFF
--- a/configs/ros2_bridge.example.yaml
+++ b/configs/ros2_bridge.example.yaml
@@ -1,0 +1,37 @@
+version: 1
+defaults:
+  timeout_s: 2.0
+  qos:
+    depth: 10
+    reliability: reliable
+sensors:
+  - name: odometry
+    topic: /robot/odom
+    message_type: nav_msgs.msg.Odometry
+    reconnect: true
+    transform:
+      fields:
+        position: pose.pose.position
+        velocity: twist.twist.linear
+effectors:
+  - command: robot.velocity
+    kind: publisher
+    topic: /robot/cmd_vel
+    message_type: geometry_msgs.msg.Twist
+    acknowledgement_topic: /robot/cmd_vel_ack
+    acknowledgement_type: singular_interfaces.msg.CommandAcknowledgement
+    transform:
+      fields:
+        linear: linear
+        angular: angular
+  - command: robot.reset_odometry
+    kind: service
+    service: /robot/reset_odometry
+    message_type: std_srvs.srv.Trigger
+  - command: robot.navigate
+    kind: action
+    action: /navigate_to_pose
+    message_type: nav2_msgs.action.NavigateToPose
+    transform:
+      fields:
+        pose: pose

--- a/deploy/ros2/compose.example.yaml
+++ b/deploy/ros2/compose.example.yaml
@@ -1,0 +1,11 @@
+services:
+  singular-ros2:
+    image: singular-ros2:operator-built
+    command: ["singular", "orchestrate", "run"]
+    environment:
+      ROS_DOMAIN_ID: "0"
+      SINGULAR_ROS2_BRIDGE: /etc/singular/ros2_bridge.yaml
+    volumes:
+      - ../../configs/ros2_bridge.example.yaml:/etc/singular/ros2_bridge.yaml:ro
+    # Example only: add devices/network privileges only after a safety review.
+    restart: unless-stopped

--- a/docs/ros2_bridge.md
+++ b/docs/ros2_bridge.md
@@ -1,0 +1,43 @@
+# Bridge ROS2 (optionnel)
+
+Le bridge est **désactivé par défaut** : sa présence ne signifie ni que ROS2, ni
+que les interfaces listées, ni qu'un robot sont disponibles. Installez une
+distribution ROS2 compatible, sourcez son environnement et installez Singular
+avec les extras nécessaires :
+
+```bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+python -m pip install -e '.[ros2,yaml]'
+```
+
+Copiez `configs/ros2_bridge.example.yaml`, remplacez les topics et types par
+ceux réellement exposés puis construisez les ports :
+
+```python
+from singular.embodiment import build_bridge_ports
+from singular.core.agent_runtime import AgentRuntime
+
+ports = build_bridge_ports("configs/my_ros2_bridge.yaml")
+runtime = AgentRuntime(perception=ports.perception, mind=my_mind, action=ports.action)
+try:
+    runtime.step()
+finally:
+    ports.perception.close()
+    ports.action.close()
+```
+
+`qos` accepte `depth`, `reliability`, `durability` et `history`. Les délais sont
+en secondes. `reconnect` recrée une souscription après une erreur de spin. Les
+transformations ne font pas d'`eval` : `fields` associe un champ de destination
+à un chemin dans le payload et `constants` ajoute des valeurs littérales.
+
+Une publication peut utiliser un topic d'acquittement dont le message contient
+`command_id`. Services et actions attendent leur réponse/résultat réel. Chaque
+adaptateur retourne le même `command_id` et place la réponse structurée dans
+`Acknowledgement.actual`. L'arrêt d'urgence est verrouillé pour toute la durée
+de vie des ports. Il faut recréer le bridge (ou réinitialiser explicitement son
+signal après une procédure opérateur) avant de reprendre.
+
+Le manifeste Compose sous `deploy/ros2/` n'est qu'un exemple. Il suppose une
+image construite par l'opérateur avec ROS2 et les paquets d'interfaces requis ;
+il ne revendique aucun accès matériel et ne monte aucun périphérique par défaut.

--- a/src/singular/embodiment/__init__.py
+++ b/src/singular/embodiment/__init__.py
@@ -17,7 +17,18 @@ from .simulators import (
     MicrophoneSimulator,
     ScriptedSensor,
 )
-from .adapters import GPIOActuator, OptionalAdapterUnavailable, ROS2Sensor
+from .adapters import (
+    GPIOActuator,
+    OptionalAdapterUnavailable,
+    ROS2ActionActuator,
+    ROS2PublisherActuator,
+    ROS2QoS,
+    ROS2Sensor,
+    ROS2ServiceActuator,
+    populate_ros_message,
+    serialize_ros_message,
+)
+from .bridge import BridgePorts, build_bridge_ports, load_bridge_config
 
 __all__ = [
     "Acknowledgement",
@@ -36,4 +47,13 @@ __all__ = [
     "GPIOActuator",
     "OptionalAdapterUnavailable",
     "ROS2Sensor",
+    "ROS2QoS",
+    "ROS2PublisherActuator",
+    "ROS2ServiceActuator",
+    "ROS2ActionActuator",
+    "serialize_ros_message",
+    "populate_ros_message",
+    "BridgePorts",
+    "build_bridge_ports",
+    "load_bridge_config",
 ]

--- a/src/singular/embodiment/adapters.py
+++ b/src/singular/embodiment/adapters.py
@@ -1,49 +1,406 @@
-"""Optional ROS2 and GPIO adapters; imports occur only when instantiated."""
+"""Optional hardware adapters.
+
+ROS imports deliberately happen at construction time so installing Singular does
+not imply that a ROS installation (or robot) is present.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Callable
+from dataclasses import dataclass, field, fields, is_dataclass
+import time
+from typing import Any, Callable, Mapping
 
-from .contracts import Acknowledgement, Command, Observation, utc_now
+from .contracts import (
+    Acknowledgement,
+    Command,
+    EmbodimentError,
+    EmergencyStop,
+    ErrorCode,
+    Observation,
+    utc_now,
+)
 
 
 class OptionalAdapterUnavailable(RuntimeError):
     pass
 
 
-@dataclass
-class ROS2Sensor:
-    topic: str
-    message_type: Any
-    node_name: str = "singular_sensor"
+def serialize_ros_message(value: Any) -> Any:
+    """Turn a ROS message into JSON-compatible, structured Python values."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return list(value)
+    if isinstance(value, Mapping):
+        return {str(k): serialize_ros_message(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [serialize_ros_message(v) for v in value]
+    if is_dataclass(value):
+        return {
+            f.name: serialize_ros_message(getattr(value, f.name)) for f in fields(value)
+        }
+    getter = getattr(value, "get_fields_and_field_types", None)
+    if callable(getter):
+        return {name: serialize_ros_message(getattr(value, name)) for name in getter()}
+    slots = getattr(value, "__slots__", ())
+    if slots:
+        return {
+            name.lstrip("_"): serialize_ros_message(getattr(value, name))
+            for name in slots
+            if hasattr(value, name)
+        }
+    if hasattr(value, "__dict__"):
+        return {
+            k.lstrip("_"): serialize_ros_message(v)
+            for k, v in vars(value).items()
+            if not k.startswith("__")
+        }
+    return str(value)
 
-    def __post_init__(self) -> None:
+
+def populate_ros_message(message: Any, payload: Mapping[str, Any]) -> Any:
+    """Recursively populate a request/message instance from a payload mapping."""
+    for key, value in payload.items():
+        if not hasattr(message, key):
+            raise ValueError(f"ROS message has no field {key!r}")
+        current = getattr(message, key)
+        if isinstance(value, Mapping) and not isinstance(current, Mapping):
+            populate_ros_message(current, value)
+        else:
+            setattr(message, key, value)
+    return message
+
+
+@dataclass(frozen=True)
+class ROS2QoS:
+    depth: int = 10
+    reliability: str | None = None
+    durability: str | None = None
+    history: str | None = None
+
+    def build(self, rclpy: Any) -> Any:
+        """Build a QoSProfile when available, otherwise retain depth semantics."""
+        try:
+            qos = rclpy.qos
+            kwargs: dict[str, Any] = {"depth": self.depth}
+            for name, enum_name in (
+                ("reliability", "QoSReliabilityPolicy"),
+                ("durability", "QoSDurabilityPolicy"),
+                ("history", "QoSHistoryPolicy"),
+            ):
+                configured = getattr(self, name)
+                if configured:
+                    kwargs[name] = getattr(getattr(qos, enum_name), configured.upper())
+            return qos.QoSProfile(**kwargs)
+        except (AttributeError, TypeError):
+            return self.depth
+
+
+class _ROS2Endpoint:
+    def _start(self, node_name: str, node: Any | None = None) -> None:
         try:
             import rclpy
         except ImportError as exc:
             raise OptionalAdapterUnavailable(
-                "ROS2 adapter requires the 'ros2' extra (rclpy)"
+                "ROS2 adapter requires rclpy and a sourced ROS2 environment"
             ) from exc
         self._rclpy = rclpy
-        rclpy.init(args=None)
-        self._node = rclpy.create_node(self.node_name)
+        self._closed = False
+        self._owns_context = False
+        if node is None:
+            ok = getattr(rclpy, "ok", lambda: False)()
+            if not ok:
+                rclpy.init(args=None)
+                self._owns_context = True
+            self._node = rclpy.create_node(node_name)
+            self._owns_node = True
+        else:
+            self._node = node
+            self._owns_node = False
+
+    def _spin_future(self, future: Any, timeout: float) -> Any:
+        self._rclpy.spin_until_future_complete(self._node, future, timeout_sec=timeout)
+        if not future.done():
+            raise TimeoutError(f"ROS2 operation timed out after {timeout}s")
+        exception = getattr(future, "exception", lambda: None)()
+        if exception:
+            raise exception
+        return future.result()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._owns_node:
+            self._node.destroy_node()
+        if self._owns_context and getattr(self._rclpy, "ok", lambda: True)():
+            self._rclpy.shutdown()
+
+
+@dataclass
+class ROS2Sensor(_ROS2Endpoint):
+    topic: str
+    message_type: Any
+    node_name: str = "singular_sensor"
+    qos: ROS2QoS = field(default_factory=ROS2QoS)
+    timeout_s: float = 0.0
+    reconnect: bool = True
+    transform: Callable[[dict[str, Any]], dict[str, Any]] = lambda payload: payload
+    node: Any | None = None
+
+    def __post_init__(self) -> None:
+        self._start(self.node_name, self.node)
         self._pending: list[Observation] = []
+        self._connect()
+
+    def _connect(self) -> None:
         self._subscription = self._node.create_subscription(
-            self.message_type, self.topic, self._receive, 10
+            self.message_type, self.topic, self._receive, self.qos.build(self._rclpy)
         )
 
     def _receive(self, message: Any) -> None:
-        payload = message if isinstance(message, dict) else {"message": str(message)}
-        self._pending.append(Observation("ros2", payload, f"ros2:{self.topic}"))
+        payload = serialize_ros_message(message)
+        if not isinstance(payload, dict):
+            payload = {"value": payload}
+        self._pending.append(
+            Observation("ros2", self.transform(payload), f"ros2:{self.topic}")
+        )
 
     def collect(self) -> list[Observation]:
-        self._rclpy.spin_once(self._node, timeout_sec=0.0)
+        try:
+            self._rclpy.spin_once(self._node, timeout_sec=self.timeout_s)
+        except Exception as exc:
+            if self.reconnect:
+                try:
+                    destroy = getattr(self._node, "destroy_subscription", None)
+                    if callable(destroy):
+                        destroy(self._subscription)
+                    self._connect()
+                except Exception:
+                    pass
+            return [
+                Observation(
+                    "ros2.error",
+                    {},
+                    f"ros2:{self.topic}",
+                    error=EmbodimentError(ErrorCode.UNAVAILABLE, str(exc)),
+                )
+            ]
         result, self._pending = self._pending, []
         return result
 
-    def close(self) -> None:
-        self._node.destroy_node()
+
+class _ROS2Actuator(_ROS2Endpoint):
+    def __init__(
+        self,
+        *,
+        node_name: str,
+        timeout_s: float,
+        node: Any | None,
+        stop: EmergencyStop | None,
+    ) -> None:
+        self.timeout_s = timeout_s
+        self.stop = stop or EmergencyStop()
+        self._start(node_name, node)
+
+    def emergency_stop(self, reason: str = "operator_request") -> None:
+        self.stop.engage(reason)
+
+    def _blocked(self, command: Command) -> Acknowledgement | None:
+        if self.stop.engaged:
+            return Acknowledgement(
+                command.action_type,
+                False,
+                "emergency stop engaged",
+                ErrorCode.EMERGENCY_STOP.value,
+                command_id=command.command_id,
+                actual={"reason": self.stop.reason},
+            )
+        return None
+
+    def _error(self, command: Command, exc: Exception) -> Acknowledgement:
+        code = (
+            ErrorCode.TIMEOUT
+            if isinstance(exc, TimeoutError)
+            else ErrorCode.UNAVAILABLE
+        )
+        return Acknowledgement(
+            command.action_type,
+            False,
+            str(exc),
+            code.value,
+            command_id=command.command_id,
+        )
+
+
+class ROS2PublisherActuator(_ROS2Actuator):
+    """Publish a command and optionally correlate an acknowledgement topic."""
+
+    def __init__(
+        self,
+        topic: str,
+        message_type: Any,
+        *,
+        qos: ROS2QoS = ROS2QoS(),
+        timeout_s: float = 1.0,
+        acknowledgement_topic: str | None = None,
+        acknowledgement_type: Any | None = None,
+        transform: Callable[[Command], Mapping[str, Any]] = lambda c: c.parameters,
+        node_name: str = "singular_publisher",
+        node: Any | None = None,
+        stop: EmergencyStop | None = None,
+    ) -> None:
+        super().__init__(node_name=node_name, timeout_s=timeout_s, node=node, stop=stop)
+        self.topic, self.message_type, self.transform = topic, message_type, transform
+        self._publisher = self._node.create_publisher(
+            message_type, topic, qos.build(self._rclpy)
+        )
+        self._acks: dict[str, Any] = {}
+        self._ack_subscription = None
+        if acknowledgement_topic and acknowledgement_type:
+            self._ack_subscription = self._node.create_subscription(
+                acknowledgement_type,
+                acknowledgement_topic,
+                self._ack,
+                qos.build(self._rclpy),
+            )
+
+    def _ack(self, message: Any) -> None:
+        data = serialize_ros_message(message)
+        command_id = data.get("command_id") if isinstance(data, dict) else None
+        if command_id:
+            self._acks[str(command_id)] = data
+
+    def execute(self, command: Command) -> Acknowledgement:
+        if blocked := self._blocked(command):
+            return blocked
+        try:
+            message = populate_ros_message(self.message_type(), self.transform(command))
+            self._publisher.publish(message)
+            if self._ack_subscription:
+                deadline = time.monotonic() + self.timeout_s
+                while (
+                    command.command_id not in self._acks and time.monotonic() < deadline
+                ):
+                    self._rclpy.spin_once(
+                        self._node, timeout_sec=max(0.0, deadline - time.monotonic())
+                    )
+                if command.command_id not in self._acks:
+                    raise TimeoutError(f"no acknowledgement for {command.command_id}")
+                actual = self._acks.pop(command.command_id)
+            else:
+                actual = {
+                    "published": serialize_ros_message(message),
+                    "topic": self.topic,
+                    "published_at": utc_now(),
+                }
+            return Acknowledgement(
+                command.action_type,
+                True,
+                "ROS2 command acknowledged",
+                command_id=command.command_id,
+                actual=actual,
+            )
+        except Exception as exc:
+            return self._error(command, exc)
+
+
+class ROS2ServiceActuator(_ROS2Actuator):
+    def __init__(
+        self,
+        service: str,
+        service_type: Any,
+        *,
+        timeout_s: float = 2.0,
+        transform: Callable[[Command], Mapping[str, Any]] = lambda c: c.parameters,
+        node_name: str = "singular_service",
+        node: Any | None = None,
+        stop: EmergencyStop | None = None,
+    ) -> None:
+        super().__init__(node_name=node_name, timeout_s=timeout_s, node=node, stop=stop)
+        self.service, self.service_type, self.transform = (
+            service,
+            service_type,
+            transform,
+        )
+        self._client = self._node.create_client(service_type, service)
+
+    def execute(self, command: Command) -> Acknowledgement:
+        if blocked := self._blocked(command):
+            return blocked
+        try:
+            if not self._client.wait_for_service(timeout_sec=self.timeout_s):
+                raise RuntimeError(f"service {self.service!r} unavailable")
+            request = populate_ros_message(
+                self.service_type.Request(), self.transform(command)
+            )
+            actual = serialize_ros_message(
+                self._spin_future(self._client.call_async(request), self.timeout_s)
+            )
+            return Acknowledgement(
+                command.action_type,
+                True,
+                "ROS2 service completed",
+                command_id=command.command_id,
+                actual=actual if isinstance(actual, dict) else {"value": actual},
+            )
+        except Exception as exc:
+            return self._error(command, exc)
+
+
+class ROS2ActionActuator(_ROS2Actuator):
+    def __init__(
+        self,
+        action: str,
+        action_type: Any,
+        *,
+        timeout_s: float = 5.0,
+        transform: Callable[[Command], Mapping[str, Any]] = lambda c: c.parameters,
+        node_name: str = "singular_action",
+        node: Any | None = None,
+        stop: EmergencyStop | None = None,
+        action_client_factory: Callable[..., Any] | None = None,
+    ) -> None:
+        super().__init__(node_name=node_name, timeout_s=timeout_s, node=node, stop=stop)
+        if action_client_factory is None:
+            from rclpy.action import ActionClient
+
+            action_client_factory = ActionClient
+        self.action, self.action_type, self.transform = action, action_type, transform
+        self._client = action_client_factory(self._node, action_type, action)
+
+    def execute(self, command: Command) -> Acknowledgement:
+        if blocked := self._blocked(command):
+            return blocked
+        try:
+            if not self._client.wait_for_server(timeout_sec=self.timeout_s):
+                raise RuntimeError(f"action {self.action!r} unavailable")
+            goal = populate_ros_message(
+                self.action_type.Goal(), self.transform(command)
+            )
+            handle = self._spin_future(
+                self._client.send_goal_async(goal), self.timeout_s
+            )
+            if not handle.accepted:
+                return Acknowledgement(
+                    command.action_type,
+                    False,
+                    "goal refused",
+                    ErrorCode.REFUSED.value,
+                    command_id=command.command_id,
+                )
+            wrapped = self._spin_future(handle.get_result_async(), self.timeout_s)
+            result = getattr(wrapped, "result", wrapped)
+            actual = serialize_ros_message(result)
+            return Acknowledgement(
+                command.action_type,
+                True,
+                "ROS2 action completed",
+                command_id=command.command_id,
+                actual=actual if isinstance(actual, dict) else {"value": actual},
+            )
+        except Exception as exc:
+            return self._error(command, exc)
 
 
 @dataclass
@@ -60,8 +417,7 @@ class GPIOActuator:
             raise OptionalAdapterUnavailable(
                 "GPIO adapter requires the 'gpio' extra (gpiozero)"
             ) from exc
-        self._device = OutputDevice(self.pin)
-        self._stopped = False
+        self._device, self._stopped = OutputDevice(self.pin), False
 
     def execute(self, command: Command) -> Acknowledgement:
         if self._stopped:

--- a/src/singular/embodiment/bridge.py
+++ b/src/singular/embodiment/bridge.py
@@ -1,0 +1,168 @@
+"""Declarative construction of ROS2 perception and action ports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from .adapters import (
+    ROS2ActionActuator,
+    ROS2PublisherActuator,
+    ROS2QoS,
+    ROS2Sensor,
+    ROS2ServiceActuator,
+)
+from .contracts import Acknowledgement, Command, EmergencyStop, ErrorCode, Observation
+
+
+def resolve_type(path: str) -> Any:
+    """Resolve ``package.msg.Type`` (and ordinary dotted Python names)."""
+    module, _, name = path.rpartition(".")
+    if not module:
+        raise ValueError(f"invalid ROS type {path!r}")
+    return getattr(importlib.import_module(module), name)
+
+
+def _get(data: Mapping[str, Any], path: str) -> Any:
+    value: Any = data
+    for part in path.split("."):
+        value = value[int(part)] if isinstance(value, list) else value[part]
+    return value
+
+
+def payload_transform(spec: Mapping[str, Any] | None):
+    """Create a safe field-selection/renaming transform (no expression eval)."""
+    spec = spec or {}
+    fields = spec.get("fields", {})
+    constants = spec.get("constants", {})
+
+    def transform(value: Any) -> dict[str, Any]:
+        source = value.parameters if isinstance(value, Command) else value
+        result = {
+            target: _get(source, source_path) for target, source_path in fields.items()
+        }
+        result.update(constants)
+        return result if fields or constants else dict(source)
+
+    return transform
+
+
+class SensorGroup:
+    def __init__(self, sensors: list[Any]) -> None:
+        self.sensors = sensors
+
+    def collect(self) -> list[Observation]:
+        return [event for sensor in self.sensors for event in sensor.collect()]
+
+    def close(self) -> None:
+        for sensor in self.sensors:
+            sensor.close()
+
+
+class ActionRouter:
+    def __init__(self, actuators: Mapping[str, Any], stop: EmergencyStop) -> None:
+        self.actuators, self.stop = dict(actuators), stop
+
+    def execute(self, command: Command) -> Acknowledgement:
+        actuator = self.actuators.get(command.action_type)
+        if actuator is None:
+            return Acknowledgement(
+                command.action_type,
+                False,
+                "no configured ROS2 effector",
+                ErrorCode.REFUSED.value,
+                command_id=command.command_id,
+            )
+        return actuator.execute(command)
+
+    def emergency_stop(self, reason: str = "operator_request") -> None:
+        self.stop.engage(reason)
+        for actuator in self.actuators.values():
+            actuator.emergency_stop(reason)
+
+    def close(self) -> None:
+        for actuator in self.actuators.values():
+            actuator.close()
+
+
+@dataclass(frozen=True)
+class BridgePorts:
+    """Ports passed as ``perception=`` and ``action=`` to AgentRuntime."""
+
+    perception: SensorGroup
+    action: ActionRouter
+
+
+def load_bridge_config(path: str | Path) -> dict[str, Any]:
+    path = Path(path)
+    text = path.read_text(encoding="utf-8")
+    if path.suffix == ".json":
+        return json.loads(text)
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError("YAML bridge files require the 'yaml' extra") from exc
+    result = yaml.safe_load(text)
+    if not isinstance(result, dict):
+        raise ValueError("bridge configuration must be a mapping")
+    return result
+
+
+def build_bridge_ports(
+    config: Mapping[str, Any] | str | Path, *, node: Any | None = None
+) -> BridgePorts:
+    """Build AgentRuntime-compatible ports from a validated declarative mapping."""
+    if isinstance(config, (str, Path)):
+        config = load_bridge_config(config)
+    stop = EmergencyStop()
+    defaults = config.get("defaults", {})
+    default_qos = defaults.get("qos", {})
+    sensors = []
+    for item in config.get("sensors", []):
+        qos = ROS2QoS(**(default_qos | item.get("qos", {})))
+        sensors.append(
+            ROS2Sensor(
+                item["topic"],
+                resolve_type(item["message_type"]),
+                qos=qos,
+                timeout_s=float(item.get("timeout_s", defaults.get("timeout_s", 0))),
+                reconnect=bool(item.get("reconnect", True)),
+                transform=payload_transform(item.get("transform")),
+                node=node,
+            )
+        )
+    actuators = {}
+    for item in config.get("effectors", []):
+        common = {
+            "timeout_s": float(item.get("timeout_s", defaults.get("timeout_s", 2))),
+            "transform": payload_transform(item.get("transform")),
+            "node": node,
+            "stop": stop,
+        }
+        kind = item["kind"]
+        ros_type = resolve_type(item["message_type"])
+        if kind == "publisher":
+            ack_type = (
+                resolve_type(item["acknowledgement_type"])
+                if item.get("acknowledgement_type")
+                else None
+            )
+            actuator = ROS2PublisherActuator(
+                item["topic"],
+                ros_type,
+                qos=ROS2QoS(**(default_qos | item.get("qos", {}))),
+                acknowledgement_topic=item.get("acknowledgement_topic"),
+                acknowledgement_type=ack_type,
+                **common,
+            )
+        elif kind == "service":
+            actuator = ROS2ServiceActuator(item["service"], ros_type, **common)
+        elif kind == "action":
+            actuator = ROS2ActionActuator(item["action"], ros_type, **common)
+        else:
+            raise ValueError(f"unknown ROS2 effector kind {kind!r}")
+        actuators[item["command"]] = actuator
+    return BridgePorts(SensorGroup(sensors), ActionRouter(actuators, stop))

--- a/tests/test_ros2_adapters.py
+++ b/tests/test_ros2_adapters.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+from singular.embodiment import (
+    Command,
+    ErrorCode,
+    ROS2PublisherActuator,
+    ROS2Sensor,
+    ROS2ServiceActuator,
+)
+
+
+class Message:
+    __slots__ = ("command_id", "value", "nested")
+
+    def __init__(self):
+        self.command_id = ""
+        self.value = 0
+        self.nested = SimpleNamespace(x=1)
+
+
+class Future:
+    def __init__(self, result=None, done=True):
+        self._result, self._done = result, done
+
+    def done(self):
+        return self._done
+
+    def exception(self):
+        return None
+
+    def result(self):
+        return self._result
+
+
+class Service:
+    Request = Message
+
+
+class Client:
+    available = True
+    future = Future(SimpleNamespace(applied=True))
+
+    def wait_for_service(self, timeout_sec):
+        return self.available
+
+    def call_async(self, request):
+        self.request = request
+        return self.future
+
+
+class Publisher:
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, message):
+        self.messages.append(message)
+
+
+class Node:
+    def __init__(self):
+        self.subscriptions = []
+        self.publisher = Publisher()
+        self.client = Client()
+        self.destroyed = False
+
+    def create_subscription(self, typ, topic, callback, qos):
+        sub = SimpleNamespace(callback=callback, topic=topic)
+        self.subscriptions.append(sub)
+        return sub
+
+    def destroy_subscription(self, sub):
+        self.subscriptions.remove(sub)
+
+    def create_publisher(self, typ, topic, qos):
+        return self.publisher
+
+    def create_client(self, typ, name):
+        return self.client
+
+    def destroy_node(self):
+        self.destroyed = True
+
+
+class FakeRclpy:
+    def __init__(self):
+        self.initialized = False
+        self.shutdown_called = False
+        self.node = Node()
+        self.spin_error = None
+        self.on_spin = None
+
+    def ok(self):
+        return self.initialized
+
+    def init(self, args=None):
+        self.initialized = True
+
+    def shutdown(self):
+        self.initialized = False
+        self.shutdown_called = True
+
+    def create_node(self, name):
+        return self.node
+
+    def spin_once(self, node, timeout_sec=0):
+        if self.spin_error:
+            raise self.spin_error
+        if self.on_spin:
+            self.on_spin()
+
+    def spin_until_future_complete(self, node, future, timeout_sec):
+        pass
+
+
+def install_ros(monkeypatch):
+    ros = FakeRclpy()
+    monkeypatch.setitem(sys.modules, "rclpy", ros)
+    return ros
+
+
+def test_structured_receive_reconnect_and_owned_context_close(monkeypatch):
+    ros = install_ros(monkeypatch)
+    sensor = ROS2Sensor("/data", Message)
+    message = Message()
+    message.value = 42
+    sensor._receive(message)
+    assert sensor.collect()[0].payload == {
+        "command_id": "",
+        "value": 42,
+        "nested": {"x": 1},
+    }
+    ros.spin_error = OSError("link lost")
+    failed = sensor.collect()[0]
+    assert failed.error.code is ErrorCode.UNAVAILABLE
+    assert len(ros.node.subscriptions) == 1  # failed subscription was replaced
+    sensor.close()
+    sensor.close()
+    assert ros.node.destroyed and ros.shutdown_called
+
+
+def test_external_node_is_not_destroyed_and_context_is_not_shutdown(monkeypatch):
+    ros = install_ros(monkeypatch)
+    ros.initialized = True
+    node = Node()
+    sensor = ROS2Sensor("/data", Message, node=node)
+    sensor.close()
+    assert not node.destroyed and not ros.shutdown_called
+
+
+def test_publication_correlates_ack_and_preserves_command_id(monkeypatch):
+    ros = install_ros(monkeypatch)
+    actuator = ROS2PublisherActuator(
+        "/cmd", Message, acknowledgement_topic="/ack", acknowledgement_type=Message
+    )
+    command = Command("move", {"value": 7})
+
+    def acknowledge():
+        ack = Message()
+        ack.command_id = command.command_id
+        ack.value = 6
+        actuator._ack(ack)
+        ros.on_spin = None
+
+    ros.on_spin = acknowledge
+    result = actuator.execute(command)
+    assert result.success and result.command_id == command.command_id
+    assert result.actual["value"] == 6
+    assert ros.node.publisher.messages[0].value == 7
+
+
+def test_publication_timeout_and_latched_emergency_stop(monkeypatch):
+    install_ros(monkeypatch)
+    actuator = ROS2PublisherActuator(
+        "/cmd",
+        Message,
+        timeout_s=0,
+        acknowledgement_topic="/ack",
+        acknowledgement_type=Message,
+    )
+    timed_out = actuator.execute(Command("move"))
+    assert timed_out.error == ErrorCode.TIMEOUT.value
+    actuator.emergency_stop("operator")
+    blocked = actuator.execute(Command("move"))
+    assert blocked.error == ErrorCode.EMERGENCY_STOP.value
+
+
+def test_service_actual_and_unavailability(monkeypatch):
+    ros = install_ros(monkeypatch)
+    actuator = ROS2ServiceActuator("/apply", Service)
+    command = Command("apply", {"value": 9})
+    result = actuator.execute(command)
+    assert result.command_id == command.command_id and result.actual == {
+        "applied": True
+    }
+    ros.node.client.available = False
+    assert actuator.execute(command).error == ErrorCode.UNAVAILABLE.value


### PR DESCRIPTION
### Motivation

- Fournir des adaptateurs ROS2 structurés, robustes et optionnels sans imposer la présence d'une installation ROS lors de l'installation du paquet.
- Permettre de déclarer les topics/types/senseurs/effecteurs via une configuration pour construire automatiquement les ports `perception` et `action` d'un `AgentRuntime`.

### Description

- Ajout d'une implémentation complète d'adaptateurs ROS2 dans `src/singular/embodiment/adapters.py` incluant sérialisation récursive des messages (`serialize_ros_message`), remplissage récursif de messages (`populate_ros_message`), QoS déclaratif (`ROS2QoS`), gestion de contexte/nœud propriétaire, timeouts, erreurs et logique de reconnexion pour les capteurs, ainsi que effecteurs pour publication, services et actions qui préservent `command_id` et respectent l'`EmergencyStop`.
- Ajout d'une fabrique déclarative `build_bridge_ports` et d'un chargeur de configuration `load_bridge_config` dans `src/singular/embodiment/bridge.py` pour construire `BridgePorts` (agrégateur de capteurs `SensorGroup` et routeur d'effecteurs `ActionRouter`) à partir de fichiers YAML/JSON.
- Export des nouvelles API et utilitaires dans `src/singular/embodiment/__init__.py` pour rendre `ROS2Sensor`, `ROS2PublisherActuator`, `ROS2ServiceActuator`, `ROS2ActionActuator`, `ROS2QoS`, `populate_ros_message`, `serialize_ros_message`, `build_bridge_ports` et `load_bridge_config` disponibles publiquement.
- Ajout d'un exemple de configuration déclarative `configs/ros2_bridge.example.yaml`, d'un manifeste Compose d'exemple `deploy/ros2/compose.example.yaml` et d'une documentation d'utilisation optionnelle `docs/ros2_bridge.md` expliquant l'installation des extras et les comportements (QoS, timeouts, acquittements, arrêt d'urgence, etc.).
- Ajout de tests unitaires simulant ROS2 dans `tests/test_ros2_adapters.py` couvrant réception structurée, reconnexion, propriété du contexte, publication + corrélation d'acquittement, timeout d'acquittement, indisponibilité des services et arrêt d'urgence verrouillé; maintien du `GPIOActuator` existant.

### Testing

- Compilation suivie de `python -m compileall -q src/singular/embodiment` a réussi.
- Tests ciblés exécutés avec `pytest -q tests/test_embodiment.py tests/test_ros2_adapters.py` ont réussi (`9 passed`).
- Formatage vérifié et appliqué avec `black` puis retesté, les fichiers modifiés ont été reformatés et les tests ciblés sont toujours passés.
- Exécution d'une suite de tests complète `pytest -q` s'est arrêtée lors de la collecte pour une erreur préexistante non liée à ces changements (import manquant `CHECKPOINT_VERSION` dans `singular.life.loop`), ce qui empêche de rapporter l'intégralité de la suite ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7610153754832abcfac9643a843f58)