### PR TITLE
feat(dashboard): add bounded life chronologies with timeseries endpoint and UI

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -44,6 +44,7 @@ from singular.dashboard.services.trajectory import (
 )
 from singular.dashboard.services.lives_comparison import (
     aggregate_lives as aggregate_lives_service,
+    build_life_timeseries,
     compute_liveness_index as compute_liveness_index_service,
     parse_ts as parse_ts_service,
     resolve_time_window_cutoff as resolve_time_window_cutoff_service,
@@ -2052,6 +2053,29 @@ def create_app(
                 "limit": limit,
             },
         }
+
+    @app.get("/api/lives/{life}/timeseries")
+    def read_life_timeseries(
+        life: str,
+        time_window: str = "24h",
+        resolution: str = "hour",
+        limit: int = 500,
+        mutation_index: int | None = None,
+    ) -> dict[str, object]:
+        """Return the bounded chronology used by the combined life detail view."""
+        slug, meta, _ = _resolve_life_entry(life)
+        if slug is None:
+            raise HTTPException(status_code=404, detail="life not found")
+        display_name = life_meta_get(meta, "name", slug)
+        aliases = {life, slug, str(display_name)}
+        records = [rec for rec in _load_run_records(False) if _record_life(rec) in aliases]
+        try:
+            return build_life_timeseries(
+                records, life=slug, time_window=time_window, resolution=resolution,
+                limit=limit, mutation_index=mutation_index, record_run_id=_record_run_id,
+            )
+        except (ValueError, IndexError) as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     @app.get("/lives/comparison")
     def read_lives_comparison(

--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from typing import Callable
+from urllib.parse import quote
 
 
 _RECENT_ACTIVITY_EVENTS = {
@@ -21,6 +22,106 @@ _ACTION_EVENTS = {"action", "mutation", "interaction", "act", "execute"}
 _INTERACTION_EVENTS = {"interaction", "conversation", "talk", "message"}
 _OBJECTIVE_EVENTS = {"quest", "quest_triggered", "objective", "goal"}
 _PROGRESS_EVENTS = {"quest_resolved", "objective_progress", "objective_completed", "goal_progress"}
+
+_SERIES_METRICS = (
+    "health", "energy", "mood", "autonomy", "liveliness", "objectives",
+    "interactions", "accepted_mutations", "failures",
+)
+
+
+def build_life_timeseries(
+    records: list[dict[str, object]], *, life: str, time_window: str = "24h",
+    resolution: str = "hour", limit: int = 500, mutation_index: int | None = None,
+    record_run_id: Callable[[dict[str, object]], str] = lambda _: "unknown",
+) -> dict[str, object]:
+    """Build a bounded, bucketed chronology while retaining source evidence links."""
+    windows = {"24h": timedelta(hours=24), "7d": timedelta(days=7), "30d": timedelta(days=30), "all": None}
+    resolutions = {"raw": None, "hour": timedelta(hours=1), "day": timedelta(days=1)}
+    if time_window not in windows:
+        raise ValueError("time_window must be one of: 24h, 7d, 30d, all")
+    if resolution not in resolutions:
+        raise ValueError("resolution must be one of: raw, hour, day")
+    if not 1 <= limit <= 1000:
+        raise ValueError("limit must be between 1 and 1000")
+
+    dated = [(ts, rec) for rec in records if (ts := parse_ts(rec.get("ts"))) is not None]
+    dated.sort(key=lambda item: item[0])
+    mutation_rows = [(ts, rec) for ts, rec in dated if any(k in rec for k in ("accepted", "ok", "score_base", "score_new", "operator", "op"))]
+    mutation_indexes = {id(rec): index for index, (_, rec) in enumerate(mutation_rows)}
+    pivot = None
+    if mutation_index is not None:
+        if mutation_index < 0 or mutation_index >= len(mutation_rows):
+            raise IndexError("mutation_index out of range")
+        pivot = mutation_rows[mutation_index][0]
+    end = dated[-1][0] if dated else datetime.now(timezone.utc)
+    cutoff = end - windows[time_window] if windows[time_window] is not None else None
+    dated = [(ts, rec) for ts, rec in dated if cutoff is None or ts >= cutoff]
+
+    def number(rec: dict[str, object], *names: str) -> float | None:
+        for name in names:
+            value: object = rec.get(name)
+            if name == "health" and isinstance(value, dict):
+                value = value.get("score")
+            if isinstance(value, (int, float)) and not isinstance(value, bool):
+                return float(value)
+        return None
+
+    buckets: dict[str, dict[str, object]] = {}
+    step = resolutions[resolution]
+    for ts, rec in dated:
+        bucket_ts = ts
+        if step == timedelta(hours=1):
+            bucket_ts = ts.replace(minute=0, second=0, microsecond=0)
+        elif step == timedelta(days=1):
+            bucket_ts = ts.replace(hour=0, minute=0, second=0, microsecond=0)
+        key = (bucket_ts.isoformat() if step else ts.isoformat())
+        bucket = buckets.setdefault(key, {"timestamp": key, "values": {metric: [] for metric in _SERIES_METRICS}, "events": [], "proofs": []})
+        values = bucket["values"]
+        assert isinstance(values, dict)
+        event = _normalized_event(rec)
+        accepted = rec.get("accepted") if isinstance(rec.get("accepted"), bool) else rec.get("ok")
+        samples = {
+            "health": number(rec, "health", "health_score"), "energy": number(rec, "energy"),
+            "mood": number(rec, "mood", "humeur"), "autonomy": number(rec, "autonomy", "autonomy_index"),
+            "liveliness": number(rec, "liveliness", "liveness", "vivacity"),
+            "objectives": number(rec, "objectives", "objectives_count"),
+            "interactions": 1.0 if event in _INTERACTION_EVENTS else None,
+            "accepted_mutations": 1.0 if accepted is True else None,
+            "failures": 1.0 if accepted is False or event in {"failure", "error", "mutation_failed"} else None,
+        }
+        for metric, value in samples.items():
+            if value is not None:
+                values[metric].append(value)
+        run_id = record_run_id(rec)
+        proof = {"timestamp": ts.isoformat(), "event": event or "observation", "run_id": run_id,
+                 "href": f"/api/runs/{quote(run_id, safe='')}/timeline?page=1&page_size=120"}
+        bucket["proofs"].append(proof)
+        notable = event in (_OBJECTIVE_EVENTS | _PROGRESS_EVENTS | _INTERACTION_EVENTS | {"mutation", "death", "birth", "skill_acquired", "skill_lost"})
+        if notable or any(key in rec for key in ("objective", "skill", "accepted", "ok")):
+            bucket["events"].append({**proof, "objective": rec.get("objective"), "skill": rec.get("skill"), "accepted": accepted,
+                                     "mutation_index": mutation_indexes.get(id(rec))})
+
+    points = list(buckets.values())[-limit:]
+    for point in points:
+        values = point["values"]
+        for metric, samples in values.items():
+            values[metric] = (round(sum(samples) / len(samples), 3) if samples and metric not in {"interactions", "accepted_mutations", "failures"} else sum(samples)) if samples else None
+    comparison = None
+    if pivot is not None:
+        before = [p for p in points if parse_ts(p["timestamp"]) < pivot]
+        after = [p for p in points if parse_ts(p["timestamp"]) >= pivot]
+        comparison = {"mutation_index": mutation_index, "pivot": pivot.isoformat(), "before": _series_averages(before), "after": _series_averages(after)}
+    return {"life": life, "window": time_window, "resolution": resolution, "limit": limit,
+            "count": len(points), "truncated": len(buckets) > limit, "metrics": list(_SERIES_METRICS),
+            "points": points, "mutation_comparison": comparison}
+
+
+def _series_averages(points: list[dict[str, object]]) -> dict[str, float | None]:
+    result: dict[str, float | None] = {}
+    for metric in _SERIES_METRICS:
+        values = [p["values"][metric] for p in points if p["values"].get(metric) is not None]
+        result[metric] = round(sum(values) / len(values), 3) if values else None
+    return result
 
 
 def parse_ts(value: object) -> datetime | None:

--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -234,6 +234,12 @@ button:hover {
 .stats-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:12px; margin-top:8px; }
 .lives-grid { display:grid; grid-template-columns: minmax(0, 2.2fr) minmax(280px, 1fr); gap: 12px; align-items:start; }
 .life-detail-panel { position: sticky; top: 10px; }
+.life-chronology { margin-top:16px; border-top:1px solid var(--table-border); padding-top:8px; }
+.chronology-chart { min-height:180px; overflow-x:auto; }
+.chronology-chart svg { width:100%; min-width:520px; height:190px; background:rgba(15,23,42,.35); border-radius:6px; }
+.chronology-legend { display:flex; flex-wrap:wrap; gap:8px; font-size:.75rem; }
+.chronology-events { max-height:260px; overflow:auto; padding-left:22px; }
+.chronology-events li { margin:5px 0; white-space:normal; }
 .life-meta-table th { width: 42%; color: var(--text-secondary); text-align: left; }
 .detail-badges { margin-bottom: 8px; }
 .summary-pill { display:inline-block; padding:2px 8px; border-radius:999px; border:1px solid rgba(255,255,255,0.2); }

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -92,6 +92,41 @@ const livesUiState={
   rowsByLife:new Map(),
 };
 
+const chronologyColors={health:'#22c55e',energy:'#eab308',mood:'#ec4899',autonomy:'#38bdf8',liveliness:'#a78bfa'};
+const loadLifeChronology=life=>{
+  const host=byId('life-chronology-chart');
+  if(!host||!life){return Promise.resolve();}
+  const windowKey=byId('life-chronology-window')?.value||'24h';
+  const resolution=byId('life-chronology-resolution')?.value||'hour';
+  const mutation=byId('life-chronology-mutation')?.value||'';
+  const query=new URLSearchParams({time_window:windowKey,resolution,limit:'500'});
+  if(mutation!==''){query.set('mutation_index',mutation);}
+  host.textContent='Chargement de la chronologie…';
+  return fetchJson(`/api/lives/${encodeURIComponent(life)}/timeseries?${query}`).then(payload=>{
+    const points=payload.points||[];
+    const width=700,height=170,pad=18;
+    const paths=Object.entries(chronologyColors).map(([metric,color])=>{
+      const samples=points.map((point,index)=>({index,value:point.values?.[metric]})).filter(item=>Number.isFinite(item.value));
+      if(!samples.length){return '';}
+      const vals=samples.map(item=>item.value),min=Math.min(...vals),max=Math.max(...vals),span=max-min||1;
+      const coords=samples.map(item=>`${pad+(item.index/Math.max(1,points.length-1))*(width-pad*2)},${height-pad-((item.value-min)/span)*(height-pad*2)}`);
+      return `<polyline fill='none' stroke='${color}' stroke-width='2' points='${coords.join(' ')}'><title>${escapeHtml(metric)}</title></polyline>`;
+    }).join('');
+    host.innerHTML=`<div class='chronology-legend'>${Object.entries(chronologyColors).map(([key,color])=>`<span style='color:${color}'>● ${escapeHtml(key)}</span>`).join('')}<span>· ${points.length} points${payload.truncated?' (limités)':''}</span></div><svg viewBox='0 0 ${width} ${height}' role='img' aria-label='Courbes santé, énergie, humeur, autonomie et vivacité'>${paths}</svg>`;
+    const events=points.flatMap(point=>(point.events||[]).map(event=>({...event,bucket:point.timestamp})));
+    const list=byId('life-chronology-events');
+    if(list){list.innerHTML=events.length?events.map(event=>`<li><a href='${escapeHtml(event.href)}'>${escapeHtml(event.timestamp||event.bucket)}</a> · ${escapeHtml(event.event)}${event.objective?` · objectif: ${escapeHtml(event.objective)}`:''}${event.skill?` · skill: ${escapeHtml(event.skill)}`:''}${typeof event.accepted==='boolean'?` · mutation ${event.accepted?'acceptée':'échouée/refusée'}`:''}</li>`).join(''):'<li>Aucun événement marquant dans cette fenêtre.</li>';}
+    const mutationSelect=byId('life-chronology-mutation');
+    if(mutationSelect&&mutationSelect.options.length===1){
+      const mutations=events.filter(event=>typeof event.accepted==='boolean');
+      mutations.forEach(event=>mutationSelect.insertAdjacentHTML('beforeend',`<option value='${event.mutation_index}'>#${event.mutation_index} · ${escapeHtml(event.timestamp)}</option>`));
+    }
+    const comparison=payload.mutation_comparison;
+    const comparisonHost=byId('life-mutation-comparison');
+    if(comparisonHost){comparisonHost.innerHTML=comparison?`<details open><summary>Comparaison autour de ${escapeHtml(comparison.pivot)}</summary><pre>${escapeHtml(JSON.stringify({avant:comparison.before,apres:comparison.after},null,2))}</pre></details>`:'';}
+  }).catch(error=>{host.textContent=`Chronologie indisponible: ${error.message}`;});
+};
+
 const formatFilterLabel=(key,value)=>{
   if(key==='quickFilter'){return `quickFilter=${value}`;}
   if(key==='focus'){return `focus=${value}`;}
@@ -305,6 +340,13 @@ const showLifeDetails=lifeName=>{
   document.querySelectorAll('#lives-table-body tr.lives-row').forEach(node=>{
     node.classList.toggle('selected',node.dataset.life===lifeName);
   });
+  ['life-chronology-window','life-chronology-resolution','life-chronology-mutation'].forEach(id=>{
+    const control=byId(id);
+    if(control&&!control.dataset.bound){control.dataset.bound='true';control.addEventListener('change',()=>loadLifeChronology(livesUiState.selectedLife));}
+  });
+  const mutationSelect=byId('life-chronology-mutation');
+  if(mutationSelect){mutationSelect.innerHTML='<option value="">Aucune</option>';}
+  loadLifeChronology(lifeName);
 };
 
 const renderUnattachedRuns=(payload)=>{

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -378,6 +378,17 @@
         <h4>Preuves de vie</h4>
         <ul id='life-detail-liveness-proofs' class='list-tight-top'><li>Aucune vie sélectionnée.</li></ul>
         <div id='life-detail-content'>Aucune vie sélectionnée.</div>
+        <section id='life-chronology' class='life-chronology' aria-label='Chronologie combinée'>
+          <h4>Chronologie combinée</h4>
+          <div class='toolbar-wrap'>
+            <label>Fenêtre <select id='life-chronology-window'><option value='24h'>24 h</option><option value='7d'>7 j</option><option value='30d'>30 j</option><option value='all'>Vie entière</option></select></label>
+            <label>Résolution <select id='life-chronology-resolution'><option value='hour'>Heure</option><option value='day'>Jour</option><option value='raw'>Événement</option></select></label>
+            <label>Avant/après mutation <select id='life-chronology-mutation'><option value=''>Aucune</option></select></label>
+          </div>
+          <div id='life-chronology-chart' class='chronology-chart'>Sélectionnez une vie.</div>
+          <div id='life-mutation-comparison'></div>
+          <ol id='life-chronology-events' class='chronology-events'></ol>
+        </section>
       </aside>
     </div>
   </section>

--- a/tests/test_dashboard_services.py
+++ b/tests/test_dashboard_services.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from singular.dashboard.services.lives_comparison import aggregate_lives
+from singular.dashboard.services.lives_comparison import aggregate_lives, build_life_timeseries
 from singular.dashboard.services.code_evolution import aggregate_code_evolution
 from singular.dashboard.services.trajectory import build_trajectory
 
@@ -70,6 +70,38 @@ def test_lives_comparison_service_aggregates_metrics() -> None:
     assert comparison["alpha"]["failure_rate"] == 0.5
     assert comparison["alpha"]["mutations"] == 2
     assert comparison["alpha"]["trend"] in {"plateau", "dégradation", "amélioration"}
+
+
+def test_life_timeseries_buckets_metrics_and_keeps_evidence() -> None:
+    records = [
+        {"ts": "2026-01-01T00:10:00Z", "health": {"score": 60}, "energy": 40,
+         "event": "mutation", "accepted": True, "run_id": "run 1"},
+        {"ts": "2026-01-01T00:50:00Z", "health": {"score": 80}, "mood": 75,
+         "event": "interaction", "run_id": "run 1"},
+        {"ts": "2026-01-01T02:00:00Z", "event": "skill_acquired", "skill": "alpha:vision",
+         "accepted": False, "run_id": "run-2"},
+    ]
+
+    payload = build_life_timeseries(
+        records, life="alpha", time_window="all", resolution="hour", limit=10,
+        mutation_index=0, record_run_id=lambda rec: str(rec["run_id"]),
+    )
+
+    assert payload["count"] == 2
+    assert payload["points"][0]["values"]["health"] == 70.0
+    assert payload["points"][0]["values"]["interactions"] == 1.0
+    assert payload["points"][0]["proofs"][0]["href"].startswith("/api/runs/run%201/")
+    assert payload["mutation_comparison"]["pivot"] == "2026-01-01T00:10:00+00:00"
+    assert payload["points"][1]["events"][0]["skill"] == "alpha:vision"
+
+
+def test_life_timeseries_rejects_unbounded_contract_values() -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="limit"):
+        build_life_timeseries([], life="alpha", limit=1001)
+    with pytest.raises(ValueError, match="time_window"):
+        build_life_timeseries([], life="alpha", time_window="year")
 
 
 def test_lives_comparison_includes_registry_life_without_records_in_table() -> None:


### PR DESCRIPTION
### Motivation

- Fournir aux vues détaillées de vie des séries temporelles agrégées et bornées pour suivre la santé, énergie, humeur, autonomie, vivacité, objectifs, interactions, mutations acceptées et échecs avec preuve source.
- Permettre l’analyse avant/après d’une mutation et offrir des résolutions temporelles explicites (évent, heure, jour) et des fenêtres `24h`, `7d`, `30d` et `all` tout en limitant le volume des points.
- Intégrer ces séries dans l’interface de détail d’une vie avec liens vers la preuve (timeline du run) pour chaque point ou événement notable.

### Description

- Ajout de la fonction `build_life_timeseries(...)` dans `src/singular/dashboard/services/lives_comparison.py` qui agrège les enregistrements par bucket, calcule moyennes/sommations par métrique, conserve `proofs` et `events`, et produit une comparaison `before`/`after` autour d’un `mutation_index` pivot.
- Exposition d’un nouvel endpoint `GET /api/lives/{life}/timeseries` dans `src/singular/dashboard/__init__.py` acceptant les paramètres `time_window`, `resolution`, `limit` et `mutation_index` et renvoyant des erreurs `404`/`422` pour les contrats invalides.
- Ajout de la zone de détail chronologique dans `src/singular/dashboard/templates/dashboard.html`, des styles associés dans `src/singular/dashboard/static/dashboard.css` et du rendu/contrôles côté client dans `src/singular/dashboard/static/render-lives.js` (courbes SVG, légende, liste d’événements et sélection de mutation pour comparaison).
- Ajout de tests unitaires dans `tests/test_dashboard_services.py` couvrant le bucketting, la conservation des preuves et la validation des paramètres via `build_life_timeseries`.

### Testing

- Exécution de `pytest -q tests/test_dashboard_services.py` — `9 passed` (succès complet pour les tests ajoutés). 
- Exécution plus large `pytest -q tests/test_dashboard*.py` — `73 passed, 5 failed` et les échecs portent sur des valeurs de politique de gouvernance et des libellés de statut vital existants et non liés aux changements de chronologie (diagnostiqués comme préexistants).
- Vérifications statiques et outils: `ruff check` sur les modules modifiés (OK), `node --check src/singular/dashboard/static/render-lives.js` (OK) et `python -m compileall -q src/singular/dashboard` (OK).
- Les commandes d’ouverture de PR via `gh` n’ont pas pu être finalisées dans l’environnement faute d’authentification, mais tous les artefacts de code et tests ci-dessus ont été produits et validés localement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7643796db8832a995db94ce236b693)