### PR TITLE
Reorder governed mutation acceptance flow

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -1614,7 +1614,7 @@ def run(
                     psyche.feel(Mood.CURIOUS)
                 seen_diffs.add(diff)
 
-            accepted = (
+            candidate_accepted = (
                 False
                 if mutation_failed or not scores_comparable
                 else (
@@ -1628,7 +1628,7 @@ def run(
             world_effects: list[dict[str, object]] = []
             security_metadata: dict[str, object] = {
                 "governance_checked": False,
-                "allowed": accepted,
+                "allowed": candidate_accepted,
                 "level": None,
                 "reason": "score_gate",
                 "corrective_action": None,
@@ -1636,10 +1636,13 @@ def run(
             if coevolution_flow is not None and not selected_org.degraded_mode:
                 can_run_coevo, coevo_state = resource_manager.apply_capability_cost("test_coevolution")
                 if not can_run_coevo:
-                    accepted = accepted and coevo_state != CapabilityStatus.UNSTABLE
+                    candidate_accepted = (
+                        candidate_accepted
+                        and coevo_state != CapabilityStatus.UNSTABLE
+                    )
                     logger.log_test_coevolution(
                         skill=skill_path.stem,
-                        accepted=accepted,
+                        accepted=candidate_accepted,
                         pool_size=len(coevolution_flow.pool.tests),
                         added=0,
                         removed=0,
@@ -1661,13 +1664,13 @@ def run(
                             mutated_code=mutated,
                             base_score=base_score,
                             mutated_score=mutated_score,
-                            initially_accepted=accepted,
+                            initially_accepted=candidate_accepted,
                             rng=rng,
                         )
-                    accepted = coevo_decision.accepted
+                    candidate_accepted = coevo_decision.accepted
                     logger.log_test_coevolution(
                         skill=skill_path.stem,
-                        accepted=accepted,
+                        accepted=candidate_accepted,
                         pool_size=coevo_decision.pool_size,
                         added=coevo_decision.tests_added,
                         removed=coevo_decision.tests_removed,
@@ -1682,47 +1685,131 @@ def run(
                         rejected_tests=list(coevo_decision.rejected_tests),
                         rejected_for_robustness=coevo_decision.rejected_for_robustness,
                     )
-            accepted = accepted and not mutation_failed and scores_comparable
+            candidate_accepted = (
+                candidate_accepted and not mutation_failed and scores_comparable
+            )
             if mutated_comparable_score is not None:
                 org.last_score = mutated_comparable_score
-            if accepted:
-                governance_root = skill_path.parent.parent if skill_path.parent.name == "skills" else skill_path.parent
-                decision = governance_policy.enforce_write(skill_path, mutated, root=governance_root)
-                security_metadata = {
-                    "governance_checked": True,
-                    "allowed": decision.allowed,
-                    "level": decision.level,
-                    "reason": decision.reason,
-                    "corrective_action": decision.corrective_action,
-                }
-                if not decision.allowed:
-                    accepted = False
+
+            # Account for sandbox execution before deciding whether enough
+            # resources remain for the mutation itself.  All gates below are
+            # evaluated before the governed write, so no observer can see a
+            # mutation which is subsequently rejected.
+            cpu_ms = ms_base + ms_new
+            moods = manage_resources(
+                resource_manager,
+                cpu_ms / 1000.0,
+                _profiled_test_runner if test_runner is not None else None,
+            )
+            governance_root = (
+                skill_path.parent.parent
+                if skill_path.parent.name == "skills"
+                else skill_path.parent
+            )
+            governance_decision = governance_policy.simulate_write(
+                skill_path, root=governance_root
+            )
+            security_metadata = {
+                "governance_checked": True,
+                "allowed": governance_decision.allowed,
+                "level": governance_decision.level,
+                "reason": governance_decision.reason,
+                "corrective_action": governance_decision.corrective_action,
+            }
+
+            can_mutate = False
+            state_flag = resource_manager.viability_state()
+            if candidate_accepted and governance_decision.allowed:
+                can_mutate, state_flag = resource_manager.apply_capability_cost(
+                    "mutation"
+                )
+                if state_flag == CapabilityStatus.FATIGUED:
+                    candidate_accepted = (
+                        candidate_accepted and mutated_score <= base_score
+                    )
+
+            final_accepted = (
+                candidate_accepted and governance_decision.allowed and can_mutate
+            )
+            if candidate_accepted and not governance_decision.allowed:
+                logger.log_interaction(
+                    "mutation.governance_rejected",
+                    organism=org_name,
+                    target=str(skill_path),
+                    level=governance_decision.level,
+                    severity=governance_decision.severity,
+                    reason=governance_decision.reason,
+                    corrective_action=governance_decision.corrective_action,
+                    alive=True,
+                )
+            elif candidate_accepted and not can_mutate:
+                logger.log_interaction(
+                    "mutation.resource_rejected",
+                    organism=org_name,
+                    target=str(skill_path),
+                    capability_status=state_flag.value,
+                    reason="mutation capability cost refused",
+                    alive=True,
+                )
+            if final_accepted:
+                try:
+                    decision = governance_policy.enforce_write(
+                        skill_path, mutated, root=governance_root
+                    )
+                except Exception as exc:
+                    # A governed write is the sole persistence attempt. Restore
+                    # the known source if an implementation fails after touching
+                    # the target, and turn that failure into an explicit verdict.
+                    if skill_path.read_text(encoding="utf-8") != original:
+                        skill_path.write_text(original, encoding="utf-8")
+                    final_accepted = False
+                    security_metadata.update(
+                        allowed=False,
+                        reason=f"governed write failed: {exc}",
+                    )
                     logger.log_interaction(
-                        "governance_violation",
+                        "mutation.write_rejected",
                         organism=org_name,
                         target=str(skill_path),
-                        level=decision.level,
-                        severity=decision.severity,
-                        reason=decision.reason,
-                        corrective_action=decision.corrective_action,
+                        reason=str(exc),
                         alive=True,
                     )
-                    org.energy -= 0.1
                 else:
-                    org.energy += 0.2
-                    effect_type = ACTION_TYPE_FROM_LOOP_EVENT["mutation.accepted"]
-                    world_effects.append(
-                        sim_world.map_action_type_to_effect(
-                            effect_type,
-                            {"health_delta": 0.2 if accepted else 0.0},
+                    final_accepted = decision.allowed
+                    security_metadata = {
+                        "governance_checked": True,
+                        "allowed": decision.allowed,
+                        "level": decision.level,
+                        "reason": decision.reason,
+                        "corrective_action": decision.corrective_action,
+                    }
+                    if not decision.allowed:
+                        logger.log_interaction(
+                            "mutation.write_rejected",
+                            organism=org_name,
+                            target=str(skill_path),
+                            reason=decision.reason,
+                            alive=True,
                         )
+
+            # From here on every reward, statistic, reputation update and event
+            # consumes this single immutable persistence verdict.
+            accepted = final_accepted
+            if accepted:
+                org.energy += 0.2
+                effect_type = ACTION_TYPE_FROM_LOOP_EVENT["mutation.accepted"]
+                world_effects.append(
+                    sim_world.map_action_type_to_effect(
+                        effect_type,
+                        {"health_delta": 0.2},
                     )
-                    world.reputation.update(
-                        org_name,
-                        "share",
-                        {"moral_weights": ecosystem_rules.reputation_action_weights},
-                    )
-                    env_artifacts.save_text(f"mutation_{state.iteration}", diff)
+                )
+                world.reputation.update(
+                    org_name,
+                    "share",
+                    {"moral_weights": ecosystem_rules.reputation_action_weights},
+                )
+                env_artifacts.save_text(f"mutation_{state.iteration}", diff)
             else:
                 org.energy -= 0.1
                 effect_type = ACTION_TYPE_FROM_LOOP_EVENT["mutation.rejected"]
@@ -1819,18 +1906,6 @@ def run(
             belief_store.forget_stale()
             state.stats = stats
 
-            # Resource accounting
-            cpu_ms = ms_base + ms_new
-            moods = manage_resources(
-                resource_manager,
-                cpu_ms / 1000.0,
-                _profiled_test_runner if test_runner is not None else None,
-            )
-            can_mutate, state_flag = resource_manager.apply_capability_cost("mutation")
-            if not can_mutate:
-                accepted = False
-            elif state_flag == CapabilityStatus.FATIGUED:
-                accepted = accepted and (mutated_score <= base_score)
             if "tired" in moods:
                 if hasattr(psyche, "feel"):
                     psyche.feel(Mood.FATIGUE)

--- a/tests/test_life_loop_targeted.py
+++ b/tests/test_life_loop_targeted.py
@@ -15,7 +15,7 @@ from singular.life.loop import EcosystemRules, Organism, WorldState, run_tick
 from singular.life.mutation_flow import select_operator
 from singular.life.reproduction_flow import ReproductionDecisionPolicy, decide_reproduction
 from singular.life.sandbox_scoring import score_code_with_error
-from singular.resource_manager import ResourceManager
+from singular.resource_manager import CapabilityStatus, ResourceManager
 
 
 def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
@@ -94,6 +94,52 @@ def test_run_tick_manages_resources_and_mutates_skill(temp_life) -> None:
     assert state.iteration == 1
     assert (temp_life["skills_dir"] / "skill.py").read_text(encoding="utf-8").strip() == "result = 1"
     assert resources.energy != before_energy
+
+
+class _MutationGateResourceManager(ResourceManager):
+    def __init__(self, path: Path, *, allow_mutation: bool) -> None:
+        super().__init__(path=path)
+        self.allow_mutation = allow_mutation
+        self.mutation_cost_calls = 0
+
+    def apply_capability_cost(self, capability: str) -> tuple[bool, CapabilityStatus]:
+        if capability == "mutation":
+            self.mutation_cost_calls += 1
+            if not self.allow_mutation:
+                return False, CapabilityStatus.FATIGUED
+        return super().apply_capability_cost(capability)
+
+
+@pytest.mark.parametrize("allow_mutation", [True, False])
+def test_mutation_is_persisted_only_after_resource_gate_accepts(
+    temp_life, monkeypatch: pytest.MonkeyPatch, allow_mutation: bool
+) -> None:
+    original = "result = 2\n"
+    skill_path = temp_life["skills_dir"] / "skill.py"
+    assert skill_path.read_text(encoding="utf-8") == original
+    resources = _MutationGateResourceManager(
+        temp_life["root"] / "gated-resources.json",
+        allow_mutation=allow_mutation,
+    )
+    monkeypatch.setattr(
+        loop,
+        "score_code_with_error",
+        lambda code: loop.SandboxScore(score=float(code.split("=")[1].strip())),
+    )
+
+    run_tick(
+        temp_life["skills_dir"],
+        temp_life["checkpoint_path"],
+        rng=random.Random(0),
+        operators={"dec": _dec_operator},
+        resource_manager=resources,
+        ecosystem_rules=EcosystemRules(crossover_interval=0),
+        tick_budget_seconds=0.05,
+    )
+
+    expected = "result = 1" if allow_mutation else original
+    assert skill_path.read_text(encoding="utf-8") == expected
+    assert resources.mutation_cost_calls == 1
 
 
 @dataclass


### PR DESCRIPTION
### Motivation

- Garantir que la décision finale d’accepter une mutation soit prise après l’évaluation du score, de la coévolution, d’une simulation de gouvernance et de la disponibilité réelle des ressources, afin d’éviter des écritures ou des facturations doubles.
- Faire en sorte que la seule écriture persistante soit réalisée par `MutationGovernancePolicy.enforce_write` une fois que toutes les portes ont été franchies et produire un verdict immuable utilisé pour toutes les mises à jour ultérieures.

### Description

- Réorganisation du flux de décision dans `run` (`src/singular/life/loop.py`) en introduisant `candidate_accepted` pour évaluer d’abord score, coevolution et conditions techniques, puis appeler `governance_policy.simulate_write` et enfin effectuer une seule évaluation de coût de capacité via `resource_manager.apply_capability_cost("mutation")` avant la tentative d’écriture.
- Remplacement du chemin antérieur où `enforce_write` était appelé prématurément par une séquence qui: simule la gouvernance (`simulate_write`), applique le coût de mutation une seule fois, appelle `enforce_write` dans un bloc `try/except` et restaure le contenu original en cas d’échec d’écriture, puis dérive `accepted` et toutes les récompenses/statistiques/événements à partir de ce verdict immuable.
- Ajout de logs explicites pour les rejets de gouvernance (`mutation.governance_rejected`), les refus par la grille de ressources (`mutation.resource_rejected`) et les échecs d’écriture (`mutation.write_rejected`).
- Tests ajoutés/modifiés dans `tests/test_life_loop_targeted.py` pour couvrir un gestionnaire de ressources personnalisé `_MutationGateResourceManager` paramétré (`allow_mutation=True/False`) et le nouveau test `test_mutation_is_persisted_only_after_resource_gate_accepts` qui vérifie que la mutation est persistée seulement si la porte ressources est acceptée et que le coût de capacité est appelé exactement une fois.

### Testing

- Exécution ciblée des nouveaux cas via `pytest tests/test_life_loop_targeted.py -q -k 'mutation_is_persisted_only_after_resource_gate_accepts'` : les deux paramètres (`allow_mutation=True` et `False`) sont passés avec succès.
- Compilation vérifiée avec `python -m compileall` sur les fichiers modifiés et vérifications statiques (diff/check) sans erreurs signalées.
- Exécution de `pytest tests/test_life_loop_targeted.py -q` complète montrant des échecs non liés à ce changement (sandbox sécurisé indisponible dans l’environnement d’exécution, p.ex. absence de podman/docker), le flux ciblé introduit ici passe dans l’environnement de test disponible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76944e5cd0832a8bbe10b6d472f7ec)