### PR TITLE
Harden LLM and sandbox network policies (OLLAMA_HOST validation & sandbox network enforcement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,18 @@ le fichier hybride dans `child/`.
 
 ## 🔒 Security
 
-- Pas de réseau (no net).
+- **Frontières de confiance** : le processus hôte orchestre les appels et peut lire la
+  mémoire ; les fournisseurs LLM sont des services séparés ; le code produit par les
+  mutations est non fiable et n'est exécuté que dans le sandbox OCI.
+- Le fournisseur OpenAI transmet ses prompts au service externe d'OpenAI. Selon le
+  flux appelant, un prompt peut contenir des secrets ou des souvenirs sensibles :
+  inspectez/minimisez les données avant d'activer ce fournisseur.
+- Ollama n'est « local » que si `OLLAMA_HOST` pointe réellement vers une adresse
+  loopback. `OLLAMA_NETWORK_POLICY=local` (valeur restrictive par défaut) le vérifie,
+  y compris après une redirection HTTP ; `disabled` interdit tout appel et
+  `unrestricted` autorise explicitement les hôtes distants.
+- Le code muté n'a pas de réseau : `SINGULAR_SANDBOX_NETWORK_POLICY=none` (défaut).
+  Toute demande d'un autre mode est refusée plutôt que silencieusement affaiblie.
 - Pas d’accès disque externe (hors dossier de l’organisme).
 - Sandbox stricte :
   - Limites CPU/RAM (`timeout` & `memory_limit` : 1.5s et 256 MB par défaut).

--- a/docs/policy_customization.md
+++ b/docs/policy_customization.md
@@ -127,6 +127,18 @@ Recommended practice:
 - use `skills/experimental` for work that should be surfaced but not auto-applied;
 - treat `force_allow_paths` as temporary and document why it was used.
 
+### Network and trust boundaries
+
+Treat the host process, LLM providers, and mutated code as separate security
+domains. The host assembles prompts and may include secrets or sensitive memories,
+depending on the caller. OpenAI sends those prompts to its external service. Ollama
+is local only when `OLLAMA_HOST` resolves exclusively to loopback addresses:
+`OLLAMA_NETWORK_POLICY=local` is the restrictive default and validates HTTP
+redirect destinations, `disabled` blocks calls, and `unrestricted` is an explicit
+opt-in for LAN/public endpoints. Untrusted mutated code is governed separately by
+`SINGULAR_SANDBOX_NETWORK_POLICY=none`; the sandbox refuses other values and asks
+the OCI runtime for system-level `--network=none` isolation.
+
 ### `autonomy`
 
 Controls mutation, runtime execution, rollback and circuit breakers:

--- a/docs/release_v2.md
+++ b/docs/release_v2.md
@@ -51,6 +51,14 @@ Les parcours suivants sont bloquants avant release:
 
 ## 4) Checklist sécurité sandbox
 
+Frontières à ne pas confondre : le processus hôte orchestre et peut construire des
+prompts contenant, selon le flux, des secrets ou souvenirs sensibles ; OpenAI les
+transmet à son service externe ; Ollama n'est local que si `OLLAMA_HOST` résout vers
+loopback ; enfin le code muté est non fiable. La politique Ollama restrictive par
+défaut est `OLLAMA_NETWORK_POLICY=local` (`disabled` coupe le réseau et
+`unrestricted` est un opt-in distant), redirections comprises. Le sandbox du code
+muté impose `SINGULAR_SANDBOX_NETWORK_POLICY=none` au niveau OCI.
+
 Avant release, vérifier systématiquement:
 
 - [ ] Exécution de code utilisateur dans un conteneur OCI dédié sous Linux ; le filtre AST reste une validation fonctionnelle, pas la frontière de sécurité.

--- a/docs/tutorial_create_life.en.md
+++ b/docs/tutorial_create_life.en.md
@@ -85,6 +85,14 @@ During this tick, Singular may select a skill, propose a mutation, evaluate it i
 
 > **Security prerequisite:** evaluating untrusted code requires Linux, `resource` limits, and Docker or Podman with active seccomp and the `python:3.11-alpine` image already available (override with `SINGULAR_SANDBOX_IMAGE`). The container runs without networking or capabilities, as an unprivileged user, with a read-only root, isolated `/tmp`, and CPU/memory/process limits. AST filtering is only complementary functional validation. Singular explicitly refuses evaluation when it cannot establish the system-isolation guarantees.
 
+The host process, the LLM provider, and untrusted mutated code are three separate
+trust boundaries. The OpenAI provider sends prompts to an external service; prompts
+may contain secrets or sensitive memories depending on the calling flow. Ollama is
+local only when `OLLAMA_HOST` really resolves to loopback. The restrictive default
+`OLLAMA_NETWORK_POLICY=local` validates redirects too; use `disabled` to prevent all
+calls. Independently, the sandbox enforces `SINGULAR_SANDBOX_NETWORK_POLICY=none`
+and refuses a less restrictive mode.
+
 ## 4. Inspect memory and checkpoint
 
 The life memory lives in `mem/`:

--- a/docs/tutorial_create_life.fr.md
+++ b/docs/tutorial_create_life.fr.md
@@ -85,6 +85,15 @@ Pendant ce tick, Singular peut sélectionner une skill, proposer une mutation, l
 
 > **Prérequis de sécurité :** l'évaluation de code non fiable exige Linux, les limites `resource`, et Docker ou Podman avec seccomp actif et l'image `python:3.11-alpine` déjà disponible (modifiable via `SINGULAR_SANDBOX_IMAGE`). Le conteneur est lancé sans réseau, sans capabilities, avec un utilisateur non privilégié, une racine en lecture seule, un `/tmp` isolé et des limites CPU/mémoire/processus. Le contrôle AST n'est qu'une validation fonctionnelle complémentaire. Singular refuse explicitement l'évaluation si l'isolation système ne peut pas être garantie.
 
+Le processus hôte, le fournisseur LLM et le code muté non fiable sont trois
+frontières distinctes. Le fournisseur OpenAI envoie les prompts à un service
+externe ; selon le flux appelant, ces prompts peuvent inclure des secrets ou des
+souvenirs sensibles. Ollama n'est local que si `OLLAMA_HOST` résout réellement vers
+une adresse loopback. La politique restrictive par défaut
+`OLLAMA_NETWORK_POLICY=local` vérifie aussi les redirections ; utilisez `disabled`
+pour couper les appels. Le sandbox impose séparément
+`SINGULAR_SANDBOX_NETWORK_POLICY=none` et refuse tout mode moins restrictif.
+
 ## 4. Inspecter mémoire et checkpoint
 
 La mémoire de la vie est située dans `mem/` :

--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -57,6 +57,7 @@ class SandboxConfig:
     multiprocessing_method: str | None = None  # retained for API compatibility
     runtime: str | None = None
     image: str = DEFAULT_IMAGE
+    network_policy: str = "none"
 
     @classmethod
     def from_environment(
@@ -84,6 +85,7 @@ class SandboxConfig:
             ),
             runtime=os.getenv("SINGULAR_SANDBOX_RUNTIME") or None,
             image=os.getenv("SINGULAR_SANDBOX_IMAGE", DEFAULT_IMAGE),
+            network_policy=os.getenv("SINGULAR_SANDBOX_NETWORK_POLICY", "none").strip().lower(),
         )
 
 
@@ -144,6 +146,10 @@ except BaseException as exc:
 
 
 def _command(runtime: str, config: SandboxConfig) -> list[str]:
+    if config.network_policy not in {"none", "disabled"}:
+        raise SandboxError(
+            "untrusted-code sandbox only supports disabled system networking"
+        )
     cpu_seconds = max(1, math.ceil(config.execution_timeout_s))
     return [
         runtime,

--- a/src/singular/providers/llm_ollama.py
+++ b/src/singular/providers/llm_ollama.py
@@ -2,26 +2,87 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import socket
 import time
 from typing import Any
+from urllib.parse import urlparse
 from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
-from . import ProviderExecutionError, ProviderMetrics, ProviderTimeoutError, ProviderUnavailableError
+from . import (
+    ProviderExecutionError,
+    ProviderMetrics,
+    ProviderMisconfiguredError,
+    ProviderTimeoutError,
+    ProviderUnavailableError,
+)
 
 MAX_RETRIES = 1
 DEFAULT_OLLAMA_HOST = "http://127.0.0.1:11434"
 DEFAULT_OLLAMA_MODEL = "llama3.2"
 DEFAULT_OLLAMA_EMBED_MODEL = "nomic-embed-text"
+DEFAULT_NETWORK_POLICY = "local"
 
 LAST_METRICS = ProviderMetrics(provider="ollama")
 
 
+class _RejectRedirects(HTTPRedirectHandler):
+    """Prevent a prompt-bearing POST from being forwarded to another host."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        raise ProviderMisconfiguredError("Ollama HTTP redirects are refused by policy")
+
+
+def _urlopen(request: Request, *, timeout: float):
+    if _network_policy() == "unrestricted":
+        return urlopen(request, timeout=timeout)  # noqa: S310 - explicitly unrestricted
+    return build_opener(_RejectRedirects()).open(request, timeout=timeout)
+
+
 def _host() -> str:
-    return (os.getenv("OLLAMA_HOST") or DEFAULT_OLLAMA_HOST).strip().rstrip("/")
+    host = (os.getenv("OLLAMA_HOST") or DEFAULT_OLLAMA_HOST).strip().rstrip("/")
+    _validate_network_target(host)
+    return host
+
+
+def _network_policy() -> str:
+    policy = (os.getenv("OLLAMA_NETWORK_POLICY") or DEFAULT_NETWORK_POLICY).strip().lower()
+    aliases = {"strict": "local", "none": "disabled", "off": "disabled"}
+    policy = aliases.get(policy, policy)
+    if policy not in {"disabled", "local", "unrestricted"}:
+        raise ProviderMisconfiguredError(
+            "OLLAMA_NETWORK_POLICY must be disabled, local, or unrestricted"
+        )
+    return policy
+
+
+def _validate_network_target(url: str) -> None:
+    """Enforce the configured policy for an initial or redirected URL."""
+
+    policy = _network_policy()
+    if policy == "disabled":
+        raise ProviderMisconfiguredError("Ollama network access is disabled by policy")
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ProviderMisconfiguredError("OLLAMA_HOST must be an HTTP(S) URL")
+    if parsed.username or parsed.password:
+        raise ProviderMisconfiguredError("OLLAMA_HOST must not contain credentials")
+    if policy == "unrestricted":
+        return
+    try:
+        addresses = {
+            item[4][0]
+            for item in socket.getaddrinfo(parsed.hostname, parsed.port, type=socket.SOCK_STREAM)
+        }
+    except socket.gaierror as exc:
+        raise ProviderMisconfiguredError("OLLAMA_HOST could not be resolved locally") from exc
+    if not addresses or any(not ipaddress.ip_address(address).is_loopback for address in addresses):
+        raise ProviderMisconfiguredError(
+            "OLLAMA_HOST must resolve only to loopback addresses in local mode"
+        )
 
 
 def _model() -> str:
@@ -43,7 +104,8 @@ def _post_json(path: str, payload: dict[str, Any], *, timeout: float) -> dict[st
     data = json.dumps(payload).encode("utf-8")
     request = Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
     try:
-        with urlopen(request, timeout=timeout) as response:  # noqa: S310 - configured local provider URL
+        with _urlopen(request, timeout=timeout) as response:
+            _validate_network_target(response.geturl())
             raw = response.read().decode("utf-8")
     except TimeoutError as exc:
         raise ProviderTimeoutError("Ollama request timed out") from exc

--- a/tests/providers/test_llm_ollama.py
+++ b/tests/providers/test_llm_ollama.py
@@ -6,13 +6,19 @@ from urllib.error import URLError
 
 import pytest
 
-from singular.providers import ProviderExecutionError, ProviderTimeoutError, ProviderUnavailableError
+from singular.providers import (
+    ProviderExecutionError,
+    ProviderMisconfiguredError,
+    ProviderTimeoutError,
+    ProviderUnavailableError,
+)
 from singular.providers import llm_ollama
 
 
 class FakeHTTPResponse:
-    def __init__(self, payload: dict[str, object]):
+    def __init__(self, payload: dict[str, object], url: str = "http://127.0.0.1:11434/api"):
         self.payload = payload
+        self.url = url
 
     def __enter__(self):
         return self
@@ -23,17 +29,21 @@ class FakeHTTPResponse:
     def read(self) -> bytes:
         return json.dumps(self.payload).encode("utf-8")
 
+    def geturl(self) -> str:
+        return self.url
+
 
 def test_generate_reply_posts_to_configured_ollama_host(monkeypatch):
     calls = []
     monkeypatch.setenv("OLLAMA_HOST", "http://ollama.test/")
     monkeypatch.setenv("OLLAMA_MODEL", " mistral ")
+    monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "unrestricted")
 
     def fake_urlopen(request, timeout):
         calls.append((request.full_url, json.loads(request.data.decode("utf-8")), timeout))
         return FakeHTTPResponse({"response": "bonjour\x00"})
 
-    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+    monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
 
     assert llm_ollama.generate_reply("salut", timeout=2.5) == "bonjour"
     assert calls == [
@@ -53,7 +63,7 @@ def test_embed_uses_configured_embedding_model(monkeypatch):
         calls.append((request.full_url, json.loads(request.data.decode("utf-8")), timeout))
         return FakeHTTPResponse({"embedding": [1, "2.5", 3.0]})
 
-    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+    monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
 
     assert llm_ollama.embed("texte", timeout=4.0) == [1.0, 2.5, 3.0]
     assert calls[0][1] == {"model": "nomic-embed-text", "prompt": "texte"}
@@ -64,7 +74,7 @@ def test_timeout_maps_to_provider_timeout(monkeypatch):
     def fake_urlopen(_request, timeout):
         raise socket.timeout("too slow")
 
-    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+    monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
 
     with pytest.raises(ProviderTimeoutError):
         llm_ollama.generate_reply("salut")
@@ -74,7 +84,7 @@ def test_network_error_maps_to_provider_unavailable(monkeypatch):
     def fake_urlopen(_request, timeout):
         raise URLError("connection refused")
 
-    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+    monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
 
     with pytest.raises(ProviderUnavailableError):
         llm_ollama.generate_reply("salut")
@@ -84,7 +94,7 @@ def test_schema_errors_map_to_provider_execution(monkeypatch):
     def fake_urlopen(_request, timeout):
         return FakeHTTPResponse({"not_response": "missing"})
 
-    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+    monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
 
     with pytest.raises(ProviderExecutionError, match="missing response text"):
         llm_ollama.generate_reply("salut")
@@ -94,7 +104,7 @@ def test_healthcheck_reports_unavailable(monkeypatch):
     def fake_urlopen(_request, timeout):
         raise URLError("connection refused")
 
-    monkeypatch.setattr(llm_ollama, "urlopen", fake_urlopen)
+    monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
 
     result = llm_ollama.healthcheck()
     assert result["ok"] is False
@@ -104,3 +114,35 @@ def test_healthcheck_reports_unavailable(monkeypatch):
 
 def test_cost_estimate_is_zero_for_local_ollama():
     assert llm_ollama.cost_estimate("prompt", "completion") == 0.0
+
+
+@pytest.mark.parametrize("host", ["http://127.0.0.1:11434", "http://[::1]:11434", "http://localhost:11434"])
+def test_local_policy_accepts_loopback(monkeypatch, host):
+    monkeypatch.setenv("OLLAMA_HOST", host)
+    monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "local")
+    assert llm_ollama._host() == host
+
+
+@pytest.mark.parametrize("host", ["http://192.168.1.20:11434", "https://203.0.113.10"])
+def test_local_policy_rejects_lan_and_public_hosts(monkeypatch, host):
+    monkeypatch.setenv("OLLAMA_HOST", host)
+    monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "local")
+    with pytest.raises(ProviderMisconfiguredError, match="loopback"):
+        llm_ollama._host()
+
+
+def test_local_policy_rejects_http_redirect_to_public_host(monkeypatch):
+    monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "local")
+
+    def fake_urlopen(_request, timeout):
+        return FakeHTTPResponse({"response": "unsafe"}, "https://203.0.113.10/api/generate")
+
+    monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
+    with pytest.raises(ProviderMisconfiguredError, match="loopback"):
+        llm_ollama.generate("hello")
+
+
+def test_disabled_policy_refuses_even_loopback(monkeypatch):
+    monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "disabled")
+    with pytest.raises(ProviderMisconfiguredError, match="disabled"):
+        llm_ollama.generate("hello")

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -134,6 +134,16 @@ def test_adversarial_io_is_rejected_before_execution(attack):
         run(attack)
 
 
+def test_sandbox_rejects_enabled_network_policy():
+    with pytest.raises(SandboxError, match="only supports disabled"):
+        sandbox._command("docker", SandboxConfig(network_policy="host"))
+
+
+def test_sandbox_network_policy_defaults_to_none(monkeypatch):
+    monkeypatch.delenv("SINGULAR_SANDBOX_NETWORK_POLICY", raising=False)
+    assert SandboxConfig.from_environment().network_policy == "none"
+
+
 def test_refuses_platform_without_resource_limits(monkeypatch):
     monkeypatch.setattr(sandbox, "resource_module", None)
     with pytest.raises(SandboxError, match="resource limits"):


### PR DESCRIPTION
### Motivation

- Clarifier les frontières de confiance entre le processus hôte, les fournisseurs LLM et le code muté non fiable afin d'éviter des fuites de secrets via les prompts. 
- Empêcher les fournisseurs LLM locaux de suivre silencieusement des redirections ou de pointer vers des hôtes LAN/public depuis une configuration par défaut censée être locale. 
- Appliquer une politique réseau explicite et restrictive par défaut pour le sandbox d'exécution du code muté afin de refuser toute configuration qui abaisserait l'isolation système.

### Description

- Ajout d'une politique réseau pour Ollama via la variable d'environnement `OLLAMA_NETWORK_POLICY` (valeurs acceptées : `disabled`, `local`, `unrestricted`) avec comportement par défaut restrictif `local`, et validation de l'URL `OLLAMA_HOST` dans `_host()`/`_validate_network_target` pour refuser hôtes non-loopback en mode `local`.
- Refus explicite des redirections HTTP dans la politique non-`unrestricted` en remplaçant l'appel direct `urlopen` par un wrapper `_urlopen` qui utilise un `HTTPRedirectHandler` personnalisé pour empêcher le forward d'un POST contenant le prompt.
- Import de `ipaddress` et résolution DNS locale via `socket.getaddrinfo()` pour s'assurer que toutes les adresses résolues sont des adresses loopback lorsque le mode est `local`; erreurs remontées comme `ProviderMisconfiguredError`/`ProviderUnavailableError` selon le cas.
- Ajout de la configuration `network_policy` au `SandboxConfig` et lecture de `SINGULAR_SANDBOX_NETWORK_POLICY` (par défaut `none`), avec refus explicite dans `_command()` si une politique autre que `none`/`disabled` est demandée, garantissant `--network=none` au niveau OCI.
- Mises à jour des docs pour préciser : (1) que l'hôte, le fournisseur LLM et le code muté sont trois frontières distinctes, (2) que OpenAI transmet les prompts à un service externe, (3) que Ollama est « local » seulement si `OLLAMA_HOST` résout vers loopback, et (4) la politique réseau par défaut du sandbox.
- Tests ajoutés/actualisés pour couvrir `OLLAMA_HOST` loopback acceptés, hôtes LAN/public rejetés, redirections HTTP rejetées en mode `local`, mode Ollama `disabled` refusant les appels, et validations du `SandboxConfig` réseau.

### Testing

- Exécuté `pytest -q tests/providers/test_llm_ollama.py tests/test_sandbox.py` and all tests passed (41 passed). 
- Lint/type/format checks were run via `ruff` and `git diff --check` and reported no issues for the modified files. 
- A full `pytest -q` run in the repository hit a preexisting unrelated collection error (`ImportError` in `tests/test_targeted_lifecycle_narrative_trajectory.py` referencing a missing symbol in `singular.life.loop`) that is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76363c0264832aa06ae5c6b33e9fab)