### PR TITLE
Ajouter une fiche synthétique progressive pour la vie sélectionnée

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -1709,6 +1709,138 @@ def create_app(
             "items": items,
         }
 
+    @app.get("/api/lives/{life}/snapshot")
+    def read_life_snapshot(life: str) -> dict[str, object]:
+        """Compose the selected life's progressive summary from domain services."""
+        life_dir = _resolve_life_dir(life)
+        if life_dir is None:
+            raise HTTPException(status_code=404, detail=f"life '{life}' not found")
+
+        records = [
+            record
+            for record in _load_run_records(current_life_only=False)
+            if _record_life(record) == life
+        ]
+        records.sort(key=lambda record: str(record.get("ts", "")))
+        comparison, _ = _aggregate_lives(current_life_only=False)
+        comparison_row = comparison.get(life, {})
+        trajectory = _build_trajectory(records)
+        objectives = trajectory.get("objectives", {})
+        active_objectives = (
+            objectives.get("in_progress", [])
+            if isinstance(objectives, dict)
+            else []
+        )
+        mutations = [record for record in records if _is_mutation_record(record)]
+        decisions = [
+            record
+            for record in records
+            if str(record.get("event", "")).startswith("orchestrator")
+            or record.get("decision") is not None
+            or _is_mutation_record(record)
+        ]
+        actions = [
+            record
+            for record in records
+            if record.get("action") is not None
+            or record.get("operator") is not None
+            or record.get("op") is not None
+        ]
+        causal_items = [
+            item
+            for item in read_causal_timeline(life_dir / "mem" / "causal_timeline.jsonl")
+            if isinstance(item, dict)
+        ]
+        causal_items.sort(key=lambda item: str(item.get("ts", item.get("recorded_at", ""))))
+
+        def _label(item: object, *keys: str, fallback: str = "Non disponible") -> str:
+            if not isinstance(item, dict):
+                return fallback
+            for key in keys:
+                value = item.get(key)
+                if value is not None and str(value).strip():
+                    return str(value)
+            return fallback
+
+        latest = records[-1] if records else {}
+        last_mutation = mutations[-1] if mutations else {}
+        last_causal = causal_items[-1] if causal_items else {}
+        alerts = alerts_from_records(records)
+        primary_alert = alerts[-1] if alerts else {}
+        trend = _label(comparison_row, "trend", fallback="plateau")
+        health = comparison_row.get("current_health_score") if isinstance(comparison_row, dict) else None
+        current_state = _label(latest, "status", "state", "event", fallback="Aucune observation")
+        if health is not None:
+            current_state = f"{current_state} · santé {health}"
+
+        need = _label(latest, "dominant_need", "need", "motivation", "drive")
+        decision = _label(decisions[-1] if decisions else None, "decision", "human_summary", "event")
+        action = _label(actions[-1] if actions else None, "action", "operator", "op")
+        consequence = _label(last_causal, "consequence", "effect", "outcome", "result")
+        remembered = _label(last_causal, "change", "memory", "summary", "event")
+        alert_label = _label(primary_alert, "message", "kind", "severity", fallback="Aucune alerte")
+
+        recommendations: list[str] = []
+        liveness = compute_liveness_index_service(records) if records else {}
+        raw_recommendations = liveness.get("recommendations", []) if isinstance(liveness, dict) else []
+        if isinstance(raw_recommendations, list):
+            recommendations.extend(str(item) for item in raw_recommendations if item)
+        if alerts:
+            recommendations.append("Examiner l’alerte principale et ses preuves avant la prochaine mutation.")
+
+        evidence: list[dict[str, object]] = []
+        for item in causal_items[-5:]:
+            evidence.append({
+                "kind": _label(item, "event", "cause", fallback="causalité"),
+                "at": _label(item, "ts", "recorded_at"),
+                "description": _label(item, "summary", "consequence", "effect", "outcome", fallback=json.dumps(item, ensure_ascii=False)),
+            })
+        if last_mutation:
+            evidence.append({
+                "kind": "mutation",
+                "at": _label(last_mutation, "ts"),
+                "description": _label(last_mutation, "human_summary", "operator", "op"),
+            })
+
+        conversation_items: list[dict[str, object]] = []
+        latest_run = _latest_run_file(current_life_only=False)
+        if latest_run is not None:
+            consciousness_path = _resolve_consciousness_path(_run_file_id(latest_run), current_life_only=False)
+            if consciousness_path is not None:
+                for line in consciousness_path.read_text(encoding="utf-8").splitlines()[-20:]:
+                    try:
+                        item = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(item, dict) and _label(item, "life", "owner", fallback=life) == life:
+                        conversation_items.append(item)
+
+        return {
+            "life": life,
+            "summary": {
+                "current_state": current_state,
+                "recent_evolution": trend,
+                "dominant_need": need,
+                "active_objective": str(active_objectives[0]) if active_objectives else "Aucun objectif actif",
+                "last_decision": decision,
+                "last_action": action,
+                "observed_consequence": consequence,
+                "memorized_change": remembered,
+                "primary_alert": alert_label,
+                "recommended_next_action": recommendations[0] if recommendations else "Poursuivre l’observation",
+            },
+            "evidence": evidence,
+            "technical": {
+                "comparison": comparison_row,
+                "trajectory": trajectory,
+                "latest_record": latest,
+                "latest_mutation": last_mutation,
+                "causal_timeline": causal_items[-20:],
+                "conversations": conversation_items,
+                "liveness": liveness,
+            },
+        }
+
     @app.get("/api/runs/{run_id}/consciousness")
     def read_run_consciousness(
         run_id: str,

--- a/src/singular/dashboard/static/bootstrap.js
+++ b/src/singular/dashboard/static/bootstrap.js
@@ -2,6 +2,7 @@ import {bindActionHandlers} from './actions.js';
 import {loadCockpit,loadContext,loadEco,loadHostVitals,loadQuests,loadRetentionStatus} from './render-cockpit.js';
 import {bindLivesHandlers,bindLiveStreamHandlers,loadGenealogy,loadLivesBoard,renderLiveEvents,updateLiveStatus} from './render-lives.js';
 import {bindReflectionHandlers,loadReflections} from './render-reflections.js';
+import {bindLifeSnapshot} from './render-life-snapshot.js';
 import {loadTimeline} from './render-timeline.js';
 import {
   PROLONGED_TIMEOUT_THRESHOLD,
@@ -428,6 +429,7 @@ export const bootstrapDashboard=()=>{
   bindLivesHandlers(loadLivesBoard);
   bindLiveStreamHandlers();
   bindReflectionHandlers(loadReflections);
+  bindLifeSnapshot();
 
   Object.entries(taskDefinitions).forEach(([name,definition])=>registerTask(name,definition.loader,definition.intervalMs));
 

--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -513,6 +513,11 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
 .conversation-composer { display:flex; flex-direction:column; gap:8px; margin-top:8px; }
 .conversation-composer textarea { width:100%; }
 .conversation-meta { display:flex; flex-direction:column; gap:6px; margin-bottom:8px; }
+.snapshot-grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:10px; }
+.life-snapshot details { margin-top:12px; border-top:1px solid var(--table-border); padding-top:10px; }
+.life-snapshot summary { cursor:pointer; font-weight:700; color:#dbe6ff; }
+.snapshot-evidence { display:grid; gap:8px; margin-top:10px; }
+.snapshot-proof { border-left:3px solid var(--accent); padding:6px 10px; background:rgba(10,20,48,.65); }
 
 .life-verdict-card {
   grid-column: span 2;

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -1,7 +1,7 @@
 import {fetchJson,withScope} from './api.js';
 import {fetchSharedDashboardContext,fetchSharedLivesComparison,fetchSharedCockpitEssential} from './dashboard-data.js';
 import {mergeLifeRows,updateOperatorLifeOptions} from './actions.js';
-import {HOST_SENSORS_THRESHOLD,na,setPanelState,setStatusTone,applyStatusIndicator,getSelectedLife,setSelectedLife,staleTimeoutTasks} from './state.js';
+import {HOST_SENSORS_THRESHOLD,na,setPanelState,setStatusTone,applyStatusIndicator,getSelectedLife,getRememberedLife,setSelectedLife,staleTimeoutTasks} from './state.js';
 import {renderQuestsSection} from './render-quests.js';
 import {renderObjectivesSection} from './render-objectives.js';
 import {renderConversationsSection} from './render-conversations.js';
@@ -331,7 +331,9 @@ const renderOperatorSummary=()=>{
         option.textContent=row.life||na();
         select.appendChild(option);
       }
-      select.value=currentValue&&rows.some(row=>row.life===currentValue)?currentValue:'';
+      const remembered=getRememberedLife();
+      select.value=currentValue&&rows.some(row=>row.life===currentValue)?currentValue:(remembered&&rows.some(row=>row.life===remembered)?remembered:'');
+      if(select.value&&!getSelectedLife()){setSelectedLife(select.value,{source:'remembered-selection'});}
     }
     if(select.dataset.bound!=='true'){
       select.dataset.bound='true';

--- a/src/singular/dashboard/static/render-life-snapshot.js
+++ b/src/singular/dashboard/static/render-life-snapshot.js
@@ -1,0 +1,35 @@
+import {fetchJson} from './api.js';
+import {getSelectedLife,SELECTED_LIFE_CHANGED_EVENT} from './state.js';
+
+const escapeHtml=value=>String(value??'Non disponible').replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;').replaceAll("'",'&#39;');
+
+const renderSnapshot=payload=>{
+  const title=document.getElementById('life-snapshot-title');
+  if(title){title.textContent=`Fiche synthétique · ${payload.life}`;}
+  for(const node of document.querySelectorAll('[data-snapshot-field]')){
+    node.textContent=payload.summary?.[node.dataset.snapshotField]??'Non disponible';
+  }
+  const evidence=document.getElementById('life-snapshot-evidence-content');
+  if(evidence){
+    const items=payload.evidence||[];
+    evidence.innerHTML=items.length?items.map(item=>`<div class='snapshot-proof'><strong>${escapeHtml(item.kind)}</strong> · ${escapeHtml(item.at)}<br>${escapeHtml(item.description)}</div>`).join(''):'Aucune preuve disponible.';
+  }
+  const raw=document.getElementById('life-snapshot-raw-content');
+  if(raw){raw.textContent=JSON.stringify(payload.technical||{},null,2);}
+};
+
+const loadSnapshot=async life=>{
+  const panel=document.getElementById('life-snapshot');
+  if(!panel){return;}
+  if(!life){panel.classList.add('panel-hidden');return;}
+  panel.classList.remove('panel-hidden');
+  const title=document.getElementById('life-snapshot-title');
+  if(title){title.textContent=`Fiche synthétique · ${life} · chargement…`;}
+  try{renderSnapshot(await fetchJson(`/api/lives/${encodeURIComponent(life)}/snapshot`));}
+  catch(error){if(title){title.textContent=`Fiche synthétique · ${life} · indisponible`;}}
+};
+
+export const bindLifeSnapshot=()=>{
+  window.addEventListener(SELECTED_LIFE_CHANGED_EVENT,event=>loadSnapshot(event.detail?.name));
+  loadSnapshot(getSelectedLife());
+};

--- a/src/singular/dashboard/static/state.js
+++ b/src/singular/dashboard/static/state.js
@@ -13,6 +13,7 @@ export const nm=()=>MISSING_TEXT.notMeasured;
 
 export const SELECTED_LIFE_CHANGED_EVENT='singular:selected-life-changed';
 export const selectedLifeState={name:null,source:null,metadata:{}};
+const SELECTED_LIFE_STORAGE_KEY='singular.dashboard.selectedLife';
 
 export const setSelectedLife=(name,{source='unknown',metadata={}}={})=>{
   const normalized=String(name||'').trim()||null;
@@ -21,6 +22,8 @@ export const setSelectedLife=(name,{source='unknown',metadata={}}={})=>{
   selectedLifeState.source=source;
   selectedLifeState.metadata=metadata&&typeof metadata==='object'?metadata:{};
   if(typeof window!=='undefined'){
+    if(normalized){window.sessionStorage?.setItem(SELECTED_LIFE_STORAGE_KEY,normalized);}
+    else{window.sessionStorage?.removeItem(SELECTED_LIFE_STORAGE_KEY);}
     window.dispatchEvent(new CustomEvent(SELECTED_LIFE_CHANGED_EVENT,{
       detail:{name:normalized,previous,source,metadata:selectedLifeState.metadata},
     }));
@@ -29,6 +32,7 @@ export const setSelectedLife=(name,{source='unknown',metadata={}}={})=>{
 };
 
 export const getSelectedLife=()=>selectedLifeState.name;
+export const getRememberedLife=()=>typeof window==='undefined'?null:(window.sessionStorage?.getItem(SELECTED_LIFE_STORAGE_KEY)||null);
 
 export const livesTableState={sortBy:'score',sortOrder:'desc'};
 export const liveState={paused:false,autoScroll:true,events:[]};

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -109,6 +109,30 @@
       </ul>
       <a id='digital-life-details-link' class='filter-chip' href='#tab-comparer-vies'>Voir détail</a>
     </div>
+    <section id='life-snapshot' class='life-snapshot panel panel-compact panel-bordered content-top-gap' aria-live='polite' aria-labelledby='life-snapshot-title'>
+      <h3 id='life-snapshot-title' class='heading-reset-top'>Fiche synthétique · sélectionnez une vie</h3>
+      <p class='section-help'>Une lecture progressive de la vie sélectionnée, construite par les services du serveur.</p>
+      <div id='life-snapshot-summary' class='snapshot-grid' data-snapshot-level='summary'>
+        <div class='card'><div class='card-label'>État actuel</div><div data-snapshot-field='current_state' class='card-value'>Non disponible</div></div>
+        <div class='card'><div class='card-label'>Évolution récente</div><div data-snapshot-field='recent_evolution' class='card-value'>Non disponible</div></div>
+        <div class='card'><div class='card-label'>Besoin dominant</div><div data-snapshot-field='dominant_need' class='card-value'>Non disponible</div></div>
+        <div class='card'><div class='card-label'>Objectif actif</div><div data-snapshot-field='active_objective' class='card-value'>Non disponible</div></div>
+        <div class='card'><div class='card-label'>Dernière décision</div><div data-snapshot-field='last_decision' class='card-value'>Non disponible</div></div>
+        <div class='card'><div class='card-label'>Dernière action</div><div data-snapshot-field='last_action' class='card-value'>Non disponible</div></div>
+        <div class='card'><div class='card-label'>Conséquence observée</div><div data-snapshot-field='observed_consequence' class='card-value'>Non disponible</div></div>
+        <div class='card'><div class='card-label'>Changement mémorisé</div><div data-snapshot-field='memorized_change' class='card-value'>Non disponible</div></div>
+        <div class='card'><div class='card-label'>Alerte principale</div><div data-snapshot-field='primary_alert' class='card-value'>Aucune alerte</div></div>
+        <div class='card'><div class='card-label'>Prochaine action recommandée</div><div data-snapshot-field='recommended_next_action' class='card-value'>Non disponible</div></div>
+      </div>
+      <details id='life-snapshot-evidence' data-snapshot-level='evidence'>
+        <summary>Preuves et causalité</summary>
+        <div id='life-snapshot-evidence-content' class='snapshot-evidence'>Aucune preuve disponible.</div>
+      </details>
+      <details id='life-snapshot-raw' data-snapshot-level='technical' class='technical-only'>
+        <summary>Données techniques brutes</summary>
+        <pre id='life-snapshot-raw-content'>{}</pre>
+      </details>
+    </section>
     <ul id='operator-lives-empty-states' class='list-tight-top'>
       <li>Chargement du registre des vies…</li>
     </ul>


### PR DESCRIPTION
### Motivation
- Offrir une fiche synthétique accessible depuis la sélection de vie présentant en un seul panneau les informations essentielles (état, évolution, besoin, objectif, dernière décision/action, conséquence, changement mémorisé, alerte principale et prochaine action recommandée). 
- Préserver le contexte de la vie sélectionnée lors de la navigation entre onglets et éviter de dupliquer la logique déjà fournie par les services côté serveur.

### Description
- Ajout d’un panneau UI dans `src/singular/dashboard/templates/dashboard.html` (`#life-snapshot`) qui expose trois niveaux progressifs : résumé, preuves/causalité et données techniques brutes (`technical-only`).
- Nouveau endpoint serveur `GET /api/lives/{life}/snapshot` implémenté dans `src/singular/dashboard/__init__.py` qui compose la fiche en réutilisant les services existants (`_aggregate_lives`, `build_trajectory`, `compute_liveness_index_service`, `read_causal_timeline`, etc.) et en agrégeant mutations, décisions, timeline causale et conversations.
- Rendu dynamique côté client via `src/singular/dashboard/static/render-life-snapshot.js` qui écoute l’événement `singular:selected-life-changed`, appelle `/api/lives/{life}/snapshot` et affiche progressivement résumé, preuves et données techniques JSON.
- Conserver la sélection de vie en session avec `sessionStorage` (`src/singular/dashboard/static/state.js`), intégrer la sélection mémorisée dans `render-cockpit.js` et démarrer le binding dans `bootstrap.js`; ajout de styles CSS pour la grille et les preuves (`src/singular/dashboard/static/dashboard.css`).

### Testing
- Compilation des modules Python avec `python -m compileall -q src/singular/dashboard` : succès.
- Vérification JS statique via `node --check src/singular/dashboard/static/render-life-snapshot.js` : succès.
- Linter `ruff` sur `src/singular/dashboard/__init__.py` : succès.
- Suite ciblée `python -m pytest tests/test_dashboard.py -q` : 48 tests réussis et 3 échecs (les échecs concernent des valeurs de politique de gouvernance et une différence `extinct`/`dead` dans le contexte de test), ces derniers sont préexistants à la fonctionnalité ajoutée et n’ont pas été causés par les changements de rendu/endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76473d56b4832ab52ba98b3130af60)