### PR TITLE
Make `assistant` the default starter profile and expose it in CLI/docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Si vous débutez, suivez **exactement** ces étapes :
 
 À la naissance, Singular initialise un **starter-pack de skills utilitaires** dans `skills/` :
 
+Le profil `assistant`, sélectionné par défaut, fournit le pack complet décrit ci-dessous
+ainsi que les skills arithmétiques historiques. Utilisez `--starter-profile minimal`
+pour ne créer que ces trois skills arithmétiques.
+
 - `validation.py` : vérifications simples d’entrées (ex. texte non vide).
 - `summary.py` : résumé court par extraction des premiers mots.
 - `intent_classification.py` : classification heuristique (`question`, `request`, `statement`).

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -951,8 +951,11 @@ def _add_life_creation_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--starter-profile",
-        default="minimal",
-        help="Profil de starter skills à appliquer (ex: minimal, assistant, ops, creative)",
+        default="assistant",
+        help=(
+            "Profil de starter skills à appliquer "
+            "(défaut: assistant; disponibles: minimal, assistant, ops, creative)"
+        ),
     )
     parser.add_argument(
         "--starter-skill",
@@ -986,6 +989,7 @@ def _create_life_with_bootstrap(
     registry_root = get_registry_root()
     os.environ["SINGULAR_HOME"] = str(metadata.path)
     print(f"Vie créée: {metadata.name} ({metadata.slug}) → {metadata.path}")
+    print(f"Profil starter: {args.starter_profile}")
     print(f"Registre de vies utilisé: {registry_root}")
 
 

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -680,7 +680,7 @@ def bootstrap_life(
     seed: int | None = None,
     *,
     psyche_overrides: dict[str, float] | None = None,
-    starter_profile: str = "minimal",
+    starter_profile: str = "assistant",
     starter_skills: list[str] | None = None,
 ) -> LifeMetadata:
     metadata = create_life(name)

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -23,11 +23,22 @@ from ..resources import config_resource
 
 _PSYCHE_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
 _PSYCHE_DEFAULTS = {trait: 0.5 for trait in _PSYCHE_TRAITS}
-_DEFAULT_STARTER_PROFILE = "minimal"
+_DEFAULT_STARTER_PROFILE = "assistant"
 _BIRTH_SCHEMA_VERSION = 1
 _STARTER_CONFIG_PATH = config_resource("starter_skills.yaml")
 _DEFAULT_STARTER_PROFILES: dict[str, list[str]] = {
     "minimal": ["addition", "subtraction", "multiplication"],
+    "assistant": [
+        "addition",
+        "subtraction",
+        "multiplication",
+        "validation",
+        "summary",
+        "intent_classification",
+        "entity_extraction",
+        "planning",
+        "metrics",
+    ],
 }
 _SKILL_TEMPLATES: dict[str, str] = {
     "addition": (

--- a/tests/test_birth_starter_profiles.py
+++ b/tests/test_birth_starter_profiles.py
@@ -2,7 +2,7 @@ from singular.life.loop import score_code_with_error
 from singular.organisms.birth import _SKILL_TEMPLATES, _resolve_starter_skills
 
 
-def test_resolve_starter_skills_falls_back_to_minimal_profile() -> None:
+def test_resolve_starter_skills_falls_back_to_assistant_profile() -> None:
     profiles = {
         "minimal": ["addition", "subtraction", "multiplication"],
         "assistant": ["summary"],
@@ -10,7 +10,7 @@ def test_resolve_starter_skills_falls_back_to_minimal_profile() -> None:
 
     resolved = _resolve_starter_skills("does-not-exist", ["summary"], profiles=profiles)
 
-    assert resolved == ["addition", "subtraction", "multiplication", "summary"]
+    assert resolved == ["summary"]
 
 
 def test_starter_skill_templates_satisfy_sandbox_scoring_contract() -> None:

--- a/tests/test_cli_birth.py
+++ b/tests/test_cli_birth.py
@@ -73,7 +73,7 @@ def test_birth_alias_and_lives_create_reject_out_of_range_psyche_override(
     "creation_command",
     [["birth"], ["lives", "create"]],
 )
-def test_birth_alias_and_lives_create_use_minimal_starter_profile_by_default(
+def test_birth_alias_and_lives_create_use_assistant_starter_profile_by_default(
     creation_command: list[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -82,13 +82,23 @@ def test_birth_alias_and_lives_create_use_minimal_starter_profile_by_default(
     monkeypatch.delenv("SINGULAR_ROOT", raising=False)
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
 
-    main(["--root", str(root), *creation_command, "--name", "Minimal"])
+    main(["--root", str(root), *creation_command, "--name", "Assistant"])
 
     registry = load_registry()
     slug = registry["active"]
     life_home = Path(registry["lives"][slug].path)
     skills = sorted(path.name for path in (life_home / "skills").glob("*.py"))
-    assert skills == ["addition.py", "multiplication.py", "subtraction.py"]
+    assert skills == [
+        "addition.py",
+        "entity_extraction.py",
+        "intent_classification.py",
+        "metrics.py",
+        "multiplication.py",
+        "planning.py",
+        "subtraction.py",
+        "summary.py",
+        "validation.py",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -133,7 +143,7 @@ def test_birth_alias_and_lives_create_apply_explicit_starter_profile(
     "creation_command",
     [["birth"], ["lives", "create"]],
 )
-def test_birth_alias_and_lives_create_unknown_profile_falls_back_to_minimal_and_adds_explicit_skills(
+def test_birth_alias_and_lives_create_unknown_profile_falls_back_to_assistant(
     creation_command: list[str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -160,7 +170,17 @@ def test_birth_alias_and_lives_create_unknown_profile_falls_back_to_minimal_and_
     slug = registry["active"]
     life_home = Path(registry["lives"][slug].path)
     skills = sorted(path.name for path in (life_home / "skills").glob("*.py"))
-    assert skills == ["addition.py", "multiplication.py", "subtraction.py", "summary.py"]
+    assert skills == [
+        "addition.py",
+        "entity_extraction.py",
+        "intent_classification.py",
+        "metrics.py",
+        "multiplication.py",
+        "planning.py",
+        "subtraction.py",
+        "summary.py",
+        "validation.py",
+    ]
 
 
 def test_birth_prints_deprecation_warning(

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -266,8 +266,21 @@ def test_lives_create_prints_registry_root_used(
 
     main(["--root", str(root), "lives", "create", "--name", "Alpha"])
     out = capsys.readouterr().out
+    assert "Profil starter: assistant" in out
     assert "Registre de vies utilisé:" in out
     assert str(root.resolve()) in out
+
+
+def test_lives_create_help_shows_default_starter_profile(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["lives", "create", "--help"])
+
+    assert excinfo.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "--starter-profile" in help_text
+    assert "défaut: assistant" in " ".join(help_text.split())
 
 
 def test_lives_create_first_run_has_no_missing_registry_warning(

--- a/tests/test_wheel_distribution.py
+++ b/tests/test_wheel_distribution.py
@@ -62,7 +62,9 @@ from singular.sensors.config import load_host_sensor_thresholds
 home = Path("life")
 birth(seed=1, home=home, name="Wheel Life")
 assert (home / "mem" / "identity.json").is_file()
-assert _load_starter_profiles()["minimal"]
+assert _load_starter_profiles()["assistant"]
+assert (home / "skills" / "validation.py").is_file()
+assert (home / "skills" / "metrics.py").is_file()
 assert load_host_sensor_thresholds().cpu_warning_percent == 85.0
 assert load_lifecycle_clock_config().cycle.veille_seconds == 2.0
 assert load_life_definition_config().schema_version == "1.0"


### PR DESCRIPTION
### Motivation

- Align the actual default starter-pack used at birth with the documented starter-pack in the README by making the richer `assistant` profile the default. 

### Description

- Set `_DEFAULT_STARTER_PROFILE` to `"assistant"` and add the `assistant` profile skills to `_DEFAULT_STARTER_PROFILES` in `src/singular/organisms/birth.py` so births receive the full utility starter-pack by default. 
- Update `bootstrap_life()` to default `starter_profile` to `"assistant"` in `src/singular/lives.py` to keep behavior consistent for programmatic life creation. 
- Change the CLI default for `--starter-profile` to `assistant`, expand the help text to show the default and available profiles, and print the selected profile on successful `lives create` in `src/singular/cli.py`. 
- Clarify the README to state that `assistant` is the default starter profile and explain how to request `--starter-profile minimal`. 
- Adjust tests in `tests/test_cli_birth.py`, `tests/test_cli_lives.py`, `tests/test_birth_starter_profiles.py` and `tests/test_wheel_distribution.py` to expect the `assistant` profile by default and to verify the CLI help and creation output accordingly. 

### Testing

- Ran `pytest -q tests/test_cli_birth.py tests/test_cli_lives.py tests/test_birth_starter_profiles.py -k 'not sandbox_scoring_contract'`, which passed (26 passed, 1 deselected). 
- Running the full suite including the sandbox scoring and wheel build revealed environment limitations: the sandbox scoring test requires Podman/Docker and the wheel build requires network access to fetch build backends, causing unrelated failures in this environment. 
- Ran `python -m compileall -q src/singular tests/test_cli_birth.py tests/test_cli_lives.py tests/test_birth_starter_profiles.py tests/test_wheel_distribution.py` which completed without compile errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76395dd634832a9abfe620a5fbb0a7)