### PR TITLE
Add offline multi-life evaluation scenario and dashboard endpoint

### DIFF
--- a/artifacts/evaluations/offline_multi_life_v1.json
+++ b/artifacts/evaluations/offline_multi_life_v1.json
@@ -1,0 +1,811 @@
+{
+  "schema_version": "singular.offline-multi-life-evaluation/v1",
+  "generated_at": "2026-08-07T21:08:22.609892+00:00",
+  "offline": true,
+  "scenario": {
+    "trace_sha256": "d325ddbc822b87040ca1cf34eeec6b02794cba138b740b3f7716767b3772d80f",
+    "steps": [
+      {
+        "perception": "red beacon beside a wall",
+        "blocked": "direct",
+        "target": "key"
+      },
+      {
+        "perception": "red beacon beside a wall",
+        "blocked": "direct",
+        "target": "key"
+      },
+      {
+        "perception": "blue door requests a key",
+        "blocked": null,
+        "target": "door"
+      },
+      {
+        "perception": "rough floor before a pit",
+        "blocked": "direct",
+        "target": "bridge"
+      },
+      {
+        "perception": "rough floor before a pit",
+        "blocked": "direct",
+        "target": "bridge"
+      },
+      {
+        "perception": "blue door requests a key",
+        "blocked": null,
+        "target": "door"
+      },
+      {
+        "perception": "green terminal offers a tool",
+        "blocked": null,
+        "target": "tool"
+      },
+      {
+        "perception": "rough floor before a pit",
+        "blocked": "direct",
+        "target": "bridge"
+      }
+    ]
+  },
+  "seeds": [
+    11,
+    23,
+    37,
+    53,
+    71
+  ],
+  "kpi_links": {
+    "config": "configs/agi_kpis.yaml#offline_multi_life",
+    "capabilities_matrix": "docs/cognitive-capabilities-matrix.md#evaluation-hors-reseau-multi-vies",
+    "target_spec": "docs/agi_target_spec.md#evaluation-hors-reseau"
+  },
+  "groups": {
+    "full": {
+      "lives": [
+        {
+          "seed": 11,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "wait",
+            "wait",
+            "interact",
+            "interact",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 1.0,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 8,
+            "stability": 1.0,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 23,
+          "decisions": [
+            "direct",
+            "detour",
+            "interact",
+            "direct",
+            "build",
+            "interact",
+            "interact",
+            "build"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.1429,
+            "adaptation_after_failure": 1.0,
+            "goal_pursuit": 0.75,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 12,
+            "stability": 0.75,
+            "useful_mutation_rate": 1.0
+          }
+        },
+        {
+          "seed": 37,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "wait",
+            "wait",
+            "interact",
+            "interact",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 1.0,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 8,
+            "stability": 1.0,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 53,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "direct",
+            "build",
+            "interact",
+            "interact",
+            "build"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.2857,
+            "adaptation_after_failure": 1.0,
+            "goal_pursuit": 0.875,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 10,
+            "stability": 0.875,
+            "useful_mutation_rate": 1.0
+          }
+        },
+        {
+          "seed": 71,
+          "decisions": [
+            "direct",
+            "detour",
+            "interact",
+            "direct",
+            "build",
+            "interact",
+            "interact",
+            "build"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.1429,
+            "adaptation_after_failure": 1.0,
+            "goal_pursuit": 0.75,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 12,
+            "stability": 0.75,
+            "useful_mutation_rate": 1.0
+          }
+        }
+      ],
+      "aggregate": {
+        "intra_life_coherence": 0.2857,
+        "adaptation_after_failure": 0.6,
+        "goal_pursuit": 0.875,
+        "perception_decision_action_causality": 1.0,
+        "memory_reuse": 0.5,
+        "effective_capability_acquisition": 1.0,
+        "cost": 10,
+        "stability": 0.875,
+        "useful_mutation_rate": 0.6,
+        "inter_life_diversity": 0.5,
+        "stability_dispersion": 0.1118
+      }
+    },
+    "no_memory": {
+      "lives": [
+        {
+          "seed": 11,
+          "decisions": [
+            "direct",
+            "direct",
+            "interact",
+            "wait",
+            "wait",
+            "interact",
+            "interact",
+            "direct"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 0.625,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.75,
+            "cost": 14,
+            "stability": 0.625,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 23,
+          "decisions": [
+            "wait",
+            "direct",
+            "interact",
+            "wait",
+            "direct",
+            "interact",
+            "interact",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.1429,
+            "adaptation_after_failure": 0.5,
+            "goal_pursuit": 0.75,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 1.0,
+            "cost": 12,
+            "stability": 0.75,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 37,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "direct",
+            "direct",
+            "interact",
+            "interact",
+            "direct"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 0.625,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.75,
+            "cost": 14,
+            "stability": 0.625,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 53,
+          "decisions": [
+            "direct",
+            "wait",
+            "interact",
+            "direct",
+            "direct",
+            "interact",
+            "interact",
+            "direct"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.2857,
+            "adaptation_after_failure": 0.25,
+            "goal_pursuit": 0.5,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.75,
+            "cost": 16,
+            "stability": 0.5,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 71,
+          "decisions": [
+            "direct",
+            "wait",
+            "interact",
+            "direct",
+            "wait",
+            "interact",
+            "interact",
+            "direct"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.1429,
+            "adaptation_after_failure": 0.6667,
+            "goal_pursuit": 0.625,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 1.0,
+            "cost": 14,
+            "stability": 0.625,
+            "useful_mutation_rate": 0.0
+          }
+        }
+      ],
+      "aggregate": {
+        "intra_life_coherence": 0.2857,
+        "adaptation_after_failure": 0.2833,
+        "goal_pursuit": 0.625,
+        "perception_decision_action_causality": 1.0,
+        "memory_reuse": 0.0,
+        "effective_capability_acquisition": 0.85,
+        "cost": 14,
+        "stability": 0.625,
+        "useful_mutation_rate": 0.0,
+        "inter_life_diversity": 1.0,
+        "stability_dispersion": 0.0791
+      }
+    },
+    "no_intrinsic_goals": {
+      "lives": [
+        {
+          "seed": 11,
+          "decisions": [
+            "direct",
+            "direct",
+            "direct",
+            "direct",
+            "wait",
+            "direct",
+            "direct",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.5714,
+            "adaptation_after_failure": 0.1667,
+            "goal_pursuit": 0.25,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.125,
+            "effective_capability_acquisition": 0.25,
+            "cost": 8,
+            "stability": 0.25,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 23,
+          "decisions": [
+            "direct",
+            "direct",
+            "wait",
+            "direct",
+            "direct",
+            "direct",
+            "wait",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.5714,
+            "adaptation_after_failure": 0.1429,
+            "goal_pursuit": 0.125,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.25,
+            "cost": 8,
+            "stability": 0.125,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 37,
+          "decisions": [
+            "wait",
+            "wait",
+            "direct",
+            "wait",
+            "wait",
+            "direct",
+            "direct",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 0.625,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.375,
+            "effective_capability_acquisition": 0.5,
+            "cost": 8,
+            "stability": 0.625,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 53,
+          "decisions": [
+            "wait",
+            "wait",
+            "direct",
+            "direct",
+            "direct",
+            "direct",
+            "wait",
+            "direct"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.5714,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 0.25,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.125,
+            "effective_capability_acquisition": 0.25,
+            "cost": 8,
+            "stability": 0.25,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 71,
+          "decisions": [
+            "direct",
+            "direct",
+            "direct",
+            "direct",
+            "direct",
+            "direct",
+            "direct",
+            "direct"
+          ],
+          "metrics": {
+            "intra_life_coherence": 1.0,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 0.0,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.0,
+            "cost": 8,
+            "stability": 0.0,
+            "useful_mutation_rate": 0.0
+          }
+        }
+      ],
+      "aggregate": {
+        "intra_life_coherence": 0.6286,
+        "adaptation_after_failure": 0.0619,
+        "goal_pursuit": 0.25,
+        "perception_decision_action_causality": 1.0,
+        "memory_reuse": 0.125,
+        "effective_capability_acquisition": 0.25,
+        "cost": 8,
+        "stability": 0.25,
+        "useful_mutation_rate": 0.0,
+        "inter_life_diversity": 1.0,
+        "stability_dispersion": 0.2092
+      }
+    },
+    "no_mutation": {
+      "lives": [
+        {
+          "seed": 11,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "wait",
+            "wait",
+            "interact",
+            "interact",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 1.0,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 8,
+            "stability": 1.0,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 23,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "wait",
+            "wait",
+            "interact",
+            "interact",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 1.0,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 8,
+            "stability": 1.0,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 37,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "wait",
+            "wait",
+            "interact",
+            "interact",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 1.0,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 8,
+            "stability": 1.0,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 53,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "wait",
+            "wait",
+            "interact",
+            "interact",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 1.0,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 8,
+            "stability": 1.0,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 71,
+          "decisions": [
+            "wait",
+            "wait",
+            "interact",
+            "wait",
+            "wait",
+            "interact",
+            "interact",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 1.0,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.5,
+            "effective_capability_acquisition": 1.0,
+            "cost": 8,
+            "stability": 1.0,
+            "useful_mutation_rate": 0.0
+          }
+        }
+      ],
+      "aggregate": {
+        "intra_life_coherence": 0.4286,
+        "adaptation_after_failure": 0.0,
+        "goal_pursuit": 1.0,
+        "perception_decision_action_causality": 1.0,
+        "memory_reuse": 0.5,
+        "effective_capability_acquisition": 1.0,
+        "cost": 8,
+        "stability": 1.0,
+        "useful_mutation_rate": 0.0,
+        "inter_life_diversity": 0.0,
+        "stability_dispersion": 0.0
+      }
+    },
+    "random_decisions": {
+      "lives": [
+        {
+          "seed": 11,
+          "decisions": [
+            "wait",
+            "wait",
+            "direct",
+            "direct",
+            "wait",
+            "wait",
+            "wait",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.7143,
+            "adaptation_after_failure": 0.25,
+            "goal_pursuit": 0.5,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.5,
+            "cost": 16,
+            "stability": 0.5,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 23,
+          "decisions": [
+            "detour",
+            "direct",
+            "direct",
+            "build",
+            "direct",
+            "wait",
+            "direct",
+            "wait"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.1429,
+            "adaptation_after_failure": 0.2,
+            "goal_pursuit": 0.375,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.5,
+            "cost": 18,
+            "stability": 0.375,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 37,
+          "decisions": [
+            "detour",
+            "detour",
+            "interact",
+            "build",
+            "wait",
+            "wait",
+            "interact",
+            "direct"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.2857,
+            "adaptation_after_failure": 0.0,
+            "goal_pursuit": 0.75,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 1.0,
+            "cost": 12,
+            "stability": 0.75,
+            "useful_mutation_rate": 0.0
+          }
+        },
+        {
+          "seed": 53,
+          "decisions": [
+            "wait",
+            "wait",
+            "wait",
+            "build",
+            "build",
+            "interact",
+            "wait",
+            "direct"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.4286,
+            "adaptation_after_failure": 0.3333,
+            "goal_pursuit": 0.625,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.75,
+            "cost": 14,
+            "stability": 0.625,
+            "useful_mutation_rate": 0.3333
+          }
+        },
+        {
+          "seed": 71,
+          "decisions": [
+            "wait",
+            "wait",
+            "wait",
+            "direct",
+            "build",
+            "interact",
+            "direct",
+            "build"
+          ],
+          "metrics": {
+            "intra_life_coherence": 0.2857,
+            "adaptation_after_failure": 0.6667,
+            "goal_pursuit": 0.625,
+            "perception_decision_action_causality": 1.0,
+            "memory_reuse": 0.0,
+            "effective_capability_acquisition": 0.75,
+            "cost": 14,
+            "stability": 0.625,
+            "useful_mutation_rate": 0.6667
+          }
+        }
+      ],
+      "aggregate": {
+        "intra_life_coherence": 0.3714,
+        "adaptation_after_failure": 0.29,
+        "goal_pursuit": 0.575,
+        "perception_decision_action_causality": 1.0,
+        "memory_reuse": 0.0,
+        "effective_capability_acquisition": 0.7,
+        "cost": 14.8,
+        "stability": 0.575,
+        "useful_mutation_rate": 0.2,
+        "inter_life_diversity": 1.0,
+        "stability_dispersion": 0.1275
+      }
+    }
+  },
+  "negative_control_comparisons": {
+    "no_memory": {
+      "metric": "memory_reuse",
+      "effect": 0.5,
+      "observable": true
+    },
+    "no_intrinsic_goals": {
+      "metric": "goal_pursuit",
+      "effect": 0.625,
+      "observable": true
+    },
+    "no_mutation": {
+      "metric": "adaptation_after_failure",
+      "effect": 0.6,
+      "observable": true
+    },
+    "random_decisions": {
+      "metric": "stability",
+      "effect": 0.3,
+      "observable": true
+    }
+  },
+  "dashboard_summary": {
+    "status": "pass",
+    "headline": "Évaluation multi-vies hors réseau",
+    "metrics": {
+      "intra_life_coherence": 0.2857,
+      "adaptation_after_failure": 0.6,
+      "goal_pursuit": 0.875,
+      "perception_decision_action_causality": 1.0,
+      "memory_reuse": 0.5,
+      "effective_capability_acquisition": 1.0,
+      "cost": 10,
+      "stability": 0.875,
+      "useful_mutation_rate": 0.6,
+      "inter_life_diversity": 0.5,
+      "stability_dispersion": 0.1118
+    },
+    "mechanism_effects": {
+      "no_memory": {
+        "metric": "memory_reuse",
+        "effect": 0.5,
+        "observable": true
+      },
+      "no_intrinsic_goals": {
+        "metric": "goal_pursuit",
+        "effect": 0.625,
+        "observable": true
+      },
+      "no_mutation": {
+        "metric": "adaptation_after_failure",
+        "effect": 0.6,
+        "observable": true
+      },
+      "random_decisions": {
+        "metric": "stability",
+        "effect": 0.3,
+        "observable": true
+      }
+    },
+    "disclaimer": "Résultats comportementaux simulés; ils ne constituent pas une preuve de conscience."
+  }
+}

--- a/configs/agi_kpis.yaml
+++ b/configs/agi_kpis.yaml
@@ -79,6 +79,13 @@ measurement:
     - language
     - task_difficulty
 
+# Seuil local du scénario synthétique; il ne remplace pas la campagne à 200
+# échantillons, les IC à 95 % ni les deux fenêtres exigées ci-dessus.
+offline_multi_life:
+  artifact_schema: "singular.offline-multi-life-evaluation/v1"
+  minimum_lives: 5
+  minimum_observable_effect: 0.05
+
 notes:
   - "Les valeurs sont des seuils minimaux (ou maximaux pour les métriques suffixées _max)."
   - "Le passage de niveau exige que tous les KPI critiques du niveau soient satisfaits sur 2 fenêtres consécutives."

--- a/docs/agi_target_spec.md
+++ b/docs/agi_target_spec.md
@@ -75,6 +75,11 @@ Résumé attendu :
 
 ## Non-objectifs (court terme)
 
+Le scénario hors réseau multi-vies de la matrice cognitive relie ses mesures aux
+familles autonomie, apprentissage long terme et robustesse. Ses contrôles négatifs
+démontrent seulement un effet dans le monde simulé : ils ne remplacent pas les
+seuils de campagne et ne sont pas une preuve de conscience.
+
 Les éléments suivants ne sont **pas** requis à court terme :
 
 - Intelligence surhumaine universelle dans tous les domaines.

--- a/docs/cognitive-capabilities-matrix.md
+++ b/docs/cognitive-capabilities-matrix.md
@@ -4,6 +4,18 @@ Cette matrice est le registre canonique de maturité des capacités montrées da
 captures. Elle décrit **ce qui est démontré dans le dépôt**, et non une intention de
 produit. La date d'observation est le 7 août 2026.
 
+## Évaluation hors réseau multi-vies
+
+`python scripts/run_offline_multi_life_eval.py` rejoue exactement la même trace de
+perceptions et contraintes dans cinq vies à seeds distinctes. L'artefact versionné
+`artifacts/evaluations/offline_multi_life_v1.json` mesure diversité inter-vies,
+cohérence intra-vie, adaptation après échec, poursuite d'objectif, chaîne causale,
+réutilisation de mémoire, acquisition de capacités, coût, stabilité et mutations
+utiles. Les ablations sans mémoire, objectifs intrinsèques, mutation, ainsi que la
+politique aléatoire, isolent un effet comportemental minimal défini dans la
+configuration KPI. Ce scénario ne satisfait pas les exigences de campagne pour V
+et **ne constitue en aucun cas une preuve de conscience**.
+
 > **Statut du document : `experimental`.** Les statuts de disponibilité emploient
 > exclusivement la [taxonomie canonique](README.md#taxonomie-de-statut). Aucune
 > capacité de cette matrice n'est déclarée `stable`; il n'existe donc pas ici de

--- a/scripts/run_offline_multi_life_eval.py
+++ b/scripts/run_offline_multi_life_eval.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+from singular.evaluation import run_multi_life_evaluation
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Replay one simulated trace across lives and negative controls (no network)."
+    )
+    parser.add_argument("--seeds", default="11,23,37,53,71")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/evaluations/offline_multi_life_v1.json"),
+    )
+    parser.add_argument(
+        "--kpi-config", type=Path, default=Path("configs/agi_kpis.yaml")
+    )
+    args = parser.parse_args()
+    result = run_multi_life_evaluation(
+        seeds=[int(x) for x in args.seeds.split(",")],
+        output=args.output,
+        kpi_config=args.kpi_config,
+    )
+    print(json.dumps(result["dashboard_summary"], ensure_ascii=False, indent=2))
+    return 0 if result["dashboard_summary"]["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -1967,6 +1967,26 @@ def create_app(
     def read_cockpit_essential(current_life_only: bool = False) -> dict[str, object]:
         return _summarize_cockpit_essential(current_life_only=current_life_only)
 
+    @app.get("/api/evaluations/offline-multi-life")
+    def read_offline_multi_life_evaluation() -> dict[str, object]:
+        """Expose the compact, dashboard-safe part of the versioned artifact."""
+        artifact = base_dir / "artifacts" / "evaluations" / "offline_multi_life_v1.json"
+        if not artifact.is_file():
+            return {"available": False, "summary": None}
+        try:
+            payload = json.loads(artifact.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"available": False, "summary": None, "error": "invalid artifact"}
+        summary = payload.get("dashboard_summary")
+        if not isinstance(summary, dict):
+            return {"available": False, "summary": None, "error": "missing summary"}
+        return {
+            "available": True,
+            "schema_version": payload.get("schema_version"),
+            "generated_at": payload.get("generated_at"),
+            "summary": summary,
+        }
+
     @app.get("/dashboard/context")
     def read_dashboard_context() -> dict[str, object]:
         policy = load_runtime_policy()

--- a/src/singular/evaluation/__init__.py
+++ b/src/singular/evaluation/__init__.py
@@ -1,0 +1,5 @@
+"""Reproducible, offline evaluation scenarios."""
+
+from .multi_life import run_multi_life_evaluation
+
+__all__ = ["run_multi_life_evaluation"]

--- a/src/singular/evaluation/multi_life.py
+++ b/src/singular/evaluation/multi_life.py
@@ -1,0 +1,204 @@
+"""Deterministic multi-life evaluation in a small, network-free world.
+
+The world trace is created once and replayed verbatim for every seed and ablation.
+It is deliberately an evaluation fixture, not a claim about subjective experience.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import random
+from statistics import mean, pstdev
+from typing import Any
+
+SCHEMA_VERSION = "singular.offline-multi-life-evaluation/v1"
+MECHANISMS = ("memory", "intrinsic_goals", "mutation")
+CONTROLS = {
+    "full": {},
+    "no_memory": {"memory": False},
+    "no_intrinsic_goals": {"intrinsic_goals": False},
+    "no_mutation": {"mutation": False},
+    "random_decisions": {"random_decisions": True},
+}
+
+
+@dataclass(frozen=True)
+class Step:
+    perception: str
+    blocked: str | None
+    target: str
+
+
+TRACE = (
+    Step("red beacon beside a wall", "direct", "key"),
+    Step("red beacon beside a wall", "direct", "key"),
+    Step("blue door requests a key", None, "door"),
+    Step("rough floor before a pit", "direct", "bridge"),
+    Step("rough floor before a pit", "direct", "bridge"),
+    Step("blue door requests a key", None, "door"),
+    Step("green terminal offers a tool", None, "tool"),
+    Step("rough floor before a pit", "direct", "bridge"),
+)
+
+
+def _simulate(seed: int, control: str) -> dict[str, Any]:
+    flags = {name: True for name in MECHANISMS}
+    flags.update(CONTROLS[control])
+    rng = random.Random(seed * 1009 + sum(map(ord, control)))
+    memory: dict[str, str] = {}
+    mutations = useful_mutations = failures = adapted = reused = 0
+    successes = constraints_met = 0
+    acquired: set[str] = set()
+    decisions: list[str] = []
+    causal = 0
+    last_failed: dict[str, str] = {}
+    for index, step in enumerate(TRACE):
+        direct = "direct"
+        alternative = {"key": "detour", "bridge": "build"}.get(step.target, "interact")
+        if flags.get("random_decisions"):
+            action = rng.choice((direct, alternative, "wait"))
+        elif flags["memory"] and step.perception in memory:
+            action = memory[step.perception]
+            reused += 1
+        elif flags["intrinsic_goals"] and step.blocked is None:
+            action = alternative
+        else:
+            action = rng.choice((direct, "wait"))
+
+        failure = step.blocked == action or (
+            step.blocked is None and action != alternative
+        )
+        if failure:
+            failures += 1
+            last_failed[step.perception] = action
+            if flags["mutation"] and flags["intrinsic_goals"]:
+                mutations += 1
+                candidate = alternative
+                # A mutation is useful only when it changes a later decision and succeeds.
+                if candidate != action:
+                    memory[step.perception] = candidate
+        else:
+            successes += 1
+            constraints_met += 1
+            acquired.add(step.target)
+            if (
+                step.perception in last_failed
+                and action != last_failed[step.perception]
+            ):
+                adapted += 1
+                if flags["mutation"] and memory.get(step.perception) == action:
+                    useful_mutations += 1
+                del last_failed[step.perception]
+            if flags["memory"]:
+                memory[step.perception] = action
+        expected_tokens = (
+            ("red", "key")
+            if step.target == "key"
+            else (("rough", "bridge") if step.target == "bridge" else ())
+        )
+        causal += int(
+            not expected_tokens
+            or any(token in step.perception for token in expected_tokens)
+        )
+        decisions.append(action)
+
+    transitions = [a == b for a, b in zip(decisions, decisions[1:])]
+    return {
+        "seed": seed,
+        "decisions": decisions,
+        "metrics": {
+            "intra_life_coherence": round(sum(transitions) / len(transitions), 4),
+            "adaptation_after_failure": round(adapted / max(1, failures), 4),
+            "goal_pursuit": round(successes / len(TRACE), 4),
+            "perception_decision_action_causality": round(causal / len(TRACE), 4),
+            "memory_reuse": round(reused / len(TRACE), 4),
+            "effective_capability_acquisition": round(len(acquired) / 4, 4),
+            "cost": len(TRACE) + mutations * 2,
+            "stability": round(constraints_met / len(TRACE), 4),
+            "useful_mutation_rate": round(useful_mutations / max(1, mutations), 4),
+        },
+    }
+
+
+def _aggregate(lives: list[dict[str, Any]]) -> dict[str, float]:
+    keys = lives[0]["metrics"]
+    result = {
+        key: round(mean(life["metrics"][key] for life in lives), 4) for key in keys
+    }
+    signatures = {tuple(life["decisions"]) for life in lives}
+    result["inter_life_diversity"] = round(
+        (len(signatures) - 1) / max(1, len(lives) - 1), 4
+    )
+    result["stability_dispersion"] = round(
+        pstdev(life["metrics"]["stability"] for life in lives), 4
+    )
+    return result
+
+
+def run_multi_life_evaluation(
+    *, seeds: list[int], output: Path, kpi_config: Path
+) -> dict[str, Any]:
+    if len(seeds) < 2 or len(set(seeds)) != len(seeds):
+        raise ValueError("at least two distinct seeds are required")
+    raw_config = kpi_config.read_text(encoding="utf-8")
+    threshold = 0.05
+    for line in raw_config.splitlines():
+        if line.strip().startswith("minimum_observable_effect:"):
+            threshold = float(line.split(":", 1)[1].strip())
+    groups: dict[str, Any] = {}
+    for control in CONTROLS:
+        lives = [_simulate(seed, control) for seed in seeds]
+        groups[control] = {"lives": lives, "aggregate": _aggregate(lives)}
+    full = groups["full"]["aggregate"]
+    comparisons = {}
+    mapping = {
+        "no_memory": "memory_reuse",
+        "no_intrinsic_goals": "goal_pursuit",
+        "no_mutation": "adaptation_after_failure",
+        "random_decisions": "stability",
+    }
+    for control, metric in mapping.items():
+        effect = round(full[metric] - groups[control]["aggregate"][metric], 4)
+        comparisons[control] = {
+            "metric": metric,
+            "effect": effect,
+            "observable": effect >= threshold,
+        }
+    trace_payload = [step.__dict__ for step in TRACE]
+    artifact = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "offline": True,
+        "scenario": {
+            "trace_sha256": hashlib.sha256(
+                json.dumps(trace_payload, sort_keys=True).encode()
+            ).hexdigest(),
+            "steps": trace_payload,
+        },
+        "seeds": seeds,
+        "kpi_links": {
+            "config": "configs/agi_kpis.yaml#offline_multi_life",
+            "capabilities_matrix": "docs/cognitive-capabilities-matrix.md#evaluation-hors-reseau-multi-vies",
+            "target_spec": "docs/agi_target_spec.md#evaluation-hors-reseau",
+        },
+        "groups": groups,
+        "negative_control_comparisons": comparisons,
+        "dashboard_summary": {
+            "status": (
+                "pass" if all(x["observable"] for x in comparisons.values()) else "fail"
+            ),
+            "headline": "Évaluation multi-vies hors réseau",
+            "metrics": full,
+            "mechanism_effects": comparisons,
+            "disclaimer": "Résultats comportementaux simulés; ils ne constituent pas une preuve de conscience.",
+        },
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(artifact, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return artifact

--- a/tests/test_offline_multi_life_evaluation.py
+++ b/tests/test_offline_multi_life_evaluation.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi_stub import TestClient
+
+from singular.dashboard import create_app
+from singular.evaluation import run_multi_life_evaluation
+
+
+def test_offline_multi_life_replays_trace_and_exposes_ablation_effects(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "agi_kpis.yaml"
+    config.write_text("minimum_observable_effect: 0.05\n", encoding="utf-8")
+    output = tmp_path / "artifact.json"
+    result = run_multi_life_evaluation(
+        seeds=[11, 23, 37, 53, 71], output=output, kpi_config=config
+    )
+    assert result["offline"] is True
+    assert result["dashboard_summary"]["status"] == "pass"
+    assert all(
+        item["observable"] for item in result["negative_control_comparisons"].values()
+    )
+    assert {
+        len(group["lives"][0]["decisions"]) for group in result["groups"].values()
+    } == {8}
+    assert json.loads(output.read_text())["schema_version"].endswith("/v1")
+
+
+def test_offline_multi_life_requires_distinct_seeds(tmp_path: Path) -> None:
+    config = tmp_path / "kpi.yaml"
+    config.write_text("")
+    with pytest.raises(ValueError, match="distinct"):
+        run_multi_life_evaluation(
+            seeds=[1, 1], output=tmp_path / "x.json", kpi_config=config
+        )
+
+
+def test_dashboard_reads_compact_evaluation_summary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact = tmp_path / "artifacts/evaluations/offline_multi_life_v1.json"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": "singular.offline-multi-life-evaluation/v1",
+                "generated_at": "2026-08-07T00:00:00+00:00",
+                "dashboard_summary": {"status": "pass", "headline": "offline"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
+    payload = (
+        TestClient(create_app(psyche_file=tmp_path / "psyche.json"))
+        .get("/api/evaluations/offline-multi-life")
+        .json()
+    )
+    assert payload["available"] is True
+    assert payload["summary"] == {"status": "pass", "headline": "offline"}


### PR DESCRIPTION
### Motivation

- Fournir un scénario reproductible d’évaluation hors réseau qui rejoue une même séquence de perceptions et contraintes sur plusieurs vies et seeds afin de mesurer l’impact des mécanismes (mémoire, objectifs intrinsèques, mutation) et leurs ablations.

### Description

- Ajout d’un paquet d’évaluation `src/singular/evaluation/multi_life.py` qui simule plusieurs vies sur une trace déterministe, calcule métriques par vie (cohérence intra‑vie, adaptation après échec, poursuite d’objectifs, causalité perception→décision→action, réutilisation de mémoire, acquisition de capacités, coût, stabilité, mutations utiles) et agrège la diversité inter‑vies et dispersion de stabilité.
- Génération d’un artefact JSON versionné (`artifacts/evaluations/offline_multi_life_v1.json`) contenant le scénario (hash de la trace), résultats par vie, comparaisons avec contrôles négatifs et un `dashboard_summary` lisible par l’interface.
- Script CLI `scripts/run_offline_multi_life_eval.py` pour exécuter la replay hors réseau et écrire l’artefact, et export `src/singular/evaluation/__init__.py` pour l’API publique.
- Endpoint dashboard `GET /api/evaluations/offline-multi-life` exposant la synthèse sûre de l’artefact et gestion des artefacts absents/invalides, et mises à jour de la config `configs/agi_kpis.yaml` et de la documentation (`docs/*`) pour lier le scénario aux KPI et préciser les limites (ne prouve pas la conscience).
- Ajout de tests `tests/test_offline_multi_life_evaluation.py` qui vérifient le rejet d’ensemblages de seeds non distincts, la génération d’un artefact conforme et l’accès compact via le dashboard TestClient.

### Testing

- Exécution du script `python scripts/run_offline_multi_life_eval.py` pour produire l’artefact JSON et afficher le résumé, qui a abouti (artefact écrit et résumé imprimé).
- Tests unitaires `pytest -q tests/test_offline_multi_life_evaluation.py` passés localement (3 tests OK, 1 avertissement sur le stub TestClient collection); les assertions valident la production d’artefacts et les comparaisons d’ablation.
- Formatage et vérification de style avec `black` et compilation avec `python -m compileall` réussis sans erreur de compilation ni warnings critiques.
- Vérification minimale de l’endpoint dashboard via `TestClient(create_app(...)).get('/api/evaluations/offline-multi-life')` incluse dans les tests et validée automatiquement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76489c7cec832a88367ca7722a595a)