### PR TITLE
Isolate mood and energy proposal warmup policy

### DIFF
--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -154,6 +154,17 @@ SKILL_SANDBOX_QUARANTINE_HOURS = int(
 ScoreCodeResult = SandboxScore
 
 
+def initial_proposal_warmup_frequency(mutation_rate: float, energy: float) -> int:
+    """Return the number of empty Graine proposals used during warmup.
+
+    Keeping this policy independent from :class:`Psyche` and the life loop
+    makes the combined influence of mood-derived mutation rate and energy
+    directly testable without running a tick.
+    """
+
+    return max(1, int(mutation_rate * (energy / 100)))
+
+
 def _graine_zones_for_skill(
     skill_path: Path, operator_names: Iterable[str]
 ) -> list[dict[str, object]]:
@@ -942,12 +953,9 @@ def run(
     start = time.time()
     learning_attempts = 0
     last_post = 0.0
-    initial_freq = max(
-        1,
-        int(
-            getattr(psyche, "mutation_rate", 1.0)
-            * (getattr(psyche, "energy", 100.0) / 100)
-        ),
+    initial_freq = initial_proposal_warmup_frequency(
+        getattr(psyche, "mutation_rate", 1.0),
+        getattr(psyche, "energy", 100.0),
     )
     for _ in range(initial_freq):
         # Warm up Graine with an empty zone list; real per-skill proposals are

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -782,64 +782,28 @@ def test_bandit_persistence_and_exploitation(tmp_path: Path, monkeypatch):
     assert second_stats["inc"]["count"] == first_stats["inc"]["count"]
 
 
-def test_angry_increases_proposals(tmp_path: Path, monkeypatch):
-    calls = {"n": 0}
-
-    def fake_propose(zones=None):
-        calls["n"] += 1
-        return []
-
-    skill_dir = tmp_path / "skills"
-    skill_dir.mkdir()
-    checkpoint = tmp_path / "ckpt.json"
-
+def test_frustration_increases_initial_proposal_warmup_frequency():
     psyche = life_loop.Psyche()
     psyche.last_mood = Mood.FRUSTRATED
     psyche.energy = 100.0
 
-    monkeypatch.setattr(life_loop, "propose_mutations", fake_propose)
-    monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: psyche))
-    monkeypatch.setattr(life_loop, "RunLogger", RecordingRunLogger)
-
-    life_loop.run(
-        skill_dir,
-        checkpoint,
-        budget_seconds=0.0,
-        rng=random.Random(0),
-        operators={"inc": _inc_operator},
+    frequency = life_loop.initial_proposal_warmup_frequency(
+        psyche.mutation_rate, psyche.energy
     )
 
-    assert calls["n"] == 2
+    assert frequency == 2
 
 
-def test_fatigue_reduces_proposals(tmp_path: Path, monkeypatch):
-    calls = {"n": 0}
-
-    def fake_propose(zones=None):
-        calls["n"] += 1
-        return []
-
-    skill_dir = tmp_path / "skills"
-    skill_dir.mkdir()
-    checkpoint = tmp_path / "ckpt.json"
-
+def test_low_energy_reduces_initial_proposal_warmup_frequency():
     psyche = life_loop.Psyche()
     psyche.last_mood = Mood.FRUSTRATED
     psyche.energy = 20.0
 
-    monkeypatch.setattr(life_loop, "propose_mutations", fake_propose)
-    monkeypatch.setattr(life_loop.Psyche, "load_state", staticmethod(lambda: psyche))
-    monkeypatch.setattr(life_loop, "RunLogger", RecordingRunLogger)
-
-    life_loop.run(
-        skill_dir,
-        checkpoint,
-        budget_seconds=0.0,
-        rng=random.Random(0),
-        operators={"inc": _inc_operator},
+    frequency = life_loop.initial_proposal_warmup_frequency(
+        psyche.mutation_rate, psyche.energy
     )
 
-    assert calls["n"] == 1
+    assert frequency == 1
 
 
 def test_sandbox_violation_burst_enters_degraded_mode_without_immediate_extinction(


### PR DESCRIPTION
### Motivation

- Make the initial Graine warmup frequency (empty-zone proposal calls) directly testable and decoupled from tick-time proposal behavior. 
- Avoid tests that conflate warmup `propose_mutations([])` calls with per-skill proposal calls during a tick so assertions target a single responsibility.

### Description

- Add a pure function `initial_proposal_warmup_frequency(mutation_rate: float, energy: float) -> int` implementing the warmup policy. 【F:src/singular/life/loop.py†L157-L165】
- Replace the inline `initial_freq` calculation in `run()` with a call to the new function and keep warmup calls as `propose_mutations([])`. 【F:src/singular/life/loop.py†L956-L963】
- Rename and simplify two tests to explicitly assert the warmup frequency (`test_frustration_increases_initial_proposal_warmup_frequency` and `test_low_energy_reduces_initial_proposal_warmup_frequency`) and remove assertions that mixed warmup and per-skill proposal counts. 【F:tests/test_loop.py†L785-L806】

### Testing

- ✅ Ran `pytest -q tests/test_loop.py -k initial_proposal_warmup_frequency` and the two targeted tests passed (`2 passed, 38 deselected`).
- ⚠️ Ran `pytest -q tests/test_loop.py` which reported `29 passed, 11 failed`; the remaining failures are caused by sandboxing checks that require Podman/Docker which are unavailable in this environment. 
- ✅ Ran `git diff --check` to validate the patch formatting and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76ad1954b0832a94dcfe6d42a663a0)