### PR TITLE
Rendre les tests dépendants du temps déterministes (horloge injectable, suppression de sleep)

### DIFF
--- a/src/singular/action/sandbox_runner.py
+++ b/src/singular/action/sandbox_runner.py
@@ -13,7 +13,6 @@ from threading import Event
 from time import monotonic
 from typing import Any, Callable, Deque, Dict, Literal, Mapping, MutableMapping
 
-
 AllowedActionName = str
 Rollback = Callable[[], None]
 RunnerMode = Literal["ghost", "live"]
@@ -77,6 +76,7 @@ class DefaultActionBackend:
 class SandboxRunner:
     backend: DefaultActionBackend
     config: RunnerConfig = field(default_factory=RunnerConfig)
+    clock: Callable[[], float] = monotonic
     _timestamps: Deque[float] = field(default_factory=deque, init=False)
     _cancel_event: Event = field(default_factory=Event, init=False)
     _consecutive_failures: int = field(default=0, init=False)
@@ -134,7 +134,11 @@ class SandboxRunner:
 
     def run_action(self, action: str, params: Mapping[str, Any] | None = None) -> Any:
         params = dict(params or {})
-        if self._mode == "live" and self.config.require_qa_before_live and not self._qa_completed:
+        if (
+            self._mode == "live"
+            and self.config.require_qa_before_live
+            and not self._qa_completed
+        ):
             raise ActionError("live mode requires a successful QA step in ghost mode")
 
         self._ensure_circuit_closed()
@@ -147,7 +151,7 @@ class SandboxRunner:
                 f"action '{action}' not allowed; allowed actions: {', '.join(self.allowed_actions)}"
             )
 
-        start = monotonic()
+        start = self.clock()
         try:
             if self._mode == "ghost":
                 result = self._simulate_action(action, params)
@@ -159,7 +163,7 @@ class SandboxRunner:
             self._rollback_best_effort()
             raise
 
-        elapsed = monotonic() - start
+        elapsed = self.clock() - start
         if elapsed > self.config.timeout_s:
             self._record_failure()
             self._rollback_best_effort()
@@ -178,7 +182,9 @@ class SandboxRunner:
             results.append(self.run_action(action, params))
         return results
 
-    def _run_with_timeout(self, handler: Callable[..., Any], params: Dict[str, Any]) -> Any:
+    def _run_with_timeout(
+        self, handler: Callable[..., Any], params: Dict[str, Any]
+    ) -> Any:
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(handler, **params)
             try:
@@ -187,7 +193,9 @@ class SandboxRunner:
                 future.cancel()
                 raise ActionTimeoutError("action timed out") from exc
 
-    def _simulate_action(self, action: str, params: Mapping[str, Any]) -> dict[str, Any]:
+    def _simulate_action(
+        self, action: str, params: Mapping[str, Any]
+    ) -> dict[str, Any]:
         simulated = {
             "ok": True,
             "simulated": True,
@@ -199,7 +207,7 @@ class SandboxRunner:
         return simulated
 
     def _check_rate_limit(self) -> None:
-        now = monotonic()
+        now = self.clock()
         window_start = now - self.config.rate_limit_window_s
         while self._timestamps and self._timestamps[0] < window_start:
             self._timestamps.popleft()
@@ -216,14 +224,14 @@ class SandboxRunner:
             raise CancellationError("runner cancelled")
 
     def _ensure_circuit_closed(self) -> None:
-        now = monotonic()
+        now = self.clock()
         if now < self._circuit_open_until:
             raise CircuitBreakerOpenError("circuit breaker open")
 
     def _record_failure(self) -> None:
         self._consecutive_failures += 1
         if self._consecutive_failures >= self.config.max_consecutive_failures:
-            self._circuit_open_until = monotonic() + self.config.circuit_open_s
+            self._circuit_open_until = self.clock() + self.config.circuit_open_s
 
     def _register_rollback(self, action: str, params: Mapping[str, Any]) -> None:
         if action == "open_app":

--- a/src/singular/perception/__init__.py
+++ b/src/singular/perception/__init__.py
@@ -18,7 +18,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from singular.environment.sim_world import load_world_state
 from singular.events import EventBus, get_global_event_bus
@@ -118,6 +118,7 @@ class PerceptionNoiseFilter:
     confidence_threshold: float = 0.45
     cooldown_seconds: float = 5.0
     deduplicate: bool = True
+    clock: Callable[[], float] = time.monotonic
     _seen_signatures: set[str] = field(default_factory=set)
     _last_emitted_at: dict[str, float] = field(default_factory=dict)
 
@@ -127,7 +128,7 @@ class PerceptionNoiseFilter:
             return False
 
         event_type = str(event.get("type", ""))
-        now = time.monotonic()
+        now = self.clock()
         last_at = self._last_emitted_at.get(event_type)
         if last_at is not None and (now - last_at) < self.cooldown_seconds:
             return False

--- a/src/singular/schedulers/reevaluation.py
+++ b/src/singular/schedulers/reevaluation.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import threading
-import time
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Callable, Iterable
 
 from singular.agents import Agent
 from singular.environment import notifications
@@ -127,7 +126,12 @@ def alerts_from_records(
     ]
 
 
-def start(interval: float, agent: Agent) -> threading.Event:
+def start(
+    interval: float,
+    agent: Agent,
+    *,
+    wait: Callable[[float], bool] | None = None,
+) -> threading.Event:
     """Start a background scheduler calling ``reevaluate_goals``.
 
     The scheduler reevaluates ``agent``'s goals every ``interval`` seconds.
@@ -136,6 +140,7 @@ def start(interval: float, agent: Agent) -> threading.Event:
     """
 
     stop_event = threading.Event()
+    wait_for_interval = wait or stop_event.wait
 
     def loop() -> None:
         while not stop_event.is_set():
@@ -150,7 +155,8 @@ def start(interval: float, agent: Agent) -> threading.Event:
                                 level=level,
                                 action=str(alert.get("action", "")),
                             )
-            time.sleep(interval)
+            if wait_for_interval(interval):
+                break
 
     threading.Thread(target=loop, daemon=True).start()
     return stop_event

--- a/tests/test_action_sandbox_runner.py
+++ b/tests/test_action_sandbox_runner.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from singular.action.sandbox_runner import (
@@ -49,9 +47,10 @@ def test_only_catalog_actions_allowed():
 
 def test_timeout_is_enforced():
     backend = SpyBackend()
+    now = [0.0]
 
     def slow_click(**kwargs):
-        time.sleep(0.08)
+        now[0] += 0.08
         return {"ok": True}
 
     backend.click = slow_click
@@ -62,6 +61,7 @@ def test_timeout_is_enforced():
             require_qa_before_live=False,
             initial_mode="live",
         ),
+        clock=lambda: now[0],
     )
 
     with pytest.raises(ActionTimeoutError):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,5 +1,3 @@
-import time
-
 from singular.resource_manager import ResourceManager
 from singular.environment.notifications import auto_post, notify
 from singular.memory import read_causal_timeline
@@ -62,7 +60,12 @@ def test_auto_post_defaults_action_for_warning() -> None:
 
 
 def test_perception_noise_filter_threshold_dedup_and_cooldown() -> None:
-    noise_filter = PerceptionNoiseFilter(confidence_threshold=0.5, cooldown_seconds=0.1)
+    now = [0.0]
+    noise_filter = PerceptionNoiseFilter(
+        confidence_threshold=0.5,
+        cooldown_seconds=0.1,
+        clock=lambda: now[0],
+    )
     weak = {
         "type": "artifact.logs.new",
         "source": "sandbox",
@@ -81,7 +84,7 @@ def test_perception_noise_filter_threshold_dedup_and_cooldown() -> None:
     # Dedup: same payload is filtered while still in seen cache.
     assert noise_filter.allow(strong) is False
 
-    time.sleep(0.11)
+    now[0] += 0.11
     # New payload after cooldown can pass.
     new_payload = {
         "type": "artifact.logs.new",

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -26,7 +26,6 @@ from singular.psyche import Psyche, Mood  # noqa: E402
 from singular.governance.policy import MutationGovernancePolicy  # noqa: E402
 from singular.life.reproduction import ReproductionDecisionPolicy  # noqa: E402
 from singular.events import EventBus  # noqa: E402
-from tests.run_logger_double import RecordingRunLogger  # noqa: E402
 
 
 def test_repository_addition_skill_satisfies_sandbox_scoring_contract():
@@ -113,7 +112,8 @@ def test_mutation_persistence(tmp_path: Path):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.1,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"dec": _dec_operator},
     )
@@ -134,7 +134,8 @@ def test_resume_from_checkpoint(tmp_path: Path):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.1,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=rng,
         operators={"dec": _dec_operator},
     )
@@ -144,7 +145,8 @@ def test_resume_from_checkpoint(tmp_path: Path):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.1,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=rng,
         operators={"dec": _dec_operator},
     )
@@ -189,7 +191,8 @@ def test_log_and_memory_update(tmp_path: Path, monkeypatch):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.1,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         run_id="loop",
         operators={"dec": _dec_operator},
@@ -295,7 +298,7 @@ def test_reproduction_decision_is_logged_with_cooldown(tmp_path: Path, monkeypat
     run(
         {"org_a": org_a, "org_b": org_b},
         checkpoint,
-        budget_seconds=0.2,
+        budget_seconds=10.0,
         max_iterations=1,
         rng=random.Random(0),
         run_id="repro-loop",
@@ -334,7 +337,8 @@ def test_run_with_legacy_checkpoint_continues_without_crash(tmp_path: Path):
     state = run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.05,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"dec": _dec_operator},
     )
@@ -635,7 +639,8 @@ def test_run_nan_score_does_not_contaminate_stats(tmp_path: Path):
     state = run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.05,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"noop": _noop_operator},
     )
@@ -654,7 +659,8 @@ def test_run_inf_score_does_not_contaminate_stats(tmp_path: Path):
     state = run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.05,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"noop": _noop_operator},
     )
@@ -697,7 +703,8 @@ def test_multi_operator_selection(tmp_path: Path, monkeypatch):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=2.0,
+        budget_seconds=10.0,
+        max_iterations=4,
         rng=random.Random(0),
         run_id="loop",
         operators=operators,
@@ -752,7 +759,8 @@ def test_bandit_persistence_and_exploitation(tmp_path: Path, monkeypatch):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.3,
+        budget_seconds=10.0,
+        max_iterations=8,
         rng=random.Random(0),
         run_id="loop1",
         operators=operators,
@@ -770,7 +778,8 @@ def test_bandit_persistence_and_exploitation(tmp_path: Path, monkeypatch):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.2,
+        budget_seconds=10.0,
+        max_iterations=8,
         rng=random.Random(0),
         run_id="loop2",
         operators=operators,
@@ -1112,7 +1121,8 @@ def test_irrational_refusal(tmp_path: Path, monkeypatch):
     life_loop.run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.05,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=rng,
         operators={"dec": _dec_operator},
     )
@@ -1135,7 +1145,8 @@ def test_irrational_delay(tmp_path: Path, monkeypatch):
     life_loop.run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.1,
+        budget_seconds=10.0,
+        max_iterations=2,
         rng=rng,
         operators={"dec": _dec_operator},
     )
@@ -1158,7 +1169,8 @@ def test_irrational_curiosity(tmp_path: Path, monkeypatch):
     life_loop.run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.05,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=rng,
         operators={"dec": _dec_operator},
     )
@@ -1225,7 +1237,8 @@ def test_energy_debit_and_food_credit(tmp_path: Path, monkeypatch):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.2,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"dec": _dec_operator},
         resource_manager=rm,
@@ -1254,7 +1267,8 @@ def test_resource_moods_trigger(monkeypatch, tmp_path):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.2,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"dec": _dec_operator},
         resource_manager=rm,
@@ -1288,7 +1302,8 @@ def test_auto_post_messages(tmp_path: Path, monkeypatch):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.5,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"dec": _dec_operator},
     )
@@ -1351,7 +1366,8 @@ def test_coevolution_rejects_regression_on_combined_score(tmp_path: Path, monkey
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.05,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"dec": _dec_operator},
         coevolve_tests=True,
@@ -1378,7 +1394,8 @@ def test_coevolution_logs_decisions(tmp_path: Path, monkeypatch):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.05,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"dec": _dec_operator},
         coevolve_tests=True,
@@ -1404,7 +1421,8 @@ def test_governance_blocks_mutation_write(tmp_path: Path):
     run(
         skills_dir,
         checkpoint,
-        budget_seconds=0.1,
+        budget_seconds=10.0,
+        max_iterations=1,
         rng=random.Random(0),
         operators={"dec": _dec_operator},
         governance_policy=policy,
@@ -1413,7 +1431,9 @@ def test_governance_blocks_mutation_write(tmp_path: Path):
     assert _read_result(skill) == 1
 
 
-def test_run_tick_with_coevolution_logs_candidates_and_rejections(tmp_path: Path, monkeypatch):
+def test_run_tick_with_coevolution_logs_candidates_and_rejections(
+    tmp_path: Path, monkeypatch
+):
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()
     skill = skills_dir / "foo.py"
@@ -1490,7 +1510,9 @@ def test_loop_logs_psyche_action_decision_before_effector(tmp_path: Path, monkey
 
     records = [
         json.loads(line)
-        for line in (tmp_path / "logs" / "loop" / "events.jsonl").read_text().splitlines()
+        for line in (tmp_path / "logs" / "loop" / "events.jsonl")
+        .read_text()
+        .splitlines()
     ]
     decision_events = [
         record["payload"]

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -1,5 +1,5 @@
+import os
 import sys
-import time
 import types
 from dataclasses import replace
 import json
@@ -45,17 +45,14 @@ def test_weather_api_timeout(monkeypatch):
     monkeypatch.setenv("SINGULAR_HTTP_TIMEOUT", "0.1")
 
     def slow_get(url, timeout):
-        time.sleep(timeout)
+        assert timeout == 0.1
         raise Exception("timeout")
 
     fake_requests = types.SimpleNamespace(get=slow_get)
     monkeypatch.setitem(sys.modules, "requests", fake_requests)
 
-    start = time.time()
     signals = capture_signals()
-    duration = time.time() - start
 
-    assert duration < 0.5
     assert "weather" not in signals
 
 
@@ -74,8 +71,9 @@ def test_capture_signals_publishes_normalized_artifact_events(tmp_path):
 
     # prime state to allow detecting modifications/new logs during second scan
     capture_signals(bus=bus, sandbox_root=sandbox)
-    time.sleep(0.02)
+    previous_mtime_ns = code.stat().st_mtime_ns
     code.write_text("# FIXME: remove this hack\nprint('ok')\n", encoding="utf-8")
+    os.utime(code, ns=(previous_mtime_ns + 1_000_000_000,) * 2)
     signals = capture_signals(bus=bus, sandbox_root=sandbox)
 
     assert any(

--- a/tests/test_scheduler_reevaluation.py
+++ b/tests/test_scheduler_reevaluation.py
@@ -1,4 +1,4 @@
-import time
+import threading
 
 from singular.agents import Agent
 from singular.schedulers import start
@@ -8,15 +8,17 @@ from singular.schedulers.reevaluation import alerts_from_records, detect_alerts
 def test_scheduler_triggers_goal_reevaluation():
     agent = Agent()
     calls = {"count": 0}
+    reevaluated = threading.Event()
 
     def spy() -> None:
         calls["count"] += 1
+        reevaluated.set()
 
     # Replace choose_goal with spy to count invocations
     agent.choose_goal = spy  # type: ignore[assignment]
 
     stop_event = start(0.01, agent)
-    time.sleep(0.05)
+    assert reevaluated.wait(timeout=1.0), "scheduler did not complete its first pass"
     stop_event.set()
 
     assert calls["count"] > 0


### PR DESCRIPTION
### Motivation

- Réduire les attentes murales et rendre le comportement des tests temporels déterministe en contrôlant explicitement les durées et le comptage de ticks.

### Description

- Ajout d'une horloge injectable à `SandboxRunner` pour mesurer elapsed, rate limiting et circuit-breaker (`src/singular/action/sandbox_runner.py`).
- Ajout d'une horloge injectable à `PerceptionNoiseFilter` pour tester le cooldown sans `time.sleep` (`src/singular/perception/__init__.py`).
- Remplacement du `time.sleep` du scheduler par une primitive d'attente injectée (`wait`), et adaptation de `start` pour permettre la synchronisation en tests (`src/singular/schedulers/reevaluation.py`).
- Mise à jour des tests ciblés pour remplacer `time.sleep` par une horloge simulée, utiliser des événements/barrières, ou forcer `max_iterations` pour rendre le nombre de ticks déterministe (`tests/test_perception.py`, `tests/test_scheduler_reevaluation.py`, `tests/test_environment.py`, `tests/test_action_sandbox_runner.py`, `tests/test_loop.py`).
- Ajustements mineurs pour produire un mtime déterministe lors de la simulation de modification de fichier dans les tests de perception.

### Testing

- Exécuté `pytest -q tests/test_perception.py tests/test_scheduler_reevaluation.py tests/test_environment.py tests/test_action_sandbox_runner.py` et obtenu `28 passed`.
- Initialement, l'exécution incluant `tests/test_loop.py` a échoué à cause d'une sandbox sécurisée indisponible dans l'environnement (podman/docker absent), ce comportement étant extérieur aux changements appliqués; les tests temporels ciblés ont ensuite été rendus déterministes et réussissent.
- Vérifications statiques et packaging : `ruff/black` checks et `python -m compileall` passés pour les fichiers modifiés, tandis que `mypy` a remonté erreurs préexistantes dans d'autres modules non touchés par ce patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76af3f9880832abfef5cf535c5c5f3)