### PR TITLE
Propagate dashboard life context explicitly (remove SINGULAR_HOME mutations)

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -2421,7 +2421,6 @@ def create_app(
         from singular.lives import resolve_life
         from singular.organisms.talk import talk
 
-        previous_home = os.environ.get("SINGULAR_HOME")
         resolved_life = resolve_life(target)
         if resolved_life is None:
             return _chat_payload(
@@ -2431,23 +2430,18 @@ def create_app(
                 status="life_unavailable",
                 timestamp=timestamp,
             )
-        os.environ["SINGULAR_HOME"] = str(resolved_life)
-
         def _run() -> dict[str, object]:
-            talk(
+            response = talk(
                 provider=provider if isinstance(provider, str) and provider.strip() else None,
                 seed=seed if isinstance(seed, int) else None,
                 prompt=message,
+                life_home=resolved_life,
             )
-            return {"life": target, "path": str(resolved_life)}
+            return {"life": target, "path": str(resolved_life), "response": response or ""}
 
         try:
             data, log = actions._capture(_run)
         except Exception as exc:  # pragma: no cover - defensive endpoint guard
-            if previous_home is None:
-                os.environ.pop("SINGULAR_HOME", None)
-            else:
-                os.environ["SINGULAR_HOME"] = previous_home
             error_status = "provider_error" if "provider" in str(exc).lower() else "error"
             return _chat_payload(
                 life=target,
@@ -2456,15 +2450,10 @@ def create_app(
                 status=error_status,
                 timestamp=timestamp,
             )
-        finally:
-            if previous_home is None:
-                os.environ.pop("SINGULAR_HOME", None)
-            else:
-                os.environ["SINGULAR_HOME"] = previous_home
-
         lines = [line.strip() for line in log.splitlines() if line.strip()]
         provider_lines = [line for line in lines if line.lower().startswith("provider ") or "provider '" in line.lower()]
-        response = lines[-1] if lines else "Conversation envoyée sans réponse textuelle."
+        explicit_response = data.get("response")
+        response = explicit_response if isinstance(explicit_response, str) and explicit_response else (lines[-1] if lines else "Conversation envoyée sans réponse textuelle.")
         response_status = "provider_error" if any("provider '" in line.lower() for line in provider_lines) else "ok"
         return _chat_payload(
             life=target,

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -407,7 +407,6 @@ class DashboardActionService:
 
         def _run() -> dict[str, Any]:
             meta = bootstrap_life(name, seed=seed)
-            os.environ["SINGULAR_HOME"] = str(meta.path)
             return {
                 "name": meta.name,
                 "slug": meta.slug,
@@ -435,11 +434,9 @@ class DashboardActionService:
         life = resolve_life(name)
         if life is None:
             raise ValueError(f"unknown life: {name}" if name else "no active life")
-        os.environ["SINGULAR_HOME"] = str(life)
-
         def _run() -> dict[str, Any]:
-            talk(provider=provider, seed=seed, prompt=prompt)
-            return {"life": str(life), "name": name, "prompt": prompt}
+            response = talk(provider=provider, seed=seed, prompt=prompt, life_home=life)
+            return {"life": str(life), "name": name, "prompt": prompt, "response": response}
 
         data, log = self._capture(_run)
         return ActionResult(ok=True, action="talk", data=data, log=log)
@@ -456,10 +453,12 @@ class DashboardActionService:
         from singular.lives import resolve_life
         from singular.runs.loop import loop
 
-        life = resolve_life(None)
+        name = params.get("name")
+        if name is not None:
+            name = self._require_non_empty_text(name, field="name", max_len=80)
+        life = resolve_life(name)
         if life is None:
             raise ValueError("no active life")
-        os.environ["SINGULAR_HOME"] = str(life)
         checkpoint = Path(life) / "life_checkpoint.json"
         skills_dir = Path(life) / "skills"
 
@@ -470,6 +469,7 @@ class DashboardActionService:
                 budget_seconds=budget,
                 run_id=run_id,
                 seed=seed,
+                life_home=life,
             )
             return {"run_id": run_id, "budget_seconds": budget}
 
@@ -484,13 +484,22 @@ class DashboardActionService:
         from singular.cli import _resolve_latest_run_id
         from singular.runs.report import report
 
+        name = params.get("name")
+        if name is not None:
+            name = self._require_non_empty_text(name, field="name", max_len=80)
+        from singular.lives import resolve_life
+        life = resolve_life(name)
+        if life is None:
+            raise ValueError(f"unknown life: {name}" if name else "no active life")
+        runs_dir = Path(life) / "runs"
+
         if run_id is None:
-            run_id = _resolve_latest_run_id()
+            run_id = _resolve_latest_run_id(runs_dir)
         if run_id is None:
             raise ValueError("no run available")
 
         def _run() -> dict[str, Any]:
-            report(run_id=run_id, output_format="json")
+            report(run_id=run_id, runs_dir=runs_dir, output_format="json")
             return {"run_id": run_id}
 
         data, log = self._capture(_run)
@@ -536,7 +545,6 @@ class DashboardActionService:
             life = resolve_life(name)
             if life is None:
                 raise ValueError(f"unknown life: {name}")
-            os.environ["SINGULAR_HOME"] = str(life)
             return {"name": name, "path": str(life)}
 
         data, log = self._capture(_run)
@@ -631,7 +639,6 @@ class DashboardActionService:
 
         def _run() -> dict[str, Any]:
             meta = clone_life(name, new_name=new_name)
-            os.environ["SINGULAR_HOME"] = str(meta.path)
             return {
                 "source": name,
                 "name": meta.name,

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -289,10 +289,10 @@ def _load_ecosystem_rules_config_cached(
     return config
 
 
-def _resolve_current_life_slug() -> str | None:
+def _resolve_current_life_slug(life_home: Path | str | None = None) -> str | None:
     """Resolve current life slug from ``SINGULAR_HOME`` and the lives registry."""
 
-    life_home = Path(os.environ.get("SINGULAR_HOME", ".")).resolve()
+    life_home = Path(life_home or os.environ.get("SINGULAR_HOME", ".")).resolve()
     registry = load_registry()
     lives = registry.get("lives", {})
     if not isinstance(lives, dict):
@@ -871,6 +871,7 @@ def run(
     social_graph: SocialGraph | None = None,
     imitation_engine: ImitationEngine | None = None,
     learning_budget: int = 1,
+    life_home: Path | str | None = None,
 ) -> Checkpoint:
     """Run the evolutionary loop for at most ``budget_seconds`` seconds.
 
@@ -888,6 +889,7 @@ def run(
     """
 
     rng = rng or random.Random()
+    life_root = Path(life_home) if life_home is not None else Path(os.environ.get("SINGULAR_HOME", "."))
     state = load_checkpoint(checkpoint_path)
     state.health_history = _retain_health_history(state.health_history)
 
@@ -958,7 +960,7 @@ def run(
     sleep_ticks_remaining = 0
     intrinsic_goals = IntrinsicGoals(value_weights=value_weights)
     self_observation = SelfObservationService(
-        Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "self_model.json"
+        life_root / "mem" / "self_model.json"
     )
     coevolution_flow: CoevolutionFlow | None = None
     if coevolve_tests:
@@ -1001,7 +1003,6 @@ def run(
         with current_tick_profiler.phase("test_runner"):
             return test_runner()
 
-    life_root = Path(os.environ.get("SINGULAR_HOME", "."))
     # Imitation is part of the normal composition. Injection remains available
     # for tests and alternative generators, but learning no longer depends on it.
     imitation_engine = imitation_engine or ImitationEngine(life_root)
@@ -1203,7 +1204,7 @@ def run(
                 health_counters=state.health_counters,
             )
             if trigger_genesis and not selected_org.degraded_mode:
-                mem_dir = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem"
+                mem_dir = life_root / "mem"
                 genesis = create_skill(
                     skills_dir=world.organisms[org_name].skills_dir,
                     mem_dir=mem_dir,
@@ -2405,7 +2406,7 @@ def run(
                 mutation_payload,
                 payload_version=1,
             )
-            life_root = Path(os.environ.get("SINGULAR_HOME", ".")).resolve()
+            life_root = life_root.resolve()
             try:
                 skill_relative_path = str(skill_path.resolve().relative_to(life_root))
             except ValueError:
@@ -2457,8 +2458,8 @@ def run(
             if hasattr(psyche, "save_state"):
                 psyche.save_state()
 
-            world_state_path = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_state.json"
-            world_effects_path = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "world_effects.json"
+            world_state_path = life_root / "mem" / "world_state.json"
+            world_effects_path = life_root / "mem" / "world_effects.json"
             updated_world_state = sim_world.apply_action_effects(
                 world_effects,
                 state_path=world_state_path,
@@ -2513,7 +2514,7 @@ def run(
                     reason=death_reason,
                     alive=False,
                 )
-                mem_dir = Path(os.environ.get("SINGULAR_HOME", ".")) / "mem"
+                mem_dir = life_root / "mem"
                 identity_id = _persistent_identity_id(mem_dir.parent)
                 autopsy_payload = _build_autopsy_report(
                     reason=death_reason,
@@ -2543,7 +2544,7 @@ def run(
                 }
                 _write_json(mem_dir / "orchestrator.stop.json", stop_payload)
 
-                life_slug = _resolve_current_life_slug()
+                life_slug = _resolve_current_life_slug(life_root)
                 if life_slug:
                     set_life_status(life_slug, "extinct")
 

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -115,11 +115,11 @@ def ensure_memory_structure(mem_dir: Path | str | None = None) -> None:
     (mem_dir / "layers").mkdir(parents=True, exist_ok=True)
 
 
-def get_memory_layer_service() -> MemoryLayerService:
+def get_memory_layer_service(root: Path | str | None = None) -> MemoryLayerService:
     """Return the memory layer service for the current memory root."""
 
     global _MEMORY_LAYER_SERVICE, _MEMORY_LAYER_SERVICE_ROOT
-    root = get_memory_layers_dir().resolve()
+    root = (Path(root) if root is not None else get_memory_layers_dir()).resolve()
     if _MEMORY_LAYER_SERVICE is None or _MEMORY_LAYER_SERVICE_ROOT != root:
         _MEMORY_LAYER_SERVICE = MemoryLayerService(
             build_backend(root=root)
@@ -334,7 +334,8 @@ def add_episode(
     path = Path(path)
     append_jsonl_line(path, episode)
     try:
-        get_memory_layer_service().ingest_episode(episode)
+        layers_root = path.parent / "layers"
+        get_memory_layer_service(layers_root).ingest_episode(episode)
     except Exception:
         # Layered memory is best effort to preserve compatibility.
         pass

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -178,17 +178,24 @@ def talk(
     prompt: str | None = None,
     demonstration: Mapping[str, Any] | None = None,
     imitation_engine: ImitationEngine | None = None,
-) -> None:
+    life_home: Path | str | None = None,
+) -> str | None:
     """Handle the ``talk`` subcommand."""
 
-    ensure_memory_structure()
+    life_root = Path(life_home) if life_home is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    mem_dir = life_root / "mem"
+    episodic_file = mem_dir / "episodic.jsonl"
+    causal_file = mem_dir / "causal_timeline.jsonl"
+    psyche_file = mem_dir / "psyche.json"
+    narrative_file = mem_dir / "self_narrative.json"
+    ensure_memory_structure(mem_dir)
 
     # Human dialogue is eligible for teaching only through a separate,
     # structured and explicitly consented demonstration payload.
     if demonstration is not None:
         (
             imitation_engine
-            or ImitationEngine(Path(os.environ.get("SINGULAR_HOME", ".")))
+            or ImitationEngine(life_root)
         ).ingest_interaction(demonstration, source="human:talk")
 
     rng = random.Random(seed)
@@ -216,15 +223,15 @@ def talk(
                 "Automatic provider selection found no available backend. Using local fallback replies."
             )
 
-    psyche = Psyche.load_state()
+    psyche = Psyche.load_state(psyche_file)
 
     def gather_context() -> tuple[
         str | None, dict | None, dict | None, str | None, str | None
     ]:
         signals = capture_signals()
-        add_episode({"event": "perception", **signals})
+        add_episode({"event": "perception", **signals}, path=episodic_file)
         psyche.consume()
-        episodes = read_episodes()
+        episodes = read_episodes(episodic_file)
         episodes_by_role = {
             "user": [e for e in episodes if e.get("role") == "user"],
             "assistant": [e for e in episodes if e.get("role") == "assistant"],
@@ -282,12 +289,11 @@ def talk(
         perf_msg: str | None,
         self_narrative_summary: str,
         self_narrative_version: int,
-    ) -> None:
+    ) -> str:
         user_signals = _extract_structured_signals(user_input)
         theme = str(user_signals.get("theme", "general"))
-        life_root = os.environ.get("SINGULAR_HOME", ".")
         retrieval = MemoryRetrievalService(
-            life_root, build_backend(root=os.path.join(life_root, "mem", "layers"))
+            life_root, build_backend(root=mem_dir / "layers")
         )
         recalled_memories = retrieval.retrieve(
             user_input,
@@ -311,7 +317,7 @@ def talk(
                     "query": user_input,
                     "memories": recalled_memories,
                     "summary": recall_summary,
-                }
+                }, path=episodic_file
             )
             add_episode(
                 {
@@ -320,11 +326,9 @@ def talk(
                     "decision": "assistant_reply",
                     "memories": recalled_memories,
                     "summary": recall_summary,
-                }
+                }, path=episodic_file
             )
-        add_episode(
-            {"role": "user", "text": user_input, "structured_signals": user_signals}
-        )
+        add_episode({"role": "user", "text": user_input, "structured_signals": user_signals}, path=episodic_file)
         mood = psyche.feel(Mood.NEUTRAL)
         mood_report = mood_event or mood.value
         system_preamble = _build_system_preamble(
@@ -389,6 +393,7 @@ def talk(
             error_category=error_category,
             llm_real=llm_real,
             active_provider=active_provider,
+            life_root=life_root,
         )
 
         parts = [reply]
@@ -426,7 +431,7 @@ def talk(
                     "recalled_memories": recalled_memories,
                     "recalled_memory_summary": recall_summary,
                 },
-            }
+            }, path=episodic_file
         )
         gain_estimate = round(
             float(user_signals.get("satisfaction", 0.0))
@@ -471,15 +476,16 @@ def talk(
                         "impact": cognitive_gain,
                     },
                 },
-            }
+            }, path=causal_file
         )
         psyche.gain()
-        psyche.save_state()
+        psyche.save_state(psyche_file)
+        return response
 
     if prompt is not None:
         context = gather_context()
-        self_narrative = load_self_narrative()
-        respond(
+        self_narrative = load_self_narrative(narrative_file)
+        return respond(
             prompt,
             *context,
             summarize_short(self_narrative),
@@ -489,7 +495,7 @@ def talk(
 
     while True:
         context = gather_context()
-        self_narrative = load_self_narrative()
+        self_narrative = load_self_narrative(narrative_file)
         try:
             user_input = input("you: ")
         except EOFError:

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -75,6 +75,7 @@ def log_provider_event(
     error_category: str | None,
     llm_real: bool,
     active_provider: str | None = None,
+    life_root: Path | str | None = None,
 ) -> None:
     """Emit a structured provider log entry."""
 
@@ -89,7 +90,7 @@ def log_provider_event(
     }
     _provider_logger.info("provider_call", extra={"payload": payload})
     try:
-        root = Path(os.environ.get("SINGULAR_HOME", "."))
+        root = Path(life_root) if life_root is not None else Path(os.environ.get("SINGULAR_HOME", "."))
         ProviderEventsRepository(SQLiteStorage(StorageConfig(root=root))).add(payload)
     except Exception:
         _provider_logger.debug("provider_event_sqlite_persist_failed", exc_info=True)

--- a/src/singular/runs/loop.py
+++ b/src/singular/runs/loop.py
@@ -19,6 +19,7 @@ def loop(
     run_id: str = "loop",
     seed: int | None = None,
     safe_mode: bool = False,
+    life_home: Path | str | None = None,
 ) -> None:
     """Wrapper around :func:`life.loop.run` used by the CLI.
 
@@ -42,4 +43,5 @@ def loop(
         rng=rng,
         run_id=run_id,
         governance_policy=governance_policy,
+        life_home=life_home,
     )


### PR DESCRIPTION
### Motivation

- Éviter les mutations temporaires de `os.environ["SINGULAR_HOME"]` pendant l’exécution des actions/dashboard afin d’empêcher le mélange de contextes entre requêtes concurrentes et garantir que chaque opération utilise explicitement le chemin de vie attendu.
- Propager un objet `Path` / chemin de vie explicite dans les fonctions métier (conversation, boucle, rapports, actions de naissance/clone/sélection) au lieu de relire l’environnement au milieu d’une requête.

### Description

- Supprime les affectations temporaires à `SINGULAR_HOME` dans le dashboard et les handlers d’action et passe désormais `life_home` (chemin résolu) à `singular.organisms.talk.talk` et aux wrappers de loop/report plutôt que de modifier l’environnement. (modifs dans `src/singular/dashboard/__init__.py`, `src/singular/dashboard/actions.py`).
- Ajoute le paramètre `life_home` à `talk` et fait retourner la réponse explicite; détache les fichiers mémoires (`episodic.jsonl`, `causal_timeline.jsonl`, `psyche.json`, `self_narrative.json`) du `Path` fourni et assure la création du répertoire mémoire via `ensure_memory_structure(mem_dir)`. (modifs dans `src/singular/organisms/talk.py`).
- Propage `life_home` à la boucle métier et au wrapper CLI (`src/singular/runs/loop.py`, `src/singular/life/loop.py`) et remplace les lectures de `os.environ` dans `life.loop.run` par l’utilisation de `life_root` explicite lorsque fourni.
- Fait évoluer le service de mémoire stratifiée pour accepter une racine (`root`) dérivée du chemin du fichier épisodique afin d’éviter le partage de backend mémoire entre vies concurrentes (`src/singular/memory.py`), et permet d’enregistrer des événements provider avec un `life_root` explicite (`src/singular/runs/logger.py`).

### Testing

- Compilation statique des modules modifiés avec `python -m py_compile` réussie pour les modules touchés (`organisms.talk`, `dashboard/__init__.py`, `dashboard/actions.py`, `runs/loop.py`, `runs/logger.py`, `memory.py`, `life/loop.py`).
- Tests ciblés `pytest -q tests/test_dashboard.py` exécutés: 45 tests passés, 3 tests ont échoué (écarts sur valeurs de politique de gouvernance et statut `dead`/`extinct` — ces échecs semblent porter sur des attentes de données de politique/état existantes et non sur la propagation de contexte).
- Tests `pytest -q tests/test_talk.py tests/test_end_to_end.py` exécutés: 20 tests passés, 2 échoués; l’un est dû à l’absence d’un runtime de sandbox (`podman`/`docker`) nécessaire pour un test d’intégration, l’autre à une différence de version de schéma du récit (`self_narrative`) attendue par un test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a762b8396d0832a96da33e0f314a06e)