### PR TITLE
Authentification sécurisée des actions du dashboard et suppression des jetons en URL

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -60,6 +60,23 @@ Le dashboard écoute par défaut sur `http://127.0.0.1:8000/`.
 | `POST /api/actions/{action}` | Exécution contrôlée d'actions (`birth`, `talk`, `loop`, `report`, `archive`, `memorial`, `clone`, `emergency_stop`). |
 | `GET /api/retention/status` | Statut de rétention et diagnostics de stockage. |
 
+## Authentification et reverse proxy
+
+Les routes mutatives (`POST /api/actions/{action}` et le chat) acceptent le
+jeton **uniquement** dans `Authorization: Bearer <jeton>` ou dans
+`X-Singular-Action-Token: <jeton>`. Le jeton ne doit jamais être placé dans la
+query string ou le JSON. Toutes les actions via `GET` sont refusées avec 405,
+y compris `birth`, `loop`, `talk` et la sélection d'une vie.
+
+Une écoute sur une adresse autre que `127.0.0.1`, `localhost` ou `::1` active
+également cette authentification sur toutes les lectures (hors fichiers
+statiques) et sur `/ws`. Derrière un reverse proxy, conserver l'en-tête
+`Authorization` ou `X-Singular-Action-Token`, utiliser HTTPS, et configurer le
+proxy pour ne pas journaliser ces en-têtes. Les URLs peuvent être journalisées
+normalement puisqu'elles ne contiennent aucun secret. L'override de
+développement non authentifié ne doit jamais être employé sur une écoute
+publique.
+
 ## Données affichées
 
 Le cockpit agrège plusieurs familles de signaux :

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -93,7 +93,10 @@ class _LogCursor:
 
 
 def create_app(
-    runs_dir: Path | str | None = None, psyche_file: Path | str | None = None
+    runs_dir: Path | str | None = None,
+    psyche_file: Path | str | None = None,
+    *,
+    require_read_auth: bool = False,
 ) -> FastAPI:
     """Create the dashboard FastAPI application."""
     registry_root = get_registry_root()
@@ -107,6 +110,44 @@ def create_app(
     quests_path = base_dir / "mem" / "quests_state.json"
     app = FastAPI()
     actions = DashboardActionService(home=base_dir)
+
+    def _request_token(request: object) -> str | None:
+        """Read credentials exclusively from request headers."""
+        headers = getattr(request, "headers", {})
+        authorization = headers.get("authorization", "")
+        if isinstance(authorization, str) and authorization.startswith("Bearer "):
+            candidate = authorization[len("Bearer ") :].strip()
+            if candidate:
+                return candidate
+        candidate = headers.get("x-singular-action-token")
+        return candidate.strip() if isinstance(candidate, str) and candidate.strip() else None
+
+    def _redact_secret(value: object) -> object:
+        """Prevent the configured credential from reaching responses or captured logs."""
+        secret = os.environ.get("SINGULAR_DASHBOARD_ACTION_TOKEN")
+        if not secret:
+            return value
+        if isinstance(value, str):
+            return value.replace(secret, "[REDACTED]")
+        if isinstance(value, dict):
+            return {key: _redact_secret(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [_redact_secret(item) for item in value]
+        return value
+
+    if require_read_auth and hasattr(app, "middleware"):
+        @app.middleware("http")
+        async def authenticate_remote_reads(request: object, call_next: object) -> object:
+            if getattr(request, "method", "") == "GET" and not str(
+                getattr(getattr(request, "url", None), "path", "")
+            ).startswith("/static/"):
+                try:
+                    actions.validate_token(_request_token(request))
+                except PermissionError:
+                    from starlette.responses import JSONResponse
+
+                    return JSONResponse({"detail": "dashboard authentication required"}, status_code=403)
+            return await call_next(request)
     dashboard_resources = files("singular.dashboard")
     templates_dir = dashboard_resources.joinpath("templates")
     static_dir = dashboard_resources.joinpath("static")
@@ -2384,7 +2425,7 @@ def create_app(
             return _chat_payload(
                 life=life,
                 message=message,
-                response=str(exc),
+                response=str(_redact_secret(str(exc))),
                 status="token_invalid",
                 timestamp=timestamp,
             )
@@ -2448,7 +2489,7 @@ def create_app(
             return _chat_payload(
                 life=target,
                 message=message,
-                response=str(exc),
+                response=str(_redact_secret(str(exc))),
                 status=error_status,
                 timestamp=timestamp,
             )
@@ -2463,14 +2504,11 @@ def create_app(
             response=response,
             status=response_status,
             timestamp=timestamp,
-            details={"log": log, "data": data, "provider_events": provider_lines},
+            details=_redact_secret({"log": log, "data": data, "provider_events": provider_lines}),
         )
 
     @app.get("/api/lives/{life}/chat")
-    def chat_with_life_get(
-        life: str, token: str | None = None, payload: str | None = None
-    ) -> dict[str, object]:
-        _ = (token, payload)
+    def chat_with_life_get(life: str) -> dict[str, object]:
         slug, meta, life_dir = _resolve_life_entry(life)
         target = slug or life
         life_status = _life_status(meta)
@@ -2502,17 +2540,15 @@ def create_app(
 
     if hasattr(app, "post"):
         async def chat_with_life_post(
-            life: str, request: StarletteRequest, token: str | None = None
+            life: str, request: StarletteRequest
         ) -> dict[str, object]:
             try:
                 body = await request.json()
             except Exception:
                 body = {}
-            return _run_life_chat(life, body, token=token)
+            return _run_life_chat(life, body, token=_request_token(request))
 
         app.post("/api/lives/{life}/chat")(chat_with_life_post)
-
-    DESTRUCTIVE_GET_ACTIONS = {"archive", "emergency_stop", "clone"}
 
     def _validate_action_token(token: str | None) -> None:
         try:
@@ -2552,30 +2588,22 @@ def create_app(
         _validate_action_token(token)
         result = actions.execute(action, params)
         if not result.get("ok"):
-            raise HTTPException(status_code=400, detail=str(result.get("error") or "action failed"))
-        return result
+            detail = _redact_secret(str(result.get("error") or "action failed"))
+            raise HTTPException(status_code=400, detail=str(detail))
+        return _redact_secret(result)
 
     @app.get("/api/actions/{action}")
-    def run_action_get(
-        action: str, token: str | None = None, payload: str | None = None
-    ) -> dict[str, object]:
-        if action in DESTRUCTIVE_GET_ACTIONS:
-            raise HTTPException(
-                status_code=405,
-                detail=(
-                    "Méthode GET dépréciée et bloquée pour cette action destructive; "
-                    "utilisez POST avec un corps JSON."
-                ),
-            )
-        params = _parse_action_payload(payload)
-        result = _execute_dashboard_action(action, params, token=token)
-        result["deprecated"] = "GET /api/actions/{action} is deprecated; use POST with a JSON body."
-        return result
+    def run_action_get(action: str) -> dict[str, object]:
+        raise HTTPException(
+            status_code=405,
+            detail="Les actions dashboard ne sont jamais exécutées via GET; utilisez POST.",
+        )
 
     if hasattr(app, "post"):
         async def run_action_post(
-            action: str, request: StarletteRequest, token: str | None = None
+            action: str, request: StarletteRequest
         ) -> dict[str, object]:
+            token = _request_token(request)
             try:
                 body = await request.body()
             except AttributeError:
@@ -2608,6 +2636,12 @@ def create_app(
 
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:
+        if require_read_auth:
+            try:
+                actions.validate_token(_request_token(ws))
+            except PermissionError:
+                await ws.close(code=1008)
+                return
         await ws.accept()
         last_psyche_mtime_ns: int | None = None
         last_quests_mtime_ns: int | None = None
@@ -2724,5 +2758,6 @@ def run(host: str = "127.0.0.1", port: int = 8000) -> None:
         )
         raise SystemExit(1) from exc
 
-    app = create_app()
+    loopback_hosts = {"127.0.0.1", "localhost", "::1"}
+    app = create_app(require_read_auth=host not in loopback_hosts)
     uvicorn.run(app, host=host, port=port)

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import secrets
 from contextlib import redirect_stdout
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -311,7 +312,7 @@ class DashboardActionService:
             os.environ.get("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS") == "1"
         )
         if expected:
-            if token != expected:
+            if token is None or not secrets.compare_digest(token, expected):
                 raise PermissionError("invalid action token")
             return
         if allow_unauthenticated:

--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -246,12 +246,11 @@ export const runAction=(action,payload,{onAfterAction}={})=>{
     writeActionResult(`Erreur action ${action}: payload invalide (${err.message}).`);
     return Promise.resolve(false);
   }
-  const q=new URLSearchParams();
-  if(token){q.set('token',token);}
-  const suffix=q.toString()?`?${q.toString()}`:'';
-  return fetch(`/api/actions/${encodeURIComponent(action)}${suffix}`,{
+  const headers={'Content-Type':'application/json'};
+  if(token){headers['X-Singular-Action-Token']=token;}
+  return fetch(`/api/actions/${encodeURIComponent(action)}`,{
     method:'POST',
-    headers:{'Content-Type':'application/json'},
+    headers,
     body,
   }).then(async r=>{
     if(!r.ok){throw new Error(await readActionError(r));}

--- a/src/singular/dashboard/static/render-conversations.js
+++ b/src/singular/dashboard/static/render-conversations.js
@@ -124,12 +124,12 @@ const bindSend=()=>{
     setFlowState('en réflexion');
     sendBtn.disabled=true;
     const token=document.getElementById('action-token')?.value||'';
-    const q=new URLSearchParams();
-    if(token){q.set('token',token);}
+    const headers={'Content-Type':'application/json'};
+    if(token){headers['X-Singular-Action-Token']=token;}
     try{
-      const response=await fetch(`/api/lives/${encodeURIComponent(life)}/chat?${q.toString()}`,{
+      const response=await fetch(`/api/lives/${encodeURIComponent(life)}/chat`,{
         method:'POST',
-        headers:{'Content-Type':'application/json'},
+        headers,
         body:JSON.stringify({message:text}),
       });
       const payload=await response.json();

--- a/tests/fastapi_stub/testclient.py
+++ b/tests/fastapi_stub/testclient.py
@@ -39,7 +39,9 @@ class TestClient:
             status = exc.status_code
         return Response(status, data)
 
-    def post(self, path: str, json: Any = None) -> Response:
+    def post(
+        self, path: str, json: Any = None, headers: dict[str, str] | None = None
+    ) -> Response:
         parsed = urlsplit(path)
         handler = self.app._post_routes.get(parsed.path)
         params = {key: values[-1] for key, values in parse_qs(parsed.query).items()}
@@ -50,7 +52,13 @@ class TestClient:
             handler = self.app._post_routes["/api/lives/{life}/chat"]
             params["life"] = parsed.path.split("/")[3]
 
+        normalized_headers = {
+            key.lower(): value for key, value in (headers or {}).items()
+        }
+
         class Request:
+            headers = normalized_headers
+
             async def body(self) -> bytes:
                 import json as json_module
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1991,7 +1991,11 @@ def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: py
     assert "Mémorial" in body
     assert "Cloner" in body
 
-    ok = client.post("/api/actions/lives_list?token=secret", json={}).json()
+    ok = client.post(
+        "/api/actions/lives_list",
+        json={},
+        headers={"Authorization": "Bearer secret"},
+    ).json()
     assert ok["ok"] is True
     assert ok["action"] == "lives_list"
     assert "context" in ok
@@ -1999,7 +2003,52 @@ def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: py
     assert "current_life_home" in ok["context"]
 
     with pytest.raises(Exception):
-        app._routes["/api/actions/{action}"]("lives_list", token="wrong", payload="{}")
+        app._routes["/api/actions/{action}"]("lives_list")
+
+
+def test_dashboard_secrets_stay_out_of_urls_errors_and_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "never-leak-this-dashboard-secret"
+    monkeypatch.setenv("SINGULAR_DASHBOARD_ACTION_TOKEN", secret)
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/actions/lives_list",
+        json={},
+        headers={"X-Singular-Action-Token": secret},
+    )
+    serialized = json.dumps(response.json())
+
+    assert response.status_code == 200
+    assert secret not in serialized
+    assert "token=" not in serialized
+
+    missing = client.post("/api/actions/lives_list", json={})
+    assert missing.status_code == 403
+    assert secret not in json.dumps(missing.json())
+
+    actions_js = Path("src/singular/dashboard/static/actions.js").read_text()
+    conversations_js = Path(
+        "src/singular/dashboard/static/render-conversations.js"
+    ).read_text()
+    assert "q.set('token'" not in actions_js + conversations_js
+    assert "X-Singular-Action-Token" in actions_js
+    assert "X-Singular-Action-Token" in conversations_js
+
+
+def test_dashboard_get_never_executes_any_action(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS", "1")
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    route = app._routes["/api/actions/{action}"]
+
+    for action in ("lives_list", "birth", "loop", "talk", "select"):
+        with pytest.raises(Exception) as exc_info:
+            route(action)
+        assert getattr(exc_info.value, "status_code", None) == 405
 
 
 def test_dashboard_actions_require_token_unless_local_dev_override(
@@ -2338,10 +2387,7 @@ def test_chat_get_reports_status_without_running_chat(
     monkeypatch.setenv("SINGULAR_DASHBOARD_ACTION_TOKEN", "secret")
 
     app = create_app(psyche_file=tmp_path / "psyche.json")
-    response = app._routes["/api/lives/{life}/chat"](
-        life="alpha",
-        payload=json.dumps({"message": "ne doit pas etre envoye"}),
-    )
+    response = app._routes["/api/lives/{life}/chat"](life="alpha")
 
     assert response["life"] == "alpha"
     assert response["available"] is True


### PR DESCRIPTION
### Motivation
- Éviter la fuite de secrets via la query string ou les logs et imposer une validation robuste des actions mutatives du dashboard.
- Prévenir l'exécution d'actions sensibles via GET et appliquer une authentification cohérente pour les lectures/WSS quand l'écoute est publique.

### Description
- Lire le jeton uniquement depuis `Authorization: Bearer <jeton>` ou `X-Singular-Action-Token` et supprimer l'usage du paramètre `token` pour les routes POST de chat et d'actions. (modifs dans `src/singular/dashboard/__init__.py` et tests)
- Envoyer le secret uniquement dans les headers depuis le front-end JS (`src/singular/dashboard/static/actions.js` et `src/singular/dashboard/static/render-conversations.js`).
- Utiliser `secrets.compare_digest` pour comparer le jeton dans `DashboardActionService.validate_token`. (`src/singular/dashboard/actions.py`)
- Refuser systématiquement l'exécution d'actions via GET en renvoyant HTTP 405 et supprimer les anciennes branches de GET mutatif. (`/api/actions/{action}`)
- Ajouter un mécanisme de redaction pour empêcher le secret de réapparaître dans les réponses, erreurs ou logs capturés, et améliorer la validation d'entrée des endpoints.
- Appliquer l'authentification aux lectures sensibles et au WebSocket lorsque l'application est liée sur une interface non loopback, et activer ce mode automatiquement depuis `run()` selon le `host` d'écoute.
- Documenter le comportement attendu derrière un reverse proxy et les en-têtes supportés dans `docs/dashboard.md`.
- Adapter le test stub HTTP (`tests/fastapi_stub/testclient.py`) et étendre les tests `tests/test_dashboard.py` pour couvrir l'envoi en header, l'absence de secret dans les URLs/erreurs et l'interdiction des actions GET.

### Testing
- Tests ciblés sur les endpoints/actions JS et chat exécutés via `pytest -q -k 'actions_endpoint or secrets_stay or actions_require or get_never or chat_get or chat_post or emergency_stop'` : 7/7 tests réussis.
- Suite élargie `pytest -q tests/test_dashboard.py tests/test_dashboard_static_smoke.py` : 56 tests passés et 3 échecs restants; ces 3 échecs sont dus à des différences de configuration de politique/governance et à une divergence du statut calculé (`dead`) vs statut de registre attendu (`extinct`) et n'affectent pas les changements d'authentification introduits.
- Contrôles statiques et compilation : `ruff` et `python -m compileall` sont OK sur les modules modifiés.
- Tous les tests ajoutés/Modifiés pour vérifier que le secret n'apparaît ni dans les URLs ni dans les payloads d'erreur ont été ajoutés et exécutés dans les cycles ci-dessus et ont passé les vérifications ciblées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7631855980832a8377fc2a99035db6)