### PR TITLE
Importer `CHECKPOINT_VERSION` dans `life.loop` et adapter le test

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -75,7 +75,7 @@ from singular.governance.values import load_value_weights
 from singular.morals import MoralAction, MoralContextBuilder, MoralDecision, MoralDecisionEngine
 from singular.identity.core import IdentityCoreService
 
-from .checkpointing import Checkpoint, load_checkpoint, save_checkpoint
+from .checkpointing import CHECKPOINT_VERSION, Checkpoint, load_checkpoint, save_checkpoint
 from .sandbox_scoring import SandboxScore, score_code_with_error, score_code, _sandbox_failure_category
 from .mutation_flow import apply_mutation, select_operator, _load_default_operators
 from .resource_flow import manage_resources

--- a/tests/test_targeted_lifecycle_narrative_trajectory.py
+++ b/tests/test_targeted_lifecycle_narrative_trajectory.py
@@ -10,7 +10,8 @@ from singular.dashboard import create_app
 from singular.environment import sim_world
 from singular.goals.quest_generation import generate_quests
 from singular.life.death import DeathMonitor
-from singular.life.loop import CHECKPOINT_VERSION, load_checkpoint
+from singular.life import loop as life_loop
+from singular.life.loop import load_checkpoint
 from singular.organisms.birth import birth
 from singular.organisms.status import status
 from singular.self_narrative import SCHEMA_VERSION, load, update_from_signals
@@ -152,7 +153,7 @@ def test_schema_invariants_and_migrations_for_narrative_and_checkpoint(tmp_path:
         encoding="utf-8",
     )
     checkpoint = load_checkpoint(checkpoint_path)
-    assert checkpoint.version == CHECKPOINT_VERSION
+    assert life_loop.CHECKPOINT_VERSION == checkpoint.version
     assert checkpoint.iteration == 5
 
 


### PR DESCRIPTION
### Motivation

- Éviter la duplication de la constante de version de checkpoint en réutilisant la valeur canonique définie dans `src/singular/life/checkpointing.py` afin de prévenir toute divergence de version.
- Faire en sorte que les tests vérifient explicitement que la version exposée par le module `life.loop` correspond à celle utilisée par `load_checkpoint`.

### Description

- Ajout de l’import de `CHECKPOINT_VERSION` depuis `src/singular/life/checkpointing.py` dans `src/singular/life/loop.py` (`from .checkpointing import CHECKPOINT_VERSION, Checkpoint, load_checkpoint, save_checkpoint`).
- Adaptation de `tests/test_targeted_lifecycle_narrative_trajectory.py` pour importer le module `life` en tant que `life_loop` et remplacer l’assertion par `assert life_loop.CHECKPOINT_VERSION == checkpoint.version`.
- La constante canonique reste uniquement dans `src/singular/life/checkpointing.py` et n’a pas été dupliquée.

### Testing

- Exécuté `pytest -q tests/test_targeted_lifecycle_narrative_trajectory.py`, résultat : 4 passed.
- Exécuté une suite plus large incluant `tests/test_loop.py`, résultat : a échoué sur `test_repository_addition_skill_satisfies_sandbox_scoring_contract` en raison de l’indisponibilité d’un sandbox sécurisé (podman/docker) dans l’environnement, ce qui est indépendant du changement apporté ici.
- Les tests affectant directement les modifications (`tests/test_targeted_lifecycle_narrative_trajectory.py`) passent avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a768fd5a698832a93d1c00a874bd1f8)