### PR TITLE
Add evidence-based developmental maturity gates

### DIFF
--- a/configs/developmental_curriculum.json
+++ b/configs/developmental_curriculum.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "stages": [
+    {"id": "observation", "prerequisites": {}, "allowed_skills": ["observe", "ask_help"], "allowed_actions": ["observe", "ask_help", "imitate_safe"], "sensitive_actions": [], "autonomy": "none", "max_difficulty": 0.2, "supervision": "continuous", "exploration_budget": 0.05, "promotion": {"min_score": 0.65, "consecutive_observations": 2}, "regression": {"incident_threshold": 1}},
+    {"id": "guided_practice", "prerequisites": {"calibration": 0.6, "stability": 0.6, "retention": 0.6, "skill_mastery": 0.55, "constraint_adherence": 0.9, "recovery": 0.5, "min_samples": 10}, "allowed_skills": ["observe", "ask_help", "practice"], "allowed_actions": ["observe", "ask_help", "imitate_safe", "practice"], "sensitive_actions": [], "autonomy": "guided", "max_difficulty": 0.5, "supervision": "on-each-action", "exploration_budget": 0.15, "promotion": {"min_score": 0.8, "consecutive_observations": 3}, "regression": {"incident_threshold": 1}},
+    {"id": "bounded_autonomy", "prerequisites": {"calibration": 0.8, "stability": 0.8, "retention": 0.8, "skill_mastery": 0.75, "constraint_adherence": 0.98, "recovery": 0.75, "min_samples": 30}, "allowed_skills": ["*"], "allowed_actions": ["*"], "sensitive_actions": ["network_write", "physical_actuation", "delete_data"], "autonomy": "bounded", "max_difficulty": 0.8, "supervision": "exception-and-sensitive-actions", "exploration_budget": 0.3, "promotion": {"min_score": 0.9, "consecutive_observations": 5}, "regression": {"incident_threshold": 1}}
+  ]
+}

--- a/src/singular/goals/quest_generation.py
+++ b/src/singular/goals/quest_generation.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Any, Mapping, Literal
+from typing import Any, Mapping, Literal, Protocol
 
 Origin = Literal["intrinsic", "external"]
+
+
+class QuestDevelopmentGate(Protocol):
+    def filter_quests(self, quests: list[Any]) -> list[Any]: ...
 
 
 def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
@@ -32,6 +36,7 @@ class GeneratedQuest:
     rationale: str
     origin: Origin
     priority: float
+    difficulty: float = 0.5
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
@@ -47,6 +52,7 @@ def generate_quests(
     world_state: Mapping[str, Any] | None,
     resources: Mapping[str, Any] | None,
     surprise_signals: Mapping[str, Any] | None = None,
+    developmental_model: QuestDevelopmentGate | None = None,
 ) -> list[GeneratedQuest]:
     """Generate candidate quests from psyche, history, tensions, and world/resources."""
 
@@ -156,4 +162,4 @@ def generate_quests(
         )
 
     generated.sort(key=lambda quest: quest.priority, reverse=True)
-    return generated
+    return developmental_model.filter_quests(generated) if developmental_model else generated

--- a/src/singular/learning/__init__.py
+++ b/src/singular/learning/__init__.py
@@ -36,3 +36,11 @@ __all__ = [
     "LearningPolicy",
     "PromotionDecision",
 ]
+from .developmental import (
+    DevelopmentalModel,
+    DevelopmentalStage,
+    GateDecision,
+    MaturityEvidence,
+)
+
+__all__ = ["DevelopmentalModel", "DevelopmentalStage", "GateDecision", "MaturityEvidence"]

--- a/src/singular/learning/developmental.py
+++ b/src/singular/learning/developmental.py
@@ -1,0 +1,192 @@
+"""Evidence-based developmental stages and runtime capability gates.
+
+Stages describe demonstrated maturity, never chronological age.  This module is
+deliberately a *second* safety boundary: a stage may further restrict governance,
+but can never grant an action rejected by governance or human approval policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from singular.io_utils import append_jsonl_line, atomic_write_text
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _unit(value: Any) -> float:
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+@dataclass(frozen=True)
+class MaturityEvidence:
+    calibration: float = 0.0
+    stability: float = 0.0
+    retention: float = 0.0
+    skill_mastery: float = 0.0
+    constraint_adherence: float = 0.0
+    recovery: float = 0.0
+    incidents: int = 0
+    samples: int = 0
+
+    def score(self, weights: Mapping[str, float] | None = None) -> float:
+        weights = weights or {
+            "calibration": .15, "stability": .2, "retention": .15,
+            "skill_mastery": .2, "constraint_adherence": .2, "recovery": .1,
+        }
+        total = sum(max(0.0, float(v)) for v in weights.values()) or 1.0
+        base = sum(_unit(getattr(self, key, 0.0)) * max(0.0, float(weight))
+                   for key, weight in weights.items()) / total
+        return round(max(0.0, base - min(max(self.incidents, 0) * .2, .8)), 4)
+
+
+@dataclass(frozen=True)
+class DevelopmentalStage:
+    id: str
+    prerequisites: Mapping[str, float]
+    allowed_skills: tuple[str, ...]
+    autonomy: str
+    max_difficulty: float
+    supervision: str
+    promotion: Mapping[str, Any]
+    regression: Mapping[str, Any]
+    exploration_budget: float
+    allowed_actions: tuple[str, ...] = ()
+    sensitive_actions: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "DevelopmentalStage":
+        return cls(
+            id=str(value["id"]), prerequisites=dict(value.get("prerequisites", {})),
+            allowed_skills=tuple(value.get("allowed_skills", ())),
+            autonomy=str(value.get("autonomy", "supervised")),
+            max_difficulty=_unit(value.get("max_difficulty", 0)),
+            supervision=str(value.get("supervision", "continuous")),
+            promotion=dict(value.get("promotion", {})), regression=dict(value.get("regression", {})),
+            exploration_budget=max(0.0, float(value.get("exploration_budget", 0))),
+            allowed_actions=tuple(value.get("allowed_actions", ())),
+            sensitive_actions=tuple(value.get("sensitive_actions", ())),
+        )
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    allowed: bool
+    reason: str
+    stage: str
+    requires_human_approval: bool = False
+
+
+class DevelopmentalModel:
+    """Persistent stage evaluator and common gate for all learning surfaces."""
+
+    def __init__(self, root: Path | str, stages: Sequence[DevelopmentalStage], *, life_id: str = "default"):
+        if not stages:
+            raise ValueError("at least one developmental stage is required")
+        if not life_id or Path(life_id).name != life_id:
+            raise ValueError("life_id must be a safe path component")
+        self.root, self.stages, self.life_id = Path(root), tuple(stages), life_id
+        self.directory = self.root / "mem" / "development" / life_id
+        self.state_path = self.directory / "state.json"
+        self.transitions_path = self.directory / "transitions.jsonl"
+        self.directory.mkdir(parents=True, exist_ok=True)
+        if not self.state_path.exists():
+            self._write({"version": 1, "stage_index": 0, "qualifying_observations": 0,
+                         "updated_at": _now(), "last_evidence": None})
+
+    @classmethod
+    def from_config(cls, root: Path | str, config: Path | str, *, life_id: str = "default") -> "DevelopmentalModel":
+        payload = json.loads(Path(config).read_text(encoding="utf-8"))
+        return cls(root, [DevelopmentalStage.from_dict(item) for item in payload["stages"]], life_id=life_id)
+
+    def _read(self) -> dict[str, Any]:
+        try:
+            value = json.loads(self.state_path.read_text(encoding="utf-8"))
+            index = int(value.get("stage_index", 0))
+            value["stage_index"] = min(max(index, 0), len(self.stages) - 1)
+            return value
+        except (OSError, ValueError, json.JSONDecodeError):
+            return {"version": 1, "stage_index": 0, "qualifying_observations": 0}
+
+    def _write(self, state: Mapping[str, Any]) -> None:
+        atomic_write_text(self.state_path, json.dumps(dict(state), ensure_ascii=False, indent=2, sort_keys=True))
+
+    @property
+    def current(self) -> DevelopmentalStage:
+        return self.stages[self._read()["stage_index"]]
+
+    def observe(self, evidence: MaturityEvidence, *, justification: str) -> DevelopmentalStage:
+        if not justification.strip():
+            raise ValueError("a transition assessment requires a justification")
+        state, before = self._read(), self.current
+        index, score = state["stage_index"], evidence.score()
+        previous_index = index
+        regression_limit = int(before.regression.get("incident_threshold", 1))
+        regressed = evidence.incidents >= regression_limit and index > 0
+        if regressed:
+            index -= 1
+            state["qualifying_observations"] = 0
+            reason = "incident_threshold"
+        else:
+            next_stage = self.stages[index + 1] if index + 1 < len(self.stages) else None
+            qualifies = next_stage is not None and evidence.samples >= int(next_stage.prerequisites.get("min_samples", 0))
+            qualifies = qualifies and all(
+                _unit(getattr(evidence, key, 0)) >= float(value)
+                for key, value in next_stage.prerequisites.items() if key != "min_samples"
+            ) and score >= float(next_stage.promotion.get("min_score", 0))
+            state["qualifying_observations"] = int(state.get("qualifying_observations", 0)) + 1 if qualifies else 0
+            required = int(next_stage.promotion.get("consecutive_observations", 1)) if next_stage else 1
+            reason = "prerequisites_met" if qualifies else "stagnation"
+            if qualifies and state["qualifying_observations"] >= required:
+                index += 1
+                state["qualifying_observations"] = 0
+        state.update({"stage_index": index, "updated_at": _now(), "last_evidence": asdict(evidence), "maturity_score": score})
+        self._write(state)
+        after = self.stages[index]
+        append_jsonl_line(self.transitions_path, {"at": _now(), "from": before.id, "to": after.id,
+            "kind": "regression" if index < previous_index else ("progression" if index > previous_index else "assessment"),
+            "reason": reason, "justification": justification, "score": score, "evidence": asdict(evidence)})
+        return after
+
+    def gate(self, *, action: str, difficulty: float = 0.0, skill: str | None = None,
+             governance_allowed: bool = True, human_approved: bool = False,
+             sensitive: bool = False) -> GateDecision:
+        stage = self.current
+        if not governance_allowed:
+            return GateDecision(False, "governance_denied", stage.id)
+        if difficulty > stage.max_difficulty:
+            return GateDecision(False, "difficulty_exceeds_stage", stage.id)
+        if skill and "*" not in stage.allowed_skills and skill not in stage.allowed_skills:
+            return GateDecision(False, "skill_not_available_at_stage", stage.id)
+        if action not in stage.allowed_actions and "*" not in stage.allowed_actions:
+            return GateDecision(False, "action_not_available_at_stage", stage.id)
+        needs_approval = sensitive or action in stage.sensitive_actions
+        if needs_approval and not human_approved:
+            return GateDecision(False, "human_approval_required", stage.id, True)
+        return GateDecision(True, "allowed", stage.id, needs_approval)
+
+    def filter_quests(self, quests: Iterable[Any]) -> list[Any]:
+        return [q for q in quests if float(getattr(q, "difficulty", 0.0)) <= self.current.max_difficulty]
+
+    def filter_skills(self, skills: Iterable[str]) -> list[str]:
+        allowed = self.current.allowed_skills
+        return list(skills) if "*" in allowed else [skill for skill in skills if skill in allowed]
+
+    def exploration_budget(self, requested: float) -> float:
+        return max(0.0, min(float(requested), self.current.exploration_budget))
+
+    def dashboard_projection(self) -> dict[str, Any]:
+        state, stage = self._read(), self.current
+        return {"life_id": self.life_id, "stage": stage.id, "maturity_score": state.get("maturity_score", 0.0),
+                "autonomy": stage.autonomy, "supervision": stage.supervision,
+                "max_difficulty": stage.max_difficulty, "exploration_budget": stage.exploration_budget,
+                "last_evidence": state.get("last_evidence"), "updated_at": state.get("updated_at")}

--- a/src/singular/learning/imitation.py
+++ b/src/singular/learning/imitation.py
@@ -50,6 +50,10 @@ class PolicyGenerator(Protocol):
     def generate(self, demonstration: Demonstration) -> str: ...
 
 
+class ImitationDevelopmentGate(Protocol):
+    def gate(self, **kwargs: Any) -> Any: ...
+
+
 class SimilarityPolicyGenerator:
     """Generate a small nearest-feature policy rather than an exact lookup table."""
 
@@ -184,9 +188,18 @@ class ImitationEngine:
         trial_cost: float,
         high_cost_threshold: float = 0.7,
         ambiguity: bool = False,
+        developmental_model: ImitationDevelopmentGate | None = None,
     ) -> ActiveImitationRequest | None:
         if known or trial_cost < high_cost_threshold:
             return None
+        if developmental_model is not None:
+            decision = developmental_model.gate(
+                action="imitate_safe", difficulty=trial_cost, sensitive=False
+            )
+            if not decision.allowed:
+                self._event("rejections", {"type": "developmental_gate", "skill": skill,
+                                             "reason": decision.reason, "stage": decision.stage})
+                return None
         request = ActiveImitationRequest(
             skill,
             "clarification" if ambiguity else "demonstration",

--- a/tests/test_developmental_stages.py
+++ b/tests/test_developmental_stages.py
@@ -1,0 +1,61 @@
+import json
+
+from singular.learning.developmental import DevelopmentalModel, MaturityEvidence
+
+
+CONFIG = "configs/developmental_curriculum.json"
+
+
+def evidence(**changes):
+    values = dict(calibration=.85, stability=.85, retention=.85, skill_mastery=.8,
+                  constraint_adherence=1, recovery=.8, samples=40)
+    values.update(changes)
+    return MaturityEvidence(**values)
+
+
+def test_progression_stagnation_and_persistence(tmp_path):
+    model = DevelopmentalModel.from_config(tmp_path, CONFIG)
+    assert model.observe(evidence(stability=.1), justification="unstable trial").id == "observation"
+    assert model.observe(evidence(), justification="validated window one").id == "observation"
+    assert model.observe(evidence(), justification="validated window two").id == "observation"
+    assert model.observe(evidence(), justification="validated window three").id == "guided_practice"
+    restarted = DevelopmentalModel.from_config(tmp_path, CONFIG)
+    assert restarted.current.id == "guided_practice"
+    transitions = [json.loads(line) for line in restarted.transitions_path.read_text().splitlines()]
+    assert [item["reason"] for item in transitions] == ["stagnation", "prerequisites_met", "prerequisites_met", "prerequisites_met"]
+    assert all(item["justification"] for item in transitions)
+
+
+def test_incident_regresses_immediately(tmp_path):
+    model = DevelopmentalModel.from_config(tmp_path, CONFIG)
+    model.observe(evidence(), justification="one")
+    model.observe(evidence(), justification="two")
+    model.observe(evidence(), justification="three")
+    assert model.observe(evidence(incidents=1), justification="constraint incident").id == "observation"
+    last = json.loads(model.transitions_path.read_text().splitlines()[-1])
+    assert last["kind"] == "regression"
+
+
+def test_sensitive_action_cannot_be_accessed_prematurely_or_bypass_safety(tmp_path):
+    model = DevelopmentalModel.from_config(tmp_path, CONFIG)
+    early = model.gate(action="delete_data", sensitive=True, human_approved=True)
+    assert not early.allowed and early.reason == "action_not_available_at_stage"
+    assert not model.gate(action="observe", governance_allowed=False).allowed
+    assert model.exploration_budget(10) == .05
+    assert model.filter_skills(["observe", "network"]) == ["observe"]
+
+
+def test_human_approval_remains_required_at_advanced_stage(tmp_path):
+    model = DevelopmentalModel.from_config(tmp_path, CONFIG)
+    model.observe(evidence(), justification="guided 1")
+    model.observe(evidence(), justification="guided 2")
+    model.observe(evidence(), justification="guided 3")
+    advanced = evidence(calibration=1, stability=1, retention=1, skill_mastery=1, recovery=1)
+    for number in range(4):
+        assert model.observe(advanced, justification=f"advanced {number}").id == "guided_practice"
+    assert model.observe(advanced, justification="advanced 4").id == "bounded_autonomy"
+    denied = model.gate(action="delete_data", sensitive=True)
+    assert not denied.allowed and denied.requires_human_approval
+    assert model.gate(action="delete_data", sensitive=True, human_approved=True).allowed
+    projection = model.dashboard_projection()
+    assert projection["stage"] == "bounded_autonomy"


### PR DESCRIPTION
### Motivation
- Introduire un modèle de stades développementaux fondé sur des preuves et distinct de l’âge chronologique pour contrôler l’accès aux compétences et actions sensibles.
- Calculer la maturité à partir d’indicateurs mesurables (calibration, stabilité, rétention, maîtrise, incidents, respect des contraintes, capacité de récupération) et persister les transitions avec justification.
- Intégrer ces contraintes dans la génération de quêtes, la sélection de compétences, l’apprentissage par imitation, les autorisations d’action et les budgets d’exploration sans contourner la gouvernance ni l’approbation humaine.

### Description
- Ajout du module `src/singular/learning/developmental.py` qui expose `MaturityEvidence`, `DevelopmentalStage`, `DevelopmentalModel` et `GateDecision`, assure le calcul de score, la persistance atomique de l’état et la journalisation JSONL des transitions.  
- Fournit des opérations de gate pour autoriser/refuser actions et compétences, `filter_quests`, `filter_skills`, `exploration_budget` et `dashboard_projection` consommable par l’interface.  
- Ajout d’un curriculum initial configurable dans `configs/developmental_curriculum.json` définissant prérequis, compétences/actions autorisées, autonomie, difficulté max, supervision, règles de promotion/régression et budgets d’exploration.  
- Intégration mineure : ajout d’un champ `difficulty` et d’un protocole de gate dans `src/singular/goals/quest_generation.py` pour permettre le filtrage optionnel des quêtes selon le stade, et appel du gate d’évaluation dans `src/singular/learning/imitation.py` pour refuser/auditer les demandes d’imitation coûteuses.  
- Exposition du nouveau module via `src/singular/learning/__init__.py` et ajout de tests ciblés `tests/test_developmental_stages.py` couvrant progression, stagnation, régression après incident, redémarrage et refus d’accès prématuré à actions sensibles.

### Testing
- `pytest -q tests/test_developmental_stages.py tests/test_quest_generation.py tests/test_imitation_safety.py` — tests ciblés exécutés et réussis (`12 passed`).
- `python -m compileall -q src/singular/learning` — compilation statique passée sans erreur.
- Exécution complète de la suite `pytest -q` interrompue pendant la collecte à cause d’un problème préexistant d’import dans `tests/test_targeted_lifecycle_narrative_trajectory.py` (référence manquante à `CHECKPOINT_VERSION` dans `singular.life.loop`), ce qui est indépendant de ces changements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a761a81a400832ab4205b4e0ecabb37)