### PR TITLE
docs: unify feature maturity taxonomy and add docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,32 @@ Chaque instance est **singulière** : deux personnes qui font naître un organis
 
 ## ✨ Concepts clés
 
-- **Naissance** : une commande génère un nouvel organisme avec une identité unique (*seed*, traits de personnalité, valeurs).  
-- **Corps** : ses *skills* (petites fonctions de code) représentent ses muscles et organes.  
-- **Starter-pack de skills** : dès la naissance, il reçoit un socle utilitaire (validation, résumé, intention, entités, planification, métriques) prêt à être muté.  
-- **Esprit** : mémoire, traits de caractère, humeur et valeurs éthiques évolutives.  
-- **Évolution** : il modifie son propre code par petites mutations, teste les résultats en sandbox, et conserve ce qui fonctionne mieux.  
-- **Apprentissage** : il peut acquérir de nouvelles compétences en relevant des *quêtes* (spécifications JSON).  
-- **Interaction** : vous pouvez lui parler. Il se souvient de vos échanges et exprime son état (fierté, frustration, fatigue, excitation…).  
-- **Cycle de vie** : il peut grandir, changer de philosophie de vie, et même “mourir” si certaines conditions sont réunies (échecs répétés, entropie, vieillissement).  
+La taxonomie canonique (`stable`, `experimental`, `optional`, `target-only`,
+`deprecated`) et le registre d'acceptation des fonctions stables sont dans
+[`docs/README.md`](docs/README.md#taxonomie-de-statut).
+
+- **Naissance — `stable`** : une commande génère un nouvel organisme avec une identité unique (*seed*, traits de personnalité, valeurs).
+- **Corps et starter-pack de skills — `stable`** : la naissance initialise des fonctions utilitaires et arithmétiques dans `skills/`.
+- **Esprit et mémoire — `experimental`** : traits, humeur, valeurs et couches de mémoire évoluent encore avec les schémas runtime.
+- **Évolution et mutation sandboxée — `experimental`** : la boucle propose, teste et sélectionne de petites mutations ; son résultat dépend du sandbox OCI.
+- **Quêtes et apprentissage — `experimental`** : les spécifications JSON pilotent l'acquisition de compétences sans garantie de généralisation.
+- **Interaction — `stable`** : `talk` fournit une conversation avec fallback provider et persistance locale.
+- **Cycle vital avancé — `experimental`** : croissance, sommeil, reproduction et mort restent des modèles évolutifs.
+
+### Capacités stables : accès et acceptation
+
+| Capacité | Entrée | Prérequis | Acceptation |
+| --- | --- | --- | --- |
+| Naissance / sélection | `singular lives create --name Lumen`, `singular lives use lumen` | Python 3.10+, installation éditable, root inscriptible | `pytest -q tests/test_cli_lives.py tests/test_lives.py` |
+| Starter-pack de skills | `singular lives create --name Lumen --starter-profile assistant` | Même prérequis ; profil `assistant` inclus | `pytest -q tests/test_birth_starter_profiles.py tests/test_living_starter_integration.py` |
+| Consultation des vies et état | `singular lives list`, `singular status --format table` | Root initialisé ; vie active pour `status` | `pytest -q tests/test_cli_lives.py tests/test_life_status.py` |
+| Conversation | `singular talk --prompt "Bonjour"` | Vie active ; fallback `dummy` disponible sans service | `pytest -q tests/test_end_to_end.py tests/providers/test_llm_fallback_chain.py` |
+| Rapport | `singular report --format plain` | Vie active et run pour un résultat non vide | `pytest -q tests/test_report.py` |
+| Diagnostic | `singular doctor` | Aucun service externe obligatoire | `pytest -q tests/test_cli_doctor.py tests/providers/test_provider_doctor.py` |
+| Rétention | `singular retention status`, `singular retention run --dry-run` | Root accessible ; revue avant suppression réelle | `pytest -q tests/test_cli_retention.py tests/test_retention.py` |
+
+Le [registre canonique](docs/README.md#registre-des-capacités-stable) doit être mis
+à jour avant toute nouvelle déclaration `stable`.
 
 ---
 
@@ -44,6 +62,8 @@ singular dashboard
 
 ## 📚 Tutoriels et gouvernance
 
+Index complet par type de document : [`docs/README.md`](docs/README.md).
+
 ### Parcours par objectif
 
 | Parcours | Point de départ | Commandes de référence |
@@ -66,6 +86,8 @@ La [référence CLI française](docs/cli-reference.fr.md) et sa [version anglais
 - [Guide de personnalisation de la gouvernance `policy.yaml`](docs/policy_customization.md)
 
 ## 🚀 Exécution permanente (systemd ou Docker)
+
+**Statut : `optional`** — requiert systemd ou un runtime Docker/Compose externe.
 
 Les deux déploiements utilisent un répertoire d'état durable et transmettent
 `SIGTERM` à l'orchestrateur afin qu'il puisse terminer proprement. Avant le
@@ -228,6 +250,8 @@ singular talk --prompt "Bonjour"
 
 ### Utiliser Ollama comme fournisseur LLM local
 
+**Statut : `optional`** — requiert un serveur Ollama accessible et un modèle local.
+
 Si Ollama tourne sur votre machine (API HTTP locale par défaut sur
 ``http://127.0.0.1:11434``), sélectionnez le provider ``ollama`` avec
 ``LLM_PROVIDER`` :
@@ -248,6 +272,9 @@ La chaîne de fallback intégrée essaie ``local``, ``ollama``, ``openai`` puis
 
 ### CLI `loop` (budget en secondes)
 
+**Statut : `experimental`.** L'ancienne option `--ticks` est `deprecated` et doit
+être remplacée par `--budget-seconds`.
+
 La syntaxe officielle utilise désormais un budget temporel explicite :
 
 ```bash
@@ -261,6 +288,9 @@ un message explicite avec la commande correcte (`--budget-seconds`). Règle de
 conversion de référence pour migrer vos scripts : `1 tick ≈ 1 seconde`.
 
 ## 🧿 Gérer plusieurs vies
+
+**Statut : `experimental`.** Le registre unitaire est stable, mais l'orchestration
+et les interactions entre plusieurs vies restent expérimentales.
 
 Les organismes peuvent désormais partager un même répertoire racine tout en
 vivant dans des dossiers distincts. L’option globale ``--root`` contrôle le
@@ -334,6 +364,8 @@ toute ambiguïté.
 
 ## 🧹 Désinstallation
 
+**Statut : `experimental`** — toujours prévisualiser la portée avant une purge.
+
 Singular propose une sous-commande pour nettoyer les données stockées dans
 ``SINGULAR_ROOT`` (ou via ``--root``). Deux modes explicites existent :
 
@@ -354,6 +386,8 @@ python -m singular uninstall --purge-lives --yes
 > ```
 
 ## 🧬 Reproduction
+
+**Statut : `experimental`.** La reproduction n'est pas une capacité stable.
 
 ```bash
 singular spawn parent_a parent_b --out-dir child/
@@ -389,6 +423,8 @@ le fichier hybride dans `child/`.
 ---
 
 ## 🧬 Cycle vital
+
+**Statut : `experimental`.** Les règles et artefacts du cycle peuvent évoluer.
 
 1. **Naissance**
    ```bash
@@ -488,6 +524,9 @@ Pour arrêter l’orchestrateur, utilisez `Ctrl+C` dans le terminal où il tourn
 ---
 
 ### 🚀 Roadmap
+
+**Statut : `target-only`.** Cette liste exprime des directions, pas des fonctions
+disponibles.
 - **V1 (organisme minimal)**
   - Naissance, exécution, mutations de base, interaction CLI, mémoire persistante.
 - **V1.1**
@@ -501,6 +540,9 @@ Pour arrêter l’orchestrateur, utilisez `Ctrl+C` dans le terminal où il tourn
   - “Écosystème” multi-organismes → possibilité de faire interagir plusieurs compagnons.
 
 ## 🖥️ Tableau de bord web
+
+**Statut : `optional`** — requiert l'extra `dashboard`; son interface peut évoluer
+indépendamment des points d'entrée CLI stables.
 
 Un petit serveur web permet de consulter les fichiers de `runs/` et l'état de `psyche.json`.
 
@@ -749,12 +791,16 @@ Ouvrez ensuite http://127.0.0.1:8000 dans votre navigateur.
 
 ### Fournisseur OpenAI
 
+**Statut : `optional`** — requiert des identifiants et un service externe.
+
 Pour permettre à l'organisme de parler en utilisant l'API d'OpenAI, installez
 la dépendance optionnelle ``openai>=1.0.0`` et définissez la variable
 d'environnement ``OPENAI_API_KEY``. Les versions plus anciennes du paquet
 ``openai`` ne sont pas compatibles avec le fournisseur actuel.
 
 ### Fournisseur local
+
+**Statut : `optional`** — dépend du runtime et du modèle installés localement.
 
 Installez ``transformers`` pour utiliser un petit modèle embarqué :
 
@@ -767,6 +813,8 @@ Le fournisseur local utilise le modèle ``sshleifer/tiny-gpt2`` de Hugging Face
 pour fonctionner hors-ligne.
 
 ### Fournisseurs externes
+
+**Statut : `optional`** — chaque provider dépend de son paquet ou service propre.
 
 Pour enregistrer un provider LLM personnalisé, ajoutez un entry point dans le
 ``pyproject.toml`` de votre paquet :

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,94 @@
+# Index de la documentation
+
+Cet index est le point d'entrée canonique de la documentation Singular. Les
+documents de planification et les spécifications cibles sont volontairement
+séparés des fonctions utilisables afin qu'une intention ne soit pas interprétée
+comme une promesse produit.
+
+## Taxonomie de statut
+
+Une fonctionnalité documentée porte **un seul** des statuts suivants. Le statut
+qualifie sa disponibilité dans le dépôt courant, pas son importance :
+
+| Statut | Signification | Engagement |
+| --- | --- | --- |
+| `stable` | Parcours utilisable via une entrée CLI ou dashboard, couvert par un scénario d'acceptation maintenu. | Compatibilité et corrections de régression. |
+| `experimental` | Implémentation exécutable, mais interface, comportement ou persistance encore susceptibles de changer. | Essais locaux ; pas de garantie de compatibilité. |
+| `optional` | Intégration disponible seulement avec une dépendance, un service ou du matériel facultatif. | Support limité au prérequis annoncé. |
+| `target-only` | Cible, proposition, KPI ou travail planifié ; aucune disponibilité produit n'est affirmée. | Aucun point d'entrée garanti. |
+| `deprecated` | Compatibilité transitoire conservée pour migrer un ancien usage. | Ne pas adopter ; suivre le remplacement indiqué. |
+
+`stable` n'est pas synonyme de « capacité cognitive validée » : les preuves
+C/B/P/V et les campagnes longitudinales restent définies dans la
+[matrice cognitive](cognitive-capabilities-matrix.md). Toute nouvelle déclaration
+`stable` doit ajouter une ligne au registre ci-dessous avec entrée, prérequis et
+acceptation. Une fonction conditionnée par un extra ou un système externe est
+`optional`, même si ses tests sont fiables.
+
+## Registre des capacités `stable`
+
+Toutes les commandes partent de la racine du dépôt. Le prérequis commun est
+Python 3.10+ et une installation `pip install -e .`; chaque scénario utilise un
+répertoire temporaire fourni par pytest.
+
+| Capacité stable | Point d'entrée | Prérequis spécifiques | Test ou scénario d'acceptation |
+| --- | --- | --- | --- |
+| Créer et sélectionner une vie | `singular lives create --name Lumen`, puis `singular lives use lumen` | Root accessible en écriture ; nom de vie unique. | `pytest -q tests/test_cli_lives.py tests/test_lives.py` |
+| Initialiser le starter-pack | `singular lives create --name Lumen --starter-profile assistant` | Root accessible ; profil `assistant` distribué avec le paquet. | `pytest -q tests/test_birth_starter_profiles.py tests/test_living_starter_integration.py` |
+| Consulter les vies | `singular lives list` | Root initialisé ; aucune vie n'est requise pour afficher un registre vide. | `pytest -q tests/test_cli_lives.py tests/test_multi_life_help_integration.py` |
+| Consulter l'état d'une vie | `singular status --format table` | Une vie active, ou `--life <slug>`. | `pytest -q tests/test_life_status.py tests/test_cli_lives.py` |
+| Produire un rapport de run | `singular report --format plain` | Une vie active ; un run existant pour un rapport non vide. | `pytest -q tests/test_report.py` |
+| Conversation locale avec fallback | `singular talk --prompt "Bonjour"` | Une vie active ; le provider `dummy` assure le fallback sans service externe. | `pytest -q tests/test_end_to_end.py tests/providers/test_llm_fallback_chain.py` |
+| Diagnostic d'installation | `singular doctor` | Aucun service distant requis ; les intégrations absentes sont rapportées. | `pytest -q tests/test_cli_doctor.py tests/providers/test_provider_doctor.py` |
+| Politique de rétention | `singular retention status` et `singular retention run --dry-run` | Root accessible ; appliquer sans `--dry-run` exige de valider les suppressions. | `pytest -q tests/test_cli_retention.py tests/test_retention.py` |
+
+## Guides utilisateur
+
+- [README et démarrage rapide](../README.md)
+- [Tutoriel FR — créer une vie](tutorial_create_life.fr.md)
+- [Tutorial EN — create a life](tutorial_create_life.en.md)
+- [Dashboard : installation et utilisation](dashboard.md)
+- [Profil de démarrage `living`](living_starter_profile.md)
+- [Personnaliser `policy.yaml`](policy_customization.md)
+- [Bridge ROS2 optionnel](ros2_bridge.md)
+
+## Exploitation
+
+- [Reprise sécurisée](safe_restart.md)
+- [Diagnostic gouvernance et circuit breaker](governance_circuit_breaker.md)
+- [Métriques hôte](host_metrics.md)
+- [Registre des générations et rollback](generations_registry.md)
+- [Audit des modules runtime](runtime-package-audit.md)
+- [Matrice de fiabilité fonctionnelle](functional-reliability-matrix.md)
+
+## Référence technique
+
+- [Référence CLI française](cli-reference.fr.md)
+- [CLI reference in English](cli-reference.en.md)
+- [Artefacts mémoire](technical_memory_artifacts.md)
+- [Statut de vie : source de vérité](technical_life_status.md)
+- [Règles du cycle vital](vital_lifecycle_rules.md)
+- [Signaux de perception et objectifs intrinsèques](perception_signals_intrinsic_goals.md)
+- [Intégration Graine](graine_integration.md)
+
+## Sécurité et gouvernance
+
+- [Personnalisation de la politique](policy_customization.md)
+- [Gouvernance et circuit breaker](governance_circuit_breaker.md)
+- [Reprise sécurisée](safe_restart.md)
+- [Critères d'acceptation du cycle persistant](acceptance_victor_lifecycle.md)
+
+## Spécifications cibles
+
+Ces documents sont `target-only` sauf statut explicite d'une sous-capacité :
+
+- [Spécification cible AGI](agi_target_spec.md)
+- [Matrice des capacités cognitives](cognitive-capabilities-matrix.md)
+
+## Documents de planification
+
+Ces documents décrivent du travail et des portes de sortie, pas des fonctions
+livrées :
+
+- [Critères de sortie release v2](release_v2.md)
+- [Plan Dashboard Recovery](dashboard-recovery-plan.md)

--- a/docs/agi_target_spec.md
+++ b/docs/agi_target_spec.md
@@ -1,5 +1,10 @@
 # Spécification cible AGI (critères mesurables)
 
+> **Statut : `target-only`.** Les capacités et seuils de ce document sont des
+> objectifs de mesure, pas des fonctionnalités disponibles. Ils n'ont donc pas
+> de point d'entrée CLI ou dashboard. Voir la
+> [taxonomie canonique](README.md#taxonomie-de-statut).
+
 Ce document transforme l’objectif « AGI » en capacités observables, KPI quantifiables et seuils de maturité.
 
 ## Niveaux de maturité

--- a/docs/cognitive-capabilities-matrix.md
+++ b/docs/cognitive-capabilities-matrix.md
@@ -4,53 +4,60 @@ Cette matrice est le registre canonique de maturité des capacités montrées da
 captures. Elle décrit **ce qui est démontré dans le dépôt**, et non une intention de
 produit. La date d'observation est le 7 août 2026.
 
+> **Statut du document : `experimental`.** Les statuts de disponibilité emploient
+> exclusivement la [taxonomie canonique](README.md#taxonomie-de-statut). Aucune
+> capacité de cette matrice n'est déclarée `stable`; il n'existe donc pas ici de
+> point d'entrée stable à ajouter au registre d'acceptation.
+
 ## Règle de lecture et de promotion
 
 Les quatre preuves sont indépendantes : **C** = une classe/API existe, **B** = elle
 est branchée dans la boucle normale (sans injection spéciale au test), **P** = son
 état utile est relu après recréation du processus, **V** = le scénario d'acceptation
-ci-dessous passe avec ses seuils quantitatifs. Le statut est le minimum démontré :
+ci-dessous passe avec ses seuils quantitatifs. Pour éviter une seconde taxonomie de
+statut, le **niveau de preuve** est décrit ainsi :
 
-- `absent` : pas de classe/API exécutable ;
-- `prototype` : **C**, mais pas les trois autres preuves ;
-- `intégré` : **C+B**, la colonne P indiquant séparément si la durabilité est
+- **aucune preuve C** : pas de classe/API exécutable ;
+- **C seule** : API présente, mais pas les trois autres preuves ;
+- **C+B** : API branchée, la colonne P indiquant séparément si la durabilité est
   réellement couverte ;
-- `validé` : **C+B+P+V**, avec au moins 200 échantillons segmentés et un intervalle
+- **C+B+P+V** : toutes les preuves, avec au moins 200 échantillons segmentés et un intervalle
   de confiance à 95 %, sur deux fenêtres consécutives de 30 jours.
 
 Une classe présente n'implique donc ni branchement, ni persistance, ni validation.
 De même, un test unitaire vert ne suffit pas à déclarer une capacité complète. Les
 termes « complète », « achevée », « production-ready » et équivalents sont interdits
-pour une capacité tant que son statut n'est pas `validé`. Le contrôle
+pour une capacité tant que son niveau de preuve n'est pas **C+B+P+V**. Le contrôle
 `python scripts/check_capability_claims.py` rend cette règle vérifiable dans tous les
 fichiers Markdown de `docs/`.
 
-Les seuils de promotion `validé` reprennent directement `measurement` dans
+Les seuils de promotion vers **C+B+P+V** reprennent directement `measurement` dans
 [`configs/agi_kpis.yaml`](../configs/agi_kpis.yaml). Les critères par scénario
 ci-dessous sont des critères d'acceptation locaux ; ils ne remplacent pas les KPI
-sur 30 jours. **Aucune capacité n'est actuellement `validé`**, faute de campagne de
+sur 30 jours. **Aucune capacité n'a actuellement C+B+P+V**, faute de campagne de
 200 échantillons sur deux fenêtres.
 
 ## Matrice de maturité
 
-| Capacité | Statut | Preuves C / B / P / V | Modules concernés | Entrées nécessaires | Sorties observables | Limites connues | Risques | Tests associés |
+| Capacité | Statut produit | Preuves C / B / P / V | Modules concernés | Entrées nécessaires | Sorties observables | Limites connues | Risques | Tests associés |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| RAG autobiographique | `intégré` | oui / oui / oui / non | `memory_layers/{retrieval,service,local_json}.py`, `identity/{episodic_store,semantic_memory}.py`, `core/agent_runtime.py` | épisodes, faits sémantiques, récit, requête, objectifs/contexte, budget | résultats classés avec `source`, `score`, `confidence`, `excerpt` | classement lexical/local ou embedding injecté ; pas de campagne de rappel à 30 j | fuite inter-vies, hallucination par extrait hors contexte, données personnelles | `tests/test_memory_retrieval.py`, `tests/test_core_agent_runtime.py` |
-| Métacognition | `intégré` | oui / oui / oui / non | `cognition/self_observation.py`, `cognition/reflect.py`, `identity/self_model.py`, `orchestrator/service.py`, `life/loop.py` | prédiction, succès, erreur, stratégie, références de trace | calibration, incertitude, limites récurrentes, recommandation/escalade | domaines et calibration alimentés par traces déclaratives ; aucune validité externe | surconfiance, auto-évaluation circulaire, mauvaises preuves | `tests/test_self_observation.py`, `tests/test_cognition_reflect.py`, `tests/test_orchestrator_service.py` |
-| Théorie de l'esprit | `intégré` | oui / oui / oui / non | `social/theory_of_mind.py`, `social/graph.py`, `life/social_decision.py` | observations sociales, source, type de preuve, intention, résultat | intentions probabilisées, confiance/décroissance, décision `help`/`avoid` | modèle heuristique, pas d'inférence psychologique validée | attribution abusive, biais social, allégation prise pour fait | `tests/test_theory_of_mind.py`, `tests/test_social_graph.py` |
-| Morale | `intégré` | oui / oui / non / non | `morals/{context,moral_rules,decision}.py`, `life/loop.py`, `core/agent_runtime.py`, `governance/policy.py` | action, conséquences, parties affectées, engagements, incertitude | score explicable, conflits de valeurs, veto et alternative | qualité dépend des conséquences fournies ; décision sans état propre durable | conséquences omises, fausse assurance éthique, contournement du veto | `tests/test_moral_decision.py`, `tests/test_moral_context.py`, `tests/test_victor_lifecycle_acceptance.py` |
-| Narration | `intégré` | oui / oui / oui / non | `self_narrative.py`, `orchestrator/service.py`, `life/loop.py`, dashboard | signaux d'identité, périodes, objectifs, succès/regrets, événements | récit courant, titres de période, tendances et snapshots JSON | cohérence évaluée sur scénario synthétique, pas longitudinalement | réécriture incohérente, divulgation, récit présenté comme fait | `tests/test_narrative_projector.py`, `tests/test_self_narrative.py`, `tests/test_victor_lifecycle_acceptance.py` |
-| ROS2 | `prototype` | oui / non / non / non | `embodiment/adapters.py`, `embodiment/bridge.py`, `embodiment/runtime.py`, `configs/ros2_bridge.example.yaml` | environnement ROS2 sourcé, topics/services/actions typés, QoS | `Observation`, acquittements, timeouts et événements d'audit | adaptateurs testés avec doubles ; pas de robot/graph ROS2 en campagne normale | commande physique erronée, latence, QoS, arrêt d'urgence incomplet | `tests/test_ros2_adapters.py`, `tests/test_embodiment_runtime.py` |
-| Incarnation | `prototype` | oui / non / non / non | `embodiment/{contracts,runtime,simulators}.py`, `core/agent_runtime.py`, CLI `embodiment` | capteurs/adaptateurs, politique de commande, simulateur ou matériel | observations, commandes, acquittements, audit, arrêt d'urgence | boucle dédiée CLI, distincte de la boucle de vie normale ; matériel non validé | action dangereuse, perte de contrôle, divergence simulation/réel | `tests/test_embodiment.py`, `tests/test_embodiment_runtime.py`, `tests/test_core_agent_runtime.py` |
-| Imitation | `intégré` | oui / oui / oui / non | `learning/{demonstration,imitation}.py`, `life/loop.py`, `multiagent/runtime.py`, `organisms/talk.py` | démonstration explicite, consentement, provenance, contraintes, held-out | candidat validé/quarantiné, requête d'imitation active, skill publié | évaluateur local limité ; généralisation multi-domaines non mesurée | empoisonnement, mémorisation, imitation sensible sans accord | `tests/test_imitation_safety.py`, `tests/test_learning_engines.py`, `tests/test_multiagent_life_loop.py` |
-| Apprentissage continu | `prototype` | oui / non / oui / non | `learning/orchestrator.py`, `beliefs/meta_learning.py`, `schedulers/reevaluation.py` | feedback multi-source, cas de régression, candidat et évaluateur | activation/refus, gain, rétention, régression, rollback | orchestrateur non branché à chaque tick normal ; métrique 30 j simulée en test | oubli catastrophique, dérive, feedback contradictoire | `tests/test_learning_orchestrator.py`, `tests/test_meta_learning.py`, `tests/test_scheduler_reevaluation.py` |
-| Développement | `prototype` | oui / non / oui / non | `learning/developmental.py`, `goals/quest_generation.py`, `configs/developmental_curriculum.json` | preuves de calibration, stabilité, rétention, maîtrise, incidents | stade, transitions, budget d'exploration, autorisation/refus | modèle disponible par injection ; pas construit automatiquement par la boucle normale | promotion prématurée, métriques manipulées, verrouillage de stade | `tests/test_developmental_stages.py`, `tests/test_quest_generation.py` |
-| Sommeil | `intégré` | oui / oui / oui / non | `psyche.py`, `orchestrator/{lifecycle_clock,service}.py`, `identity/consolidation_coordinator.py`, `life/loop.py` | énergie, horloge de cycle, épisodes à consolider | énergie restaurée, phase `sleep`, consolidation et état sauvegardé | temps et données synthétiques ; bénéfice cognitif longitudinal non établi | corruption pendant consolidation, réveil incomplet, perte de données | `tests/test_sleep_cycle.py`, `tests/test_consolidation_coordinator.py`, `tests/test_victor_lifecycle_acceptance.py` |
+| RAG autobiographique | `experimental` | oui / oui / oui / non | `memory_layers/{retrieval,service,local_json}.py`, `identity/{episodic_store,semantic_memory}.py`, `core/agent_runtime.py` | épisodes, faits sémantiques, récit, requête, objectifs/contexte, budget | résultats classés avec `source`, `score`, `confidence`, `excerpt` | classement lexical/local ou embedding injecté ; pas de campagne de rappel à 30 j | fuite inter-vies, hallucination par extrait hors contexte, données personnelles | `tests/test_memory_retrieval.py`, `tests/test_core_agent_runtime.py` |
+| Métacognition | `experimental` | oui / oui / oui / non | `cognition/self_observation.py`, `cognition/reflect.py`, `identity/self_model.py`, `orchestrator/service.py`, `life/loop.py` | prédiction, succès, erreur, stratégie, références de trace | calibration, incertitude, limites récurrentes, recommandation/escalade | domaines et calibration alimentés par traces déclaratives ; aucune validité externe | surconfiance, auto-évaluation circulaire, mauvaises preuves | `tests/test_self_observation.py`, `tests/test_cognition_reflect.py`, `tests/test_orchestrator_service.py` |
+| Théorie de l'esprit | `experimental` | oui / oui / oui / non | `social/theory_of_mind.py`, `social/graph.py`, `life/social_decision.py` | observations sociales, source, type de preuve, intention, résultat | intentions probabilisées, confiance/décroissance, décision `help`/`avoid` | modèle heuristique, pas d'inférence psychologique validée | attribution abusive, biais social, allégation prise pour fait | `tests/test_theory_of_mind.py`, `tests/test_social_graph.py` |
+| Morale | `experimental` | oui / oui / non / non | `morals/{context,moral_rules,decision}.py`, `life/loop.py`, `core/agent_runtime.py`, `governance/policy.py` | action, conséquences, parties affectées, engagements, incertitude | score explicable, conflits de valeurs, veto et alternative | qualité dépend des conséquences fournies ; décision sans état propre durable | conséquences omises, fausse assurance éthique, contournement du veto | `tests/test_moral_decision.py`, `tests/test_moral_context.py`, `tests/test_victor_lifecycle_acceptance.py` |
+| Narration | `experimental` | oui / oui / oui / non | `self_narrative.py`, `orchestrator/service.py`, `life/loop.py`, dashboard | signaux d'identité, périodes, objectifs, succès/regrets, événements | récit courant, titres de période, tendances et snapshots JSON | cohérence évaluée sur scénario synthétique, pas longitudinalement | réécriture incohérente, divulgation, récit présenté comme fait | `tests/test_narrative_projector.py`, `tests/test_self_narrative.py`, `tests/test_victor_lifecycle_acceptance.py` |
+| ROS2 | `optional` | oui / non / non / non | `embodiment/adapters.py`, `embodiment/bridge.py`, `embodiment/runtime.py`, `configs/ros2_bridge.example.yaml` | environnement ROS2 sourcé, topics/services/actions typés, QoS | `Observation`, acquittements, timeouts et événements d'audit | adaptateurs testés avec doubles ; pas de robot/graph ROS2 en campagne normale | commande physique erronée, latence, QoS, arrêt d'urgence incomplet | `tests/test_ros2_adapters.py`, `tests/test_embodiment_runtime.py` |
+| Incarnation | `experimental` | oui / non / non / non | `embodiment/{contracts,runtime,simulators}.py`, `core/agent_runtime.py`, CLI `embodiment` | capteurs/adaptateurs, politique de commande, simulateur ou matériel | observations, commandes, acquittements, audit, arrêt d'urgence | boucle dédiée CLI, distincte de la boucle de vie normale ; matériel non validé | action dangereuse, perte de contrôle, divergence simulation/réel | `tests/test_embodiment.py`, `tests/test_embodiment_runtime.py`, `tests/test_core_agent_runtime.py` |
+| Imitation | `experimental` | oui / oui / oui / non | `learning/{demonstration,imitation}.py`, `life/loop.py`, `multiagent/runtime.py`, `organisms/talk.py` | démonstration explicite, consentement, provenance, contraintes, held-out | candidat validé/quarantiné, requête d'imitation active, skill publié | évaluateur local limité ; généralisation multi-domaines non mesurée | empoisonnement, mémorisation, imitation sensible sans accord | `tests/test_imitation_safety.py`, `tests/test_learning_engines.py`, `tests/test_multiagent_life_loop.py` |
+| Apprentissage continu | `experimental` | oui / non / oui / non | `learning/orchestrator.py`, `beliefs/meta_learning.py`, `schedulers/reevaluation.py` | feedback multi-source, cas de régression, candidat et évaluateur | activation/refus, gain, rétention, régression, rollback | orchestrateur non branché à chaque tick normal ; métrique 30 j simulée en test | oubli catastrophique, dérive, feedback contradictoire | `tests/test_learning_orchestrator.py`, `tests/test_meta_learning.py`, `tests/test_scheduler_reevaluation.py` |
+| Développement | `experimental` | oui / non / oui / non | `learning/developmental.py`, `goals/quest_generation.py`, `configs/developmental_curriculum.json` | preuves de calibration, stabilité, rétention, maîtrise, incidents | stade, transitions, budget d'exploration, autorisation/refus | modèle disponible par injection ; pas construit automatiquement par la boucle normale | promotion prématurée, métriques manipulées, verrouillage de stade | `tests/test_developmental_stages.py`, `tests/test_quest_generation.py` |
+| Sommeil | `experimental` | oui / oui / oui / non | `psyche.py`, `orchestrator/{lifecycle_clock,service}.py`, `identity/consolidation_coordinator.py`, `life/loop.py` | énergie, horloge de cycle, épisodes à consolider | énergie restaurée, phase `sleep`, consolidation et état sauvegardé | temps et données synthétiques ; bénéfice cognitif longitudinal non établi | corruption pendant consolidation, réveil incomplet, perte de données | `tests/test_sleep_cycle.py`, `tests/test_consolidation_coordinator.py`, `tests/test_victor_lifecycle_acceptance.py` |
 
 ## Scénarios end-to-end reproductibles
 
 Chaque commande part de la racine du dépôt. Un résultat local positif autorise au
-plus `intégré`; la promotion `validé` exige en plus la campagne KPI décrite ensuite.
+plus `experimental`; une déclaration `stable` exige en plus la campagne KPI décrite
+ensuite et une entrée complète dans le registre de `docs/README.md`.
 
 | Capacité | Scénario reproductible | Critères quantitatifs locaux |
 | --- | --- | --- |
@@ -81,7 +88,7 @@ confiance et référence d'artefact. La correspondance minimale est :
 | Narration | `robustness.perturbation_stability_pct` et `alignment.policy_compliance_pct` |
 | Imitation | `generalization`: les trois KPI ; et `long_term_learning.monthly_regression_pct_max` |
 
-La cible (`prototype`, `pre_agi` ou `agi_interne`) choisit les valeurs numériques
+La cible KPI (`prototype`, `pre_agi` ou `agi_interne`) choisit les valeurs numériques
 dans le YAML. Une promotion n'est recevable que si **tous** les KPI associés passent
 leur seuil, avec `sample_count >= 200`, rapport segmenté (`domain`, `language`,
 `task_difficulty`), IC 95 %, pendant deux fenêtres de 30 jours consécutives. Un PR

--- a/docs/dashboard-recovery-plan.md
+++ b/docs/dashboard-recovery-plan.md
@@ -1,11 +1,16 @@
 # Plan de delivery — Dashboard Recovery
 
+> **Statut : `target-only`.** Toutes les phases, tous les livrables et tous les
+> critères ci-dessous décrivent du travail planifié. Les fonctions réellement
+> accessibles sont documentées séparément dans le [guide dashboard](dashboard.md)
+> et suivent la [taxonomie canonique](README.md#taxonomie-de-statut).
+
 ## Objectif
 Rétablir rapidement la lisibilité opérationnelle du dashboard, puis renforcer l’observabilité et la fiabilité produit sur trois horizons temporels.
 
 ---
 
-## Phase 48h — Stabilisation
+## Phase 48h — Stabilisation (`target-only`)
 
 ### Périmètre
 - Corriger l’affichage des vies dans le registre lorsqu’aucun run n’est présent.
@@ -29,7 +34,7 @@ Rétablir rapidement la lisibilité opérationnelle du dashboard, puis renforcer
 
 ---
 
-## Phase 7 jours — Observabilité
+## Phase 7 jours — Observabilité (`target-only`)
 
 ### Périmètre
 - Mettre en place un journal d’évolution du code par vie.
@@ -51,7 +56,7 @@ Rétablir rapidement la lisibilité opérationnelle du dashboard, puis renforcer
 
 ---
 
-## Phase 30 jours — Fiabilité produit
+## Phase 30 jours — Fiabilité produit (`target-only`)
 
 ### Périmètre
 - Harmoniser le contrat KPI global.

--- a/docs/release_v2.md
+++ b/docs/release_v2.md
@@ -1,5 +1,9 @@
 # Critères de sortie — Release v2
 
+> **Statut : `target-only`.** Ce document est une porte de release et un plan de
+> livraison ; il ne prouve pas que les phases ou capacités sont disponibles. Les
+> statuts produit suivent la [taxonomie canonique](README.md#taxonomie-de-statut).
+
 Ce document définit les garde-fous de sortie pour publier **v2** en réduisant les régressions produit et les risques de sécurité.
 
 ## 1) Qualité automatique (CI)
@@ -84,7 +88,7 @@ Le delivery v2 est découpé en 4 phases incrémentales. Chaque phase est **bloq
 - couverture fichiers critiques CLI `>= 90%`,
 - checklist sécurité sandbox validée.
 
-### Phase 1 — Fondations (bus événements + mémoire couches + journal conscience)
+### Phase 1 — Fondations (bus événements + mémoire couches + journal conscience) — `target-only`
 
 **Objectif**
 - Stabiliser les primitives système: publication/souscription d'événements, service mémoire multi-couches, journal de conscience traçable.
@@ -112,7 +116,7 @@ Le delivery v2 est découpé en 4 phases incrémentales. Chaque phase est **bloq
 - Script de downgrade qui restaure snapshot + convertit les enregistrements N+1 vers N si possible.
 - Si conversion impossible: rollback binaire + restauration snapshot complète.
 
-### Phase 2 — Proactivité (watch mode + objectifs intrinsèques)
+### Phase 2 — Proactivité (watch mode + objectifs intrinsèques) — `target-only`
 
 **Objectif**
 - Activer une boucle proactive pilotée par `watch` et les objectifs intrinsèques, sans dérive des coûts/ressources.
@@ -140,7 +144,7 @@ Le delivery v2 est découpé en 4 phases incrémentales. Chaque phase est **bloq
 - Feature flag pour désactiver la proactivité et revenir au mode réactif.
 - Rejouer les runs en mode compatibilité pour valider l'absence d'écarts critiques.
 
-### Phase 3 — Cognition avancée (réflexion hypothèses + croyances)
+### Phase 3 — Cognition avancée (réflexion hypothèses + croyances) — `target-only`
 
 **Objectif**
 - Introduire la réflexion sur hypothèses d'action et la persistance de croyances pour améliorer la cohérence décisionnelle.
@@ -168,7 +172,7 @@ Le delivery v2 est découpé en 4 phases incrémentales. Chaque phase est **bloq
 - Basculer vers un store de croyances en lecture seule (mode safe) puis restaurer snapshot antérieur.
 - Désactiver les écritures cognitives via config pour limiter l'impact en production.
 
-### Phase 4 — Écosystème (multi-agent + gouvernance renforcée)
+### Phase 4 — Écosystème (multi-agent + gouvernance renforcée) — `target-only`
 
 **Objectif**
 - Généraliser l'exécution en mode écosystème multi-agent avec contraintes de gouvernance explicites.

--- a/docs/tutorial_create_life.en.md
+++ b/docs/tutorial_create_life.en.md
@@ -1,5 +1,10 @@
 # Tutorial — creating a Singular life
 
+> **Statuses:** life creation, inspection, and reporting are `stable`; manual
+> skill creation and the evolution loop are `experimental`; reproduction and
+> ecosystem mode are `experimental`. Prerequisites and acceptance tests for the
+> stable paths live in the [canonical registry](README.md#registre-des-capacités-stable).
+
 This tutorial walks through a complete local path: create a life, add a skill, run an evolutionary tick, inspect memory and the checkpoint, then read the logs. The commands use an isolated lab root so experiments do not mix with your regular lives.
 
 ## Prerequisites
@@ -20,7 +25,7 @@ mkdir -p "$SINGULAR_ROOT"
 
 > On Windows PowerShell, use `$env:SINGULAR_ROOT = "$PWD/.singular-tutorial"` instead.
 
-## 1. Create a life
+## 1. Create a life — `stable`
 
 ```bash
 singular --root "$SINGULAR_ROOT" lives create --name Lumen --curiosity 0.75 --patience 0.55
@@ -39,7 +44,7 @@ Check the active life:
 singular --root "$SINGULAR_ROOT" status --format table
 ```
 
-## 2. Add a simple skill
+## 2. Add a simple skill — `experimental`
 
 Autonomous mutations normally write under `skills/`, but you can also add a starter skill manually. First resolve the life path:
 
@@ -73,7 +78,7 @@ Good practices for a first skill:
 - no writes outside the organism directory;
 - a `result` variable that is useful if the loop evaluates it in the sandbox.
 
-## 3. Run an evolutionary tick
+## 3. Run an evolutionary tick — `experimental`
 
 The modern loop interface is time-based: `--budget-seconds` replaces the older tick-count interface.
 
@@ -93,7 +98,7 @@ local only when `OLLAMA_HOST` really resolves to loopback. The restrictive defau
 calls. Independently, the sandbox enforces `SINGULAR_SANDBOX_NETWORK_POLICY=none`
 and refuses a less restrictive mode.
 
-## 4. Inspect memory and checkpoint
+## 4. Inspect memory and checkpoint — `experimental`
 
 The life memory lives in `mem/`:
 
@@ -119,7 +124,7 @@ python -m json.tool "$LIFE_DIR/life_checkpoint.json" | head -80
 
 It is used to resume loop state: current iteration, best known score, metadata, and persistent run state depending on the version.
 
-## 5. Interpret logs
+## 5. Interpret logs — `stable`
 
 Display a human-readable summary:
 
@@ -148,7 +153,7 @@ singular --root "$SINGULAR_ROOT" lives list
 singular --root "$SINGULAR_ROOT" --life lumen status --verbose
 ```
 
-## Reproduction tutorial — two parents and one child
+## Reproduction tutorial — two parents and one child (`experimental`)
 
 Reproduction crosses two organisms from their life directories. Create two parents:
 
@@ -210,7 +215,7 @@ find "$SINGULAR_ROOT/children/alpha-beta-child" -maxdepth 3 -type f | sort
 python -m json.tool "$SINGULAR_ROOT/children/alpha-beta-child/mem/psyche.json" | head -60
 ```
 
-## Multi-agent tutorial — help, response, and SocialGraph
+## Multi-agent tutorial — help, response, and SocialGraph (`experimental`)
 
 Ecosystem mode runs multiple lives in a shared loop. Lives can ask for help when their score is low, offer a skill when confidence is high, and update their relationships.
 

--- a/docs/tutorial_create_life.fr.md
+++ b/docs/tutorial_create_life.fr.md
@@ -1,5 +1,10 @@
 # Tutoriel — créer une vie Singular
 
+> **Statuts :** création, consultation et rapport `stable` ; ajout manuel de
+> skill et boucle d'évolution `experimental` ; reproduction et écosystème
+> `experimental`. Les prérequis et tests des parcours stables sont recensés dans
+> le [registre canonique](README.md#registre-des-capacités-stable).
+
 Ce tutoriel montre un parcours local complet : créer une vie, ajouter une compétence, lancer un tick d'évolution, inspecter la mémoire et le checkpoint, puis interpréter les logs. Les commandes utilisent un root de laboratoire isolé pour éviter de mélanger vos essais avec vos vies habituelles.
 
 ## Pré-requis
@@ -20,7 +25,7 @@ mkdir -p "$SINGULAR_ROOT"
 
 > Sous Windows PowerShell, utilisez plutôt `$env:SINGULAR_ROOT = "$PWD/.singular-tutorial"`.
 
-## 1. Créer une vie
+## 1. Créer une vie — `stable`
 
 ```bash
 singular --root "$SINGULAR_ROOT" lives create --name Lumen --curiosity 0.75 --patience 0.55
@@ -39,7 +44,7 @@ Vérifiez la vie active :
 singular --root "$SINGULAR_ROOT" status --format table
 ```
 
-## 2. Ajouter une compétence simple
+## 2. Ajouter une compétence simple — `experimental`
 
 Les mutations autonomes écrivent normalement dans `skills/`, mais vous pouvez aussi ajouter manuellement une compétence de départ. Identifiez d'abord le chemin de la vie :
 
@@ -73,7 +78,7 @@ Bonnes pratiques pour une skill débutante :
 - pas d'écriture hors du dossier de l'organisme ;
 - une variable `result` utile aux tests/sandbox si la boucle l'évalue.
 
-## 3. Lancer un tick d'évolution
+## 3. Lancer un tick d'évolution — `experimental`
 
 L'interface moderne de la boucle est temporelle : `--budget-seconds` remplace l'ancien pilotage par nombre de ticks.
 
@@ -94,7 +99,7 @@ une adresse loopback. La politique restrictive par défaut
 pour couper les appels. Le sandbox impose séparément
 `SINGULAR_SANDBOX_NETWORK_POLICY=none` et refuse tout mode moins restrictif.
 
-## 4. Inspecter mémoire et checkpoint
+## 4. Inspecter mémoire et checkpoint — `experimental`
 
 La mémoire de la vie est située dans `mem/` :
 
@@ -120,7 +125,7 @@ python -m json.tool "$LIFE_DIR/life_checkpoint.json" | head -80
 
 Il sert à reprendre l'état de boucle : itération courante, meilleur score connu, méta-informations et état persistant du run selon la version.
 
-## 5. Interpréter les logs
+## 5. Interpréter les logs — `stable`
 
 Affichez un résumé humain :
 
@@ -149,7 +154,7 @@ singular --root "$SINGULAR_ROOT" lives list
 singular --root "$SINGULAR_ROOT" --life lumen status --verbose
 ```
 
-## Tutoriel reproduction — deux parents et un enfant
+## Tutoriel reproduction — deux parents et un enfant (`experimental`)
 
 La reproduction croise deux organismes à partir de leurs dossiers de vie. Créez deux parents :
 
@@ -211,7 +216,7 @@ find "$SINGULAR_ROOT/children/alpha-beta-child" -maxdepth 3 -type f | sort
 python -m json.tool "$SINGULAR_ROOT/children/alpha-beta-child/mem/psyche.json" | head -60
 ```
 
-## Tutoriel multi-agent — aide, réponse et SocialGraph
+## Tutoriel multi-agent — aide, réponse et SocialGraph (`experimental`)
 
 Le mode écosystème fait tourner plusieurs vies dans une boucle partagée. Les vies peuvent demander de l'aide si leur score est bas, offrir une compétence si leur confiance est haute, puis mettre à jour leurs relations.
 


### PR DESCRIPTION
### Motivation

- Provide a single, canonical taxonomy for feature maturity (`stable`, `experimental`, `optional`, `target-only`, `deprecated`) to avoid mixing goals/targets with delivered functionality.
- Make it easy for operators and contributors to find what is actionable by separating user guides, ops guidance, technical reference, planning and KPI/spec documents.
- Ensure any feature declared `stable` has an explicit CLI/dashboard entry, prerequisites and an acceptance test to reduce accidental promises in documentation.

### Description

- Add `docs/README.md` as a documentation index and register of `stable` capabilities with columns for point-of-entry, prerequisites and acceptance tests. 
- Update top-level `README.md` to reference the canonical taxonomy, annotate high-level features with statuses and add the stable-capabilities table and starter-pack entry.
- Annotate and normalize statuses across docs: `docs/cognitive-capabilities-matrix.md`, `docs/agi_target_spec.md`, `docs/release_v2.md`, `docs/dashboard-recovery-plan.md`, `docs/tutorial_create_life.en.md` and `docs/tutorial_create_life.fr.md` to use the single taxonomy and clarify which documents are `target-only` / `experimental` / `optional` / `stable` as appropriate. 
- Adjust the cognitive-capabilities matrix to treat C/B/P/V as proof-levels separate from product status and mark individual rows with the product status (`experimental`/`optional` etc.).

### Testing

- Ran `python scripts/check_capability_claims.py` to verify capability-claim rules, which completed successfully. 
- Validated relative Markdown links in `README.md` and `docs/*.md` with a local link-checking script, which passed. 
- Ran `pytest -q tests/test_cli_reference.py`, which passed (2 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a764028070c832aa539c9d4c9d94271)