### PR TITLE
Centralize sandbox DSL builtins and add `float` to worker allowlist

### DIFF
--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -22,7 +22,17 @@ except ImportError:  # pragma: no cover - unsupported platforms
     resource_module = None
 
 
-ALLOWED_BUILTINS = ("abs", "min", "max", "range", "len", "sum", "all", "any")
+ALLOWED_BUILTINS = (
+    "abs",
+    "min",
+    "max",
+    "range",
+    "len",
+    "sum",
+    "all",
+    "any",
+    "float",
+)
 FORBIDDEN_NAMES = {
     "open",
     "exec",
@@ -133,7 +143,7 @@ def _runtime(configured: str | None) -> str:
 _CONTAINER_WORKER = r"""
 import builtins, json, sys
 code = sys.stdin.read()
-allowed_names = ("abs", "min", "max", "range", "len", "sum", "all", "any")
+allowed_names = __ALLOWED_BUILTINS__
 env = {"__builtins__": {name: getattr(builtins, name) for name in allowed_names}}
 try:
     exec(compile(code, "<sandbox>", "exec"), env, env)
@@ -142,7 +152,7 @@ try:
     print(json.dumps({"status": "result", "payload": env["result"]}))
 except BaseException as exc:
     print(json.dumps({"status": "error", "type": type(exc).__name__, "message": str(exc)}))
-"""
+""".replace("__ALLOWED_BUILTINS__", repr(ALLOWED_BUILTINS))
 
 
 def _command(runtime: str, config: SandboxConfig) -> list[str]:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 import random
 import functools
@@ -15,6 +16,7 @@ sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / "src"))
 
 import singular.life.loop as life_loop  # noqa: E402
+import singular.life.sandbox as life_sandbox  # noqa: E402
 from singular.life.loop import EcosystemRules, run  # noqa: E402
 from singular.life.checkpointing import load_checkpoint  # noqa: E402
 from singular.life.health import detect_health_state  # noqa: E402
@@ -31,6 +33,22 @@ def test_repository_addition_skill_satisfies_sandbox_scoring_contract():
         life_loop.score_code_with_error(Path("skills/addition.py").read_text()).ok
         is True
     )
+
+
+def test_float_conversion_skill_satisfies_sandbox_scoring_contract(monkeypatch):
+    def execute_with_dsl_builtins(code):
+        namespace = {
+            "__builtins__": {
+                name: getattr(builtins, name) for name in life_sandbox.ALLOWED_BUILTINS
+            }
+        }
+        exec(code, namespace, namespace)
+        return namespace["result"]
+
+    monkeypatch.setattr(life_sandbox, "run", execute_with_dsl_builtins)
+    assert life_loop.score_code_with_error(
+        "result = float('2.5')"
+    ) == life_loop.SandboxScore(score=2.5)
 
 
 def test_score_code_with_error_returns_structured_sandbox_score():

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,4 +1,5 @@
 import ast
+import builtins
 import json
 import subprocess
 
@@ -22,7 +23,11 @@ def isolated_runtime(monkeypatch):
         if "300 * 1024" in code:
             payload = {"status": "error", "type": "MemoryError", "message": ""}
         else:
-            env = {"__builtins__": sandbox.__dict__["__builtins__"]}
+            env = {
+                "__builtins__": {
+                    name: getattr(builtins, name) for name in sandbox.ALLOWED_BUILTINS
+                }
+            }
             # These snippets have already passed validation; this emulates only
             # the container protocol, not its security boundary.
             try:
@@ -41,8 +46,43 @@ def isolated_runtime(monkeypatch):
     monkeypatch.setattr(sandbox.subprocess, "run", fake_run)
 
 
-def test_basic_execution(isolated_runtime):
-    assert run("result = max(1, 2)") == 2
+@pytest.mark.parametrize(
+    ("builtin_expression", "expected"),
+    [
+        ("abs(-2)", 2),
+        ("min(3, 1)", 1),
+        ("max(1, 2)", 2),
+        ("sum(range(4))", 6),
+        ("len('abc')", 3),
+        ("sum((1, 2, 3))", 6),
+        ("all((True, True))", True),
+        ("any((False, True))", True),
+        ("float('2.5')", 2.5),
+    ],
+)
+def test_allowed_builtins_are_available(isolated_runtime, builtin_expression, expected):
+    assert run(f"result = {builtin_expression}") == expected
+
+
+@pytest.mark.parametrize(
+    "builtin_expression",
+    [
+        "print('not exposed')",
+        "int('2')",
+        "bool(1)",
+        "getattr((), 'count')",
+        "isinstance(1, int)",
+        "RuntimeError('not exposed')",
+    ],
+)
+def test_unapproved_builtins_are_inaccessible(isolated_runtime, builtin_expression):
+    with pytest.raises(SandboxError, match="NameError"):
+        run(f"result = {builtin_expression}")
+
+
+def test_container_worker_uses_the_canonical_builtin_list():
+    assert f"allowed_names = {sandbox.ALLOWED_BUILTINS!r}" in sandbox._CONTAINER_WORKER
+    assert "__ALLOWED_BUILTINS__" not in sandbox._CONTAINER_WORKER
 
 
 def test_missing_result_raises_sandbox_error(isolated_runtime):


### PR DESCRIPTION
### Motivation

- Avoid accidental divergence between the host and container worker builtins by centralising the DSL allowlist into a single canonical source.  
- Ensure numeric skills that rely on `float(...)` are supported by the DSL while keeping noisy or dangerous globals (e.g. `print`, exception classes, introspection helpers) out of the DSL surface.  

### Description

- Introduce a canonical `ALLOWED_BUILTINS` tuple (including `float`) in `src/singular/life/sandbox.py` and make the container worker template build its `__builtins__` from that tuple.  
- Replace the inline allowed-names list in `_CONTAINER_WORKER` with a substitution of `ALLOWED_BUILTINS` so the worker and host cannot diverge.  
- Update `isolated_runtime` and the test container emulation to construct the `__builtins__` mapping from `ALLOWED_BUILTINS`.  
- Add tests: parameterised positive cases for every officially allowed builtin and negative cases asserting unapproved builtins are inaccessible in `tests/test_sandbox.py`, and add a targeted `float('2.5')` scoring contract test in `tests/test_loop.py` that exercises the life loop scoring path.  

### Testing

- Ran the targeted pytest commands `pytest -q tests/test_sandbox.py tests/test_loop.py::test_float_conversion_skill_satisfies_sandbox_scoring_contract` and the updated tests passed (all relevant tests succeeded).  
- Ran `pytest -q tests/test_sandbox.py` to validate sandbox tests specifically and they passed.  
- Ran formatting and static checks `python -m black --check src/singular/life/sandbox.py tests/test_sandbox.py tests/test_loop.py`, `python -m compileall -q ...`, and `git diff --check`, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76a2810000832a9b50c9dcc73c3639)