### PR TITLE
Add `living` starter profile and integrate living skills with runtime and memory

### DIFF
--- a/configs/starter_skills.yaml
+++ b/configs/starter_skills.yaml
@@ -28,6 +28,16 @@
       "entity_extraction",
       "planning",
       "addition"
+    ],
+    "living": [
+      "observe_world",
+      "assess_needs",
+      "select_goal",
+      "plan_action",
+      "act_on_world",
+      "verify_outcome",
+      "interact",
+      "reflect"
     ]
   },
   "scoring_contract": {

--- a/docs/living_starter_profile.md
+++ b/docs/living_starter_profile.md
@@ -1,0 +1,54 @@
+# Profil de démarrage `living`
+
+Le profil `living` fournit huit capacités élémentaires : observation, évaluation
+des besoins, choix d'objectif, planification, action, vérification du résultat,
+interaction et réflexion. Ce ne sont **pas** les étapes d'une nouvelle boucle.
+Ce sont des skills sélectionnables par `SkillRuntime`, comme les autres skills.
+
+## Raccordement au cycle existant
+
+À chaque exécution, le runtime ajoute au contexte une copie JSON en lecture seule
+de `mem/world_state.json`, `mem/goals.json` (objectifs intrinsèques) et
+`mem/psyche.json`. Le skill ne peut ni ouvrir ces fichiers ni les modifier. Une
+action réussie continue d'utiliser le mapping d'effets de `sim_world`, publie les
+événements `skill.execution.*` et `world.effect.applied`, puis une capacité
+`living.*` publie `living.stage.completed` et écrit le même résultat dans
+`mem/episodic.jsonl`. L'orchestrateur, la perception, l'arbitrage des objectifs et
+la consolidation de mémoire restent donc les propriétaires du cycle de vie.
+
+## Garanties et limites
+
+### Déterministe
+
+* La résolution du profil, l'ordre des huit fichiers générés, l'extraction des
+  métadonnées du catalogue et le filtrage par capacité sont déterministes pour
+  des fichiers d'entrée identiques.
+* Les huit fonctions de départ sont des règles locales : elles testent seulement
+  la présence de données explicites dans leur contexte et renvoient `0.0` ou
+  `1.0`. Elles ne font aucun appel réseau et aucun échantillonnage.
+* Le seed de naissance stabilise le nom généré et le `soulseed`. Les horodatages,
+  identifiants de naissance et détails d'exécution propres à la plateforme ne
+  sont pas promis identiques bit à bit.
+* Le test d'intégration remplace uniquement la frontière du conteneur sandbox par
+  un exécuteur Python local déterministe. Il exerce les vrais fichiers de
+  naissance, le catalogue, le runtime, le bus, les conséquences du monde et la
+  mémoire épisodique.
+
+### Dépendant d'un fournisseur LLM
+
+Les skills de ce profil n'appellent pas de LLM. Si l'orchestrateur fournit un
+objectif, un plan, une action, une interaction ou une réflexion produits par son
+adaptateur LLM, leur **contenu** et leur reproductibilité dépendent du fournisseur,
+du modèle, de sa version, du prompt, des paramètres d'échantillonnage et de sa
+disponibilité. Le profil ne présente pas ces sorties comme déterministes et ne
+contourne pas l'adaptateur existant.
+
+### Ce qui peut réellement évoluer
+
+Peuvent évoluer par les mécanismes existants : les poids et l'historique des
+objectifs intrinsèques, les traits et l'état social de la psyché, les ressources
+et effets de `world_state.json`, les métriques et états de cycle de vie des
+skills, ainsi que les épisodes ensuite consolidés. Les huit sources générées et
+leurs métadonnées ne s'auto-modifient pas : elles ne changent que par mutation de
+skill, configuration ou mise à jour du logiciel déjà gouvernée par Singular.
+

--- a/src/singular/data/configs/starter_skills.yaml
+++ b/src/singular/data/configs/starter_skills.yaml
@@ -28,6 +28,16 @@
       "entity_extraction",
       "planning",
       "addition"
+    ],
+    "living": [
+      "observe_world",
+      "assess_needs",
+      "select_goal",
+      "plan_action",
+      "act_on_world",
+      "verify_outcome",
+      "interact",
+      "reflect"
     ]
   },
   "scoring_contract": {

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -39,6 +39,16 @@ _DEFAULT_STARTER_PROFILES: dict[str, list[str]] = {
         "planning",
         "metrics",
     ],
+    "living": [
+        "observe_world",
+        "assess_needs",
+        "select_goal",
+        "plan_action",
+        "act_on_world",
+        "verify_outcome",
+        "interact",
+        "reflect",
+    ],
 }
 _SKILL_TEMPLATES: dict[str, str] = {
     "addition": (
@@ -128,6 +138,60 @@ _SKILL_TEMPLATES: dict[str, str] = {
         "    return max(0.0, min(1.0, ratio))\n\n"
         "result = completion_ratio(1, 2)\n"
     ),
+    "observe_world": (
+        '"""Observe the persisted world supplied by the runtime.\n\n'
+        "Capabilities: living.observation, perception\nInput: dict\nOutput: float\n"
+        'Estimated_cost: 0.05\nReliability: 1.0\n"""\n\n'
+        "def run(context):\n"
+        "    world = context.get('singular_state', {}).get('world', {})\n"
+        "    return 1.0 if world else 0.0\n\nresult = 0.0\n"
+    ),
+    "assess_needs": (
+        '"""Assess needs from world resources and psyche.\n\n'
+        "Capabilities: living.needs_assessment\nInput: dict\nOutput: float\n"
+        'Estimated_cost: 0.05\nReliability: 1.0\n"""\n\n'
+        "def run(context):\n"
+        "    state = context.get('singular_state', {})\n"
+        "    return 1.0 if state.get('world') and state.get('psyche') else 0.0\n\nresult = 0.0\n"
+    ),
+    "select_goal": (
+        '"""Select among existing intrinsic goals.\n\n'
+        "Capabilities: living.goal_selection, intrinsic_goals\nInput: dict\nOutput: float\n"
+        'Estimated_cost: 0.05\nReliability: 1.0\n"""\n\n'
+        "def run(context):\n"
+        "    goals = context.get('singular_state', {}).get('goals', {})\n"
+        "    return 1.0 if goals.get('weights') else 0.0\n\nresult = 0.0\n"
+    ),
+    "plan_action": (
+        '"""Build a bounded action plan from the selected goal.\n\n'
+        "Capabilities: living.planning, planning\nInput: dict\nOutput: float\n"
+        'Estimated_cost: 0.08\nReliability: 1.0\n"""\n\n'
+        "def run(context):\n    return 1.0 if context.get('goal') else 0.0\n\nresult = 0.0\n"
+    ),
+    "act_on_world": (
+        '"""Request an action through the existing skill runtime.\n\n'
+        "Capabilities: living.action\nInput: dict\nOutput: float\n"
+        'Estimated_cost: 0.1\nReliability: 1.0\n"""\n\n'
+        "def run(context):\n    return 1.0 if context.get('action') else 0.0\n\nresult = 0.0\n"
+    ),
+    "verify_outcome": (
+        '"""Verify an action consequence already represented by the runtime.\n\n'
+        "Capabilities: living.outcome_verification\nInput: dict\nOutput: float\n"
+        'Estimated_cost: 0.05\nReliability: 1.0\n"""\n\n'
+        "def run(context):\n    return 1.0 if context.get('consequence') else 0.0\n\nresult = 0.0\n"
+    ),
+    "interact": (
+        '"""Represent a social interaction for the event bus and psyche.\n\n'
+        "Capabilities: living.interaction, social\nInput: dict\nOutput: float\n"
+        'Estimated_cost: 0.08\nReliability: 1.0\n"""\n\n'
+        "def run(context):\n    return 1.0 if context.get('interaction') else 0.0\n\nresult = 0.0\n"
+    ),
+    "reflect": (
+        '"""Reflect on an episodic outcome without inventing a second loop.\n\n'
+        "Capabilities: living.reflection, episodic_memory\nInput: dict\nOutput: float\n"
+        'Estimated_cost: 0.08\nReliability: 1.0\n"""\n\n'
+        "def run(context):\n    return 1.0 if context.get('episode') else 0.0\n\nresult = 0.0\n"
+    ),
 }
 
 
@@ -155,7 +219,9 @@ def _resolve_psyche_overrides(
     return normalized
 
 
-def _load_starter_profiles(config_path: Any = _STARTER_CONFIG_PATH) -> dict[str, list[str]]:
+def _load_starter_profiles(
+    config_path: Any = _STARTER_CONFIG_PATH,
+) -> dict[str, list[str]]:
     """Load starter skill profiles from configuration with a safe default fallback."""
 
     if not config_path.exists():
@@ -335,6 +401,7 @@ def birth(
     mem_dir = home / "mem"
     values_defaults = ValueWeights().to_dict()
     goals_init = GoalState().to_dict()
+    _atomic_write_json(mem_dir / "goals.json", {"schema_version": 1, **goals_init})
     world_init = default_world_state()
     save_world_state(world_init, path=mem_dir / "world_state.json")
     _atomic_write_json(

--- a/src/singular/skills/runtime.py
+++ b/src/singular/skills/runtime.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +12,7 @@ from singular.environment import sim_world
 from singular.events import EventBus, get_global_event_bus
 from singular.life import sandbox
 from singular.life.skill_catalog import read_skill_catalog, refresh_skill_catalog
-from singular.memory import read_skills
+from singular.memory import append_jsonl_line_safe, read_skills
 
 
 @dataclass(frozen=True)
@@ -46,19 +48,29 @@ class SkillRuntime:
         self.mem_dir = Path(mem_dir)
         self.bus = bus or get_global_event_bus()
 
-    def execute_best_skill(self, task: str | dict[str, Any], context: dict[str, Any]) -> SkillExecutionResult:
+    def execute_best_skill(
+        self, task: str | dict[str, Any], context: dict[str, Any]
+    ) -> SkillExecutionResult:
         """Execute the best compatible skill for ``task`` and ``context``."""
 
         task_dict = self._normalize_task(task)
         skills_state = read_skills(self.mem_dir / "skills.json")
         catalog = read_skill_catalog(self.mem_dir)
         if not catalog:
-            catalog = refresh_skill_catalog(skills_dir=self.skills_dir, mem_dir=self.mem_dir)
+            catalog = refresh_skill_catalog(
+                skills_dir=self.skills_dir, mem_dir=self.mem_dir
+            )
 
-        strategy = context.get("execution_strategy", {}) if isinstance(context, dict) else {}
-        candidates = self._compatible_candidates(task_dict, skills_state, catalog, strategy=strategy)
+        strategy = (
+            context.get("execution_strategy", {}) if isinstance(context, dict) else {}
+        )
+        candidates = self._compatible_candidates(
+            task_dict, skills_state, catalog, strategy=strategy
+        )
         if not candidates:
-            result = SkillExecutionResult(skill=None, status="failed", reason="no_compatible_skill")
+            result = SkillExecutionResult(
+                skill=None, status="failed", reason="no_compatible_skill"
+            )
             self._apply_world_effect("skill.execution.no_compatible")
             self.bus.publish(
                 "skill.execution.failed",
@@ -80,7 +92,8 @@ class SkillRuntime:
         )
         try:
             code = top.path.read_text(encoding="utf-8")
-            wrapped = self._wrap_for_sandbox(code, context)
+            runtime_context = self._context_with_persisted_state(context)
+            wrapped = self._wrap_for_sandbox(code, runtime_context)
             output = sandbox.run(wrapped)
             result = SkillExecutionResult(
                 skill=top.skill,
@@ -98,6 +111,7 @@ class SkillRuntime:
                 },
             )
             self._apply_world_effect("skill.execution.succeeded")
+            self._record_living_stage(top, task_dict, output)
             return result
         except Exception as exc:
             result = SkillExecutionResult(
@@ -117,6 +131,53 @@ class SkillRuntime:
             )
             self._apply_world_effect("skill.execution.failed")
             return result
+
+    def _context_with_persisted_state(self, context: dict[str, Any]) -> dict[str, Any]:
+        """Expose canonical life state read-only to a sandboxed skill.
+
+        Skills receive JSON values, never paths or persistence APIs.  Consequently
+        all changes still pass through the existing runtime, event bus and world
+        effect machinery rather than establishing another life loop.
+        """
+
+        enriched = dict(context)
+        state: dict[str, Any] = {}
+        for name in ("world", "goals", "psyche"):
+            path = (
+                self.mem_dir / f"{name}_state.json"
+                if name == "world"
+                else self.mem_dir / f"{name}.json"
+            )
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                payload = {}
+            state[name] = payload if isinstance(payload, dict) else {}
+        enriched["singular_state"] = state
+        return enriched
+
+    def _record_living_stage(
+        self,
+        candidate: _ScoredCandidate,
+        task: dict[str, Any],
+        output: Any,
+    ) -> None:
+        """Project living capabilities onto the normal bus and episodic memory."""
+
+        tags = candidate.metadata.get("catalog", {}).get("capability_tags", [])
+        living_tags = [str(tag) for tag in tags if str(tag).startswith("living.")]
+        if not living_tags:
+            return
+        payload = {
+            "event": "living_skill_completed",
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "skill": candidate.skill,
+            "capabilities": living_tags,
+            "task": task.get("name", "task"),
+            "outcome": output,
+        }
+        self.bus.publish("living.stage.completed", dict(payload), payload_version=1)
+        append_jsonl_line_safe(self.mem_dir / "episodic.jsonl", payload)
 
     def _apply_world_effect(self, action_type: str) -> None:
         effect = sim_world.map_action_type_to_effect(action_type)
@@ -163,27 +224,59 @@ class SkillRuntime:
 
             raw_metadata = skills_state.get(skill)
             metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
-            lifecycle = metadata.get("lifecycle") if isinstance(metadata.get("lifecycle"), dict) else {}
-            if lifecycle.get("state") in {"archived", "deleted", "temporarily_disabled"}:
+            lifecycle = (
+                metadata.get("lifecycle")
+                if isinstance(metadata.get("lifecycle"), dict)
+                else {}
+            )
+            if lifecycle.get("state") in {
+                "archived",
+                "deleted",
+                "temporarily_disabled",
+            }:
                 continue
 
-            signature = metadata.get("signature") if isinstance(metadata.get("signature"), str) else None
-            if isinstance(required_signature, str) and isinstance(signature, str) and signature != required_signature:
+            signature = (
+                metadata.get("signature")
+                if isinstance(metadata.get("signature"), str)
+                else None
+            )
+            if (
+                isinstance(required_signature, str)
+                and isinstance(signature, str)
+                and signature != required_signature
+            ):
                 continue
 
-            descriptor_caps = descriptor.get("capability_tags") if isinstance(descriptor.get("capability_tags"), list) else []
-            metadata_caps = metadata.get("capabilities") if isinstance(metadata.get("capabilities"), list) else []
+            descriptor_caps = (
+                descriptor.get("capability_tags")
+                if isinstance(descriptor.get("capability_tags"), list)
+                else []
+            )
+            metadata_caps = (
+                metadata.get("capabilities")
+                if isinstance(metadata.get("capabilities"), list)
+                else []
+            )
             capability_tags = {str(cap) for cap in [*descriptor_caps, *metadata_caps]}
-            if required_capabilities and not required_capabilities.issubset(capability_tags):
+            if required_capabilities and not required_capabilities.issubset(
+                capability_tags
+            ):
                 continue
 
             preconditions = set(descriptor.get("preconditions", []))
-            if required_preconditions and not required_preconditions.issubset(preconditions):
+            if required_preconditions and not required_preconditions.issubset(
+                preconditions
+            ):
                 continue
 
-            if isinstance(required_input, str) and descriptor.get("input_format") not in {required_input, "unknown"}:
+            if isinstance(required_input, str) and descriptor.get(
+                "input_format"
+            ) not in {required_input, "unknown"}:
                 continue
-            if isinstance(required_output, str) and descriptor.get("output_format") not in {required_output, "unknown"}:
+            if isinstance(required_output, str) and descriptor.get(
+                "output_format"
+            ) not in {required_output, "unknown"}:
                 continue
 
             risk = self._estimated_risk(metadata, descriptor)
@@ -194,7 +287,9 @@ class SkillRuntime:
                     skill=skill,
                     path=path,
                     metadata={"state": metadata, "catalog": descriptor},
-                    score=self._score_candidate(metadata, descriptor, strategy=strategy),
+                    score=self._score_candidate(
+                        metadata, descriptor, strategy=strategy
+                    ),
                 )
             )
         return candidates
@@ -206,10 +301,14 @@ class SkillRuntime:
         *,
         strategy: dict[str, Any] | None = None,
     ) -> float:
-        metrics = metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
+        metrics = (
+            metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
+        )
         usage_count = max(int(metrics.get("usage_count", 0) or 0), 0)
         average_gain = float(metrics.get("average_gain", 0.0) or 0.0)
-        average_cost = float(metrics.get("average_cost", descriptor.get("estimated_cost", 0.5)) or 0.0)
+        average_cost = float(
+            metrics.get("average_cost", descriptor.get("estimated_cost", 0.5)) or 0.0
+        )
         failure_count = max(int(metrics.get("failure_count", 0) or 0), 0)
 
         success_rate = float(descriptor.get("reliability", 0.5) or 0.5)
@@ -221,7 +320,8 @@ class SkillRuntime:
         resource_cost = max(0.0, average_cost)
         risk = self._estimated_risk(metadata, descriptor)
         mode = str((strategy or {}).get("mode", "balanced"))
-        frustration = max(0.0, min(1.0, float((strategy or {}).get("frustration", 0.0) or 0.0))
+        frustration = max(
+            0.0, min(1.0, float((strategy or {}).get("frustration", 0.0) or 0.0))
         )
         urgency = max(0.0, min(1.0, float((strategy or {}).get("urgency", 0.0) or 0.0)))
 
@@ -244,28 +344,59 @@ class SkillRuntime:
             expected_utility += novelty_bonus * 0.15
             risk_w -= 0.03
 
-        return (expected_utility * utility_w) + (success_rate * success_w) - (resource_cost * cost_w) - (risk * risk_w)
+        return (
+            (expected_utility * utility_w)
+            + (success_rate * success_w)
+            - (resource_cost * cost_w)
+            - (risk * risk_w)
+        )
 
-    def _estimated_risk(self, metadata: dict[str, Any], descriptor: dict[str, Any]) -> float:
-        metrics = metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
+    def _estimated_risk(
+        self, metadata: dict[str, Any], descriptor: dict[str, Any]
+    ) -> float:
+        metrics = (
+            metadata.get("metrics") if isinstance(metadata.get("metrics"), dict) else {}
+        )
         usage_count = max(int(metrics.get("usage_count", 0) or 0), 0)
         failure_count = max(int(metrics.get("failure_count", 0) or 0), 0)
         historical_risk = (failure_count / usage_count) if usage_count else 0.5
-        declared_risk = float(metadata.get("risk", 1.0 - float(descriptor.get("reliability", 0.5))) or historical_risk)
+        declared_risk = float(
+            metadata.get("risk", 1.0 - float(descriptor.get("reliability", 0.5)))
+            or historical_risk
+        )
         return max(0.0, min(1.0, declared_risk))
 
     def _normalize_task(self, task: str | dict[str, Any]) -> dict[str, Any]:
         if isinstance(task, str):
-            return {"name": task, "capabilities": [], "preconditions": [], "max_risk": 1.0}
-        capabilities = task.get("capabilities") if isinstance(task.get("capabilities"), list) else []
-        preconditions = task.get("preconditions") if isinstance(task.get("preconditions"), list) else []
+            return {
+                "name": task,
+                "capabilities": [],
+                "preconditions": [],
+                "max_risk": 1.0,
+            }
+        capabilities = (
+            task.get("capabilities")
+            if isinstance(task.get("capabilities"), list)
+            else []
+        )
+        preconditions = (
+            task.get("preconditions")
+            if isinstance(task.get("preconditions"), list)
+            else []
+        )
         normalized = {
             "name": str(task.get("name") or "task"),
-            "signature": task.get("signature") if isinstance(task.get("signature"), str) else None,
+            "signature": task.get("signature")
+            if isinstance(task.get("signature"), str)
+            else None,
             "capabilities": [str(cap) for cap in capabilities],
             "preconditions": [str(pre) for pre in preconditions],
-            "input_format": task.get("input_format") if isinstance(task.get("input_format"), str) else None,
-            "output_format": task.get("output_format") if isinstance(task.get("output_format"), str) else None,
+            "input_format": task.get("input_format")
+            if isinstance(task.get("input_format"), str)
+            else None,
+            "output_format": task.get("output_format")
+            if isinstance(task.get("output_format"), str)
+            else None,
             "max_risk": float(task.get("max_risk", 1.0) or 1.0),
         }
         return normalized
@@ -282,7 +413,9 @@ class SkillRuntime:
         )
 
 
-def execute_best_skill(task: str | dict[str, Any], context: dict[str, Any]) -> SkillExecutionResult:
+def execute_best_skill(
+    task: str | dict[str, Any], context: dict[str, Any]
+) -> SkillExecutionResult:
     """Convenience API using default paths and global event bus."""
 
     from singular.memory import get_base_dir, get_mem_dir

--- a/tests/test_living_starter_integration.py
+++ b/tests/test_living_starter_integration.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+
+from singular.events import EventBus
+from singular.organisms.birth import birth
+from singular.skills.runtime import SkillRuntime
+
+
+def _deterministic_sandbox(source: str):
+    namespace: dict = {}
+    exec(source, namespace, namespace)
+    return namespace["result"]
+
+
+def test_birth_perception_decision_action_consequence_memory(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Exercise one static path through existing runtime integration points."""
+
+    monkeypatch.setattr("singular.skills.runtime.sandbox.run", _deterministic_sandbox)
+    home = tmp_path / "living"
+    birth(seed=7, home=home, name="Ada", starter_profile="living")
+
+    events: list[str] = []
+    bus = EventBus()
+    for event_type in (
+        "skill.execution.succeeded",
+        "world.effect.applied",
+        "living.stage.completed",
+    ):
+        bus.subscribe(event_type, lambda event: events.append(event.event_type))
+    runtime = SkillRuntime(skills_dir=home / "skills", mem_dir=home / "mem", bus=bus)
+
+    perception = runtime.execute_best_skill(
+        {"name": "perceive", "capabilities": ["living.observation"]}, {}
+    )
+    decision = runtime.execute_best_skill(
+        {"name": "decide", "capabilities": ["living.goal_selection"]}, {}
+    )
+    action = runtime.execute_best_skill(
+        {"name": "act", "capabilities": ["living.action"]},
+        {"action": "inspect"},
+    )
+
+    assert [perception.output, decision.output, action.output] == [1.0, 1.0, 1.0]
+    assert events.count("living.stage.completed") == 3
+    assert events.count("world.effect.applied") == 3
+    world_effects = json.loads((home / "mem" / "world_effects.json").read_text())
+    assert world_effects["last_effect_count"] == 1
+    episodes = [
+        json.loads(line)
+        for line in (home / "mem" / "episodic.jsonl").read_text().splitlines()
+    ]
+    assert [episode["task"] for episode in episodes] == ["perceive", "decide", "act"]
+    assert all(episode["event"] == "living_skill_completed" for episode in episodes)


### PR DESCRIPTION
### Motivation

- Introduire un profil `living` couvrant observation, évaluation des besoins, choix d’objectif, planification, action, vérification, interaction et réflexion afin de fournir des compétences de base exploitables par le runtime existant.
- Faire en sorte que ces compétences s’appuient sur l’état canonique (`world_state.json`, objectifs intrinsèques, `psyche.json`), le bus d’événements et la mémoire épisodique plutôt que de créer une boucle de vie parallèle.
- Rendre clair ce qui est déterministe localement et ce qui dépend d’un fournisseur LLM, pour permettre un test d’intégration statiquement déterministe du parcours naissance→perception→décision→action→conséquence→mémoire.

### Description

- Ajout du profil `living` dans `configs/starter_skills.yaml` et `src/singular/data/configs/starter_skills.yaml` avec huit compétences (`observe_world`, `assess_needs`, `select_goal`, `plan_action`, `act_on_world`, `verify_outcome`, `interact`, `reflect`).
- Ajout des modèles correspondants dans `_SKILL_TEMPLATES` de `src/singular/organisms/birth.py` et écriture de `mem/goals.json` à la naissance via `_atomic_write_json` pour rendre les objectifs intrinsèques immédiatement accessibles.
- Enrichissement du contexte passé aux skills dans `src/singular/skills/runtime.py` via `_context_with_persisted_state` (lecture JSON en lecture seule de `world_state.json`, `goals.json`, `psyche.json`) et publication/écriture des résultats `living.*` sur le bus et dans `mem/episodic.jsonl` via `_record_living_stage` afin de réutiliser le mécanisme existant d’effets de monde (`sim_world`) et d’événements.
- Documentation ajoutée `docs/living_starter_profile.md` précisant les garanties (déterminisme local), les dépendances LLM et ce qui peut évoluer, et ajout d’un test d’intégration déterministe `tests/test_living_starter_integration.py` couvrant naissance→perception→décision→action→conséquence→mémoire.

### Testing

- Exécution ciblée des tests : `pytest -q tests/test_living_starter_integration.py tests/test_skill_runtime.py tests/test_cli_birth.py` — 17 tests réussis (all passed).
- Outils de style/formattage : `ruff check` et `ruff format --check` sur les fichiers modifiés — vérifications passées et fichiers reformattés où nécessaire.
- Vérification de cohérence : `git diff --check` — sans erreurs; note qu’un `pytest -q` global échoue lors de la collecte sur un test préexistant non lié (`CHECKPOINT_VERSION` manquant dans `singular.life.loop`), ce qui est indépendant de ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a763abca850832aad49ece7692dce27)