### PR TITLE
Make persisted timestamps timezone-aware (UTC)

### DIFF
--- a/src/singular/environment/artifacts.py
+++ b/src/singular/environment/artifacts.py
@@ -1,10 +1,14 @@
-"""Utilities to generate and persist simple artifacts."""
+"""Utilities to generate and persist simple artifacts.
+
+Metadata dates use ISO 8601 at second precision with the explicit UTC offset
+``+00:00``.
+"""
 
 from __future__ import annotations
 
 import os
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
@@ -57,7 +61,7 @@ def _save_metadata(path: Path, mood: str, resources: dict | None = None) -> Path
     """Persist metadata for the artifact located at ``path``."""
 
     meta = {
-        "date": datetime.utcnow().isoformat(timespec="seconds"),
+        "date": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "mood": mood,
         "resources": resources or {},
     }

--- a/src/singular/runs/generations.py
+++ b/src/singular/runs/generations.py
@@ -1,8 +1,12 @@
-"""Generation registry utilities linked to mutation runs."""
+"""Generation registry utilities linked to mutation runs.
+
+Registry timestamps use ISO 8601 at second precision with the explicit UTC
+offset ``+00:00``.
+"""
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 import hashlib
 import json
 import os
@@ -100,7 +104,7 @@ def record_generation(
         "parent_generation_id": parent.get("generation_id") if parent else None,
         "run_id": run_id,
         "iteration": iteration,
-        "ts": datetime.utcnow().isoformat(timespec="seconds"),
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "skill": skill,
         "skill_path": skill_relative_path,
         "mutation": {"operator": operator, "diff": mutation_diff},

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -1,9 +1,14 @@
-"""Utilities for recording execution runs."""
+"""Utilities for recording execution runs.
+
+Persisted timestamps use ISO 8601 at second precision with an explicit UTC
+offset (``+00:00``). Compact timestamps used in filenames remain UTC
+``YYYYmmddHHMMSS`` strings for backwards-compatible paths.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 import json
 import logging
@@ -144,7 +149,7 @@ class RunLogger:
             json.dumps(
                 {
                     "run_id": self.run_id,
-                    "started_at": datetime.utcnow().isoformat(timespec="seconds"),
+                    "started_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
                 }
             ),
             encoding="utf-8",
@@ -173,7 +178,7 @@ class RunLogger:
             self.timestamp = stem.split("-", 1)[1]
             self._file = self.tmp_path.open("a", encoding="utf-8")
         else:
-            self.timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+            self.timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
             self.path = self.root / f"{self.run_id}-{self.timestamp}.jsonl"
             self.tmp_path = self.path.with_suffix(self.path.suffix + ".tmp")
             _ensure_dir(self.tmp_path)
@@ -288,7 +293,7 @@ class RunLogger:
 
         payload = {
             "version": USAGE_REPUTATION_SCHEMA_VERSION,
-            "updated_at": datetime.utcnow().isoformat(timespec="seconds"),
+            "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "skills": self._skill_reputation,
         }
         self.skill_reputation_path.write_text(json.dumps(payload), encoding="utf-8")
@@ -330,7 +335,7 @@ class RunLogger:
     ) -> None:
         """Record a reflection event in ``runs/<run_id>/consciousness.jsonl``."""
 
-        ts = datetime.utcnow().isoformat(timespec="seconds")
+        ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
         record: dict[str, Any] = {
             "ts": ts,
             "event": "consciousness",
@@ -374,7 +379,7 @@ class RunLogger:
     ) -> None:
         """Append a mutation record to the log file."""
 
-        ts = datetime.utcnow().isoformat(timespec="seconds")
+        ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
         record: dict[str, Any] = {
             "ts": ts,
             "skill": skill,
@@ -432,7 +437,7 @@ class RunLogger:
         """Record life-loop phase timings for profiling and dashboard views."""
 
         record: dict[str, Any] = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "event": "life_loop_phase_metrics",
             "iteration": iteration,
             "phase_metrics": {
@@ -451,7 +456,7 @@ class RunLogger:
         """Record a death event with optional additional information."""
 
         record: dict[str, Any] = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "event": "death",
             "reason": reason,
             **info,
@@ -464,7 +469,7 @@ class RunLogger:
         """Record a refusal to mutate ``skill``."""
 
         record: dict[str, Any] = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "event": "refuse",
             "skill": skill,
         }
@@ -476,7 +481,7 @@ class RunLogger:
         """Record a procrastination event for ``skill``."""
 
         record: dict[str, Any] = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "event": "delay",
             "skill": skill,
             "resume_at": resume_at,
@@ -489,7 +494,7 @@ class RunLogger:
         """Record an absurd mutation event."""
 
         record: dict[str, Any] = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "event": "absurde",
             "skill": skill,
             "diff": diff,
@@ -502,7 +507,7 @@ class RunLogger:
         """Record an explicit ecosystem interaction event."""
 
         record: dict[str, Any] = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "event": "interaction",
             "interaction": event,
             **info,
@@ -515,7 +520,7 @@ class RunLogger:
         """Record a named run event without wrapping it as an interaction."""
 
         record: dict[str, Any] = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "event": event,
             **info,
         }
@@ -545,7 +550,7 @@ class RunLogger:
         """Record co-evolution decisions for the living test pool."""
 
         record: dict[str, Any] = {
-            "ts": datetime.utcnow().isoformat(timespec="seconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "event": "test_coevolution",
             "skill": skill,
             "accepted": accepted,

--- a/tests/test_generations_registry.py
+++ b/tests/test_generations_registry.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import ast
 import json
+from datetime import datetime, timezone
 from pathlib import Path
+import warnings
 
 import singular.cli as cli
 from singular.life import loop as life_loop
@@ -12,6 +14,33 @@ from singular.runs.generations import get_generations_path, record_generation
 
 def _read_jsonl(path: Path) -> list[dict]:
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_generation_timestamp_is_timezone_aware_without_deprecation_warning(
+    tmp_path: Path,
+) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        generation = record_generation(
+            run_id="timestamp-run",
+            iteration=1,
+            skill="sample",
+            operator="noop",
+            mutation_diff="",
+            score_base=1.0,
+            score_new=1.0,
+            accepted=False,
+            reason="test",
+            parent_hash="parent",
+            candidate_code="result = 1\n",
+            skill_relative_path="skills/sample.py",
+            security_metadata={},
+            base_dir=tmp_path,
+        )
+
+    timestamp = datetime.fromisoformat(generation["ts"])
+    assert timestamp.tzinfo is not None
+    assert timestamp.utcoffset() == timezone.utc.utcoffset(timestamp)
 
 
 def test_generation_registry_stays_coherent_with_run_events(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -2,6 +2,8 @@ import json
 import random
 import functools
 import sys
+import warnings
+from datetime import datetime, timezone
 from pathlib import Path
 
 import ast
@@ -1366,9 +1368,11 @@ def test_artifact_creation_persistence(tmp_path: Path, monkeypatch):
 
     mood = "neutre"
     resources = {"energy": 1}
-    text = create_text_art("bonjour", mood=mood, resources=resources)
-    drawing = create_ascii_drawing(2, 2, mood=mood, resources=resources)
-    melody = create_simple_melody(["C", "E", "G"], mood=mood, resources=resources)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        text = create_text_art("bonjour", mood=mood, resources=resources)
+        drawing = create_ascii_drawing(2, 2, mood=mood, resources=resources)
+        melody = create_simple_melody(["C", "E", "G"], mood=mood, resources=resources)
 
     art_dir = tmp_path / "runs" / "artifacts"
     assert ARTIFACTS_DIR == art_dir
@@ -1380,6 +1384,9 @@ def test_artifact_creation_persistence(tmp_path: Path, monkeypatch):
         assert meta["mood"] == mood
         assert meta["resources"] == resources
         assert "date" in meta
+        timestamp = datetime.fromisoformat(meta["date"])
+        assert timestamp.tzinfo is not None
+        assert timestamp.utcoffset() == timezone.utc.utcoffset(timestamp)
 
 
 def test_coevolution_rejects_regression_on_combined_score(tmp_path: Path, monkeypatch):

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -1,5 +1,7 @@
 import json
+from datetime import datetime, timezone
 from pathlib import Path
+import warnings
 
 from singular.runs import RunLogger
 from singular.runs.explain import summarize_mutation
@@ -34,8 +36,6 @@ def test_default_root_follows_two_successive_lives(
 
 
 def test_log_creation(tmp_path: Path) -> None:
-    logger = RunLogger("test", root=tmp_path)
-    assert (tmp_path / "test" / ".active.lock").exists()
     summary = summarize_mutation(
         operator="op",
         impacted_file="skill.py",
@@ -46,20 +46,27 @@ def test_log_creation(tmp_path: Path) -> None:
         score_base=0.2,
         score_new=0.1,
     )
-    logger.log(
-        "skill",
-        "op",
-        "diff",
-        True,
-        1.0,
-        2.0,
-        0.2,
-        0.1,
-        impacted_file="skill.py",
-        decision_reason="accepted: score improved",
-        human_summary=summary,
-    )
-    logger.close()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        logger = RunLogger("test", root=tmp_path)
+        lock_payload = json.loads(
+            (tmp_path / "test" / ".active.lock").read_text(encoding="utf-8")
+        )
+        logger.log(
+            "skill",
+            "op",
+            "diff",
+            True,
+            1.0,
+            2.0,
+            0.2,
+            0.1,
+            impacted_file="skill.py",
+            decision_reason="accepted: score improved",
+            human_summary=summary,
+        )
+        logger.close()
+
     files = list(tmp_path.glob("test-*.jsonl"))
     assert len(files) == 1
     with files[0].open(encoding="utf-8") as fh:
@@ -69,6 +76,10 @@ def test_log_creation(tmp_path: Path) -> None:
     assert line["human_summary"]
     assert "op=op" in line["human_summary"]
     assert line["impacted_file"] == "skill.py"
+    for timestamp in (lock_payload["started_at"], line["ts"]):
+        parsed = datetime.fromisoformat(timestamp)
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset() == timezone.utc.utcoffset(parsed)
 
     events_path = tmp_path / "test" / "events.jsonl"
     assert events_path.exists()


### PR DESCRIPTION
### Motivation

- Remplacer les appels à `datetime.utcnow()` par une version consciente du fuseau pour éviter les `DeprecationWarning` et produire des horodatages explicites et non ambigus.
- Documenter et normaliser les formats persistés pour utiliser ISO 8601 à la seconde avec un décalage UTC explicite tout en conservant le format compact historique pour les noms de fichiers.

### Description

- Remplacé les `datetime.utcnow()` par `datetime.now(timezone.utc)` et ajusté les imports dans `src/singular/runs/logger.py`, `src/singular/runs/generations.py` et `src/singular/environment/artifacts.py`.
- Ajouté des précisions de format dans les docstrings des modules pour indiquer l'utilisation d'ISO 8601 avec l'offset `+00:00`, et conservé le format compact `YYYYmmddHHMMSS` pour les noms de fichiers.
- Mis à jour les tests `tests/test_runs_logger.py`, `tests/test_generations_registry.py` et `tests/test_loop.py` pour attraper les `DeprecationWarning` (`warnings.catch_warnings()`), vérifier que les timestamps sont analysables avec `datetime.fromisoformat()` et qu'ils sont timezone-aware (UTC).

### Testing

- Exécuté `python -m pytest -q tests/test_runs_logger.py tests/test_generations_registry.py tests/test_loop.py::test_artifact_creation_persistence -W error::DeprecationWarning` et obtenu `14 passed` (tests verts).
- Vérifié qu'il n'y a plus d'occurrence de `datetime.utcnow(` avec `rg` sur les fichiers modifiés, et `git diff --check` n'a retourné d'erreurs.
- Exécuté `black --check` qui signale que 6 fichiers seraient reformattés (le reformatage n'a pas été appliqué dans ce PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76a156caa0832a96f9c996669212c5)