### PR TITLE
Add transactional LearningOrchestrator for normalized feedback with promotion/rollback

### DIFF
--- a/src/singular/learning/__init__.py
+++ b/src/singular/learning/__init__.py
@@ -11,6 +11,14 @@ from .imitation import (
     SimilarityPolicyGenerator,
 )
 
+from .orchestrator import (
+    FEEDBACK_SOURCES,
+    FeedbackEvent,
+    LearningOrchestrator,
+    LearningPolicy,
+    PromotionDecision,
+)
+
 __all__ = [
     "CuriosityEngine",
     "CuriosityWeights",
@@ -22,4 +30,9 @@ __all__ = [
     "DEMONSTRATION_SCHEMA_VERSION",
     "PolicyGenerator",
     "SimilarityPolicyGenerator",
+    "FEEDBACK_SOURCES",
+    "FeedbackEvent",
+    "LearningOrchestrator",
+    "LearningPolicy",
+    "PromotionDecision",
 ]

--- a/src/singular/learning/orchestrator.py
+++ b/src/singular/learning/orchestrator.py
@@ -1,0 +1,294 @@
+"""Conservative, transactional learning from normalized feedback events.
+
+The orchestrator deliberately keeps observations and candidates separate from the
+state used by the rest of a life.  A candidate only becomes active after enough
+independent evidence and a successful persistent regression-suite evaluation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any, Callable, Mapping
+import uuid
+
+from singular.beliefs.store import BeliefStore
+from singular.io_utils import atomic_write_text, file_lock
+
+
+FEEDBACK_SOURCES = frozenset({"run", "conversation", "action", "perception", "social"})
+UPDATE_KINDS = frozenset({"strategy", "belief", "skill"})
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class FeedbackEvent:
+    """Source-independent feedback contract accepted by :meth:`ingest`."""
+
+    source: str
+    subject: str
+    reward: float
+    context: Mapping[str, Any] = field(default_factory=dict)
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    event_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    occurred_at: str = field(default_factory=_now)
+    life_id: str = "default"
+
+    def __post_init__(self) -> None:
+        if self.source not in FEEDBACK_SOURCES:
+            raise ValueError(f"unsupported feedback source: {self.source}")
+        if not self.subject.strip():
+            raise ValueError("feedback subject must not be empty")
+        if not math.isfinite(float(self.reward)):
+            raise ValueError("reward must be finite")
+
+
+@dataclass(frozen=True)
+class LearningPolicy:
+    max_events_per_cycle: int = 100
+    max_candidates_per_cycle: int = 10
+    minimum_evidence: int = 3
+    minimum_distinct_sources: int = 2
+    minimum_regression_cases: int = 1
+    promotion_reward: float = 0.0
+    decay: float = 0.98
+    drift_threshold: float = 0.45
+    max_regression: float = 0.05
+    minimum_retention: float = 0.90
+
+
+@dataclass(frozen=True)
+class PromotionDecision:
+    candidate_id: str
+    activated: bool
+    reason: str
+    evaluation: Mapping[str, float]
+    rollback_path: str | None
+
+
+Evaluator = Callable[[str, str, Any, list[dict[str, Any]]], Mapping[str, float]]
+
+
+class LearningOrchestrator:
+    """Per-life feedback aggregation, evaluation, promotion and rollback."""
+
+    def __init__(
+        self,
+        root: Path | str,
+        *,
+        life_id: str = "default",
+        policy: LearningPolicy | None = None,
+        belief_store: BeliefStore | None = None,
+        evaluator: Evaluator | None = None,
+    ) -> None:
+        self.root = Path(root)
+        self.life_id = life_id
+        self.policy = policy or LearningPolicy()
+        # The life id is a directory component only after rejecting traversal.
+        if not life_id or Path(life_id).name != life_id:
+            raise ValueError("life_id must be a single safe path component")
+        self.directory = self.root / "mem" / "learning" / life_id
+        self.state_path = self.directory / "state.json"
+        self.journal_path = self.directory / "transaction.json"
+        self.regression_path = self.directory / "regression.json"
+        self.metrics_path = self.directory / "metrics.json"
+        self.belief_store = belief_store or BeliefStore(
+            path=self.root / "mem" / life_id / "beliefs.json"
+        )
+        self.evaluator = evaluator or self._default_evaluator
+        self.directory.mkdir(parents=True, exist_ok=True)
+        self._recover()
+
+    def _empty_state(self) -> dict[str, Any]:
+        return {"version": 1, "active": {}, "candidates": {}, "events": {}, "cycle": {}}
+
+    def _read(self, path: Path, default: Any) -> Any:
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return default
+
+    def _write(self, path: Path, value: Any) -> None:
+        atomic_write_text(path, json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+
+    def _recover(self) -> None:
+        """Finish an interrupted commit; the journal contains the complete next state."""
+        with file_lock(self.state_path):
+            transaction = self._read(self.journal_path, None)
+            if isinstance(transaction, dict) and isinstance(transaction.get("state"), dict):
+                self._write(self.state_path, transaction["state"])
+                self.journal_path.unlink(missing_ok=True)
+
+    def _commit(self, state: dict[str, Any]) -> None:
+        transaction = {"prepared_at": _now(), "state": state}
+        self._write(self.journal_path, transaction)
+        self._write(self.state_path, state)
+        self.journal_path.unlink(missing_ok=True)
+
+    @staticmethod
+    def normalize(source: str, raw: Mapping[str, Any], *, life_id: str = "default") -> FeedbackEvent:
+        """Normalize an event emitted by any supported runtime surface."""
+        reward = raw.get("reward", raw.get("reward_delta", raw.get("score", 0.0)))
+        subject = raw.get("subject", raw.get("target", raw.get("hypothesis", "")))
+        return FeedbackEvent(
+            source=source,
+            subject=str(subject),
+            reward=float(reward),
+            context=dict(raw.get("context", {})),
+            payload=dict(raw.get("payload", raw)),
+            event_id=str(raw.get("event_id", uuid.uuid4().hex)),
+            occurred_at=str(raw.get("occurred_at", _now())),
+            life_id=life_id,
+        )
+
+    def ingest(self, event: FeedbackEvent, *, kind: str, proposed_value: Any) -> str:
+        """Record evidence and update a candidate, without changing active state."""
+        if event.life_id != self.life_id:
+            raise ValueError("cross-life feedback is forbidden")
+        if kind not in UPDATE_KINDS:
+            raise ValueError(f"unsupported update kind: {kind}")
+        key = f"{kind}:{event.subject}"
+        candidate_id = hashlib.sha256(key.encode()).hexdigest()[:20]
+        with file_lock(self.state_path):
+            state = self._read(self.state_path, self._empty_state())
+            if event.event_id in state["events"]:
+                return candidate_id
+            cycle = state.setdefault("cycle", {})
+            today = datetime.now(timezone.utc).date().isoformat()
+            if cycle.get("id") != today:
+                cycle.clear(); cycle.update({"id": today, "events": 0, "candidates": []})
+                self._apply_decay(state)
+            if cycle["events"] >= self.policy.max_events_per_cycle:
+                raise RuntimeError("learning event budget exhausted")
+            if candidate_id not in state["candidates"] and len(cycle["candidates"]) >= self.policy.max_candidates_per_cycle:
+                raise RuntimeError("candidate budget exhausted")
+            previous = state["active"].get(key)
+            candidate = state["candidates"].setdefault(candidate_id, {
+                "id": candidate_id, "key": key, "kind": kind, "subject": event.subject,
+                "proposed_value": proposed_value, "previous_version": previous,
+                "evidence": [], "reward_sum": 0.0, "status": "candidate", "created_at": _now(),
+            })
+            # Contradictory proposals never silently overwrite an accumulated candidate.
+            if candidate["proposed_value"] != proposed_value:
+                candidate["contradictions"] = int(candidate.get("contradictions", 0)) + 1
+            candidate["evidence"].append(asdict(event))
+            candidate["reward_sum"] += float(event.reward)
+            state["events"][event.event_id] = {"candidate_id": candidate_id, "at": _now()}
+            cycle["events"] += 1
+            if candidate_id not in cycle["candidates"]:
+                cycle["candidates"].append(candidate_id)
+            self._commit(state)
+        return candidate_id
+
+    def _apply_decay(self, state: dict[str, Any]) -> None:
+        for candidate in state.get("candidates", {}).values():
+            candidate["reward_sum"] *= min(1.0, max(0.0, self.policy.decay))
+
+    def add_regression_case(self, case_id: str, context: Mapping[str, Any], expected: Any) -> None:
+        """Persist a protected capability example used by every promotion."""
+        with file_lock(self.regression_path):
+            suite = self._read(self.regression_path, {})
+            suite[case_id] = {"context": dict(context), "expected": expected, "updated_at": _now()}
+            self._write(self.regression_path, suite)
+
+    def evaluate_and_promote(self, candidate_id: str) -> PromotionDecision:
+        with file_lock(self.state_path):
+            state = self._read(self.state_path, self._empty_state())
+            candidate = state["candidates"].get(candidate_id)
+            if candidate is None:
+                raise KeyError(candidate_id)
+            evidence = candidate["evidence"]
+            sources = {item["source"] for item in evidence}
+            mean = candidate["reward_sum"] / max(len(evidence), 1)
+            rewards = [float(item["reward"]) for item in evidence]
+            drift = (max(rewards) - min(rewards)) if rewards else 0.0
+            reasons = []
+            if len(evidence) < self.policy.minimum_evidence: reasons.append("insufficient_evidence")
+            if len(sources) < self.policy.minimum_distinct_sources: reasons.append("insufficient_source_diversity")
+            if mean < self.policy.promotion_reward: reasons.append("reward_below_threshold")
+            if drift > self.policy.drift_threshold: reasons.append("drift_detected")
+            if candidate.get("contradictions", 0): reasons.append("contradictory_feedback")
+            suite = list(self._read(self.regression_path, {}).values())
+            if len(suite) < self.policy.minimum_regression_cases: reasons.append("regression_suite_missing")
+            evaluation = dict(self.evaluator(candidate["kind"], candidate["subject"], candidate["proposed_value"], suite))
+            regression = float(evaluation.get("regression", 0.0))
+            retention = float(evaluation.get("retention", 1.0))
+            gain = float(evaluation.get("gain", mean))
+            if regression > self.policy.max_regression: reasons.append("regression_limit")
+            if retention < self.policy.minimum_retention: reasons.append("catastrophic_forgetting_risk")
+            activated = not reasons
+            rollback_path = None
+            if activated:
+                version = int(state.get("version", 1)) + 1
+                rollback_path = str(self.directory / "rollback" / f"{version}-{candidate_id}.json")
+                self._write(Path(rollback_path), {"key": candidate["key"], "previous": candidate["previous_version"]})
+                active = {"value": candidate["proposed_value"], "version": version, "activated_at": _now(),
+                          "candidate_id": candidate_id, "evaluation": evaluation, "rollback_path": rollback_path}
+                state["active"][candidate["key"]] = active
+                state["version"] = version
+                candidate["status"] = "active"
+                self._publish(candidate, active)
+            else:
+                candidate["status"] = "rejected"
+            candidate["evaluation"] = evaluation
+            candidate["activation_decision"] = {"activated": activated, "reasons": reasons, "at": _now()}
+            candidate["rollback_path"] = rollback_path
+            self._commit(state)
+            self._record_metrics(gain, retention, regression)
+            return PromotionDecision(candidate_id, activated, ",".join(reasons) or "promoted", evaluation, rollback_path)
+
+    @staticmethod
+    def _default_evaluator(kind: str, subject: str, value: Any, suite: list[dict[str, Any]]) -> Mapping[str, float]:
+        # With no domain evaluator, preserve the suite rather than claiming improvement.
+        return {"gain": 0.0, "retention": 1.0, "regression": 0.0, "samples": float(len(suite))}
+
+    def _publish(self, candidate: Mapping[str, Any], active: Mapping[str, Any]) -> None:
+        """Connect validated state to beliefs, skill metadata, and planner choices."""
+        kind, subject = candidate["kind"], candidate["subject"]
+        if kind == "belief":
+            self.belief_store.update_after_run(subject, success=True, evidence=f"learning:{candidate['id']}", reward_delta=float(candidate["reward_sum"]))
+        filename = "skill_catalog.json" if kind == "skill" else "planning_learning.json"
+        if kind in {"skill", "strategy"}:
+            path = self.root / "mem" / self.life_id / filename
+            payload = self._read(path, {})
+            if kind == "skill":
+                descriptor = payload.setdefault(subject, {"skill": subject})
+                descriptor["learning"] = dict(active)
+                if isinstance(candidate["proposed_value"], Mapping):
+                    descriptor.update(candidate["proposed_value"])
+            else:
+                payload[subject] = dict(active)
+            self._write(path, payload)
+
+    def rollback(self, *, key: str) -> bool:
+        with file_lock(self.state_path):
+            state = self._read(self.state_path, self._empty_state())
+            active = state["active"].get(key)
+            if not active: return False
+            snapshot = self._read(Path(active["rollback_path"]), {})
+            previous = snapshot.get("previous")
+            if previous is None: state["active"].pop(key, None)
+            else: state["active"][key] = previous
+            self._commit(state)
+            return True
+
+    def _record_metrics(self, gain: float, retention: float, regression: float) -> None:
+        metrics = self._read(self.metrics_path, {"samples": []})
+        metrics["samples"].append({"at": _now(), "post_feedback_gain_pct": gain * 100,
+                                   "retention_30d_pct": retention * 100,
+                                   "monthly_regression_pct": regression * 100})
+        self._write(self.metrics_path, metrics)
+
+    def metrics(self) -> Mapping[str, float]:
+        samples = self._read(self.metrics_path, {"samples": []})["samples"]
+        if not samples:
+            return {"post_feedback_gain_pct": 0.0, "retention_30d_pct": 100.0, "monthly_regression_pct": 0.0}
+        return {key: sum(float(x[key]) for x in samples) / len(samples) for key in
+                ("post_feedback_gain_pct", "retention_30d_pct", "monthly_regression_pct")}

--- a/tests/test_learning_orchestrator.py
+++ b/tests/test_learning_orchestrator.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+
+from singular.learning import FeedbackEvent, LearningOrchestrator, LearningPolicy
+
+
+POLICY = LearningPolicy(minimum_evidence=2, minimum_distinct_sources=2)
+
+
+def event(source: str, reward: float, *, event_id: str, life_id: str = "one") -> FeedbackEvent:
+    return FeedbackEvent(source, "route", reward, {"domain": "test"}, event_id=event_id, life_id=life_id)
+
+
+def ready(tmp_path, *, evaluator=None) -> LearningOrchestrator:
+    learner = LearningOrchestrator(tmp_path, life_id="one", policy=POLICY, evaluator=evaluator)
+    learner.add_regression_case("known", {"prompt": "1+1"}, 2)
+    return learner
+
+
+def test_incremental_feedback_stays_candidate_until_evidence_threshold(tmp_path):
+    learner = ready(tmp_path)
+    candidate = learner.ingest(event("run", 0.3, event_id="a"), kind="strategy", proposed_value="careful")
+    assert not learner.evaluate_and_promote(candidate).activated
+    learner.ingest(event("conversation", 0.4, event_id="b"), kind="strategy", proposed_value="careful")
+    assert learner.evaluate_and_promote(candidate).activated
+    assert learner.metrics()["retention_30d_pct"] == 100.0
+
+
+def test_contradictory_feedback_blocks_activation(tmp_path):
+    learner = ready(tmp_path)
+    candidate = learner.ingest(event("run", 0.8, event_id="a"), kind="strategy", proposed_value="fast")
+    learner.ingest(event("action", 0.8, event_id="b"), kind="strategy", proposed_value="slow")
+    decision = learner.evaluate_and_promote(candidate)
+    assert not decision.activated
+    assert "contradictory_feedback" in decision.reason
+
+
+def test_rollback_restores_previous_active_version(tmp_path):
+    learner = ready(tmp_path)
+    candidate = learner.ingest(event("run", 0.2, event_id="a"), kind="strategy", proposed_value="v1")
+    learner.ingest(event("action", 0.2, event_id="b"), kind="strategy", proposed_value="v1")
+    assert learner.evaluate_and_promote(candidate).activated
+    assert learner.rollback(key="strategy:route")
+    state = json.loads(learner.state_path.read_text())
+    assert "strategy:route" not in state["active"]
+
+
+def test_drift_and_forgetting_protection_reject_candidate(tmp_path):
+    learner = ready(tmp_path, evaluator=lambda *_: {"gain": .2, "retention": .4, "regression": .2})
+    candidate = learner.ingest(event("run", -0.4, event_id="a"), kind="skill", proposed_value={"reliability": .8})
+    learner.ingest(event("social", 0.8, event_id="b"), kind="skill", proposed_value={"reliability": .8})
+    decision = learner.evaluate_and_promote(candidate)
+    assert not decision.activated
+    assert "drift_detected" in decision.reason
+    assert "catastrophic_forgetting_risk" in decision.reason
+
+
+def test_lives_are_isolated(tmp_path):
+    first = ready(tmp_path)
+    second = LearningOrchestrator(tmp_path, life_id="two", policy=POLICY)
+    first.ingest(event("run", .1, event_id="shared"), kind="belief", proposed_value=True)
+    second.ingest(event("run", .1, event_id="shared", life_id="two"), kind="belief", proposed_value=True)
+    assert first.state_path != second.state_path
+    assert json.loads(first.state_path.read_text())["events"].keys() == json.loads(second.state_path.read_text())["events"].keys()
+
+
+def test_interrupted_transaction_is_recovered(tmp_path):
+    learner = ready(tmp_path)
+    recovered = learner._empty_state()
+    recovered["version"] = 9
+    learner._write(learner.journal_path, {"prepared_at": "now", "state": recovered})
+    restarted = LearningOrchestrator(tmp_path, life_id="one", policy=POLICY)
+    assert json.loads(restarted.state_path.read_text())["version"] == 9
+    assert not restarted.journal_path.exists()


### PR DESCRIPTION
### Motivation

- Implement a conservative, per-life learning orchestrator that ingests normalized feedback from `run`, `conversation`, `action`, `perception` and `social` sources.  
- Separate candidate proposals from active state and persist full provenance (sources, reward, context, previous version, evaluation, activation decision and rollback path).  
- Enforce budgets, minimum-evidence and source-diversity thresholds, controlled decay, drift detection and protection against catastrophic forgetting, and require a persistent regression-suite before promotion.  
- Surface validated results to the `BeliefStore`, the per-life skill catalog and planning artifacts, and produce KPIs compatible with `configs/agi_kpis.yaml`.

### Description

- Add `src/singular/learning/orchestrator.py` implementing `FeedbackEvent`, `LearningPolicy`, `PromotionDecision` and `LearningOrchestrator` with `normalize`, `ingest`, `evaluate_and_promote`, `add_regression_case`, `rollback` and `metrics` methods, using `atomic_write_text` and `file_lock` for transactional persistence.  
- Implement a journaled, atomic commit/recovery path so interrupted transactions are recovered on startup and state transitions are durable.  
- Implement promotion checks that aggregate evidence, check distinct source counts, detect drift and contradictions, run an injectable regression evaluator, write rollback snapshots, and publish accepted learning to `BeliefStore` and per-life `mem/` artifacts (`skill_catalog.json` or `planning_learning.json`).  
- Export the new orchestrator API from `src/singular/learning/__init__.py` and add `tests/test_learning_orchestrator.py` covering incremental feedback, contradictory feedback, rollback, drift/forgetting protection, life isolation and transaction recovery.

### Testing

- `python -m py_compile src/singular/learning/orchestrator.py` completed successfully.  
- Targeted test run `pytest -q tests/test_learning_orchestrator.py tests/test_imitation_safety.py tests/test_learning_engines.py tests/test_meta_learning.py tests/test_beliefs_store.py tests/test_skill_catalog.py` passed with `26 passed` (full output: `26 passed in 9.11s`).  
- An earlier pytest collection error caused by missing exports was resolved by exporting the new orchestrator symbols, after which the targeted test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7618cbee34832a98c3166d6377bf54)