### PR TITLE
Bundle runtime configs as package data and load via importlib.resources; add wheel distribution test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ package-dir = { "" = "src" }
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"singular.data" = ["configs/*.yaml", "configs/ecosystem/*.json"]
+"singular.dashboard" = ["templates/*.html", "static/*"]
+
 [tool.black]
 target-version = ["py310"]
 extend-exclude = '''

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import os
 import sys
+from importlib.resources import files
 from pathlib import Path
 from urllib.parse import quote
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
@@ -106,8 +107,9 @@ def create_app(
     quests_path = base_dir / "mem" / "quests_state.json"
     app = FastAPI()
     actions = DashboardActionService(home=base_dir)
-    templates_dir = Path(__file__).parent / "templates"
-    static_dir = Path(__file__).parent / "static"
+    dashboard_resources = files("singular.dashboard")
+    templates_dir = dashboard_resources.joinpath("templates")
+    static_dir = dashboard_resources.joinpath("static")
     app.mount("/static", StaticFiles(directory=static_dir), name="dashboard-static")
     run_repository = RunRecordsRepository(
         base_dir=base_dir,

--- a/src/singular/data/configs/ecosystem/lab.json
+++ b/src/singular/data/configs/ecosystem/lab.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "mode": "lab",
+  "resource_competition_unit": 0.8,
+  "passive_energy_decay": 0.04,
+  "passive_resource_decay": 0.015,
+  "crossover_interval": 30,
+  "cooperation_probability": 0.35,
+  "competition_bid_ceiling": 6.0,
+  "reputation_action_weights": {"share": 0.35, "steal": -0.3}
+}

--- a/src/singular/data/configs/ecosystem/production.json
+++ b/src/singular/data/configs/ecosystem/production.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "mode": "production",
+  "resource_competition_unit": 1.0,
+  "passive_energy_decay": 0.05,
+  "passive_resource_decay": 0.02,
+  "crossover_interval": 50,
+  "cooperation_probability": 0.2,
+  "competition_bid_ceiling": 5.0,
+  "reputation_action_weights": {"share": 0.2, "steal": -0.2}
+}

--- a/src/singular/data/configs/host_sensors.yaml
+++ b/src/singular/data/configs/host_sensors.yaml
@@ -1,0 +1,12 @@
+host_sensors:
+  cpu:
+    warning_percent: 85
+    critical_percent: 95
+  ram:
+    warning_percent: 80
+    critical_percent: 92
+  temperature:
+    warning_c: 75
+    critical_c: 85
+  disk:
+    critical_percent: 95

--- a/src/singular/data/configs/life_definition.yaml
+++ b/src/singular/data/configs/life_definition.yaml
@@ -1,0 +1,69 @@
+schema_version: "1.1"
+
+criteria:
+  persistent_identity: true
+  generation_registry: true
+  stable_cycle: true
+  intrinsic_goals: true
+  reproduction_capability: true
+  narrative_continuity: true
+
+weighted_score:
+  total_points: 100
+  criteria:
+    persistent_identity:
+      points: 20
+      required_for_alive: true
+      description: "Identité persistante et vérifiable sur les artefacts de vie."
+    generation_registry:
+      points: 15
+      required_for_alive: true
+      description: "Présence dans le registre de générations ou filiation traçable."
+    stable_cycle:
+      points: 20
+      required_for_alive: true
+      description: "Cycle vital stable et observé sur un minimum de cycles."
+    continuous_intrinsic_goals:
+      points: 20
+      required_for_alive: true
+      description: "Objectifs intrinsèques continus, non réduits à une tâche ponctuelle."
+    reproduction_capability:
+      points: 10
+      required_for_alive: false
+      description: "Reproduction possible ou capacité déclarée compatible avec les règles vitales."
+    narrative_continuity:
+      points: 15
+      required_for_alive: true
+      minimum_days: 7
+      description: "Narration cohérente sur N jours."
+  terminal_signals:
+    autopsy_present: true
+    registry_extinct: true
+    death_event_confirmed: true
+  severe_degradation_signals:
+    terminal_lifecycle_state: true
+    critical_health_score: true
+    terminal_failure_streak: true
+    high_failure_rate: true
+
+thresholds:
+  minimum_narrative_trajectory_days: 7
+  minimum_observed_cycles: 3
+  maximum_cycle_anomalies: 1
+  alive_minimum_score: 80
+  fragile_minimum_score: 50
+  dying_degradation_minimum_score: 40
+
+statuses:
+  not_alive_yet: not_alive_yet
+  fragile: fragile
+  alive: alive
+  dying: dying
+  extinct: extinct
+
+status_rules:
+  not_alive_yet: "Score insuffisant ou signaux fondamentaux absents."
+  fragile: "Score intermédiaire mais continuité incomplète."
+  alive: "Score supérieur ou égal au seuil alive et aucun signal terminal."
+  dying: "Signal terminal ou dégradation forte détectés, sans extinction confirmée."
+  extinct: "Autopsy présente, registre extinct ou événement death confirmé."

--- a/src/singular/data/configs/lifecycle.yaml
+++ b/src/singular/data/configs/lifecycle.yaml
@@ -1,0 +1,29 @@
+cycle:
+  veille_seconds: 2.0
+  sommeil_seconds: 3.0
+  introspection_frequency_ticks: 1
+  mutation_window_seconds: 0.2
+
+coevolution:
+  enabled: false
+  robustness_weight: 1.0
+  max_test_candidates: 3
+  ttl: 3
+
+phases:
+  veille:
+    cpu_budget_percent: 30
+    allowed_actions: [perception, resource_scan]
+    slowdown_on_fatigue: 1.1
+  action:
+    cpu_budget_percent: 75
+    allowed_actions: [mutation, evaluation, checkpoint]
+    slowdown_on_fatigue: 1.5
+  introspection:
+    cpu_budget_percent: 40
+    allowed_actions: [self_review]
+    slowdown_on_fatigue: 1.2
+  sommeil:
+    cpu_budget_percent: 15
+    allowed_actions: [recovery, cooldown, memory_consolidation]
+    slowdown_on_fatigue: 1.0

--- a/src/singular/data/configs/starter_skills.yaml
+++ b/src/singular/data/configs/starter_skills.yaml
@@ -1,0 +1,36 @@
+{
+  "profiles": {
+    "minimal": [
+      "addition",
+      "subtraction",
+      "multiplication"
+    ],
+    "assistant": [
+      "addition",
+      "subtraction",
+      "multiplication",
+      "validation",
+      "summary",
+      "intent_classification",
+      "entity_extraction",
+      "planning",
+      "metrics"
+    ],
+    "ops": [
+      "validation",
+      "planning",
+      "metrics",
+      "summary",
+      "intent_classification"
+    ],
+    "creative": [
+      "summary",
+      "entity_extraction",
+      "planning",
+      "addition"
+    ]
+  },
+  "scoring_contract": {
+    "result": "Every generated starter skill must assign a finite numeric sandbox result."
+  }
+}

--- a/src/singular/life/life_definition.py
+++ b/src/singular/life/life_definition.py
@@ -8,13 +8,10 @@ from typing import Any
 
 from singular.life.life_status import AUTHORIZED_LIFE_STATUSES
 from singular.orchestrator.lifecycle_clock import _load_simple_yaml
+from singular.resources import config_resource
 
-DEFAULT_LIFECYCLE_CONFIG_PATH = (
-    Path(__file__).resolve().parents[3] / "configs" / "lifecycle.yaml"
-)
-DEFAULT_LIFE_DEFINITION_CONFIG_PATH = (
-    Path(__file__).resolve().parents[3] / "configs" / "life_definition.yaml"
-)
+DEFAULT_LIFECYCLE_CONFIG_PATH = config_resource("lifecycle.yaml")
+DEFAULT_LIFE_DEFINITION_CONFIG_PATH = config_resource("life_definition.yaml")
 
 
 @dataclass(frozen=True)

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import ast
 import difflib
+from importlib.resources import as_file
 import json
 import logging
 import math
@@ -37,6 +38,7 @@ from singular.memory import (
     recall_relevant_episodes,
 )
 from singular.psyche import Psyche, Mood, choose_action_from_psyche
+from singular.resources import config_resource
 from singular.runs.logger import RunLogger
 from singular.runs.explain import summarize_mutation
 from singular.runs.generations import record_generation
@@ -898,10 +900,9 @@ def run(
 
     world = world or WorldState()
     if ecosystem_rules is None:
-        config_path = (
-            Path(__file__).resolve().parents[3] / "configs" / "ecosystem" / f"{ecosystem_mode}.json"
-        )
-        config = _load_ecosystem_rules_config_cached(config_path, setup_profiler)
+        resource = config_resource("ecosystem", f"{ecosystem_mode}.json")
+        with as_file(resource) as config_path:
+            config = _load_ecosystem_rules_config_cached(config_path, setup_profiler)
         if config is not None:
             ecosystem_rules = EcosystemRules(
                 resource_competition_unit=config.resource_competition_unit,

--- a/src/singular/orchestrator/lifecycle_clock.py
+++ b/src/singular/orchestrator/lifecycle_clock.py
@@ -6,8 +6,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from singular.resources import config_resource
 
-DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "lifecycle.yaml"
+
+DEFAULT_CONFIG_PATH = config_resource("lifecycle.yaml")
 
 
 @dataclass(frozen=True)

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -19,14 +19,13 @@ from ..identity import create_identity
 from ..memory import ensure_memory_structure, update_score, write_profile
 from ..psyche import Psyche
 from ..life.skill_catalog import refresh_skill_catalog
+from ..resources import config_resource
 
 _PSYCHE_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
 _PSYCHE_DEFAULTS = {trait: 0.5 for trait in _PSYCHE_TRAITS}
 _DEFAULT_STARTER_PROFILE = "minimal"
 _BIRTH_SCHEMA_VERSION = 1
-_STARTER_CONFIG_PATH = (
-    Path(__file__).resolve().parents[3] / "configs" / "starter_skills.yaml"
-)
+_STARTER_CONFIG_PATH = config_resource("starter_skills.yaml")
 _DEFAULT_STARTER_PROFILES: dict[str, list[str]] = {
     "minimal": ["addition", "subtraction", "multiplication"],
 }
@@ -145,9 +144,7 @@ def _resolve_psyche_overrides(
     return normalized
 
 
-def _load_starter_profiles(
-    config_path: Path = _STARTER_CONFIG_PATH,
-) -> dict[str, list[str]]:
+def _load_starter_profiles(config_path: Any = _STARTER_CONFIG_PATH) -> dict[str, list[str]]:
     """Load starter skill profiles from configuration with a safe default fallback."""
 
     if not config_path.exists():

--- a/src/singular/resources.py
+++ b/src/singular/resources.py
@@ -1,0 +1,15 @@
+"""Access to resources shipped with the :mod:`singular` package."""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from importlib.resources.abc import Traversable
+
+
+def config_resource(*parts: str) -> Traversable:
+    """Return a traversable for a bundled runtime configuration."""
+
+    resource = files("singular.data").joinpath("configs")
+    for part in parts:
+        resource = resource.joinpath(part)
+    return resource

--- a/src/singular/sensors/config.py
+++ b/src/singular/sensors/config.py
@@ -8,7 +8,9 @@ import os
 from pathlib import Path
 from typing import Any, Mapping
 
-DEFAULT_HOST_SENSORS_CONFIG_PATH = Path(__file__).resolve().parents[3] / "configs" / "host_sensors.yaml"
+from singular.resources import config_resource
+
+DEFAULT_HOST_SENSORS_CONFIG_PATH = config_resource("host_sensors.yaml")
 ENV_HOST_SENSORS_CONFIG_PATH = "SINGULAR_HOST_SENSORS_CONFIG"
 ENV_HOST_SENSORS_OVERRIDES = "SINGULAR_HOST_SENSORS_OVERRIDES"
 HOST_METRIC_STATUS_AVAILABLE = "available"

--- a/tests/test_wheel_distribution.py
+++ b/tests/test_wheel_distribution.py
@@ -1,0 +1,73 @@
+"""Validate runtime resources from an installed wheel, outside the checkout."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_installed_wheel_contains_all_runtime_resources(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    wheelhouse = tmp_path / "wheelhouse"
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "wheel",
+            ".",
+            "--no-deps",
+            "-w",
+            str(wheelhouse),
+        ],
+        cwd=repo_root,
+        check=True,
+    )
+    wheel = next(wheelhouse.glob("singular-*.whl"))
+
+    venv = tmp_path / "venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--system-site-packages", str(venv)],
+        check=True,
+    )
+    python = venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    subprocess.run([python, "-m", "pip", "install", "--no-deps", str(wheel)], check=True)
+
+    execution_dir = tmp_path / "installed-runtime"
+    execution_dir.mkdir()
+    script = r'''
+from importlib.resources import as_file, files
+from pathlib import Path
+
+from singular.dashboard import create_app
+from singular.life.ecosystem import EcosystemRulesConfig
+from singular.life.life_definition import load_life_definition_config
+from singular.orchestrator.lifecycle_clock import load_lifecycle_clock_config
+from singular.organisms.birth import _load_starter_profiles, birth
+from singular.resources import config_resource
+from singular.sensors.config import load_host_sensor_thresholds
+
+home = Path("life")
+birth(seed=1, home=home, name="Wheel Life")
+assert (home / "mem" / "identity.json").is_file()
+assert _load_starter_profiles()["minimal"]
+assert load_host_sensor_thresholds().cpu_warning_percent == 85.0
+assert load_lifecycle_clock_config().cycle.veille_seconds == 2.0
+assert load_life_definition_config().schema_version == "1.0"
+for mode in ("lab", "production"):
+    with as_file(config_resource("ecosystem", f"{mode}.json")) as config_path:
+        config = EcosystemRulesConfig.from_file(config_path)
+    assert config.resource_competition_unit > 0
+
+dashboard = files("singular.dashboard")
+assert dashboard.joinpath("templates", "dashboard.html").is_file()
+assert dashboard.joinpath("templates", "mutation_detail.html").is_file()
+assert dashboard.joinpath("static", "dashboard.css").is_file()
+app = create_app()
+assert any(getattr(route, "name", None) == "dashboard-static" for route in app.routes)
+'''
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    subprocess.run([python, "-c", script], cwd=execution_dir, env=env, check=True)


### PR DESCRIPTION
### Motivation

- Rendre les configurations runtime et les ressources du dashboard disponibles depuis une installation (wheel) plutôt que via des chemins fondés sur le checkout (`Path(__file__).parents[3]`).
- Uniformiser l’accès aux ressources embarquées avec `importlib.resources` pour permettre un packaging propre et sécurisé tout en préservant la possibilité de fournir des fichiers externes explicites.
- Vérifier via un test de distribution que la wheel installe bien les données et que l’application peut créer une vie et charger les configurations et templates sans `PYTHONPATH` pointant sur le checkout.

### Description

- Ajout d’un utilitaire `src/singular/resources.py` exposant `config_resource()` qui utilise `importlib.resources.files` pour résoudre les ressources embarquées. 
- Déplacement des configurations runtime dans `src/singular/data/configs/` et adaptation des chargeurs pour utiliser `config_resource` ou `importlib.resources.as_file` (`birth.py`, `sensors/config.py`, `orchestrator/lifecycle_clock.py`, `life/life_definition.py`, `life/loop.py`).
- Dashboard: résolution des templates et du répertoire `static` via `importlib.resources.files` et montage de `StaticFiles` sur le résultat, afin d’utiliser les assets embarqués au lieu de chemins relatifs au checkout. 
- Déclaration des fichiers de données dans `pyproject.toml` sous `[tool.setuptools.package-data]` pour inclure `singular.data` (`configs/*.yaml`, `configs/ecosystem/*.json`) et `singular.dashboard` (`templates/*.html`, `static/*`).
- Ajout d’un test d’intégration `tests/test_wheel_distribution.py` qui construit une wheel, l’installe dans un `venv` temporaire sans `PYTHONPATH`, puis exécute un script qui crée une vie, charge chaque configuration par défaut et vérifie la présence des templates et fichiers statiques.

### Testing

- `python -m compileall -q src/singular tests/test_wheel_distribution.py` ran without errors. ✅
- Basic repository checks (`git diff --check`) reported no whitespace/patch issues. ✅
- Targeted unit tests for configuration loaders and dashboard smoke were executed with the majority passing (targeted runs showed the config and dashboard static checks passing). ✅
- `pytest` runs revealed one unrelated dashboard assertion mismatch in `test_dashboard_endpoints` where runtime governance defaults differ from the test expectation, causing a failing test. ❌
- The distribution test `tests/test_wheel_distribution.py` attempted to build/install an isolated wheel but failed in this environment because `pip` could not download build-time dependencies (`setuptools>=61`) due to network/build restrictions, so the full wheel-install verification could not complete here. ❌

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a762d892dc4832a8e0f2bac68a13006)