### PR TITLE
Add bilingual CLI reference, extract `_build_parser`, and add parity tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,23 @@ singular dashboard
 
 ## 📚 Tutoriels et gouvernance
 
+### Parcours par objectif
+
+| Parcours | Point de départ | Commandes de référence |
+|---|---|---|
+| Découverte | [Quickstart](#-quickstart) | [`quickstart`, `lives create`, `status`](docs/cli-reference.fr.md#quickstart) |
+| Conversation | [Guide d’utilisation](#-guide-dutilisation-clair-pas-à-pas) | [`talk`](docs/cli-reference.fr.md#talk) |
+| Évolution | [CLI `loop`](#cli-loop-budget-en-secondes) | [`loop`, `quest`, `synthesize`](docs/cli-reference.fr.md#loop) |
+| Supervision permanente | [Exécution permanente](#-exécution-permanente-systemd-ou-docker) | [`watch`, `daemon`, `orchestrate run`](docs/cli-reference.fr.md#watch) |
+| Diagnostic | [Lecture du dashboard](#comment-lire-le-dashboard-rapidement) | [`status`, `report`, `diagnose`, `doctor`](docs/cli-reference.fr.md#diagnose) |
+| Gouvernance | [Sécurité](#-security) | [`policy`, `values`, `beliefs`](docs/cli-reference.fr.md#policy) |
+| Reproduction | [Reproduction](#-reproduction) | [`spawn`, `lives reproduce`](docs/cli-reference.fr.md#lives-reproduce) |
+| Écosystème | [Gérer plusieurs vies](#-gérer-plusieurs-vies) | [`ecosystem run`, relations entre vies](docs/cli-reference.fr.md#ecosystem-run) |
+| Sauvegarde | [Registre des générations et rollback](#registre-des-générations-et-rollback) | [`report --export`, `rollback`, `lives archive`](docs/cli-reference.fr.md#rollback) |
+| Suppression | [Désinstallation](#-désinstallation) | [`retention run`, `lives delete`, `uninstall`](docs/cli-reference.fr.md#uninstall) |
+
+La [référence CLI française](docs/cli-reference.fr.md) et sa [version anglaise](docs/cli-reference.en.md) détaillent, pour chaque sous-commande, la syntaxe, les défauts, les fichiers et les effets de bord.
+
 - [Tutoriel FR — créer une vie, ajouter une compétence, lancer un tick et lire les logs](docs/tutorial_create_life.fr.md)
 - [Tutorial EN — create a life, add a skill, run a tick and read logs](docs/tutorial_create_life.en.md)
 - [Guide de personnalisation de la gouvernance `policy.yaml`](docs/policy_customization.md)

--- a/docs/cli-reference.en.md
+++ b/docs/cli-reference.en.md
@@ -1,0 +1,1252 @@
+# Singular CLI reference
+
+This reference inventories **every** parser built by `_build_parser`. It is automatically checked by `tests/test_cli_reference.py`.
+
+## Scope and global options
+
+Every syntax accepts, before the command: `singular [--seed INT] [--root PATH] [--home PATH] [--life NAME] [--format {table,json,plain}] [--safe-mode] …`. Defaults: seed/root/home/life `None` (root/home may come from the environment), format `plain`, safe mode `false`. `--root` selects the registry; `--home` directly selects a life directory; `--life` resolves a life in the registry. `SINGULAR_ROOT`, `SINGULAR_HOME`, `OPENAI_API_KEY`, and provider variables can therefore change context.
+
+Paths below are relative to the root or `SINGULAR_HOME`. Always back up before deletion, reset, rollback, or real retention.
+
+<!-- cli-command: embodiment -->
+## `embodiment`
+
+**Syntax :** `singular embodiment [-h] --config CONFIG [--mode {simulation,dry-run,hardware}] [--steps STEPS] [--audit AUDIT]`
+
+**Arguments and defaults :** `--config` (requis/required); `--mode` (`simulation`; choix/choices: simulation, dry-run, hardware); `--steps` (`None`); `--audit` (`None`)
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular embodiment --config configs/embodiment.yaml`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json embodiment --config configs/embodiment.yaml`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: birth -->
+## `birth`
+
+**Syntax :** `singular birth [-h] [--name NAME] [--curiosity CURIOSITY] [--patience PATIENCE] [--playfulness PLAYFULNESS] [--optimism OPTIMISM] [--resilience RESILIENCE] [--starter-profile STARTER_PROFILE] [--starter-skill STARTER_SKILL]`
+
+**Arguments and defaults :** `--name` (`New life`); `--curiosity` (`None`); `--patience` (`None`); `--playfulness` (`None`); `--optimism` (`None`); `--resilience` (`None`); `--starter-profile` (`assistant`); `--starter-skill` (`[]`)
+
+**Prerequisites :** Writable root; valid starter profile.
+
+**Target root and life :** Resolved root; creates and activates a new life.
+
+**Files read or written :** Writes `lives/registry.json` and `lives/<slug>/` (identity, psyche, skills, memory).
+
+**Side effects :** Creates directories and sets `SINGULAR_HOME`; `birth` is deprecated.
+
+**Minimal example :** `singular birth --name Ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json birth --name Ada`
+
+**Common errors :** Trait outside [0,1], invalid name/profile, unwritable root.
+
+<!-- cli-command: spawn -->
+## `spawn`
+
+**Syntax :** `singular spawn [-h] [--out-dir OUT_DIR] parent_a parent_b`
+
+**Arguments and defaults :** `parent_a` (requis/required); `parent_b` (requis/required); `--out-dir` (`None`)
+
+**Prerequisites :** Required inputs present and writable root/life.
+
+**Target root and life :** Active life, except `spawn`, which targets parent paths and output.
+
+**Files read or written :** Reads parents/spec/memory; writes child, skill, memory, or restored generation depending on command.
+
+**Side effects :** Creates/changes artifacts; `rollback` atomically replaces active state.
+
+**Minimal example :** `singular spawn life/a life/b`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json spawn life/a life/b`
+
+**Common errors :** Missing/invalid input, unknown generation, existing or unwritable output.
+
+<!-- cli-command: run -->
+## `run`
+
+**Syntax :** `singular run [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular run`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json run`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: loop -->
+## `loop`
+
+**Syntax :** `singular loop [-h] [--skills-dir SKILLS_DIR] [--checkpoint CHECKPOINT] [--budget-seconds BUDGET_SECONDS] [--ticks TICKS] [--run-id RUN_ID]`
+
+**Arguments and defaults :** `--skills-dir` (`None`); `--checkpoint` (`None`); `--budget-seconds` (`None`); `--ticks` (`None`); `--run-id` (`loop`)
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular loop --budget-seconds 10`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json loop --budget-seconds 10`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: status -->
+## `status`
+
+**Syntax :** `singular status [-h] [--verbose] [--format {table,json,plain}]`
+
+**Arguments and defaults :** `--verbose` (`false`); `--format` (`None`; choix/choices: table, json, plain)
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular status`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json status`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: talk -->
+## `talk`
+
+**Syntax :** `singular talk [-h] [--provider PROVIDER] [--prompt PROMPT] [--life TALK_LIFE] [--live TALK_LIFE_LEGACY]`
+
+**Arguments and defaults :** `--provider` (`None`); `--prompt` (`None`); `--life` (`None`); `--live` (`None`)
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular talk --prompt "Bonjour"`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json talk --prompt "Bonjour"`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: quest -->
+## `quest`
+
+**Syntax :** `singular quest [-h] [--example] [--schema] [spec]`
+
+**Arguments and defaults :** `spec` (`None`); `--example` (`false`); `--schema` (`false`)
+
+**Prerequisites :** Required inputs present and writable root/life.
+
+**Target root and life :** Active life, except `spawn`, which targets parent paths and output.
+
+**Files read or written :** Reads parents/spec/memory; writes child, skill, memory, or restored generation depending on command.
+
+**Side effects :** Creates/changes artifacts; `rollback` atomically replaces active state.
+
+**Minimal example :** `singular quest --example`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json quest --example`
+
+**Common errors :** Missing/invalid input, unknown generation, existing or unwritable output.
+
+<!-- cli-command: synthesize -->
+## `synthesize`
+
+**Syntax :** `singular synthesize [-h] code`
+
+**Arguments and defaults :** `code` (requis/required)
+
+**Prerequisites :** Required inputs present and writable root/life.
+
+**Target root and life :** Active life, except `spawn`, which targets parent paths and output.
+
+**Files read or written :** Reads parents/spec/memory; writes child, skill, memory, or restored generation depending on command.
+
+**Side effects :** Creates/changes artifacts; `rollback` atomically replaces active state.
+
+**Minimal example :** `singular synthesize "result = 1"`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json synthesize "result = 1"`
+
+**Common errors :** Missing/invalid input, unknown generation, existing or unwritable output.
+
+<!-- cli-command: report -->
+## `report`
+
+**Syntax :** `singular report [-h] [--id ID] [--format {table,json,plain}] [--export EXPORT]`
+
+**Arguments and defaults :** `--id` (`None`); `--format` (`None`; choix/choices: table, json, plain); `--export` (`None`)
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular report`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json report`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: rollback -->
+## `rollback`
+
+**Syntax :** `singular rollback [-h] --generation GENERATION`
+
+**Arguments and defaults :** `--generation` (requis/required)
+
+**Prerequisites :** Required inputs present and writable root/life.
+
+**Target root and life :** Active life, except `spawn`, which targets parent paths and output.
+
+**Files read or written :** Reads parents/spec/memory; writes child, skill, memory, or restored generation depending on command.
+
+**Side effects :** Creates/changes artifacts; `rollback` atomically replaces active state.
+
+**Minimal example :** `singular rollback --generation 2`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json rollback --generation 2`
+
+**Common errors :** Missing/invalid input, unknown generation, existing or unwritable output.
+
+<!-- cli-command: dashboard -->
+## `dashboard`
+
+**Syntax :** `singular dashboard [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular dashboard`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json dashboard`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: quickstart -->
+## `quickstart`
+
+**Syntax :** `singular quickstart [-h] [--name NAME]`
+
+**Arguments and defaults :** `--name` (`None`)
+
+**Prerequisites :** Required inputs present and writable root/life.
+
+**Target root and life :** Active life, except `spawn`, which targets parent paths and output.
+
+**Files read or written :** Reads parents/spec/memory; writes child, skill, memory, or restored generation depending on command.
+
+**Side effects :** Creates/changes artifacts; `rollback` atomically replaces active state.
+
+**Minimal example :** `singular quickstart --name Ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json quickstart --name Ada`
+
+**Common errors :** Missing/invalid input, unknown generation, existing or unwritable output.
+
+<!-- cli-command: monitor -->
+## `monitor`
+
+**Syntax :** `singular monitor [-h] [--verbose]`
+
+**Arguments and defaults :** `--verbose` (`false`)
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular monitor`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json monitor`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: watch -->
+## `watch`
+
+**Syntax :** `singular watch [-h] [--interval INTERVAL] [--sources SOURCES] [--cpu-budget CPU_BUDGET] [--memory-budget MEMORY_BUDGET] [--watch-dir WATCH_DIR] [--dry-run]`
+
+**Arguments and defaults :** `--interval` (`5.0`); `--sources` (`file,weather,runs,folder`); `--cpu-budget` (`50.0`); `--memory-budget` (`512.0`); `--watch-dir` (`None`); `--dry-run` (`false`)
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular watch --dry-run`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json watch --dry-run`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: orchestrate -->
+## `orchestrate`
+
+**Syntax :** `singular orchestrate [-h] {run} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular orchestrate run --dry-run`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json orchestrate run --dry-run`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: orchestrate run -->
+## `orchestrate run`
+
+**Syntax :** `singular orchestrate run [-h] [--veille-seconds VEILLE_SECONDS] [--action-seconds ACTION_SECONDS] [--introspection-seconds INTROSPECTION_SECONDS] [--sommeil-seconds SOMMEIL_SECONDS] [--poll-interval POLL_INTERVAL] [--tick-budget TICK_BUDGET] [--lifecycle-config LIFECYCLE_CONFIG] [--dry-run]`
+
+**Arguments and defaults :** `--veille-seconds` (`None`); `--action-seconds` (`None`); `--introspection-seconds` (`None`); `--sommeil-seconds` (`None`); `--poll-interval` (`None`); `--tick-budget` (`None`); `--lifecycle-config` (`None`); `--dry-run` (`false`)
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular orchestrate run --dry-run`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json orchestrate run --dry-run`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: daemon -->
+## `daemon`
+
+**Syntax :** `singular daemon [-h] --life LIFE [--interval INTERVAL] [--budget-seconds BUDGET_SECONDS] [--max-errors MAX_ERRORS] [--dashboard] [--dry-run]`
+
+**Arguments and defaults :** `--life` (requis/required); `--interval` (`5.0`); `--budget-seconds` (`None`); `--max-errors` (`3`); `--dashboard` (`false`); `--dry-run` (`false`)
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular daemon --life ada --budget-seconds 30 --dry-run`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json daemon --life ada --budget-seconds 30 --dry-run`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: diagnose -->
+## `diagnose`
+
+**Syntax :** `singular diagnose [-h] {sandbox,evolution} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular diagnose sandbox`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json diagnose sandbox`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: diagnose sandbox -->
+## `diagnose sandbox`
+
+**Syntax :** `singular diagnose sandbox [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular diagnose sandbox`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json diagnose sandbox`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: diagnose evolution -->
+## `diagnose evolution`
+
+**Syntax :** `singular diagnose evolution [-h] [--life LIFE]`
+
+**Arguments and defaults :** `--life` (`None`)
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular diagnose evolution`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json diagnose evolution`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: retention -->
+## `retention`
+
+**Syntax :** `singular retention [-h] {run,status,config} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular retention status`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json retention status`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: retention run -->
+## `retention run`
+
+**Syntax :** `singular retention run [-h] [--dry-run]`
+
+**Arguments and defaults :** `--dry-run` (`false`)
+
+**Prerequisites :** Write permission; appropriate confirmation/destructive option.
+
+**Target root and life :** Global root for config/retention/uninstall; active life for beliefs.
+
+**Files read or written :** Writes/deletes configuration, `runs/`, `mem/`, beliefs, or `lives/` depending on command.
+
+**Side effects :** Persistent effect; purge/reset/uninstall may be irreversible. Use dry-run when available.
+
+**Minimal example :** `singular retention run --dry-run`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json retention run --dry-run`
+
+**Common errors :** Missing required option, invalid key/value, refused confirmation, repository protection, permissions.
+
+<!-- cli-command: retention status -->
+## `retention status`
+
+**Syntax :** `singular retention status [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular retention status`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json retention status`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: retention config -->
+## `retention config`
+
+**Syntax :** `singular retention config [-h] {show} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular retention config show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json retention config show`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: retention config show -->
+## `retention config show`
+
+**Syntax :** `singular retention config show [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular retention config show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json retention config show`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: doctor -->
+## `doctor`
+
+**Syntax :** `singular doctor [-h] [--fix]`
+
+**Arguments and defaults :** `--fix` (`false`)
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular doctor`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json doctor`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: config -->
+## `config`
+
+**Syntax :** `singular config [-h] {openai,providers,root} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular config root show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json config root show`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: config openai -->
+## `config openai`
+
+**Syntax :** `singular config openai [-h] [--api-key API_KEY] [--shell-profile SHELL_PROFILE] [--test]`
+
+**Arguments and defaults :** `--api-key` (`None`); `--shell-profile` (`None`); `--test` (`false`)
+
+**Prerequisites :** Write permission; appropriate confirmation/destructive option.
+
+**Target root and life :** Global root for config/retention/uninstall; active life for beliefs.
+
+**Files read or written :** Writes/deletes configuration, `runs/`, `mem/`, beliefs, or `lives/` depending on command.
+
+**Side effects :** Persistent effect; purge/reset/uninstall may be irreversible. Use dry-run when available.
+
+**Minimal example :** `singular config openai --api-key sk-example-key`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json config openai --api-key sk-example-key`
+
+**Common errors :** Missing required option, invalid key/value, refused confirmation, repository protection, permissions.
+
+<!-- cli-command: config providers -->
+## `config providers`
+
+**Syntax :** `singular config providers [-h] {doctor} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular config providers doctor`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json config providers doctor`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: config providers doctor -->
+## `config providers doctor`
+
+**Syntax :** `singular config providers doctor [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular config providers doctor`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json config providers doctor`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: config root -->
+## `config root`
+
+**Syntax :** `singular config root [-h] {set,show} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular config root show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json config root show`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: config root set -->
+## `config root set`
+
+**Syntax :** `singular config root set [-h] [--scope {global,project}] path`
+
+**Arguments and defaults :** `path` (requis/required); `--scope` (`global`; choix/choices: global, project)
+
+**Prerequisites :** Write permission; appropriate confirmation/destructive option.
+
+**Target root and life :** Global root for config/retention/uninstall; active life for beliefs.
+
+**Files read or written :** Writes/deletes configuration, `runs/`, `mem/`, beliefs, or `lives/` depending on command.
+
+**Side effects :** Persistent effect; purge/reset/uninstall may be irreversible. Use dry-run when available.
+
+**Minimal example :** `singular config root set /srv/singular`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json config root set /srv/singular`
+
+**Common errors :** Missing required option, invalid key/value, refused confirmation, repository protection, permissions.
+
+<!-- cli-command: config root show -->
+## `config root show`
+
+**Syntax :** `singular config root show [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular config root show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json config root show`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: lives -->
+## `lives`
+
+**Syntax :** `singular lives [-h] {list,create,use,delete,archive,memorial,clone,reproduce,relations,ally,rival,reconcile,proximity} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular lives list`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives list`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: lives list -->
+## `lives list`
+
+**Syntax :** `singular lives list [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads `lives/registry.json` and affected life directories.
+
+**Side effects :** Display only.
+
+**Minimal example :** `singular lives list`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives list`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives create -->
+## `lives create`
+
+**Syntax :** `singular lives create [-h] [--name NAME] [--curiosity CURIOSITY] [--patience PATIENCE] [--playfulness PLAYFULNESS] [--optimism OPTIMISM] [--resilience RESILIENCE] [--starter-profile STARTER_PROFILE] [--starter-skill STARTER_SKILL]`
+
+**Arguments and defaults :** `--name` (`New life`); `--curiosity` (`None`); `--patience` (`None`); `--playfulness` (`None`); `--optimism` (`None`); `--resilience` (`None`); `--starter-profile` (`assistant`); `--starter-skill` (`[]`)
+
+**Prerequisites :** Writable root; valid starter profile.
+
+**Target root and life :** Resolved root; creates and activates a new life.
+
+**Files read or written :** Writes `lives/registry.json` and `lives/<slug>/` (identity, psyche, skills, memory).
+
+**Side effects :** Creates directories and sets `SINGULAR_HOME`; `birth` is deprecated.
+
+**Minimal example :** `singular lives create --name Ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives create --name Ada`
+
+**Common errors :** Trait outside [0,1], invalid name/profile, unwritable root.
+
+<!-- cli-command: lives use -->
+## `lives use`
+
+**Syntax :** `singular lives use [-h] name`
+
+**Arguments and defaults :** `name` (requis/required)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives use ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives use ada`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives delete -->
+## `lives delete`
+
+**Syntax :** `singular lives delete [-h] name`
+
+**Arguments and defaults :** `name` (requis/required)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives delete ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives delete ada`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives archive -->
+## `lives archive`
+
+**Syntax :** `singular lives archive [-h] name`
+
+**Arguments and defaults :** `name` (requis/required)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives archive ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives archive ada`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives memorial -->
+## `lives memorial`
+
+**Syntax :** `singular lives memorial [-h] [--message MESSAGE] name`
+
+**Arguments and defaults :** `name` (requis/required); `--message` (`Merci pour ce cycle de vie.`)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives memorial ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives memorial ada`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives clone -->
+## `lives clone`
+
+**Syntax :** `singular lives clone [-h] [--new-name NEW_NAME] name`
+
+**Arguments and defaults :** `name` (requis/required); `--new-name` (`None`)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives clone ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives clone ada`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives reproduce -->
+## `lives reproduce`
+
+**Syntax :** `singular lives reproduce [-h] [--new-name NEW_NAME] parent_a parent_b`
+
+**Arguments and defaults :** `parent_a` (requis/required); `parent_b` (requis/required); `--new-name` (`None`)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives reproduce ada bob`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives reproduce ada bob`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives relations -->
+## `lives relations`
+
+**Syntax :** `singular lives relations [-h] [--name NAME]`
+
+**Arguments and defaults :** `--name` (`None`)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads `lives/registry.json` and affected life directories.
+
+**Side effects :** Display only.
+
+**Minimal example :** `singular lives relations`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives relations`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives ally -->
+## `lives ally`
+
+**Syntax :** `singular lives ally [-h] name other`
+
+**Arguments and defaults :** `name` (requis/required); `other` (requis/required)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives ally ada bob`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives ally ada bob`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives rival -->
+## `lives rival`
+
+**Syntax :** `singular lives rival [-h] name other`
+
+**Arguments and defaults :** `name` (requis/required); `other` (requis/required)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives rival ada bob`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives rival ada bob`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives reconcile -->
+## `lives reconcile`
+
+**Syntax :** `singular lives reconcile [-h] name other`
+
+**Arguments and defaults :** `name` (requis/required); `other` (requis/required)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives reconcile ada bob`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives reconcile ada bob`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: lives proximity -->
+## `lives proximity`
+
+**Syntax :** `singular lives proximity [-h] --score SCORE name`
+
+**Arguments and defaults :** `name` (requis/required); `--score` (requis/required)
+
+**Prerequisites :** Existing registry; named lives must exist.
+
+**Target root and life :** Resolved root; named life/lives, or active life for `relations`.
+
+**Files read or written :** Reads/writes `lives/registry.json` and affected life directories.
+
+**Side effects :** Changes registry and/or life data; `delete` is permanent.
+
+**Minimal example :** `singular lives proximity ada --score 0.7`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json lives proximity ada --score 0.7`
+
+**Common errors :** Unknown/ambiguous life, ineligible reproduction, score outside [0,1], active deletion refused.
+
+<!-- cli-command: values -->
+## `values`
+
+**Syntax :** `singular values [-h] {show} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular values show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json values show`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: values show -->
+## `values show`
+
+**Syntax :** `singular values show [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular values show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json values show`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: policy -->
+## `policy`
+
+**Syntax :** `singular policy [-h] {show,set} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular policy show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json policy show`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: policy show -->
+## `policy show`
+
+**Syntax :** `singular policy show [-h]`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular policy show`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json policy show`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: policy set -->
+## `policy set`
+
+**Syntax :** `singular policy set [-h] --key {autonomy.auto_rollback_cost_threshold,autonomy.auto_rollback_failure_threshold,autonomy.circuit_breaker_cooldown_seconds,autonomy.circuit_breaker_threshold,autonomy.circuit_breaker_window_seconds,autonomy.mutation_quota_per_window,autonomy.mutation_quota_window_seconds,autonomy.runtime_blacklisted_capabilities,autonomy.runtime_call_quota_per_hour,autonomy.safe_mode,autonomy.safe_mode_review_required_skill_families,autonomy.skill_circuit_breaker_cooldown_seconds,autonomy.skill_circuit_breaker_cost_threshold,autonomy.skill_circuit_breaker_failure_threshold,forgetting.enabled,forgetting.max_episodic_entries,memory.preserve_threshold,permissions.forbidden_paths,permissions.force_allow_paths,permissions.modifiable_paths,permissions.review_required_paths} --value VALUE`
+
+**Arguments and defaults :** `--key` (requis/required; choix/choices: autonomy.auto_rollback_cost_threshold, autonomy.auto_rollback_failure_threshold, autonomy.circuit_breaker_cooldown_seconds, autonomy.circuit_breaker_threshold, autonomy.circuit_breaker_window_seconds, autonomy.mutation_quota_per_window, autonomy.mutation_quota_window_seconds, autonomy.runtime_blacklisted_capabilities, autonomy.runtime_call_quota_per_hour, autonomy.safe_mode, autonomy.safe_mode_review_required_skill_families, autonomy.skill_circuit_breaker_cooldown_seconds, autonomy.skill_circuit_breaker_cost_threshold, autonomy.skill_circuit_breaker_failure_threshold, forgetting.enabled, forgetting.max_episodic_entries, memory.preserve_threshold, permissions.forbidden_paths, permissions.force_allow_paths, permissions.modifiable_paths, permissions.review_required_paths); `--value` (requis/required)
+
+**Prerequisites :** Write permission; appropriate confirmation/destructive option.
+
+**Target root and life :** Global root for config/retention/uninstall; active life for beliefs.
+
+**Files read or written :** Writes/deletes configuration, `runs/`, `mem/`, beliefs, or `lives/` depending on command.
+
+**Side effects :** Persistent effect; purge/reset/uninstall may be irreversible. Use dry-run when available.
+
+**Minimal example :** `singular policy set --key autonomy.safe_mode --value true`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json policy set --key autonomy.safe_mode --value true`
+
+**Common errors :** Missing required option, invalid key/value, refused confirmation, repository protection, permissions.
+
+<!-- cli-command: ecosystem -->
+## `ecosystem`
+
+**Syntax :** `singular ecosystem [-h] {run} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular ecosystem run --life ada --budget-seconds 10`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json ecosystem run --life ada --budget-seconds 10`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: ecosystem run -->
+## `ecosystem run`
+
+**Syntax :** `singular ecosystem run [-h] [--life ECOSYSTEM_LIVES] [--life-group ECOSYSTEM_GROUPS] [--checkpoint CHECKPOINT] --budget-seconds BUDGET_SECONDS [--run-id RUN_ID]`
+
+**Arguments and defaults :** `--life` (`[]`); `--life-group` (`[]`); `--checkpoint` (`None`); `--budget-seconds` (requis/required); `--run-id` (`ecosystem`)
+
+**Prerequisites :** Active life and mode-specific config/provider; positive budget when required.
+
+**Target root and life :** Life selected by `--home`/`--life`; `ecosystem run` targets all listed lives.
+
+**Files read or written :** Reads config and memory; writes events, checkpoints, and runs under the life. `embodiment` reads `--config`; `dashboard` serves these data.
+
+**Side effects :** May call an LLM/sensor, mutate skills, write logs, or start a service; `--dry-run` limits mutations.
+
+**Minimal example :** `singular ecosystem run --life ada --budget-seconds 10`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json ecosystem run --life ada --budget-seconds 10`
+
+**Common errors :** Missing life/provider/config, invalid budget/interval, unavailable sensor, daemon error limit.
+
+<!-- cli-command: beliefs -->
+## `beliefs`
+
+**Syntax :** `singular beliefs [-h] {audit,reset} ...`
+
+**Arguments and defaults :** Aucune / None.
+
+**Prerequisites :** None; select a subcommand.
+
+**Target root and life :** Registry root; no life until a subcommand is selected.
+
+**Files read or written :** No file directly.
+
+**Side effects :** Shows help or delegates; no direct effect.
+
+**Minimal example :** `singular beliefs audit`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json beliefs audit`
+
+**Common errors :** Missing subcommand.
+
+<!-- cli-command: beliefs audit -->
+## `beliefs audit`
+
+**Syntax :** `singular beliefs audit [-h] [--limit LIMIT]`
+
+**Arguments and defaults :** `--limit` (`25`)
+
+**Prerequisites :** Active life for life diagnostics; relevant dependencies available.
+
+**Target root and life :** `SINGULAR_HOME`/selected life; `doctor` and `config root show` are global.
+
+**Files read or written :** Depending on command, reads registry, `mem/`, `runs/`, `skills/`, policy, or config; `report --export` writes the requested file.
+
+**Side effects :** Display only, except report export and `doctor --fix` (Windows user PATH).
+
+**Minimal example :** `singular beliefs audit`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json beliefs audit`
+
+**Common errors :** Missing life/run/file, invalid JSON, sandbox failure, invalid format/export.
+
+<!-- cli-command: beliefs reset -->
+## `beliefs reset`
+
+**Syntax :** `singular beliefs reset [-h] (--hypothesis HYPOTHESIS | --prefix PREFIX | --all)`
+
+**Arguments and defaults :** `--hypothesis` (`None`); `--prefix` (`None`); `--all` (`false`)
+
+**Prerequisites :** Write permission; appropriate confirmation/destructive option.
+
+**Target root and life :** Global root for config/retention/uninstall; active life for beliefs.
+
+**Files read or written :** Writes/deletes configuration, `runs/`, `mem/`, beliefs, or `lives/` depending on command.
+
+**Side effects :** Persistent effect; purge/reset/uninstall may be irreversible. Use dry-run when available.
+
+**Minimal example :** `singular beliefs reset --hypothesis test`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json beliefs reset --hypothesis test`
+
+**Common errors :** Missing required option, invalid key/value, refused confirmation, repository protection, permissions.
+
+<!-- cli-command: uninstall -->
+## `uninstall`
+
+**Syntax :** `singular uninstall [-h] (--keep-lives | --purge-lives) [--yes] [--force]`
+
+**Arguments and defaults :** `--keep-lives` (`false`); `--purge-lives` (`false`); `--yes` (`false`); `--force` (`false`)
+
+**Prerequisites :** Write permission; appropriate confirmation/destructive option.
+
+**Target root and life :** Global root for config/retention/uninstall; active life for beliefs.
+
+**Files read or written :** Writes/deletes configuration, `runs/`, `mem/`, beliefs, or `lives/` depending on command.
+
+**Side effects :** Persistent effect; purge/reset/uninstall may be irreversible. Use dry-run when available.
+
+**Minimal example :** `singular uninstall --keep-lives --yes`
+
+**Advanced example :** `singular --root /srv/singular --life ada --format json uninstall --keep-lives --yes`
+
+**Common errors :** Missing required option, invalid key/value, refused confirmation, repository protection, permissions.
+
+## Aliases and help
+
+`veille` is an exact alias of `watch`; `talk --live` is a deprecated alias for `talk --life`; `birth` can be disabled with `SINGULAR_ENABLE_BIRTH_ALIAS=0`. `singular <command> --help` remains the executable source for metavar details.

--- a/docs/cli-reference.fr.md
+++ b/docs/cli-reference.fr.md
@@ -1,0 +1,1252 @@
+# Référence CLI Singular
+
+Cette référence inventorie **tous** les parsers construits par `_build_parser`. Elle est contrôlée automatiquement par `tests/test_cli_reference.py`.
+
+## Portée et options globales
+
+Toutes les syntaxes acceptent avant la commande : `singular [--seed INT] [--root PATH] [--home PATH] [--life NAME] [--format {table,json,plain}] [--safe-mode] …`. Défauts : seed/root/home/life `None` (root/home peuvent venir de l’environnement), format `plain`, safe mode `false`. `--root` choisit le registre; `--home` choisit directement un dossier de vie; `--life` résout une vie dans le registre. `SINGULAR_ROOT`, `SINGULAR_HOME`, `OPENAI_API_KEY` et les variables provider peuvent donc modifier le contexte.
+
+Les chemins ci-dessous sont relatifs au root ou à `SINGULAR_HOME`. Toujours sauvegarder avant une suppression, un reset, un rollback ou une rétention réelle.
+
+<!-- cli-command: embodiment -->
+## `embodiment`
+
+**Syntaxe :** `singular embodiment [-h] --config CONFIG [--mode {simulation,dry-run,hardware}] [--steps STEPS] [--audit AUDIT]`
+
+**Arguments et défauts :** `--config` (requis/required); `--mode` (`simulation`; choix/choices: simulation, dry-run, hardware); `--steps` (`None`); `--audit` (`None`)
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular embodiment --config configs/embodiment.yaml`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json embodiment --config configs/embodiment.yaml`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: birth -->
+## `birth`
+
+**Syntaxe :** `singular birth [-h] [--name NAME] [--curiosity CURIOSITY] [--patience PATIENCE] [--playfulness PLAYFULNESS] [--optimism OPTIMISM] [--resilience RESILIENCE] [--starter-profile STARTER_PROFILE] [--starter-skill STARTER_SKILL]`
+
+**Arguments et défauts :** `--name` (`New life`); `--curiosity` (`None`); `--patience` (`None`); `--playfulness` (`None`); `--optimism` (`None`); `--resilience` (`None`); `--starter-profile` (`assistant`); `--starter-skill` (`[]`)
+
+**Prérequis :** Root accessible; profil starter valide.
+
+**Root et vie ciblés :** Root résolu; crée et active une nouvelle vie.
+
+**Fichiers lus ou écrits :** Écrit `lives/registry.json` et le dossier `lives/<slug>/` (identité, psyché, skills et mémoire).
+
+**Effets de bord :** Crée des répertoires et positionne `SINGULAR_HOME`; `birth` est dépréciée.
+
+**Exemple minimal :** `singular birth --name Ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json birth --name Ada`
+
+**Erreurs usuelles :** Trait hors [0,1], nom/profil invalide, root non inscriptible.
+
+<!-- cli-command: spawn -->
+## `spawn`
+
+**Syntaxe :** `singular spawn [-h] [--out-dir OUT_DIR] parent_a parent_b`
+
+**Arguments et défauts :** `parent_a` (requis/required); `parent_b` (requis/required); `--out-dir` (`None`)
+
+**Prérequis :** Entrées demandées présentes et root/vie inscriptible.
+
+**Root et vie ciblés :** Vie active, sauf `spawn` qui cible les chemins parents et la sortie.
+
+**Fichiers lus ou écrits :** Lit les parents/la spec/la mémoire; écrit enfant, skill, mémoire ou génération restaurée selon la commande.
+
+**Effets de bord :** Crée/modifie des artefacts; `rollback` remplace atomiquement l'état actif.
+
+**Exemple minimal :** `singular spawn life/a life/b`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json spawn life/a life/b`
+
+**Erreurs usuelles :** Entrée absente/invalide, génération inconnue, sortie existante ou non inscriptible.
+
+<!-- cli-command: run -->
+## `run`
+
+**Syntaxe :** `singular run [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular run`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json run`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: loop -->
+## `loop`
+
+**Syntaxe :** `singular loop [-h] [--skills-dir SKILLS_DIR] [--checkpoint CHECKPOINT] [--budget-seconds BUDGET_SECONDS] [--ticks TICKS] [--run-id RUN_ID]`
+
+**Arguments et défauts :** `--skills-dir` (`None`); `--checkpoint` (`None`); `--budget-seconds` (`None`); `--ticks` (`None`); `--run-id` (`loop`)
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular loop --budget-seconds 10`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json loop --budget-seconds 10`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: status -->
+## `status`
+
+**Syntaxe :** `singular status [-h] [--verbose] [--format {table,json,plain}]`
+
+**Arguments et défauts :** `--verbose` (`false`); `--format` (`None`; choix/choices: table, json, plain)
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular status`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json status`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: talk -->
+## `talk`
+
+**Syntaxe :** `singular talk [-h] [--provider PROVIDER] [--prompt PROMPT] [--life TALK_LIFE] [--live TALK_LIFE_LEGACY]`
+
+**Arguments et défauts :** `--provider` (`None`); `--prompt` (`None`); `--life` (`None`); `--live` (`None`)
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular talk --prompt "Bonjour"`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json talk --prompt "Bonjour"`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: quest -->
+## `quest`
+
+**Syntaxe :** `singular quest [-h] [--example] [--schema] [spec]`
+
+**Arguments et défauts :** `spec` (`None`); `--example` (`false`); `--schema` (`false`)
+
+**Prérequis :** Entrées demandées présentes et root/vie inscriptible.
+
+**Root et vie ciblés :** Vie active, sauf `spawn` qui cible les chemins parents et la sortie.
+
+**Fichiers lus ou écrits :** Lit les parents/la spec/la mémoire; écrit enfant, skill, mémoire ou génération restaurée selon la commande.
+
+**Effets de bord :** Crée/modifie des artefacts; `rollback` remplace atomiquement l'état actif.
+
+**Exemple minimal :** `singular quest --example`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json quest --example`
+
+**Erreurs usuelles :** Entrée absente/invalide, génération inconnue, sortie existante ou non inscriptible.
+
+<!-- cli-command: synthesize -->
+## `synthesize`
+
+**Syntaxe :** `singular synthesize [-h] code`
+
+**Arguments et défauts :** `code` (requis/required)
+
+**Prérequis :** Entrées demandées présentes et root/vie inscriptible.
+
+**Root et vie ciblés :** Vie active, sauf `spawn` qui cible les chemins parents et la sortie.
+
+**Fichiers lus ou écrits :** Lit les parents/la spec/la mémoire; écrit enfant, skill, mémoire ou génération restaurée selon la commande.
+
+**Effets de bord :** Crée/modifie des artefacts; `rollback` remplace atomiquement l'état actif.
+
+**Exemple minimal :** `singular synthesize "result = 1"`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json synthesize "result = 1"`
+
+**Erreurs usuelles :** Entrée absente/invalide, génération inconnue, sortie existante ou non inscriptible.
+
+<!-- cli-command: report -->
+## `report`
+
+**Syntaxe :** `singular report [-h] [--id ID] [--format {table,json,plain}] [--export EXPORT]`
+
+**Arguments et défauts :** `--id` (`None`); `--format` (`None`; choix/choices: table, json, plain); `--export` (`None`)
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular report`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json report`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: rollback -->
+## `rollback`
+
+**Syntaxe :** `singular rollback [-h] --generation GENERATION`
+
+**Arguments et défauts :** `--generation` (requis/required)
+
+**Prérequis :** Entrées demandées présentes et root/vie inscriptible.
+
+**Root et vie ciblés :** Vie active, sauf `spawn` qui cible les chemins parents et la sortie.
+
+**Fichiers lus ou écrits :** Lit les parents/la spec/la mémoire; écrit enfant, skill, mémoire ou génération restaurée selon la commande.
+
+**Effets de bord :** Crée/modifie des artefacts; `rollback` remplace atomiquement l'état actif.
+
+**Exemple minimal :** `singular rollback --generation 2`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json rollback --generation 2`
+
+**Erreurs usuelles :** Entrée absente/invalide, génération inconnue, sortie existante ou non inscriptible.
+
+<!-- cli-command: dashboard -->
+## `dashboard`
+
+**Syntaxe :** `singular dashboard [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular dashboard`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json dashboard`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: quickstart -->
+## `quickstart`
+
+**Syntaxe :** `singular quickstart [-h] [--name NAME]`
+
+**Arguments et défauts :** `--name` (`None`)
+
+**Prérequis :** Entrées demandées présentes et root/vie inscriptible.
+
+**Root et vie ciblés :** Vie active, sauf `spawn` qui cible les chemins parents et la sortie.
+
+**Fichiers lus ou écrits :** Lit les parents/la spec/la mémoire; écrit enfant, skill, mémoire ou génération restaurée selon la commande.
+
+**Effets de bord :** Crée/modifie des artefacts; `rollback` remplace atomiquement l'état actif.
+
+**Exemple minimal :** `singular quickstart --name Ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json quickstart --name Ada`
+
+**Erreurs usuelles :** Entrée absente/invalide, génération inconnue, sortie existante ou non inscriptible.
+
+<!-- cli-command: monitor -->
+## `monitor`
+
+**Syntaxe :** `singular monitor [-h] [--verbose]`
+
+**Arguments et défauts :** `--verbose` (`false`)
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular monitor`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json monitor`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: watch -->
+## `watch`
+
+**Syntaxe :** `singular watch [-h] [--interval INTERVAL] [--sources SOURCES] [--cpu-budget CPU_BUDGET] [--memory-budget MEMORY_BUDGET] [--watch-dir WATCH_DIR] [--dry-run]`
+
+**Arguments et défauts :** `--interval` (`5.0`); `--sources` (`file,weather,runs,folder`); `--cpu-budget` (`50.0`); `--memory-budget` (`512.0`); `--watch-dir` (`None`); `--dry-run` (`false`)
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular watch --dry-run`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json watch --dry-run`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: orchestrate -->
+## `orchestrate`
+
+**Syntaxe :** `singular orchestrate [-h] {run} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular orchestrate run --dry-run`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json orchestrate run --dry-run`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: orchestrate run -->
+## `orchestrate run`
+
+**Syntaxe :** `singular orchestrate run [-h] [--veille-seconds VEILLE_SECONDS] [--action-seconds ACTION_SECONDS] [--introspection-seconds INTROSPECTION_SECONDS] [--sommeil-seconds SOMMEIL_SECONDS] [--poll-interval POLL_INTERVAL] [--tick-budget TICK_BUDGET] [--lifecycle-config LIFECYCLE_CONFIG] [--dry-run]`
+
+**Arguments et défauts :** `--veille-seconds` (`None`); `--action-seconds` (`None`); `--introspection-seconds` (`None`); `--sommeil-seconds` (`None`); `--poll-interval` (`None`); `--tick-budget` (`None`); `--lifecycle-config` (`None`); `--dry-run` (`false`)
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular orchestrate run --dry-run`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json orchestrate run --dry-run`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: daemon -->
+## `daemon`
+
+**Syntaxe :** `singular daemon [-h] --life LIFE [--interval INTERVAL] [--budget-seconds BUDGET_SECONDS] [--max-errors MAX_ERRORS] [--dashboard] [--dry-run]`
+
+**Arguments et défauts :** `--life` (requis/required); `--interval` (`5.0`); `--budget-seconds` (`None`); `--max-errors` (`3`); `--dashboard` (`false`); `--dry-run` (`false`)
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular daemon --life ada --budget-seconds 30 --dry-run`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json daemon --life ada --budget-seconds 30 --dry-run`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: diagnose -->
+## `diagnose`
+
+**Syntaxe :** `singular diagnose [-h] {sandbox,evolution} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular diagnose sandbox`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json diagnose sandbox`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: diagnose sandbox -->
+## `diagnose sandbox`
+
+**Syntaxe :** `singular diagnose sandbox [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular diagnose sandbox`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json diagnose sandbox`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: diagnose evolution -->
+## `diagnose evolution`
+
+**Syntaxe :** `singular diagnose evolution [-h] [--life LIFE]`
+
+**Arguments et défauts :** `--life` (`None`)
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular diagnose evolution`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json diagnose evolution`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: retention -->
+## `retention`
+
+**Syntaxe :** `singular retention [-h] {run,status,config} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular retention status`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json retention status`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: retention run -->
+## `retention run`
+
+**Syntaxe :** `singular retention run [-h] [--dry-run]`
+
+**Arguments et défauts :** `--dry-run` (`false`)
+
+**Prérequis :** Droits d'écriture; confirmation/option destructive appropriée.
+
+**Root et vie ciblés :** Root global pour config/rétention/désinstallation; vie active pour croyances.
+
+**Fichiers lus ou écrits :** Écrit/supprime configuration, `runs/`, `mem/`, croyances ou `lives/` selon la commande.
+
+**Effets de bord :** Effet persistant; purge/reset/uninstall peuvent être irréversibles. Utiliser dry-run quand disponible.
+
+**Exemple minimal :** `singular retention run --dry-run`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json retention run --dry-run`
+
+**Erreurs usuelles :** Option requise absente, clé/valeur invalide, confirmation refusée, protection du repo, permissions.
+
+<!-- cli-command: retention status -->
+## `retention status`
+
+**Syntaxe :** `singular retention status [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular retention status`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json retention status`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: retention config -->
+## `retention config`
+
+**Syntaxe :** `singular retention config [-h] {show} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular retention config show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json retention config show`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: retention config show -->
+## `retention config show`
+
+**Syntaxe :** `singular retention config show [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular retention config show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json retention config show`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: doctor -->
+## `doctor`
+
+**Syntaxe :** `singular doctor [-h] [--fix]`
+
+**Arguments et défauts :** `--fix` (`false`)
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular doctor`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json doctor`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: config -->
+## `config`
+
+**Syntaxe :** `singular config [-h] {openai,providers,root} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular config root show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json config root show`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: config openai -->
+## `config openai`
+
+**Syntaxe :** `singular config openai [-h] [--api-key API_KEY] [--shell-profile SHELL_PROFILE] [--test]`
+
+**Arguments et défauts :** `--api-key` (`None`); `--shell-profile` (`None`); `--test` (`false`)
+
+**Prérequis :** Droits d'écriture; confirmation/option destructive appropriée.
+
+**Root et vie ciblés :** Root global pour config/rétention/désinstallation; vie active pour croyances.
+
+**Fichiers lus ou écrits :** Écrit/supprime configuration, `runs/`, `mem/`, croyances ou `lives/` selon la commande.
+
+**Effets de bord :** Effet persistant; purge/reset/uninstall peuvent être irréversibles. Utiliser dry-run quand disponible.
+
+**Exemple minimal :** `singular config openai --api-key sk-example-key`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json config openai --api-key sk-example-key`
+
+**Erreurs usuelles :** Option requise absente, clé/valeur invalide, confirmation refusée, protection du repo, permissions.
+
+<!-- cli-command: config providers -->
+## `config providers`
+
+**Syntaxe :** `singular config providers [-h] {doctor} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular config providers doctor`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json config providers doctor`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: config providers doctor -->
+## `config providers doctor`
+
+**Syntaxe :** `singular config providers doctor [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular config providers doctor`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json config providers doctor`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: config root -->
+## `config root`
+
+**Syntaxe :** `singular config root [-h] {set,show} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular config root show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json config root show`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: config root set -->
+## `config root set`
+
+**Syntaxe :** `singular config root set [-h] [--scope {global,project}] path`
+
+**Arguments et défauts :** `path` (requis/required); `--scope` (`global`; choix/choices: global, project)
+
+**Prérequis :** Droits d'écriture; confirmation/option destructive appropriée.
+
+**Root et vie ciblés :** Root global pour config/rétention/désinstallation; vie active pour croyances.
+
+**Fichiers lus ou écrits :** Écrit/supprime configuration, `runs/`, `mem/`, croyances ou `lives/` selon la commande.
+
+**Effets de bord :** Effet persistant; purge/reset/uninstall peuvent être irréversibles. Utiliser dry-run quand disponible.
+
+**Exemple minimal :** `singular config root set /srv/singular`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json config root set /srv/singular`
+
+**Erreurs usuelles :** Option requise absente, clé/valeur invalide, confirmation refusée, protection du repo, permissions.
+
+<!-- cli-command: config root show -->
+## `config root show`
+
+**Syntaxe :** `singular config root show [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular config root show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json config root show`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: lives -->
+## `lives`
+
+**Syntaxe :** `singular lives [-h] {list,create,use,delete,archive,memorial,clone,reproduce,relations,ally,rival,reconcile,proximity} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular lives list`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives list`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: lives list -->
+## `lives list`
+
+**Syntaxe :** `singular lives list [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Affichage uniquement.
+
+**Exemple minimal :** `singular lives list`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives list`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives create -->
+## `lives create`
+
+**Syntaxe :** `singular lives create [-h] [--name NAME] [--curiosity CURIOSITY] [--patience PATIENCE] [--playfulness PLAYFULNESS] [--optimism OPTIMISM] [--resilience RESILIENCE] [--starter-profile STARTER_PROFILE] [--starter-skill STARTER_SKILL]`
+
+**Arguments et défauts :** `--name` (`New life`); `--curiosity` (`None`); `--patience` (`None`); `--playfulness` (`None`); `--optimism` (`None`); `--resilience` (`None`); `--starter-profile` (`assistant`); `--starter-skill` (`[]`)
+
+**Prérequis :** Root accessible; profil starter valide.
+
+**Root et vie ciblés :** Root résolu; crée et active une nouvelle vie.
+
+**Fichiers lus ou écrits :** Écrit `lives/registry.json` et le dossier `lives/<slug>/` (identité, psyché, skills et mémoire).
+
+**Effets de bord :** Crée des répertoires et positionne `SINGULAR_HOME`; `birth` est dépréciée.
+
+**Exemple minimal :** `singular lives create --name Ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives create --name Ada`
+
+**Erreurs usuelles :** Trait hors [0,1], nom/profil invalide, root non inscriptible.
+
+<!-- cli-command: lives use -->
+## `lives use`
+
+**Syntaxe :** `singular lives use [-h] name`
+
+**Arguments et défauts :** `name` (requis/required)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives use ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives use ada`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives delete -->
+## `lives delete`
+
+**Syntaxe :** `singular lives delete [-h] name`
+
+**Arguments et défauts :** `name` (requis/required)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives delete ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives delete ada`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives archive -->
+## `lives archive`
+
+**Syntaxe :** `singular lives archive [-h] name`
+
+**Arguments et défauts :** `name` (requis/required)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives archive ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives archive ada`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives memorial -->
+## `lives memorial`
+
+**Syntaxe :** `singular lives memorial [-h] [--message MESSAGE] name`
+
+**Arguments et défauts :** `name` (requis/required); `--message` (`Merci pour ce cycle de vie.`)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives memorial ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives memorial ada`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives clone -->
+## `lives clone`
+
+**Syntaxe :** `singular lives clone [-h] [--new-name NEW_NAME] name`
+
+**Arguments et défauts :** `name` (requis/required); `--new-name` (`None`)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives clone ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives clone ada`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives reproduce -->
+## `lives reproduce`
+
+**Syntaxe :** `singular lives reproduce [-h] [--new-name NEW_NAME] parent_a parent_b`
+
+**Arguments et défauts :** `parent_a` (requis/required); `parent_b` (requis/required); `--new-name` (`None`)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives reproduce ada bob`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives reproduce ada bob`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives relations -->
+## `lives relations`
+
+**Syntaxe :** `singular lives relations [-h] [--name NAME]`
+
+**Arguments et défauts :** `--name` (`None`)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Affichage uniquement.
+
+**Exemple minimal :** `singular lives relations`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives relations`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives ally -->
+## `lives ally`
+
+**Syntaxe :** `singular lives ally [-h] name other`
+
+**Arguments et défauts :** `name` (requis/required); `other` (requis/required)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives ally ada bob`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives ally ada bob`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives rival -->
+## `lives rival`
+
+**Syntaxe :** `singular lives rival [-h] name other`
+
+**Arguments et défauts :** `name` (requis/required); `other` (requis/required)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives rival ada bob`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives rival ada bob`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives reconcile -->
+## `lives reconcile`
+
+**Syntaxe :** `singular lives reconcile [-h] name other`
+
+**Arguments et défauts :** `name` (requis/required); `other` (requis/required)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives reconcile ada bob`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives reconcile ada bob`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: lives proximity -->
+## `lives proximity`
+
+**Syntaxe :** `singular lives proximity [-h] --score SCORE name`
+
+**Arguments et défauts :** `name` (requis/required); `--score` (requis/required)
+
+**Prérequis :** Registre existant; les noms cités doivent exister.
+
+**Root et vie ciblés :** Root résolu; vie(s) indiquée(s), ou vie active pour `relations`.
+
+**Fichiers lus ou écrits :** Lit/écrit `lives/registry.json` et les dossiers de vie concernés.
+
+**Effets de bord :** Modifie le registre et/ou les données de vie; `delete` supprime définitivement.
+
+**Exemple minimal :** `singular lives proximity ada --score 0.7`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json lives proximity ada --score 0.7`
+
+**Erreurs usuelles :** Vie introuvable/ambiguë, reproduction non éligible, score hors [0,1], suppression active refusée.
+
+<!-- cli-command: values -->
+## `values`
+
+**Syntaxe :** `singular values [-h] {show} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular values show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json values show`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: values show -->
+## `values show`
+
+**Syntaxe :** `singular values show [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular values show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json values show`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: policy -->
+## `policy`
+
+**Syntaxe :** `singular policy [-h] {show,set} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular policy show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json policy show`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: policy show -->
+## `policy show`
+
+**Syntaxe :** `singular policy show [-h]`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular policy show`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json policy show`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: policy set -->
+## `policy set`
+
+**Syntaxe :** `singular policy set [-h] --key {autonomy.auto_rollback_cost_threshold,autonomy.auto_rollback_failure_threshold,autonomy.circuit_breaker_cooldown_seconds,autonomy.circuit_breaker_threshold,autonomy.circuit_breaker_window_seconds,autonomy.mutation_quota_per_window,autonomy.mutation_quota_window_seconds,autonomy.runtime_blacklisted_capabilities,autonomy.runtime_call_quota_per_hour,autonomy.safe_mode,autonomy.safe_mode_review_required_skill_families,autonomy.skill_circuit_breaker_cooldown_seconds,autonomy.skill_circuit_breaker_cost_threshold,autonomy.skill_circuit_breaker_failure_threshold,forgetting.enabled,forgetting.max_episodic_entries,memory.preserve_threshold,permissions.forbidden_paths,permissions.force_allow_paths,permissions.modifiable_paths,permissions.review_required_paths} --value VALUE`
+
+**Arguments et défauts :** `--key` (requis/required; choix/choices: autonomy.auto_rollback_cost_threshold, autonomy.auto_rollback_failure_threshold, autonomy.circuit_breaker_cooldown_seconds, autonomy.circuit_breaker_threshold, autonomy.circuit_breaker_window_seconds, autonomy.mutation_quota_per_window, autonomy.mutation_quota_window_seconds, autonomy.runtime_blacklisted_capabilities, autonomy.runtime_call_quota_per_hour, autonomy.safe_mode, autonomy.safe_mode_review_required_skill_families, autonomy.skill_circuit_breaker_cooldown_seconds, autonomy.skill_circuit_breaker_cost_threshold, autonomy.skill_circuit_breaker_failure_threshold, forgetting.enabled, forgetting.max_episodic_entries, memory.preserve_threshold, permissions.forbidden_paths, permissions.force_allow_paths, permissions.modifiable_paths, permissions.review_required_paths); `--value` (requis/required)
+
+**Prérequis :** Droits d'écriture; confirmation/option destructive appropriée.
+
+**Root et vie ciblés :** Root global pour config/rétention/désinstallation; vie active pour croyances.
+
+**Fichiers lus ou écrits :** Écrit/supprime configuration, `runs/`, `mem/`, croyances ou `lives/` selon la commande.
+
+**Effets de bord :** Effet persistant; purge/reset/uninstall peuvent être irréversibles. Utiliser dry-run quand disponible.
+
+**Exemple minimal :** `singular policy set --key autonomy.safe_mode --value true`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json policy set --key autonomy.safe_mode --value true`
+
+**Erreurs usuelles :** Option requise absente, clé/valeur invalide, confirmation refusée, protection du repo, permissions.
+
+<!-- cli-command: ecosystem -->
+## `ecosystem`
+
+**Syntaxe :** `singular ecosystem [-h] {run} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular ecosystem run --life ada --budget-seconds 10`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json ecosystem run --life ada --budget-seconds 10`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: ecosystem run -->
+## `ecosystem run`
+
+**Syntaxe :** `singular ecosystem run [-h] [--life ECOSYSTEM_LIVES] [--life-group ECOSYSTEM_GROUPS] [--checkpoint CHECKPOINT] --budget-seconds BUDGET_SECONDS [--run-id RUN_ID]`
+
+**Arguments et défauts :** `--life` (`[]`); `--life-group` (`[]`); `--checkpoint` (`None`); `--budget-seconds` (requis/required); `--run-id` (`ecosystem`)
+
+**Prérequis :** Vie active et configuration/fournisseur requis par le mode; budget positif lorsqu'il est requis.
+
+**Root et vie ciblés :** Vie choisie par `--home`/`--life`; `ecosystem run` cible toutes les vies listées.
+
+**Fichiers lus ou écrits :** Lit la configuration et la mémoire; écrit événements, checkpoints et runs sous la vie. `embodiment` lit `--config`; `dashboard` sert ces données.
+
+**Effets de bord :** Peut appeler un LLM/capteur, muter des skills, écrire des logs ou lancer un service; `--dry-run` limite les mutations.
+
+**Exemple minimal :** `singular ecosystem run --life ada --budget-seconds 10`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json ecosystem run --life ada --budget-seconds 10`
+
+**Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: beliefs -->
+## `beliefs`
+
+**Syntaxe :** `singular beliefs [-h] {audit,reset} ...`
+
+**Arguments et défauts :** Aucune / None.
+
+**Prérequis :** Aucun; choisir une sous-commande.
+
+**Root et vie ciblés :** Root de registre; aucune vie tant que la sous-commande n'est pas choisie.
+
+**Fichiers lus ou écrits :** Aucun fichier directement.
+
+**Effets de bord :** Affiche l'aide ou délègue; aucun effet direct.
+
+**Exemple minimal :** `singular beliefs audit`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json beliefs audit`
+
+**Erreurs usuelles :** Sous-commande absente.
+
+<!-- cli-command: beliefs audit -->
+## `beliefs audit`
+
+**Syntaxe :** `singular beliefs audit [-h] [--limit LIMIT]`
+
+**Arguments et défauts :** `--limit` (`25`)
+
+**Prérequis :** Vie active pour les diagnostics liés à une vie; dépendances correspondantes disponibles.
+
+**Root et vie ciblés :** `SINGULAR_HOME`/vie sélectionnée; `doctor` et `config root show` sont globaux.
+
+**Fichiers lus ou écrits :** Lit selon la commande: registre, `mem/`, `runs/`, `skills/`, politique ou configuration; `report --export` écrit le fichier demandé.
+
+**Effets de bord :** Affichage seulement, sauf export de rapport et `doctor --fix` (PATH utilisateur Windows).
+
+**Exemple minimal :** `singular beliefs audit`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json beliefs audit`
+
+**Erreurs usuelles :** Vie/run/fichier absent, JSON invalide, skill sandbox KO, format/export invalide.
+
+<!-- cli-command: beliefs reset -->
+## `beliefs reset`
+
+**Syntaxe :** `singular beliefs reset [-h] (--hypothesis HYPOTHESIS | --prefix PREFIX | --all)`
+
+**Arguments et défauts :** `--hypothesis` (`None`); `--prefix` (`None`); `--all` (`false`)
+
+**Prérequis :** Droits d'écriture; confirmation/option destructive appropriée.
+
+**Root et vie ciblés :** Root global pour config/rétention/désinstallation; vie active pour croyances.
+
+**Fichiers lus ou écrits :** Écrit/supprime configuration, `runs/`, `mem/`, croyances ou `lives/` selon la commande.
+
+**Effets de bord :** Effet persistant; purge/reset/uninstall peuvent être irréversibles. Utiliser dry-run quand disponible.
+
+**Exemple minimal :** `singular beliefs reset --hypothesis test`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json beliefs reset --hypothesis test`
+
+**Erreurs usuelles :** Option requise absente, clé/valeur invalide, confirmation refusée, protection du repo, permissions.
+
+<!-- cli-command: uninstall -->
+## `uninstall`
+
+**Syntaxe :** `singular uninstall [-h] (--keep-lives | --purge-lives) [--yes] [--force]`
+
+**Arguments et défauts :** `--keep-lives` (`false`); `--purge-lives` (`false`); `--yes` (`false`); `--force` (`false`)
+
+**Prérequis :** Droits d'écriture; confirmation/option destructive appropriée.
+
+**Root et vie ciblés :** Root global pour config/rétention/désinstallation; vie active pour croyances.
+
+**Fichiers lus ou écrits :** Écrit/supprime configuration, `runs/`, `mem/`, croyances ou `lives/` selon la commande.
+
+**Effets de bord :** Effet persistant; purge/reset/uninstall peuvent être irréversibles. Utiliser dry-run quand disponible.
+
+**Exemple minimal :** `singular uninstall --keep-lives --yes`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json uninstall --keep-lives --yes`
+
+**Erreurs usuelles :** Option requise absente, clé/valeur invalide, confirmation refusée, protection du repo, permissions.
+
+## Alias et aide
+
+`veille` est un alias exact de `watch`; `talk --live` est un alias déprécié de `talk --life`; `birth` peut être désactivé avec `SINGULAR_ENABLE_BIRTH_ALIAS=0`. `singular <commande> --help` reste la source exécutable pour le détail des metavars.

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -993,32 +993,12 @@ def _create_life_with_bootstrap(
     print(f"Registre de vies utilisé: {registry_root}")
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Run the singular command line interface."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the complete argparse command tree.
 
-    implicit_root_before_override = (
-        _implicit_registry_root_from_env_or_default().resolve()
-    )
-    argv_list = list(argv) if argv is not None else None
-    _preparse_environment(argv_list)
-
-    from .lives import (
-        ally_lives,
-        archive_life,
-        bootstrap_life,
-        clone_life,
-        delete_life,
-        get_registry_root,
-        list_relations,
-        load_registry,
-        memorialize_life,
-        reconcile_lives,
-        reproduce_lives,
-        resolve_life,
-        rival_lives,
-        set_proximity,
-        uninstall_singular,
-    )
+    Keeping parser construction isolated makes the public CLI and its reference
+    documentation mechanically comparable without executing a command.
+    """
 
     parser = argparse.ArgumentParser(prog="singular")
     parser.add_argument(
@@ -1579,6 +1559,38 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Allow purge even if root looks like a development repository",
     )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the singular command line interface."""
+
+    implicit_root_before_override = (
+        _implicit_registry_root_from_env_or_default().resolve()
+    )
+    argv_list = list(argv) if argv is not None else None
+    _preparse_environment(argv_list)
+
+    from .lives import (
+        ally_lives,
+        archive_life,
+        bootstrap_life,
+        clone_life,
+        delete_life,
+        get_registry_root,
+        list_relations,
+        load_registry,
+        memorialize_life,
+        reconcile_lives,
+        reproduce_lives,
+        resolve_life,
+        rival_lives,
+        set_proximity,
+        uninstall_singular,
+    )
+
+    parser = _build_parser()
 
     try:
         args = parser.parse_args(argv_list)

--- a/tests/test_cli_reference.py
+++ b/tests/test_cli_reference.py
@@ -1,0 +1,88 @@
+"""Static parity checks between argparse and the bilingual CLI reference."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from singular.cli import _build_parser
+
+COMMAND_MARKER = re.compile(r"^<!-- cli-command: (.+) -->$", re.MULTILINE)
+REFERENCE_FILES = (
+    Path("docs/cli-reference.fr.md"),
+    Path("docs/cli-reference.en.md"),
+)
+
+
+def _argparse_command_paths(
+    parser: argparse.ArgumentParser, prefix: tuple[str, ...] = ()
+) -> set[str]:
+    """Return canonical command paths, ignoring aliases of the same parser."""
+
+    paths: set[str] = set()
+    for action in parser._actions:
+        if not isinstance(action, argparse._SubParsersAction):
+            continue
+        seen_parsers: set[int] = set()
+        for name, child in action.choices.items():
+            if id(child) in seen_parsers:
+                continue
+            seen_parsers.add(id(child))
+            child_prefix = (*prefix, name)
+            paths.add(" ".join(child_prefix))
+            paths.update(_argparse_command_paths(child, child_prefix))
+    return paths
+
+
+def test_every_argparse_command_is_documented_in_both_languages(
+    monkeypatch,
+) -> None:
+    """Fail when a parser is added without matching FR and EN sections."""
+
+    monkeypatch.setenv("SINGULAR_ENABLE_BIRTH_ALIAS", "1")
+    expected = _argparse_command_paths(_build_parser())
+
+    for reference in REFERENCE_FILES:
+        contents = reference.read_text(encoding="utf-8")
+        markers = COMMAND_MARKER.findall(contents)
+        assert len(markers) == len(set(markers)), f"duplicate marker in {reference}"
+        assert set(markers) == expected, (
+            f"{reference} is out of sync with _build_parser: "
+            f"missing={sorted(expected - set(markers))}, "
+            f"extra={sorted(set(markers) - expected)}"
+        )
+
+
+def test_each_reference_entry_covers_the_documentation_contract() -> None:
+    """Keep each command entry useful, not merely present as an empty heading."""
+
+    required_fr = (
+        "**Syntaxe :**",
+        "**Arguments et défauts :**",
+        "**Prérequis :**",
+        "**Root et vie ciblés :**",
+        "**Fichiers lus ou écrits :**",
+        "**Effets de bord :**",
+        "**Exemple minimal :**",
+        "**Exemple avancé :**",
+        "**Erreurs usuelles :**",
+    )
+    required_en = (
+        "**Syntax :**",
+        "**Arguments and defaults :**",
+        "**Prerequisites :**",
+        "**Target root and life :**",
+        "**Files read or written :**",
+        "**Side effects :**",
+        "**Minimal example :**",
+        "**Advanced example :**",
+        "**Common errors :**",
+    )
+
+    for reference, required in zip(REFERENCE_FILES, (required_fr, required_en)):
+        contents = reference.read_text(encoding="utf-8")
+        entries = COMMAND_MARKER.split(contents)[2::2]
+        for entry in entries:
+            for label in required:
+                assert label in entry, f"{label} missing from an entry in {reference}"


### PR DESCRIPTION
### Motivation

- Provide an exhaustive, machine-checkable reference of every CLI parser/subcommand so documentation remains in sync with the code.
- Enable generating both French and English references without executing the CLI, so docs can be validated in CI.
- Make it possible to statically compare the argparse tree to the human-maintained docs to detect undocumented commands.

### Description

- Extracted parser construction into a new function ` _build_parser()` in `src/singular/cli.py` and updated `main()` to reuse it so the parser tree can be inspected without running commands.
- Added complete bilingual CLI reference documents `docs/cli-reference.fr.md` and `docs/cli-reference.en.md` that enumerate every parser and subcommand with syntax, defaults, prerequisites, target root/life, files read/written, side effects, a minimal example, an advanced example and common errors.
- Added a static test `tests/test_cli_reference.py` that walks `_build_parser()`, canonicalizes command paths (ignoring alias duplicates) and asserts parity with both FR/EN reference files and the presence of required documentation sections per command.
- Updated `README.md` to include a "Parcours par objectif" table linking common user journeys to the CLI reference and relevant guides.

### Testing

- Ran formatting checks: `python -m black --check src/singular/cli.py tests/test_cli_reference.py` which passed or was fixed where needed.
- Executed the new static tests with `PYTHONPATH=src pytest -q tests/test_cli_reference.py` which passed.
- Ran related targeted CLI tests `PYTHONPATH=src pytest -q tests/test_cli_config.py` which passed in the debugging runs shown.
- Note: running the full test suite (`PYTHONPATH=src pytest -q`) hits a pre-existing unrelated collection error in another test that imports `CHECKPOINT_VERSION` from `singular.life.loop`; this failure is external to the changes in this PR and blocks full-suite execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a763e64fbc8832a976e13cb8237f4ad)