### PR TITLE
Add embodied perception-action composition runtime

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -1055,6 +1055,16 @@ def main(argv: list[str] | None = None) -> int:
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    embodiment_parser = subparsers.add_parser(
+        "embodiment", help="Démarrer la boucle perception-action configurée"
+    )
+    embodiment_parser.add_argument("--config", type=Path, required=True)
+    embodiment_parser.add_argument(
+        "--mode", choices=("simulation", "dry-run", "hardware"), default="simulation"
+    )
+    embodiment_parser.add_argument("--steps", type=int, default=None)
+    embodiment_parser.add_argument("--audit", type=Path, default=None)
+
     if _birth_alias_enabled():
         birth_parser = subparsers.add_parser(
             "birth",
@@ -1620,7 +1630,56 @@ def main(argv: list[str] | None = None) -> int:
     if args.safe_mode:
         os.environ["SINGULAR_SAFE_MODE"] = "1"
 
-    if args.command == "birth":
+    if args.command == "embodiment":
+        from .embodiment import (
+            EmbodimentRuntime,
+            build_bridge_ports,
+            build_simulated_runtime,
+            jsonl_audit_sink,
+            load_bridge_config,
+            run_configured_loop,
+        )
+
+        config = load_bridge_config(args.config)
+        audit_path = args.audit or args.config.with_suffix(".audit.jsonl")
+        sink = jsonl_audit_sink(audit_path)
+        if args.mode == "hardware":
+            ports = build_bridge_ports(config)
+            runtime = EmbodimentRuntime(
+                {
+                    f"sensor.{i}": sensor
+                    for i, sensor in enumerate(ports.perception.sensors)
+                },
+                ports.action.actuators,
+                emergency_stop=ports.action.stop,
+                audit_sink=sink,
+            )
+        else:
+            runtime = build_simulated_runtime(
+                config, dry_run=args.mode == "dry-run", audit_sink=sink
+            )
+        steps = args.steps if args.steps is not None else int(config.get("steps", 1))
+        try:
+            actions = run_configured_loop(runtime, config, steps=steps)
+        except KeyboardInterrupt:
+            runtime.request_emergency_stop("keyboard_interrupt")
+            actions = 0
+        finally:
+            runtime.close()
+        payload = {
+            "mode": args.mode,
+            "steps": steps,
+            "actions": actions,
+            "audit": str(audit_path),
+        }
+        if args.output_format == "json":
+            print(json.dumps(payload, ensure_ascii=False))
+        else:
+            print(
+                f"Boucle embodiment terminée: {actions} commande(s), audit={audit_path}"
+            )
+
+    elif args.command == "birth":
         sys.stderr.write(
             "⚠️ `singular birth` est déprécié et sera supprimé après la période "
             "de transition. Migrez vers `singular lives create --name ...`.\n"

--- a/src/singular/embodiment/__init__.py
+++ b/src/singular/embodiment/__init__.py
@@ -29,6 +29,14 @@ from .adapters import (
     serialize_ros_message,
 )
 from .bridge import BridgePorts, build_bridge_ports, load_bridge_config
+from .runtime import (
+    AdapterStatus,
+    EmbodimentRuntime,
+    RuntimeState,
+    build_simulated_runtime,
+    jsonl_audit_sink,
+    run_configured_loop,
+)
 
 __all__ = [
     "Acknowledgement",
@@ -56,4 +64,10 @@ __all__ = [
     "BridgePorts",
     "build_bridge_ports",
     "load_bridge_config",
+    "AdapterStatus",
+    "EmbodimentRuntime",
+    "RuntimeState",
+    "jsonl_audit_sink",
+    "build_simulated_runtime",
+    "run_configured_loop",
 ]

--- a/src/singular/embodiment/runtime.py
+++ b/src/singular/embodiment/runtime.py
@@ -1,0 +1,331 @@
+"""Composition runtime joining sensors, perception, and routed effectors.
+
+The class in this module deliberately implements both the ``PerceptionPort`` and
+``ActionPort`` structural protocols.  It can therefore be passed directly to an
+``AgentRuntime`` without either layer depending on the other.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from threading import RLock
+from typing import Any, Callable, Iterable, Mapping
+
+from .contracts import (
+    Acknowledgement,
+    Command,
+    EmbodimentError,
+    EmergencyStop,
+    ErrorCode,
+    Observation,
+    Sensor,
+    utc_now,
+)
+
+AuditSink = Callable[[dict[str, Any]], None]
+
+
+@dataclass
+class AdapterStatus:
+    kind: str
+    healthy: bool = True
+    closed: bool = False
+    error: str | None = None
+    operations: int = 0
+
+
+@dataclass
+class RuntimeState:
+    adapters: dict[str, AdapterStatus] = field(default_factory=dict)
+    latest_observations: dict[str, Observation] = field(default_factory=dict)
+    pending_commands: dict[str, Command] = field(default_factory=dict)
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    emergency_stop: EmergencyStop = field(default_factory=EmergencyStop)
+    closed: bool = False
+
+
+class EmbodimentRuntime:
+    """Own multiple adapters and provide deterministic perception/action I/O.
+
+    Every acknowledgement, including a refusal, is converted to an
+    ``action.result`` observation.  It is returned by the *next* ``collect`` so
+    the mind can perceive measured outcomes rather than treating actuation as a
+    terminal side effect.
+    """
+
+    def __init__(
+        self,
+        sensors: Mapping[str, Sensor] | Iterable[Sensor],
+        actuators: Mapping[str, Any],
+        *,
+        emergency_stop: EmergencyStop | None = None,
+        audit_sink: AuditSink | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        if isinstance(sensors, Mapping):
+            self.sensors = dict(sensors)
+        else:
+            self.sensors = {
+                f"sensor.{index}": sensor for index, sensor in enumerate(sensors)
+            }
+        self.actuators = dict(actuators)
+        self.state = RuntimeState(emergency_stop=emergency_stop or EmergencyStop())
+        self.audit_sink = audit_sink
+        self.dry_run = dry_run
+        self._feedback: deque[Observation] = deque()
+        self._lock = RLock()
+        for name in self.sensors:
+            self.state.adapters[f"sensor:{name}"] = AdapterStatus("sensor")
+        for route in self.actuators:
+            self.state.adapters[f"actuator:{route}"] = AdapterStatus("actuator")
+        self._audit("embodiment.started", {"dry_run": dry_run})
+
+    def _snapshot(self) -> dict[str, Any]:
+        stop = self.state.emergency_stop
+        return {
+            "adapters": {
+                name: asdict(status) for name, status in self.state.adapters.items()
+            },
+            "latest_observations": {
+                source: asdict(value)
+                for source, value in self.state.latest_observations.items()
+            },
+            "pending_commands": {
+                command_id: asdict(value)
+                for command_id, value in self.state.pending_commands.items()
+            },
+            "errors": list(self.state.errors),
+            "emergency_stop": asdict(stop),
+            "closed": self.state.closed,
+        }
+
+    def _audit(self, event: str, data: Mapping[str, Any] | None = None) -> None:
+        if self.audit_sink is not None:
+            self.audit_sink(
+                {
+                    "event": event,
+                    "recorded_at": utc_now(),
+                    "data": dict(data or {}),
+                    "state": self._snapshot(),
+                }
+            )
+
+    def _record_error(self, adapter: str, exc: BaseException) -> None:
+        status = self.state.adapters[adapter]
+        status.healthy = False
+        status.error = str(exc)
+        error = {"adapter": adapter, "message": str(exc), "at": utc_now()}
+        self.state.errors.append(error)
+        self._audit("embodiment.adapter.failed", error)
+
+    def collect(self) -> list[Observation]:
+        """Collect all sensors and prepend queued action-result feedback."""
+        with self._lock:
+            if self.state.closed:
+                return []
+            observations = list(self._feedback)
+            self._feedback.clear()
+            for name, sensor in self.sensors.items():
+                key = f"sensor:{name}"
+                try:
+                    values = sensor.collect()
+                    self.state.adapters[key].operations += 1
+                except Exception as exc:  # adapters are isolation boundaries
+                    self._record_error(key, exc)
+                    values = [
+                        Observation(
+                            "adapter.error",
+                            {"adapter": key, "message": str(exc)},
+                            key,
+                            error=EmbodimentError(ErrorCode.IO_ERROR, str(exc)),
+                        )
+                    ]
+                observations.extend(values)
+            for observation in observations:
+                self.state.latest_observations[observation.source] = observation
+            self._audit("embodiment.perception.collected", {"count": len(observations)})
+            return observations
+
+    def execute(self, command: Command) -> Acknowledgement:
+        """Route a command and queue its acknowledgement as perception feedback."""
+        with self._lock:
+            self.state.pending_commands[command.command_id] = command
+            self._audit(
+                "embodiment.command.pending", {"command_id": command.command_id}
+            )
+            actuator = self.actuators.get(command.action_type)
+            key = f"actuator:{command.action_type}"
+            if self.state.emergency_stop.engaged:
+                ack = Acknowledgement(
+                    command.action_type,
+                    False,
+                    "emergency stop engaged",
+                    ErrorCode.EMERGENCY_STOP.value,
+                    command_id=command.command_id,
+                    actual={"executed": False},
+                )
+            elif actuator is None:
+                ack = Acknowledgement(
+                    command.action_type,
+                    False,
+                    "no effector configured",
+                    ErrorCode.REFUSED.value,
+                    command_id=command.command_id,
+                    actual={"executed": False},
+                )
+            elif self.dry_run:
+                ack = Acknowledgement(
+                    command.action_type,
+                    True,
+                    "simulated (dry-run)",
+                    command_id=command.command_id,
+                    actual={"executed": False, "dry_run": True},
+                )
+            else:
+                try:
+                    ack = actuator.execute(command)
+                    self.state.adapters[key].operations += 1
+                except Exception as exc:
+                    self._record_error(key, exc)
+                    ack = Acknowledgement(
+                        command.action_type,
+                        False,
+                        "actuator failed",
+                        str(exc),
+                        command_id=command.command_id,
+                        actual={"executed": False},
+                    )
+            self.state.pending_commands.pop(command.command_id, None)
+            feedback = Observation(
+                "action.result",
+                {
+                    "action_type": ack.action_type,
+                    "success": ack.success,
+                    "message": ack.message,
+                    "error": ack.error,
+                    "actual": dict(ack.actual),
+                    "command_id": ack.command_id or command.command_id,
+                },
+                f"actuator:{command.action_type}",
+                observed_at=ack.completed_at,
+            )
+            self._feedback.append(feedback)
+            self.state.latest_observations[feedback.source] = feedback
+            self._audit("embodiment.command.acknowledged", feedback.payload)
+            return ack
+
+    def request_emergency_stop(self, reason: str = "operator_request") -> None:
+        with self._lock:
+            self.state.emergency_stop.engage(reason)
+            for route, actuator in self.actuators.items():
+                try:
+                    actuator.emergency_stop(reason)
+                except Exception as exc:
+                    self._record_error(f"actuator:{route}", exc)
+            self._audit("embodiment.emergency_stop", {"reason": reason})
+
+    emergency_stop = request_emergency_stop
+
+    def close(self) -> None:
+        """Close every owned resource once, in reverse declaration order."""
+        with self._lock:
+            if self.state.closed:
+                return
+            resources = [
+                *((f"sensor:{name}", sensor) for name, sensor in self.sensors.items()),
+                *(
+                    (f"actuator:{name}", actuator)
+                    for name, actuator in self.actuators.items()
+                ),
+            ]
+            seen: set[int] = set()
+            for key, resource in reversed(resources):
+                if id(resource) in seen:
+                    self.state.adapters[key].closed = True
+                    continue
+                seen.add(id(resource))
+                close = getattr(resource, "close", None)
+                try:
+                    if callable(close):
+                        close()
+                    self.state.adapters[key].closed = True
+                except Exception as exc:
+                    self._record_error(key, exc)
+            self.state.closed = True
+            self._audit("embodiment.closed")
+
+    def __enter__(self) -> "EmbodimentRuntime":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+
+def jsonl_audit_sink(path: str | Path) -> AuditSink:
+    """Return an audit sink appending one JSON object per line."""
+    import json
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    def write(event: dict[str, Any]) -> None:
+        with target.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(event, ensure_ascii=False, default=str) + "\n")
+
+    return write
+
+
+def build_simulated_runtime(
+    config: Mapping[str, Any],
+    *,
+    dry_run: bool = False,
+    audit_sink: AuditSink | None = None,
+) -> EmbodimentRuntime:
+    """Build deterministic adapters from the portable CLI configuration schema."""
+    from .simulators import ActuatorSimulator, ScriptedSensor
+
+    sensors: dict[str, ScriptedSensor] = {}
+    for index, item in enumerate(config.get("sensors", [])):
+        name = str(item.get("name", f"sensor.{index}"))
+        sensors[name] = ScriptedSensor(
+            source=str(item.get("source", name)),
+            event_type=str(item["event_type"]),
+            readings=item.get("readings", ()),
+            latency_s=float(item.get("latency_s", 0)),
+            unavailable_at=frozenset(item.get("unavailable_at", ())),
+        )
+    actuators = {
+        str(item["command"]): ActuatorSimulator(
+            latency_s=float(item.get("latency_s", 0)),
+            refused_actions=frozenset(item.get("refused_actions", ())),
+        )
+        for item in config.get("effectors", [])
+    }
+    return EmbodimentRuntime(sensors, actuators, dry_run=dry_run, audit_sink=audit_sink)
+
+
+def run_configured_loop(
+    runtime: EmbodimentRuntime, config: Mapping[str, Any], *, steps: int
+) -> int:
+    """Run simple declarative perception/action rules, returning action count."""
+    rules = list(config.get("rules", ()))
+    count = 0
+    for _ in range(max(0, steps)):
+        for observation in runtime.collect():
+            for rule in rules:
+                if rule.get("event_type") != observation.event_type:
+                    continue
+                parameters = dict(rule.get("parameters", {}))
+                if rule.get("include_payload", True):
+                    parameters.update(observation.payload)
+                runtime.execute(
+                    Command(
+                        str(rule["command"]),
+                        parameters,
+                        str(rule.get("intent_goal", "configured_rule")),
+                    )
+                )
+                count += 1
+    return count

--- a/src/singular/embodiment/simulators.py
+++ b/src/singular/embodiment/simulators.py
@@ -130,3 +130,6 @@ class ActuatorSimulator:
 
     def emergency_stop(self, reason: str = "operator_request") -> None:
         self.stop.engage(reason)
+
+    def close(self) -> None:
+        return None

--- a/tests/test_embodiment_runtime.py
+++ b/tests/test_embodiment_runtime.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+
+from singular import cli
+from singular.embodiment import (
+    ActuatorSimulator,
+    Command,
+    EmbodimentRuntime,
+    ErrorCode,
+    ScriptedSensor,
+)
+
+
+def test_multiple_sensors_effectors_and_measured_feedback() -> None:
+    events = []
+    motor = ActuatorSimulator()
+    speaker = ActuatorSimulator()
+    runtime = EmbodimentRuntime(
+        {
+            "camera": ScriptedSensor("camera", "vision", [{"target": "left"}]),
+            "microphone": ScriptedSensor("microphone", "audio", [{"text": "go"}]),
+        },
+        {"motor.move": motor, "speaker.say": speaker},
+        audit_sink=events.append,
+    )
+
+    assert {item.event_type for item in runtime.collect()} == {"vision", "audio"}
+    move = runtime.execute(Command("motor.move", {"distance": 2}))
+    say = runtime.execute(Command("speaker.say", {"text": "ok"}))
+    feedback = runtime.collect()
+
+    assert move.success and say.success
+    assert motor.commands[0].parameters == {"distance": 2}
+    assert speaker.commands[0].parameters == {"text": "ok"}
+    assert [item.event_type for item in feedback] == ["action.result", "action.result"]
+    assert feedback[0].payload["actual"]["parameters"] == {"distance": 2}
+    assert events[-1]["state"]["latest_observations"]
+    assert events[-1]["state"]["pending_commands"] == {}
+
+
+def test_refusal_adapter_failure_emergency_stop_and_deterministic_close() -> None:
+    class FailingSensor:
+        closed = 0
+
+        def collect(self):
+            raise RuntimeError("camera disconnected")
+
+        def close(self):
+            self.closed += 1
+
+    sensor = FailingSensor()
+    actuator = ActuatorSimulator(refused_actions=frozenset({"motor.move"}))
+    runtime = EmbodimentRuntime({"camera": sensor}, {"motor.move": actuator})
+
+    failed = runtime.collect()[0]
+    assert failed.error is not None and failed.error.code is ErrorCode.IO_ERROR
+    assert runtime.execute(Command("motor.move")).error == ErrorCode.REFUSED.value
+    runtime.request_emergency_stop("operator")
+    assert (
+        runtime.execute(Command("motor.move")).error == ErrorCode.EMERGENCY_STOP.value
+    )
+    runtime.close()
+    runtime.close()
+
+    assert sensor.closed == 1
+    assert runtime.state.closed is True
+    assert runtime.state.emergency_stop.reason == "operator"
+    assert runtime.state.errors[0]["adapter"] == "sensor:camera"
+
+
+def test_dry_run_does_not_touch_actuator() -> None:
+    actuator = ActuatorSimulator()
+    runtime = EmbodimentRuntime([], {"motor.move": actuator}, dry_run=True)
+    acknowledgement = runtime.execute(Command("motor.move"))
+    assert acknowledgement.actual == {"executed": False, "dry_run": True}
+    assert actuator.commands == []
+
+
+def test_cli_runs_simulated_configuration_and_writes_audit(tmp_path, capsys) -> None:
+    config = tmp_path / "embodiment.json"
+    audit = tmp_path / "audit.jsonl"
+    config.write_text(
+        json.dumps(
+            {
+                "steps": 2,
+                "sensors": [
+                    {"name": "range", "event_type": "range", "readings": [{"cm": 3}]}
+                ],
+                "effectors": [{"command": "motor.stop"}],
+                "rules": [{"event_type": "range", "command": "motor.stop"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        cli.main(
+            [
+                "--format",
+                "json",
+                "embodiment",
+                "--config",
+                str(config),
+                "--audit",
+                str(audit),
+            ]
+        )
+        == 0
+    )
+    output = json.loads(capsys.readouterr().out)
+    assert output["actions"] == 1
+    records = [
+        json.loads(line) for line in audit.read_text(encoding="utf-8").splitlines()
+    ]
+    assert records[-1]["event"] == "embodiment.closed"
+    assert records[-1]["state"]["closed"] is True


### PR DESCRIPTION
### Motivation

- Provide a single composition runtime that aggregates multiple `Sensor` adapters, adapts their `Observation`s into a `PerceptionPort`, routes `Command`s to the appropriate `Actuator`, and deterministically closes resources.
- Ensure actuation produces measurable feedback by reinjecting acknowledgements as `action.result` observations so perception–action forms a closed-loop rather than terminal side effects.
- Expose adapter state, latest observations, pending commands, errors and emergency-stop in auditable snapshots for operator visibility and post-hoc inspection.
- Support running the loop from the CLI in `simulation`, `dry-run` and `hardware` modes driven by a declarative config file.

### Description

- Add `src/singular/embodiment/runtime.py` implementing `EmbodimentRuntime`, `RuntimeState`, `AdapterStatus`, `jsonl_audit_sink`, `build_simulated_runtime` and `run_configured_loop`, which provide collection, routing, feedback reinjection, emergency-stop propagation and deterministic close behavior.
- Reinject every actuator `Acknowledgement` as an `Observation` with event type `action.result` that is delivered on the next `collect` call, and include command ids and measured outcome in the payload.
- Add a CLI subcommand `singular embodiment` (in `src/singular/cli.py`) that accepts a JSON/YAML configuration and supports `simulation`, `dry-run` and `hardware` modes and writes per-step audit JSONL snapshots.
- Export the new runtime helpers via `src/singular/embodiment/__init__.py`, add a `close()` contract on the `ActuatorSimulator` in `src/singular/embodiment/simulators.py`, and add fully simulated integration tests in `tests/test_embodiment_runtime.py` covering multi-sensor/multi-actuator routing, refusals, adapter failures, emergency stop, dry-run behavior and CLI audit output.

### Testing

- Formatted modified files with `python -m black src/singular/embodiment/runtime.py src/singular/embodiment/__init__.py src/singular/embodiment/simulators.py src/singular/cli.py tests/test_embodiment_runtime.py` which completed successfully.
- Byte-compiled the new runtime with `python -m py_compile src/singular/embodiment/runtime.py` which succeeded.
- Ran integration/unit tests with `pytest -q tests/test_embodiment.py tests/test_embodiment_runtime.py tests/test_core_agent_runtime.py` and `pytest -q tests/test_cli_config.py tests/test_ros2_adapters.py tests/test_embodiment_runtime.py`, with all targeted tests passing (17 and 23 tests respectively in those runs).
- Verified repository cleanliness with `git diff --check` and committed the changes (commit message: "Add embodied perception-action composition runtime").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76134db510832aa52e31431cc565b1)