### PR TITLE
Sélection du protocole WebSocket (ws/wss) et prise en charge d’un préfixe reverse-proxy

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -77,6 +77,33 @@ normalement puisqu'elles ne contiennent aucun secret. L'override de
 développement non authentifié ne doit jamais être employé sur une écoute
 publique.
 
+Le proxy doit aussi transmettre explicitement l'upgrade WebSocket. Par exemple,
+avec nginx (le bloc `location` doit correspondre au chemin public retenu) :
+
+```nginx
+location /ws {
+    proxy_pass http://127.0.0.1:8000/ws;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+}
+```
+
+Le navigateur sélectionne automatiquement `ws:` pour une page HTTP et `wss:`
+pour une page HTTPS. Si le dashboard est publié sous un sous-chemin (par exemple
+`/singular/dashboard`), définir le préfixe avant de charger le module du
+dashboard, puis exposer le WebSocket au chemin préfixé correspondant :
+
+```html
+<script>window.SINGULAR_DASHBOARD_PATH_PREFIX = '/singular/dashboard';</script>
+<script type="module" src="/singular/dashboard/static/dashboard.js"></script>
+```
+
+Dans cet exemple, le client se connecte à `/singular/dashboard/ws`; le reverse
+proxy doit router ce chemin vers `/ws` sur le service Singular en conservant les
+en-têtes `Upgrade`, `Connection` et `Host` montrés ci-dessus.
+
 ## Données affichées
 
 Le cockpit agrège plusieurs familles de signaux :

--- a/src/singular/dashboard/static/bootstrap.js
+++ b/src/singular/dashboard/static/bootstrap.js
@@ -372,10 +372,17 @@ const markRealtimeUnavailable=error=>{
   console.warn('Dashboard WebSocket unavailable',error);
 };
 
+export const buildWebSocketUrl=(currentLocation=location,pathPrefix=window.SINGULAR_DASHBOARD_PATH_PREFIX||'')=>{
+  const protocol=currentLocation.protocol==='https:'?'wss:':'ws:';
+  const normalizedPrefix=String(pathPrefix).trim().replace(/^\/+|\/+$/g,'');
+  const path=normalizedPrefix?`/${normalizedPrefix}/ws`:'/ws';
+  return `${protocol}//${currentLocation.host}${path}`;
+};
+
 export const initWebSocket=()=>{
   let ws;
   try{
-    ws=new WebSocket(`ws://${location.host}/ws`);
+    ws=new WebSocket(buildWebSocketUrl());
   }catch(error){
     markRealtimeUnavailable(error);
     return null;

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -501,6 +501,31 @@ if (!result.textContent.includes('Saisissez le nom exact')) {{ throw new Error(`
     subprocess.run(["node", str(script)], check=True)
 
 
+def test_dashboard_websocket_url_supports_http_https_and_proxy_prefix(tmp_path: Path) -> None:
+    """The browser protocol and optional reverse-proxy prefix determine the WebSocket URL."""
+    script = tmp_path / "dashboard_websocket_url_check.mjs"
+    module_path = (Path.cwd() / DASHBOARD_STATIC / "bootstrap.js").as_uri()
+    script.write_text(
+        f"""
+globalThis.window = {{ SINGULAR_DASHBOARD_PATH_PREFIX: '' }};
+const {{ buildWebSocketUrl }} = await import('{module_path}');
+
+const cases = [
+  [{{ protocol: 'http:', host: 'localhost:8000' }}, '', 'ws://localhost:8000/ws'],
+  [{{ protocol: 'https:', host: 'dashboard.example.test' }}, '', 'wss://dashboard.example.test/ws'],
+  [{{ protocol: 'https:', host: 'example.test' }}, '/singular/dashboard/', 'wss://example.test/singular/dashboard/ws'],
+];
+for (const [location, prefix, expected] of cases) {{
+  const actual = buildWebSocketUrl(location, prefix);
+  if (actual !== expected) {{ throw new Error(`expected ${{expected}}, got ${{actual}}`); }}
+}}
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(["node", str(script)], check=True)
+
+
 def test_empty_lives_comparison_keeps_birth_action_enabled(tmp_path: Path) -> None:
     """Critical birth action remains usable when /lives/comparison has no lives."""
     script = tmp_path / "empty_lives_birth_action_check.mjs"


### PR DESCRIPTION
### Motivation

- Garantir que le client choisit `wss:` quand la page est servie en `https:` et `ws:` en `http:` pour éviter les erreurs de connexion sécurisée.
- Permettre au dashboard d’être monté sous un sous-chemin de reverse-proxy en construisant l’URL WebSocket à partir de `location.host` et d’un préfixe configuré.
- Documenter les en-têtes proxy nécessaires pour l’upgrade WebSocket afin d’aider les déploiements derrière nginx/équivalents.

### Description

- Ajout de `buildWebSocketUrl(currentLocation=location, pathPrefix=window.SINGULAR_DASHBOARD_PATH_PREFIX||'')` qui choisit `wss:` pour `https:` et `ws:` pour `http:`, normalise un `pathPrefix` optionnel et retourne l’URL complète vers `/ws` (ou `/<prefix>/ws`).
- Remplacement de la construction statique `new WebSocket(`ws://${location.host}/ws`)` par `new WebSocket(buildWebSocketUrl())` dans `src/singular/dashboard/static/bootstrap.js`.
- Ajout d’un test JS `test_dashboard_websocket_url_supports_http_https_and_proxy_prefix` dans `tests/test_dashboard_static_smoke.py` qui vérifie les combinaisons HTTP/HTTPS et déploiement sous-préfixé.
- Mise à jour de `docs/dashboard.md` avec un exemple nginx et les en-têtes `Upgrade`, `Connection` et `Host`, et une note sur la configuration du préfixe via `window.SINGULAR_DASHBOARD_PATH_PREFIX`.

### Testing

- Exécution de `pytest -q tests/test_dashboard_static_smoke.py` qui a réussi localement (10 passed).
- Les scripts Node invoqués par ces tests (vérifications JS) ont été exécutés avec succès dans le contexte des tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7633ad411c832aaeee412490c47e21)