### PR TITLE
Harden sandbox execution with OCI system isolation and stricter AST validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Contrairement aux chatbots classiques (qui ne changent pas leur cœur) ou aux si
 
 - **Vie artificielle** : un organisme qui modifie réellement son code et s’optimise par sélection naturelle.  
 - **Compagnon interactif** : une entité qui parle, garde une mémoire et exprime des émotions.  
-- **Open-source et local** : chacun peut “faire naître” son compagnon, qui vivra et évoluera à sa manière, en toute sécurité (sandbox, pas de réseau).
+- **Open-source et local** : chacun peut “faire naître” son compagnon, qui vivra et évoluera à sa manière. Le code non fiable n'est exécuté que si un runtime OCI compatible fournit l'isolation décrite ci-dessous.
 
 ---
 
@@ -433,6 +433,7 @@ Pour arrêter l’orchestrateur, utilisez `Ctrl+C` dans le terminal où il tourn
   - Tests fonctionnels (résultats corrects).
   - Performance (temps d’exécution).
   - Complexité (taille AST).
+- Le filtre AST est une validation fonctionnelle et une défense complémentaire, **pas une frontière de sécurité**. L'exécution repose sur Docker ou Podman sous Linux : conteneur sans réseau, utilisateur non privilégié, racine en lecture seule et `/tmp` isolé, aucune capability, limites de processus/CPU/mémoire, `no-new-privileges` et seccomp actif. Si ces garanties (y compris les limites `resource`) ne peuvent pas être vérifiées, Singular refuse l'exécution au lieu de revenir à un processus local moins isolé. L'image, déjà présente localement (aucun pull automatique), est configurable avec `SINGULAR_SANDBOX_IMAGE`.
 - Si la mutation est meilleure → elle remplace l’ancienne.
 
 **Esprit**

--- a/docs/release_v2.md
+++ b/docs/release_v2.md
@@ -53,10 +53,11 @@ Les parcours suivants sont bloquants avant release:
 
 Avant release, vérifier systématiquement:
 
-- [ ] Exécution de code utilisateur dans un environnement sandboxé (pas d'exécution arbitraire hors cadre).
-- [ ] Restrictions réseau appliquées côté sandbox quand requis.
-- [ ] Limites CPU / temps d'exécution configurées pour éviter les boucles non bornées.
-- [ ] Écritures disque bornées aux répertoires autorisés.
+- [ ] Exécution de code utilisateur dans un conteneur OCI dédié sous Linux ; le filtre AST reste une validation fonctionnelle, pas la frontière de sécurité.
+- [ ] Réseau désactivé, utilisateur non privilégié, capabilities supprimées, `no-new-privileges` et profil seccomp actif.
+- [ ] Limites CPU / temps / mémoire / nombre de processus configurées pour éviter les abus de ressources.
+- [ ] Racine en lecture seule et seul `/tmp` isolé accessible en écriture.
+- [ ] Refus explicite si Docker/Podman, seccomp ou les limites `resource` ne sont pas disponibles ; aucun repli vers une exécution locale.
 - [ ] Aucune clé/API secret en clair dans logs, erreurs, ou artefacts de test.
 - [ ] Messages d'erreur explicites en cas de violation sandbox (pas de stacktrace sensible exposée).
 

--- a/docs/tutorial_create_life.en.md
+++ b/docs/tutorial_create_life.en.md
@@ -83,6 +83,8 @@ singular --root "$SINGULAR_ROOT" --life lumen loop --budget-seconds 5 --run-id t
 
 During this tick, Singular may select a skill, propose a mutation, evaluate it in the sandbox, score the result, apply write governance, and journal the verdict. A rejected mutation is normal: the log explains whether the rejection came from the sandbox, score, governance, or a quota.
 
+> **Security prerequisite:** evaluating untrusted code requires Linux, `resource` limits, and Docker or Podman with active seccomp and the `python:3.11-alpine` image already available (override with `SINGULAR_SANDBOX_IMAGE`). The container runs without networking or capabilities, as an unprivileged user, with a read-only root, isolated `/tmp`, and CPU/memory/process limits. AST filtering is only complementary functional validation. Singular explicitly refuses evaluation when it cannot establish the system-isolation guarantees.
+
 ## 4. Inspect memory and checkpoint
 
 The life memory lives in `mem/`:

--- a/docs/tutorial_create_life.fr.md
+++ b/docs/tutorial_create_life.fr.md
@@ -83,6 +83,8 @@ singular --root "$SINGULAR_ROOT" --life lumen loop --budget-seconds 5 --run-id t
 
 Pendant ce tick, Singular peut sélectionner une skill, proposer une mutation, l'évaluer en sandbox, scorer le résultat, appliquer la gouvernance d'écriture, puis journaliser le verdict. Une mutation rejetée est normale : le journal explique si le rejet vient du sandbox, du score, de la gouvernance ou d'un quota.
 
+> **Prérequis de sécurité :** l'évaluation de code non fiable exige Linux, les limites `resource`, et Docker ou Podman avec seccomp actif et l'image `python:3.11-alpine` déjà disponible (modifiable via `SINGULAR_SANDBOX_IMAGE`). Le conteneur est lancé sans réseau, sans capabilities, avec un utilisateur non privilégié, une racine en lecture seule, un `/tmp` isolé et des limites CPU/mémoire/processus. Le contrôle AST n'est qu'une validation fonctionnelle complémentaire. Singular refuse explicitement l'évaluation si l'isolation système ne peut pas être garantie.
+
 ## 4. Inspecter mémoire et checkpoint
 
 La mémoire de la vie est située dans `mem/` :

--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -1,39 +1,28 @@
-"""Restricted sandbox execution environment."""
+"""Functional validation and system-isolated execution of untrusted snippets.
+
+The AST checks in this module are defence in depth.  They are deliberately not
+treated as a security boundary; that boundary is an OCI container runtime.
+"""
 
 from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
-import logging
-import multiprocessing
+import json
+import math
 import os
-import queue as queue_module
+import shutil
+import subprocess
 import sys
-import tempfile
-from types import ModuleType
-from typing import Any, Dict
+from typing import Any
 
-resource_module: ModuleType | None
 try:
     import resource as resource_module
-except ImportError:  # pragma: no cover - Windows or unsupported platforms
+except ImportError:  # pragma: no cover - unsupported platforms
     resource_module = None
 
 
-logger = logging.getLogger(__name__)
-
-
-ALLOWED_BUILTINS = {
-    "abs": abs,
-    "min": min,
-    "max": max,
-    "range": range,
-    "len": len,
-    "sum": sum,
-    "all": all,
-    "any": any,
-}
-
+ALLOWED_BUILTINS = ("abs", "min", "max", "range", "len", "sum", "all", "any")
 FORBIDDEN_NAMES = {
     "open",
     "exec",
@@ -41,185 +30,144 @@ FORBIDDEN_NAMES = {
     "compile",
     "__import__",
     "input",
-    # Block access to common system modules even if provided
     "os",
     "sys",
     "socket",
     "subprocess",
 }
-
-FORBIDDEN_NODES = (
-    ast.Import,
-    ast.ImportFrom,
-    ast.With,
-    ast.AsyncWith,
-)
+FORBIDDEN_NODES = (ast.Import, ast.ImportFrom, ast.With, ast.AsyncWith)
 
 DEFAULT_TIMEOUT_S = 3.0
 MIN_TIMEOUT_S = 0.05
 DEFAULT_STARTUP_GRACE_S = 2.0
 DEFAULT_MEMORY_LIMIT = 256 * 1024 * 1024
-SANDBOX_TIMEOUT_ENV = "SINGULAR_SANDBOX_TIMEOUT"
-SANDBOX_STARTUP_GRACE_ENV = "SINGULAR_SANDBOX_STARTUP_GRACE"
-SANDBOX_MEMORY_LIMIT_ENV = "SINGULAR_SANDBOX_MEMORY_LIMIT"
-SANDBOX_MP_METHOD_ENV = "SINGULAR_SANDBOX_MP_METHOD"
+DEFAULT_IMAGE = "python:3.11-alpine"
+
+
+class SandboxError(RuntimeError):
+    """Raised when validation fails or secure isolation is unavailable."""
 
 
 @dataclass(frozen=True)
 class SandboxConfig:
-    """Centralized sandbox process/resource configuration."""
-
     execution_timeout_s: float = DEFAULT_TIMEOUT_S
     startup_grace_s: float = DEFAULT_STARTUP_GRACE_S
     min_timeout_s: float = MIN_TIMEOUT_S
     memory_limit: int = DEFAULT_MEMORY_LIMIT
-    multiprocessing_method: str | None = None
+    multiprocessing_method: str | None = None  # retained for API compatibility
+    runtime: str | None = None
+    image: str = DEFAULT_IMAGE
 
     @classmethod
     def from_environment(
-        cls,
-        *,
-        timeout: float | None = None,
-        memory_limit: int | None = None,
+        cls, *, timeout: float | None = None, memory_limit: int | None = None
     ) -> "SandboxConfig":
-        """Build sandbox configuration from explicit values and environment policy."""
-        min_timeout_s = _read_env_float("SINGULAR_SANDBOX_MIN_TIMEOUT", MIN_TIMEOUT_S)
-        execution_timeout_s = _coerce_timeout(
-            timeout
-            if timeout is not None
-            else _read_env_float(SANDBOX_TIMEOUT_ENV, DEFAULT_TIMEOUT_S),
-            min_timeout_s,
-        )
-        startup_grace_s = _coerce_timeout(
-            _read_env_float(SANDBOX_STARTUP_GRACE_ENV, DEFAULT_STARTUP_GRACE_S),
-            min_timeout_s,
-        )
-        configured_memory_limit = (
-            memory_limit
-            if memory_limit is not None
-            else _read_env_int(SANDBOX_MEMORY_LIMIT_ENV, DEFAULT_MEMORY_LIMIT)
-        )
-        method = os.environ.get(SANDBOX_MP_METHOD_ENV) or None
         return cls(
-            execution_timeout_s=execution_timeout_s,
-            startup_grace_s=startup_grace_s,
-            min_timeout_s=min_timeout_s,
-            memory_limit=configured_memory_limit,
-            multiprocessing_method=method,
+            execution_timeout_s=max(
+                float(
+                    timeout
+                    if timeout is not None
+                    else os.getenv("SINGULAR_SANDBOX_TIMEOUT", DEFAULT_TIMEOUT_S)
+                ),
+                float(os.getenv("SINGULAR_SANDBOX_MIN_TIMEOUT", MIN_TIMEOUT_S)),
+            ),
+            startup_grace_s=float(
+                os.getenv("SINGULAR_SANDBOX_STARTUP_GRACE", DEFAULT_STARTUP_GRACE_S)
+            ),
+            min_timeout_s=float(
+                os.getenv("SINGULAR_SANDBOX_MIN_TIMEOUT", MIN_TIMEOUT_S)
+            ),
+            memory_limit=int(
+                memory_limit
+                if memory_limit is not None
+                else os.getenv("SINGULAR_SANDBOX_MEMORY_LIMIT", DEFAULT_MEMORY_LIMIT)
+            ),
+            runtime=os.getenv("SINGULAR_SANDBOX_RUNTIME") or None,
+            image=os.getenv("SINGULAR_SANDBOX_IMAGE", DEFAULT_IMAGE),
         )
-
-
-def _read_env_float(name: str, default: float) -> float:
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    try:
-        return float(value)
-    except ValueError:
-        logger.warning("invalid %s=%r; using %s", name, value, default)
-        return default
-
-
-def _read_env_int(name: str, default: int) -> int:
-    value = os.environ.get(name)
-    if value is None:
-        return default
-    try:
-        return int(value)
-    except ValueError:
-        logger.warning("invalid %s=%r; using %s", name, value, default)
-        return default
-
-
-def _coerce_timeout(timeout: float, minimum: float) -> float:
-    return max(float(timeout), minimum)
-
-
-class SandboxError(RuntimeError):
-    """Raised when sandboxed code violates a restriction."""
 
 
 def _validate_ast(tree: ast.AST) -> None:
-    """Ensure that the AST does not contain forbidden constructs."""
+    """Apply functional restrictions (not a security boundary)."""
     for node in ast.walk(tree):
         if isinstance(node, FORBIDDEN_NODES):
             raise SandboxError("forbidden syntax detected")
         if isinstance(node, ast.Name) and node.id in FORBIDDEN_NAMES:
             raise SandboxError(f"use of '{node.id}' is forbidden")
-
-
-def _sandbox_worker(
-    code: str,
-    execution_timeout_s: float,
-    memory_limit: int,
-    queue: multiprocessing.Queue[Any],
-) -> None:
-    """Execute sandboxed code in a child process and return output through *queue*."""
-    if resource_module is not None and sys.platform != "win32":
-        resource_module.setrlimit(resource_module.RLIMIT_AS, (memory_limit, memory_limit))
-        # Keep the OS CPU limit slightly above the user-code timeout so tight
-        # loops are reported as sandbox timeouts instead of opaque worker exits.
-        cpu_seconds = max(1, int(execution_timeout_s) + 1)
-        resource_module.setrlimit(resource_module.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
-
-    tree = ast.parse(code, mode="exec")
-    os.environ.clear()
-    prev_cwd = os.getcwd()
-    with tempfile.TemporaryDirectory() as tmpdir:
-        try:
-            os.chdir(tmpdir)
-            queue.put(("started", None))
-            allowed = {name: ALLOWED_BUILTINS[name] for name in ALLOWED_BUILTINS}
-            env: Dict[str, Any] = {"__builtins__": allowed}
-            try:
-                exec(compile(tree, "<sandbox>", "exec"), env, env)
-                if "result" not in env:
-                    queue.put(("error", SandboxError("sandbox code did not set a result")))
-                else:
-                    queue.put(("result", env["result"]))
-            except Exception as exc:  # pragma: no cover - delivered to parent
-                queue.put(("error", exc))
-        finally:
-            try:
-                os.chdir(prev_cwd)
-            except OSError as exc:  # pragma: no cover - platform specific cleanup guard
-                logger.warning("failed to restore cwd during sandbox cleanup: %s", exc)
-
-
-def _select_multiprocessing_method(configured_method: str | None = None) -> str:
-    """Choose the lowest-overhead multiprocessing method available for this host."""
-    available = multiprocessing.get_all_start_methods()
-    if configured_method:
-        if configured_method not in available:
+        if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
             raise SandboxError(
-                f"multiprocessing method {configured_method!r} is unavailable; "
-                f"available methods: {', '.join(available)}"
+                f"access to private attribute '{node.attr}' is forbidden"
             )
-        return configured_method
-    if os.name == "posix":
-        for method in ("forkserver", "fork", "spawn"):
-            if method in available:
-                return method
-    return "spawn" if "spawn" in available else available[0]
 
 
-def _read_message(
-    queue: multiprocessing.Queue[Any],
-    proc: multiprocessing.Process,
-    timeout_s: float,
-    empty_message: str,
-) -> tuple[str, Any]:
+def _runtime(configured: str | None) -> str:
+    if sys.platform != "linux" or resource_module is None:
+        raise SandboxError(
+            "secure sandbox unavailable: Linux resource limits are required"
+        )
+    candidate = configured or shutil.which("podman") or shutil.which("docker")
+    if not candidate or not shutil.which(candidate):
+        raise SandboxError("secure sandbox unavailable: podman or docker is required")
     try:
-        message = queue.get(timeout=timeout_s)
-    except queue_module.Empty as exc:
-        if proc.exitcode not in (0, None):
-            raise SandboxError(
-                f"sandbox worker exited without payload (exit code {proc.exitcode})"
-            ) from exc
-        raise SandboxError(empty_message) from exc
-    if not (isinstance(message, tuple) and len(message) == 2):
-        return ("result", message)
-    return message
+        probe = subprocess.run(
+            [candidate, "info", "--format", "{{json .SecurityOptions}}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SandboxError(
+            "secure sandbox unavailable: container runtime probe failed"
+        ) from exc
+    security = (probe.stdout + probe.stderr).lower()
+    if probe.returncode or "seccomp" not in security:
+        raise SandboxError(
+            "secure sandbox unavailable: an active seccomp profile is required"
+        )
+    return candidate
+
+
+_CONTAINER_WORKER = r"""
+import builtins, json, sys
+code = sys.stdin.read()
+allowed_names = ("abs", "min", "max", "range", "len", "sum", "all", "any")
+env = {"__builtins__": {name: getattr(builtins, name) for name in allowed_names}}
+try:
+    exec(compile(code, "<sandbox>", "exec"), env, env)
+    if "result" not in env:
+        raise RuntimeError("sandbox code did not set a result")
+    print(json.dumps({"status": "result", "payload": env["result"]}))
+except BaseException as exc:
+    print(json.dumps({"status": "error", "type": type(exc).__name__, "message": str(exc)}))
+"""
+
+
+def _command(runtime: str, config: SandboxConfig) -> list[str]:
+    cpu_seconds = max(1, math.ceil(config.execution_timeout_s))
+    return [
+        runtime,
+        "run",
+        "--rm",
+        "-i",
+        "--pull=never",
+        "--network=none",
+        "--user=65534:65534",
+        "--read-only",
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges",
+        "--pids-limit=32",
+        f"--memory={config.memory_limit}",
+        "--cpus=1",
+        f"--ulimit=cpu={cpu_seconds}:{cpu_seconds}",
+        "--tmpfs=/tmp:rw,noexec,nosuid,nodev,size=16777216,mode=700,uid=65534,gid=65534",
+        "--workdir=/tmp",
+        config.image,
+        "python",
+        "-I",
+        "-c",
+        _CONTAINER_WORKER,
+    ]
 
 
 def run(
@@ -229,72 +177,43 @@ def run(
     *,
     config: SandboxConfig | None = None,
 ) -> Any:
-    """Execute *code* in a restricted environment and return the value of `result`.
+    """Validate *code*, then execute it inside a locked-down OCI container.
 
-    A :class:`TimeoutError` is raised if user code exceeds the configured
-    execution timeout. Process startup has a separate grace period so normal
-    process creation overhead is not charged to user code. Defaults can be
-    overridden with ``SINGULAR_SANDBOX_TIMEOUT`` and related sandbox variables.
-
-    On Windows (or platforms without :mod:`resource`), memory/CPU limits are not
-    enforced.
+    Execution is refused rather than silently falling back to a local child
+    process when the required Linux, resource-limit, runtime, and seccomp
+    guarantees cannot be established.
     """
-    tree = ast.parse(code, mode="exec")
-    _validate_ast(tree)
-
-    sandbox_config = config or SandboxConfig.from_environment(
-        timeout=timeout,
-        memory_limit=memory_limit,
+    _validate_ast(ast.parse(code, mode="exec"))
+    policy = config or SandboxConfig.from_environment(
+        timeout=timeout, memory_limit=memory_limit
     )
-    method = _select_multiprocessing_method(sandbox_config.multiprocessing_method)
-    ctx = multiprocessing.get_context(method)
-    queue: multiprocessing.Queue[Any] = ctx.Queue()
-    proc = ctx.Process(
-        target=_sandbox_worker,
-        args=(
-            code,
-            sandbox_config.execution_timeout_s,
-            sandbox_config.memory_limit,
-            queue,
-        ),
-    )
-    proc.start()
-
+    runtime = _runtime(policy.runtime)
     try:
-        status, payload = _read_message(
-            queue,
-            proc,
-            sandbox_config.startup_grace_s,
-            "sandbox worker did not start before the startup grace period elapsed",
+        completed = subprocess.run(
+            _command(runtime, policy),
+            input=code,
+            capture_output=True,
+            text=True,
+            timeout=policy.startup_grace_s + policy.execution_timeout_s,
+            check=False,
+            env={"PATH": os.environ.get("PATH", "")},
         )
-    except SandboxError as exc:
-        if proc.is_alive():
-            proc.terminate()
-            proc.join()
-            raise TimeoutError("sandbox process startup timed out") from exc
-        proc.join()
-        raise
-
-    if status != "started":
-        proc.join()
-        if status == "error" and isinstance(payload, Exception):
-            raise payload
-        return payload
-
-    proc.join(sandbox_config.execution_timeout_s)
-    if proc.is_alive():
-        proc.terminate()
-        proc.join()
-        raise TimeoutError("sandbox execution timed out")
-
-    status, payload = _read_message(
-        queue,
-        proc,
-        sandbox_config.min_timeout_s,
-        "sandbox worker finished without returning a payload",
-    )
-    if status == "error" and isinstance(payload, Exception):
-        raise payload
-    if status != "result":
-        raise SandboxError(f"sandbox worker returned unexpected status {status!r}")
-    return payload
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError("sandbox execution timed out") from exc
+    if completed.returncode:
+        raise SandboxError(
+            f"isolated sandbox failed (exit {completed.returncode}): {completed.stderr.strip()}"
+        )
+    try:
+        message = json.loads(completed.stdout.strip())
+    except (json.JSONDecodeError, AttributeError) as exc:
+        raise SandboxError("isolated sandbox returned an invalid response") from exc
+    if message.get("status") == "result":
+        return message.get("payload")
+    error_type = message.get("type")
+    detail = message.get("message", "sandbox execution failed")
+    if error_type == "MemoryError":
+        raise MemoryError(detail)
+    if error_type == "RuntimeError" and "did not set a result" in detail:
+        raise SandboxError(detail)
+    raise SandboxError(f"sandboxed code raised {error_type}: {detail}")

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,188 +1,159 @@
+import ast
+import json
+import subprocess
+
 import pytest
 
-from singular.life.sandbox import run, SandboxError
+import singular.life.sandbox as sandbox
+from singular.life.sandbox import SandboxConfig, SandboxError, run
 
 
-def test_basic_execution():
+@pytest.fixture
+def isolated_runtime(monkeypatch):
+    """Model a runtime without requiring a container daemon in unit tests."""
+    monkeypatch.setattr(sandbox.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def fake_run(command, **kwargs):
+        if command[1] == "info":
+            return subprocess.CompletedProcess(command, 0, '["name=seccomp"]', "")
+        code = kwargs["input"]
+        if "while True" in code:
+            raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+        if "300 * 1024" in code:
+            payload = {"status": "error", "type": "MemoryError", "message": ""}
+        else:
+            env = {"__builtins__": sandbox.__dict__["__builtins__"]}
+            # These snippets have already passed validation; this emulates only
+            # the container protocol, not its security boundary.
+            try:
+                exec(compile(code, "<test-container>", "exec"), env, env)
+                if "result" not in env:
+                    raise RuntimeError("sandbox code did not set a result")
+                payload = {"status": "result", "payload": env["result"]}
+            except Exception as exc:
+                payload = {
+                    "status": "error",
+                    "type": type(exc).__name__,
+                    "message": str(exc),
+                }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr(sandbox.subprocess, "run", fake_run)
+
+
+def test_basic_execution(isolated_runtime):
     assert run("result = max(1, 2)") == 2
 
 
-def test_spawn_context_simple_execution():
-    assert run("result = 1") == 1
-
-
-def test_missing_result_raises_sandbox_error():
+def test_missing_result_raises_sandbox_error(isolated_runtime):
     with pytest.raises(SandboxError, match="result"):
         run("value = 1")
 
 
-def test_forbidden_import():
+@pytest.mark.parametrize(
+    "code", ["import os", 'open("foo")', "import socket", "import subprocess"]
+)
+def test_forbidden_names_and_imports(code):
     with pytest.raises(SandboxError):
-        run("import os")
-
-
-def test_forbidden_name():
-    with pytest.raises(SandboxError):
-        run('open("foo")')
-
-
-def test_timeout():
-    with pytest.raises(TimeoutError):
-        run("while True: pass", timeout=0.5)
-
-
-def test_memory_limit():
-    with pytest.raises(MemoryError):
-        run("'x' * (300 * 1024 * 1024)")
-
-
-def test_forbidden_network_access():
-    with pytest.raises(SandboxError):
-        run("import socket\nsocket.socket()")
-
-
-def test_forbidden_subprocess_access():
-    with pytest.raises(SandboxError):
-        run("import subprocess\nsubprocess.run(['echo', 'hi'])")
-
-def test_run_windows_cleanup_guard(monkeypatch, caplog):
-    import singular.life.sandbox as sandbox_module
-
-    class InlineProcess:
-        def __init__(self, target, args):
-            self._target = target
-            self._args = args
-            self._alive = False
-
-        def start(self):
-            self._alive = True
-            self._target(*self._args)
-            self._alive = False
-
-        def join(self, _timeout=None):
-            return None
-
-        def is_alive(self):
-            return self._alive
-
-        def terminate(self):
-            self._alive = False
-
-    class InlineQueue:
-        def __init__(self):
-            self._items = []
-
-        def put(self, value):
-            self._items.append(value)
-
-        def get(self, timeout=None):
-            return self._items.pop(0)
-
-        def empty(self):
-            return not self._items
-
-    class InlineContext:
-        def Queue(self):
-            return InlineQueue()
-
-        def Process(self, target, args):
-            return InlineProcess(target, args)
-
-    monkeypatch.setattr(sandbox_module.multiprocessing, "get_context", lambda _name: InlineContext())
-
-    real_chdir = sandbox_module.os.chdir
-    chdir_calls = []
-
-    def fake_chdir(path):
-        chdir_calls.append(path)
-        if len(chdir_calls) == 2:
-            real_chdir(path)
-            raise OSError("simulated windows cleanup lock")
-        return real_chdir(path)
-
-    monkeypatch.setattr(sandbox_module.os, "chdir", fake_chdir)
-
-    caplog.set_level("WARNING", logger=sandbox_module.__name__)
-    assert sandbox_module.run("result = 1") == 1
-    assert len(chdir_calls) == 2
-    assert "failed to restore cwd during sandbox cleanup" in caplog.text
-
-
-def test_run_consecutive_calls_do_not_return_none_with_unreliable_empty_check(monkeypatch):
-    import singular.life.sandbox as sandbox_module
-
-    class InlineProcess:
-        def __init__(self, target, args):
-            self._target = target
-            self._args = args
-            self._alive = False
-            self.exitcode = None
-
-        def start(self):
-            self._alive = True
-            self._target(*self._args)
-            self._alive = False
-            self.exitcode = 0
-
-        def join(self, _timeout=None):
-            return None
-
-        def is_alive(self):
-            return self._alive
-
-        def terminate(self):
-            self._alive = False
-            self.exitcode = -15
-
-    class FlakyEmptyQueue:
-        def __init__(self):
-            self._items = []
-            self._empty_checks = 0
-
-        def put(self, value):
-            self._items.append(value)
-
-        def get(self, timeout=None):
-            assert timeout is not None
-            return self._items.pop(0)
-
-        def empty(self):
-            self._empty_checks += 1
-            if self._empty_checks == 1:
-                return True
-            return not self._items
-
-    class InlineContext:
-        def Queue(self):
-            return FlakyEmptyQueue()
-
-        def Process(self, target, args):
-            return InlineProcess(target, args)
-
-    monkeypatch.setattr(sandbox_module.multiprocessing, "get_context", lambda _name: InlineContext())
-
-    for _ in range(20):
-        assert sandbox_module.run("result = 42") == 42
+        run(code)
 
 
 @pytest.mark.parametrize(
-    ("code", "expected"),
+    "attribute",
     [
-        ("result = 1", 1),
-        ("result = 5 - 2", 3),
-        (
-            "total = 0\n"
-            "for value in range(1000):\n"
-            "    total = total + value\n"
-            "result = total",
-            499500,
-        ),
+        "__class__",
+        "__mro__",
+        "__base__",
+        "__subclasses__",
+        "__globals__",
+        "__builtins__",
+        "__getattribute__",
+        "__dict__",
+        "_private",
     ],
 )
-def test_simple_snippets_do_not_timeout_on_standard_budget(code, expected):
-    assert run(code) == expected
+def test_object_introspection_attributes_are_rejected(attribute):
+    with pytest.raises(SandboxError, match="private attribute"):
+        sandbox._validate_ast(ast.parse(f"result = value.{attribute}"))
 
 
-def test_timeout_can_be_configured_from_environment(monkeypatch):
-    monkeypatch.setenv("SINGULAR_SANDBOX_TIMEOUT", "4.0")
-    assert run("result = 5 - 2") == 3
+def test_builtin_recovery_chain_is_rejected():
+    code = "result = ().__class__.__base__.__subclasses__()"
+    with pytest.raises(SandboxError):
+        run(code)
+
+
+def test_timeout(isolated_runtime):
+    with pytest.raises(TimeoutError):
+        run("while True: pass", timeout=0.1)
+
+
+def test_memory_limit(isolated_runtime):
+    with pytest.raises(MemoryError):
+        run("result = 'x' * (300 * 1024 * 1024)")
+
+
+def test_container_has_all_required_system_isolation(isolated_runtime, monkeypatch):
+    commands = []
+    original = sandbox.subprocess.run
+
+    def record(command, **kwargs):
+        commands.append(command)
+        return original(command, **kwargs)
+
+    monkeypatch.setattr(sandbox.subprocess, "run", record)
+    assert run("result = 1") == 1
+    command = commands[-1]
+    for expected in (
+        "--network=none",
+        "--read-only",
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges",
+        "--pids-limit=32",
+        "--user=65534:65534",
+        "--cpus=1",
+    ):
+        assert expected in command
+    assert any(value.startswith("--memory=") for value in command)
+    assert any(value.startswith("--ulimit=cpu=") for value in command)
+    assert any(
+        value.startswith("--tmpfs=/tmp:rw,noexec,nosuid,nodev") for value in command
+    )
+
+
+@pytest.mark.parametrize(
+    "attack",
+    [
+        'result = open("/etc/passwd").read()',  # host files
+        "import socket\nresult = socket.socket()",  # network
+        "import subprocess\nresult = subprocess.run(['id'])",  # processes
+    ],
+)
+def test_adversarial_io_is_rejected_before_execution(attack):
+    with pytest.raises(SandboxError):
+        run(attack)
+
+
+def test_refuses_platform_without_resource_limits(monkeypatch):
+    monkeypatch.setattr(sandbox, "resource_module", None)
+    with pytest.raises(SandboxError, match="resource limits"):
+        run("result = 1")
+
+
+def test_refuses_runtime_without_seccomp(monkeypatch):
+    monkeypatch.setattr(sandbox.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        sandbox.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, '["apparmor"]', ""
+        ),
+    )
+    with pytest.raises(SandboxError, match="seccomp"):
+        run("result = 1")
+
+
+def test_refuses_missing_container_runtime(monkeypatch):
+    monkeypatch.setattr(sandbox.shutil, "which", lambda _name: None)
+    with pytest.raises(SandboxError, match="podman or docker"):
+        run("result = 1")


### PR DESCRIPTION
### Motivation

- Treat AST filtering as functional validation only and not as a security boundary for untrusted code execution.
- Execute untrusted snippets only when a Linux OCI runtime (Docker/Podman) with seccomp and `resource` limits can be verified, and refuse execution otherwise.
- Add defensive tests and documentation so the project and users understand the real isolation guarantees and prerequisites.

### Description

- Replace the previous local `multiprocessing`-based worker with execution inside a locked-down OCI container launched via `docker`/`podman`, configured with no network, an unprivileged user, read-only root, isolated `/tmp`, `--cap-drop=ALL`, `--security-opt=no-new-privileges`, CPU/memory/pids limits and an `ulimit` for CPU. Execution is refused if the required platform/runtime/seccomp/resource guarantees cannot be established (see `src/singular/life/sandbox.py`).
- Extend ` _validate_ast` to reject attribute access where the attribute name starts with `_` (covering `__class__`, `__mro__`, `__base__`, `__subclasses__`, `__globals__`, `__builtins__`, `__getattribute__`, `__dict__`, etc.) and continue to forbid imports and named forbidden identifiers; document that the AST check is defence-in-depth and not a security boundary.
- Add an in-process container protocol and `SandboxConfig` environment-driven configuration (including `SINGULAR_SANDBOX_IMAGE`) in `src/singular/life/sandbox.py` and add tests in `tests/test_sandbox.py` that cover introspection attacks, builtin-recovery chains, file access, socket/process attempts, memory limits, platforms without `resource`, missing container runtime, and missing seccomp.
- Align user-facing documentation in `README.md`, `docs/tutorial_create_life.fr.md`, `docs/tutorial_create_life.en.md` and `docs/release_v2.md` to accurately describe the runtime prerequisites and the fact that execution is refused when system isolation cannot be guaranteed.

### Testing

- Ran `pytest -q tests/test_sandbox.py`; `25 passed`.
- Ran `python -m compileall -q src/singular/life/sandbox.py` and formatter `python -m black` on the changed files; formatting and compilation succeeded.
- Verified the new unit tests exercise the new runtime checks via monkeypatched `subprocess.run` emulation in tests and the expected sandbox errors are raised.
- Ran the full test collection with `pytest -q` but collection was interrupted by a pre-existing unrelated import error in a different test (`CHECKPOINT_VERSION` missing from `singular.life.loop`), which is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76229fa2e8832a9166f6e8d5eecb3c)