### PR TITLE
Centraliser l'extra `test`, séparer les extras d'intégration et mettre à jour la CI/README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install lint dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . ruff black
+          pip install '.[test]'
       - name: Ruff
         run: ruff check .
       - name: Black
@@ -46,7 +46,7 @@ jobs:
       - name: Install typecheck dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . mypy
+          pip install '.[test]'
       - name: Mypy
         run: mypy src
 
@@ -64,9 +64,9 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install . pytest pytest-cov
+          pip install '.[test]'
       - name: Pytest with global coverage guardrail
-        run: pytest --cov=src/singular --cov-fail-under=85 --cov-report=term-missing --cov-report=xml:coverage.xml
+        run: pytest -m "not integration" --cov=src/singular --cov-fail-under=85 --cov-report=term-missing --cov-report=xml:coverage.xml
       - name: Validate critical modules coverage >= 90%
         run: |
           python scripts/check_coverage_thresholds.py \
@@ -74,10 +74,41 @@ jobs:
             --threshold src/singular/cli.py=90 \
             --threshold src/singular/lives.py=90
 
+  optional-integrations:
+    name: optional integration (${{ matrix.integration }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - integration: dashboard
+            extra: dashboard
+            tests: tests/test_dashboard.py tests/test_dashboard_smoke_e2e.py
+          - integration: openai-provider
+            extra: llm-openai
+            tests: tests/providers/test_llm_openai.py
+          - integration: local-llm-provider
+            extra: llm-local
+            tests: tests/providers/test_llm_local.py
+          - integration: container-sandbox
+            extra: sandbox
+            tests: tests/test_sandbox.py
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install optional integration dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[test,${{ matrix.extra }}]"
+      - name: Run optional integration contract
+        run: pytest -q ${{ matrix.tests }}
+
   build:
     name: build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, tests]
+    needs: [lint, typecheck, tests, optional-integrations]
     if: ${{ always() }}
     steps:
       - name: Fail when dependencies failed
@@ -86,4 +117,4 @@ jobs:
           echo "Upstream CI job failed or was cancelled."
           exit 1
       - name: CI summary
-        run: echo "lint/typecheck/tests completed successfully."
+        run: echo "lint/typecheck/tests/optional-integrations completed successfully."

--- a/README.md
+++ b/README.md
@@ -567,11 +567,29 @@ pip install -e .
 
 #### Dépendances optionnelles
 
+- `pip install -e '.[test]'` est la commande canonique pour installer
+  l'environnement de contribution et la suite obligatoire (pytest, couverture,
+  lint, formatage et typage), sans installer d'intégration facultative.
 - `pip install -e .[dashboard]` pour activer le tableau de bord web.
 - `pip install -e .[viz]` pour générer des graphiques via `viz.py`.
 - `pip install -e .[yaml]` pour ajouter **PyYAML** et gérer `values.yaml`.
-- `pip install openai>=1.0.0` pour permettre à l'organisme de parler via l'API OpenAI.
-- `pip install transformers` pour activer un modèle local via Hugging Face.
+- `pip install -e '.[llm-openai]'` pour permettre à l'organisme de parler via l'API OpenAI.
+- `pip install -e '.[llm-local]'` pour activer un modèle local via Hugging Face.
+- `pip install -e '.[ros2]'` dans un environnement ROS2 préalablement sourcé
+  pour activer le bridge ROS2.
+- `pip install -e '.[sandbox]'` documente le sandbox conteneurisé ; un exécutable
+  Podman ou Docker compatible reste requis sur l'hôte.
+
+La suite obligatoire exacte, identique à celle de la CI, s'exécute avec :
+
+```bash
+pytest -m "not integration" --cov=src/singular --cov-fail-under=85 --cov-report=term-missing --cov-report=xml:coverage.xml
+```
+
+Les extras `dashboard`, `llm-openai`, `llm-local`, `ros2` et `sandbox` restent
+volontairement séparés de `test` : leurs tests de contrat sont facultatifs et
+peuvent nécessiter un service, des identifiants, une distribution ROS2 ou un
+runtime de conteneurs.
 
 Après installation, la commande CLI `singular` est disponible :
 
@@ -805,7 +823,7 @@ Ouvrez ensuite http://127.0.0.1:8000 dans votre navigateur.
 **Statut : `optional`** — requiert des identifiants et un service externe.
 
 Pour permettre à l'organisme de parler en utilisant l'API d'OpenAI, installez
-la dépendance optionnelle ``openai>=1.0.0`` et définissez la variable
+la dépendance optionnelle avec ``pip install -e '.[llm-openai]'`` et définissez la variable
 d'environnement ``OPENAI_API_KEY``. Les versions plus anciennes du paquet
 ``openai`` ne sont pas compatibles avec le fournisseur actuel.
 
@@ -813,10 +831,10 @@ d'environnement ``OPENAI_API_KEY``. Les versions plus anciennes du paquet
 
 **Statut : `optional`** — dépend du runtime et du modèle installés localement.
 
-Installez ``transformers`` pour utiliser un petit modèle embarqué :
+Installez l'extra dédié pour utiliser un petit modèle embarqué :
 
 ```bash
-pip install transformers
+pip install -e '.[llm-local]'
 singular talk --provider local --prompt "Bonjour"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,15 @@ dependencies = [
 # Optional dependency policy mirrors runtime constraints:
 # - pin minimum known-compatible versions
 # - keep major-version upper caps for safer updates
+# The mandatory unit-test/quality suite deliberately has no optional runtime
+# integration dependencies.  Install it with ``.[test]``.
+test = [
+    "pytest>=8.2,<9",
+    "pytest-cov>=5,<7",
+    "ruff>=0.4,<1",
+    "black>=24.4,<26",
+    "mypy>=1.10,<2",
+]
 yaml = ["pyyaml>=6.0,<7"]
 dashboard = [
     "fastapi>=0.110,<1",
@@ -22,8 +31,17 @@ dashboard = [
     "websockets>=12,<16",
 ]
 viz = ["matplotlib>=3.8,<4"]
+# LLM clients are isolated from the mandatory test extra because they can pull
+# large model stacks or require external credentials/services.
+llm-openai = ["openai>=1.30,<3"]
+llm-local = ["transformers>=4.41,<6"]
+# rclpy is supplied by a sourced ROS2 distribution rather than by the standard
+# Python test environment.  The version range documents the supported API.
 ros2 = ["rclpy>=3.3,<4"]
 gpio = ["gpiozero>=2.0,<3"]
+# The secure sandbox has no Python dependency: it requires a compatible
+# Podman or Docker executable on the host.
+sandbox = []
 
 [project.scripts]
 singular = "singular.cli:main"


### PR DESCRIPTION
### Motivation

- Fournir un extra canonique `test` regroupant les outils de test/coverage/lint/format/typecheck afin que la suite obligatoire s'installe de manière reproductible avec `.[test]`.
- Séparer clairement les dépendances d'intégration (dashboard, fournisseurs LLM, ROS2, sandbox conteneurisé) pour éviter d'imposer de lourdes ou externes dépendances au contributeur standard.
- Simplifier la CI en installant le package via l'extra de test et en déplacer les tests d'intégration vers une matrice dédiée.

### Description

- Ajout de l'extra `test` et des extras dédiés `llm-openai`, `llm-local` et `sandbox` dans `pyproject.toml`, et commentaires expliquant pourquoi `ros2` reste séparé; le `sandbox` reste vide car il dépend d'un runtime hôte (Podman/Docker). (`pyproject.toml`)
- Mise à jour de `.github/workflows/ci.yml` pour installer le projet avec `pip install '.[test]'` dans les jobs `lint`, `typecheck` et `tests`, pour exclure les tests marqués `integration` de la suite obligatoire (`pytest -m "not integration"`), et ajout d'un job `optional-integrations` avec une matrice qui installe `.[test,${{ matrix.extra }}]` et exécute les tests de contrat d'intégration ciblés. (`.github/workflows/ci.yml`)
- Documentation mise à jour dans `README.md` pour promouvoir la commande canonique d'installation `pip install -e '.[test]'`, pour documenter les extras `llm-openai`, `llm-local`, `ros2` et `sandbox`, et pour fournir la ligne exacte de la suite obligatoire `pytest -m "not integration" --cov=src/singular --cov-fail-under=85 --cov-report=term-missing --cov-report=xml:coverage.xml`.
- Harmonisation des sections décrivant les fournisseurs OpenAI/Hugging Face pour référencer les nouveaux extras dédiés. (`README.md`)

### Testing

- `pyproject.toml` a été parsé avec `tomllib` et la présence des extras attendus a été vérifiée avec succès.
- Le workflow CI YAML a été parsé (`ruby -e 'YAML.load_file(...)'`) et `git diff --check`/`git status` sont passés localement après le commit.
- Tentative d'installer `.[test]` dans l'environnement local a échoué à cause d'un blocage réseau (index PyPI inaccessible / HTTP 403 lors de la récupération de `setuptools`), empêchant l'installation complète des dépendances de build et des extras dans cet environnement d'exécution.
- Exécution locale de la suite obligatoire `pytest -m 'not integration'` a été tentée et a produit un résultat partiel de tests avec 119 échecs et 750 réussites (1 ignoré, 1 désélectionné), les échecs étant majoritairement liés à des prérequis d'environnement manquants (absence de Podman/Docker pour la sandbox, accès réseau limité pour la construction/installation, et autres dépendances d'intégration non présentes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76b0d6dd90832aa5fdcb0f9aac03e6)