### PR TITLE
Clarifier la pénalité de régression dans la coévolution et renforcer les tests

### DIFF
--- a/src/singular/life/coevolution_flow.py
+++ b/src/singular/life/coevolution_flow.py
@@ -143,9 +143,19 @@ class CoevolutionFlow:
 
         detection_rate = self.evaluate_against_mutation(base_code, mutated_code)
         robustness_score = self.robustness_from_detection_rate(detection_rate)
+        regression_penalty = self.config.robustness_weight * detection_rate
         combined_base = base_score
-        combined_new = mutated_score + (self.config.robustness_weight * detection_rate)
-        accepted = initially_accepted and combined_new <= combined_base
+        # Scores follow the minimization convention: detected regressions add a
+        # cost.  ``robustness_score`` remains a bounded reporting metric and is
+        # deliberately not mixed into the objective with the opposite sign.
+        combined_new = mutated_score + regression_penalty
+        strict_regression_rejection = self.config.robustness_weight > 0.0
+        regression_allowed = not strict_regression_rejection or detection_rate == 0.0
+        accepted = (
+            initially_accepted
+            and combined_new <= combined_base
+            and regression_allowed
+        )
         rejected_for_robustness = initially_accepted and not accepted
 
         proposed: list[TestCandidate] = []

--- a/tests/test_life_loop_targeted.py
+++ b/tests/test_life_loop_targeted.py
@@ -154,24 +154,50 @@ def test_reproduction_decision_accepts_healthy_governed_parents(temp_life) -> No
     assert decision.score >= 0.1
 
 
-def test_coevolution_rejects_regression_detected_by_living_test() -> None:
+@pytest.mark.parametrize(
+    (
+        "mutated_code",
+        "mutated_score",
+        "robustness_weight",
+        "expected_accepted",
+        "expected_combined",
+    ),
+    [
+        pytest.param("result = 2", 0.0, 1.0, False, 1.0, id="detected-regression"),
+        pytest.param("result = 1", 1.0, 1.0, True, 1.0, id="no-regression"),
+        pytest.param("result = 2", 1.0, 0.0, True, 1.0, id="zero-weight"),
+    ],
+)
+def test_coevolution_rejects_regression_detected_by_living_test(
+    mutated_code: str,
+    mutated_score: float,
+    robustness_weight: float,
+    expected_accepted: bool,
+    expected_combined: float,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     flow = CoevolutionFlow(
         pool=LivingTestPool(tests=[TestCandidate("result == 1")], ttl={"result == 1": 3}),
-        config=CoevolutionConfig(enabled=True, robustness_weight=1.0),
+        config=CoevolutionConfig(enabled=True, robustness_weight=robustness_weight),
     )
+    monkeypatch.setattr(flow.pool, "evaluate", lambda code: [code == "result = 1"])
 
     decision = flow.decide(
         base_code="result = 1",
-        mutated_code="result = 2",
+        mutated_code=mutated_code,
         base_score=1.0,
-        mutated_score=1.0,
+        mutated_score=mutated_score,
         initially_accepted=True,
         rng=random.Random(0),
     )
 
-    assert decision.accepted is False
-    assert decision.rejected_for_robustness is True
-    assert decision.regression_detection_rate == 1.0
+    regression_detected = mutated_code == "result = 2"
+    assert decision.accepted is expected_accepted
+    assert decision.rejected_for_robustness is (not expected_accepted)
+    assert decision.regression_detection_rate == float(regression_detected)
+    assert decision.robustness_score == float(not regression_detected)
+    assert decision.score_combined_base == 1.0
+    assert decision.score_combined_new == expected_combined
 
 
 def test_cycle_complet_creation_tick_mutation_learning_reproduction_and_stop(temp_life) -> None:


### PR DESCRIPTION
### Motivation

- Séparer explicitement la pénalité de régression du score de robustesse pour respecter la convention de minimisation des scores et éviter d’utiliser `robustness_score` avec un signe contradictoire.
- Faire en sorte que l’acceptation tienne compte de l’état initial, du score combiné (mutation + pénalité) et d’une politique de rejet strict lorsque le poids de robustesse est activé.

### Description

- Introduit `regression_penalty = self.config.robustness_weight * detection_rate` et calcule `score_combined_new` comme `mutated_score + regression_penalty` dans `CoevolutionFlow.decide`.
- Ajout d’un contrôle `strict_regression_rejection` / `regression_allowed` : quand `robustness_weight > 0.0`, toute régression détectée conduit au rejet même si le score combiné serait favorable, sinon la décision suit la comparaison `combined_new <= combined_base` combinée à `initially_accepted`.
- Conserve `robustness_score` comme métrique informative bornée (ne l’intègre pas avec un signe opposé dans l’objectif).
- Renforce `tests/test_life_loop_targeted.py::test_coevolution_rejects_regression_detected_by_living_test` en le paramétrant pour couvrir trois cas (`detected-regression`, `no-regression`, `zero-weight`), en se moquant de l’évaluation du pool avec `monkeypatch`, et en vérifiant `accepted`, `rejected_for_robustness`, `regression_detection_rate`, `robustness_score`, `score_combined_base` et `score_combined_new`.

### Testing

- Exécuté le test ciblé paramétré `tests/test_life_loop_targeted.py::test_coevolution_rejects_regression_detected_by_living_test` (trois cas) : `3 passed`.
- Exécuté `ruff` et les contrôles de diff (`git diff --check`) sur les fichiers modifiés : tous les checks sont passés.
- Exécution de la suite `tests/test_life_loop_targeted.py` complète : plusieurs autres tests dans ce fichier ont échoué en environnement CI local à cause de l’absence d’un runtime de sandbox (Podman/Docker) requis, ces échecs sont indépendants du changement de logique de coévolution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a769282d770832aa8e8d2344cc9d91d)