### PR TITLE
test: add in-memory RecordingRunLogger and use it in life-loop tests

### DIFF
--- a/tests/run_logger_double.py
+++ b/tests/run_logger_double.py
@@ -1,0 +1,61 @@
+"""In-memory test double for the logger used by the life loop."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class RecordingRunLogger:
+    """Implement the ``RunLogger`` surface consumed by ``life.loop``.
+
+    Unlike the production logger, this double never opens or writes a file.
+    Every logging call is retained in :attr:`calls` as a small dictionary so a
+    test can inspect emitted events without knowing anything about persistence.
+    """
+
+    def __init__(self, run_id: str, **_: Any) -> None:
+        self.run_id = run_id
+        self.calls: list[dict[str, Any]] = []
+        self.reputation: dict[str, dict[str, float | int]] = {}
+
+    def __enter__(self) -> "RecordingRunLogger":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> bool:
+        return False
+
+    def _record(self, method: str, *args: Any, **kwargs: Any) -> None:
+        self.calls.append({"method": method, "args": args, "kwargs": kwargs})
+
+    def log(self, *args: Any, **kwargs: Any) -> None:
+        self._record("log", *args, **kwargs)
+
+    def log_event(self, event: str, **info: Any) -> None:
+        self._record("log_event", event, **info)
+
+    def log_interaction(self, event: str, **info: Any) -> None:
+        self._record("log_interaction", event, **info)
+
+    def log_death(self, reason: str, **info: Any) -> None:
+        self._record("log_death", reason, **info)
+
+    def log_consciousness(self, *args: Any, **kwargs: Any) -> None:
+        self._record("log_consciousness", *args, **kwargs)
+
+    def log_phase_metrics(self, *args: Any, **kwargs: Any) -> None:
+        self._record("log_phase_metrics", *args, **kwargs)
+
+    def log_refusal(self, skill: str) -> None:
+        self._record("log_refusal", skill)
+
+    def log_delay(self, skill: str, resume_at: float) -> None:
+        self._record("log_delay", skill, resume_at)
+
+    def log_absurde(self, skill: str, diff: str) -> None:
+        self._record("log_absurde", skill, diff)
+
+    def log_test_coevolution(self, *args: Any, **kwargs: Any) -> None:
+        self._record("log_test_coevolution", *args, **kwargs)
+
+    def skill_reputation(self) -> dict[str, dict[str, float | int]]:
+        return self.reputation

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -26,6 +26,7 @@ from singular.psyche import Psyche, Mood  # noqa: E402
 from singular.governance.policy import MutationGovernancePolicy  # noqa: E402
 from singular.life.reproduction import ReproductionDecisionPolicy  # noqa: E402
 from singular.events import EventBus  # noqa: E402
+from tests.run_logger_double import RecordingRunLogger  # noqa: E402
 
 
 def test_repository_addition_skill_satisfies_sandbox_scoring_contract():
@@ -788,25 +789,6 @@ def test_angry_increases_proposals(tmp_path: Path, monkeypatch):
         calls["n"] += 1
         return []
 
-    class DummyLogger:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-        def log(self, *a, **k):
-            pass
-
-        def log_death(self, *a, **k):
-            pass
-
-        def log_consciousness(self, *a, **k):
-            pass
-
     skill_dir = tmp_path / "skills"
     skill_dir.mkdir()
     checkpoint = tmp_path / "ckpt.json"
@@ -817,7 +799,7 @@ def test_angry_increases_proposals(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(life_loop, "propose_mutations", fake_propose)
     monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: psyche))
-    monkeypatch.setattr(life_loop, "RunLogger", DummyLogger)
+    monkeypatch.setattr(life_loop, "RunLogger", RecordingRunLogger)
 
     life_loop.run(
         skill_dir,
@@ -837,25 +819,6 @@ def test_fatigue_reduces_proposals(tmp_path: Path, monkeypatch):
         calls["n"] += 1
         return []
 
-    class DummyLogger:
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-        def log(self, *a, **k):
-            pass
-
-        def log_death(self, *a, **k):
-            pass
-
-        def log_consciousness(self, *a, **k):
-            pass
-
     skill_dir = tmp_path / "skills"
     skill_dir.mkdir()
     checkpoint = tmp_path / "ckpt.json"
@@ -866,7 +829,7 @@ def test_fatigue_reduces_proposals(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(life_loop, "propose_mutations", fake_propose)
     monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: psyche))
-    monkeypatch.setattr(life_loop, "RunLogger", DummyLogger)
+    monkeypatch.setattr(life_loop, "RunLogger", RecordingRunLogger)
 
     life_loop.run(
         skill_dir,

--- a/tests/test_run_logger_double.py
+++ b/tests/test_run_logger_double.py
@@ -1,0 +1,52 @@
+"""Contract tests for the life-loop logger double."""
+
+from tests.run_logger_double import RecordingRunLogger
+
+
+def test_recording_run_logger_implements_life_loop_contract():
+    logger = RecordingRunLogger("contract-run")
+
+    methods_used_by_life_loop = {
+        "log",
+        "log_absurde",
+        "log_consciousness",
+        "log_death",
+        "log_delay",
+        "log_event",
+        "log_interaction",
+        "log_phase_metrics",
+        "log_refusal",
+        "log_test_coevolution",
+        "skill_reputation",
+    }
+
+    assert logger.run_id == "contract-run"
+    assert all(callable(getattr(logger, method, None)) for method in methods_used_by_life_loop)
+    assert logger.__enter__() is logger
+    assert logger.__exit__(None, None, None) is False
+
+
+def test_recording_run_logger_keeps_events_in_memory():
+    logger = RecordingRunLogger("in-memory-run")
+
+    logger.log_event("skill.quarantined", skill="unsafe.py")
+    logger.log_interaction("memory.recalled", count=2)
+    logger.log_death("energy_depleted", age=12)
+
+    assert logger.calls == [
+        {
+            "method": "log_event",
+            "args": ("skill.quarantined",),
+            "kwargs": {"skill": "unsafe.py"},
+        },
+        {
+            "method": "log_interaction",
+            "args": ("memory.recalled",),
+            "kwargs": {"count": 2},
+        },
+        {
+            "method": "log_death",
+            "args": ("energy_depleted",),
+            "kwargs": {"age": 12},
+        },
+    ]


### PR DESCRIPTION
### Motivation

- Fournir un double en mémoire et réutilisable pour l'interface minimale de `singular.runs.logger.RunLogger` afin d'éviter les écritures disque lors des tests de la boucle de vie.
- Centraliser le comportement des loggers de test pour réduire la duplication des classes locales `DummyLogger` dans `tests/test_loop.py`.
- Vérifier contractuellement que le double expose le protocole attendu (gestionnaire de contexte, `run_id`, méthodes de journalisation et `skill_reputation`).

### Description

- Ajout de `tests/run_logger_double.py` implémentant `RecordingRunLogger` qui enregistre tous les appels dans `calls` et expose `run_id` et `skill_reputation` sans écrire sur le disque.
- Remplacement des définitions locales `DummyLogger` dans `tests/test_loop.py` par `RecordingRunLogger` via `monkeypatch.setattr(life_loop, "RunLogger", RecordingRunLogger)`.
- Ajout de `tests/test_run_logger_double.py` qui contient un test contractuel assurant la présence des méthodes utilisées par la boucle et un test vérifiant l'enregistrement en mémoire de plusieurs appels (`log_event`, `log_interaction`, `log_death`).
- Le changement est strictement orienté tests et n'altère pas le code de production ; l'API fournie par le double couvre les méthodes invoquées par `src/singular/life/loop.py`.

### Testing

- `ruff check tests/run_logger_double.py tests/test_run_logger_double.py tests/test_loop.py` a été exécuté et a passé sans erreur.
- Exécution ciblée `pytest -q tests/test_run_logger_double.py tests/test_loop.py -k 'recording_run_logger or angry_increases_proposals or fatigue_reduces_proposals'` a réussi avec `4 passed`.
- Exécution plus large `pytest -q tests/test_run_logger_double.py tests/test_loop.py` a retourné des tests supplémentaires en échec (11 failures, 31 passed) liés à l'indisponibilité du bac à sable sécurisé (dépendance à `podman`/`docker`) et non aux modifications du double.
- Les tests ajoutés vérifient que le double implémente le protocole attendu et que les appels sont conservés en mémoire, et ces tests automatisés ont passé dans l'environnement de test ciblé.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76a441a150832a91dd0c4648bd92b9)