### PR TITLE
Separate OCI sandbox integration tests; add `sandbox_oci` marker, local sandbox fixture, image checks and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,6 @@ jobs:
           - integration: local-llm-provider
             extra: llm-local
             tests: tests/providers/test_llm_local.py
-          - integration: container-sandbox
-            extra: sandbox
-            tests: tests/test_sandbox.py
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -105,10 +102,51 @@ jobs:
       - name: Run optional integration contract
         run: pytest -q ${{ matrix.tests }}
 
+  sandbox-oci:
+    name: OCI sandbox (Docker + seccomp)
+    runs-on: ubuntu-latest
+    env:
+      SINGULAR_SANDBOX_RUNTIME: docker
+      SINGULAR_SANDBOX_IMAGE: python:3.11-alpine
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install '.[test,sandbox]'
+      - name: Verify Docker and seccomp
+        run: |
+          command -v docker || { echo "OCI sandbox unavailable: docker runtime is missing"; exit 1; }
+          security_options="$(docker info --format '{{json .SecurityOptions}}')" || {
+            echo "OCI sandbox unavailable: docker daemon probe failed"
+            exit 1
+          }
+          echo "$security_options"
+          grep -qi seccomp <<<"$security_options" || {
+            echo "OCI sandbox unavailable: docker does not report active seccomp support"
+            exit 1
+          }
+      - name: Prepare configured sandbox image
+        run: |
+          echo "Preparing SINGULAR_SANDBOX_IMAGE=$SINGULAR_SANDBOX_IMAGE"
+          docker pull "$SINGULAR_SANDBOX_IMAGE" || {
+            echo "OCI sandbox unavailable: failed to prepare $SINGULAR_SANDBOX_IMAGE"
+            exit 1
+          }
+          docker image inspect "$SINGULAR_SANDBOX_IMAGE" >/dev/null || {
+            echo "OCI sandbox unavailable: $SINGULAR_SANDBOX_IMAGE is not present locally"
+            exit 1
+          }
+      - name: Run OCI sandbox tests only
+        run: pytest -q -m sandbox_oci
+
   build:
     name: build
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, tests, optional-integrations]
+    needs: [lint, typecheck, tests, optional-integrations, sandbox-oci]
     if: ${{ always() }}
     steps:
       - name: Fail when dependencies failed
@@ -117,4 +155,4 @@ jobs:
           echo "Upstream CI job failed or was cancelled."
           exit 1
       - name: CI summary
-        run: echo "lint/typecheck/tests/optional-integrations completed successfully."
+        run: echo "lint/typecheck/tests/optional-integrations/sandbox-oci completed successfully."

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
     integration: integration tests that may execute an injected deployment command
+    sandbox_oci: tests requiring Linux, Docker or Podman, seccomp, and SINGULAR_SANDBOX_IMAGE
 testpaths = tests
 pythonpath = .

--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -95,7 +95,9 @@ class SandboxConfig:
             ),
             runtime=os.getenv("SINGULAR_SANDBOX_RUNTIME") or None,
             image=os.getenv("SINGULAR_SANDBOX_IMAGE", DEFAULT_IMAGE),
-            network_policy=os.getenv("SINGULAR_SANDBOX_NETWORK_POLICY", "none").strip().lower(),
+            network_policy=os.getenv("SINGULAR_SANDBOX_NETWORK_POLICY", "none")
+            .strip()
+            .lower(),
         )
 
 
@@ -138,6 +140,28 @@ def _runtime(configured: str | None) -> str:
             "secure sandbox unavailable: an active seccomp profile is required"
         )
     return candidate
+
+
+def _ensure_image_available(runtime: str, image: str) -> None:
+    """Refuse execution when the explicitly configured local image is absent."""
+
+    try:
+        probe = subprocess.run(
+            [runtime, "image", "inspect", image],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SandboxError(
+            f"secure sandbox unavailable: could not inspect OCI image '{image}'"
+        ) from exc
+    if probe.returncode:
+        raise SandboxError(
+            f"secure sandbox unavailable: OCI image '{image}' is not available locally; "
+            "prepare SINGULAR_SANDBOX_IMAGE explicitly (implicit pulls are disabled)"
+        )
 
 
 _CONTAINER_WORKER = r"""
@@ -204,6 +228,7 @@ def run(
         timeout=timeout, memory_limit=memory_limit
     )
     runtime = _runtime(policy.runtime)
+    _ensure_image_available(runtime, policy.image)
     try:
         completed = subprocess.run(
             _command(runtime, policy),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import ast
+import builtins
 import os
 import sys
 from pathlib import Path
@@ -29,8 +31,25 @@ sys.modules.setdefault("fastapi.staticfiles", fastapi_stub.staticfiles)
 import pytest  # noqa: E402
 
 from singular.life.checkpointing import Checkpoint, save_checkpoint  # noqa: E402
+from singular.life import sandbox as life_sandbox  # noqa: E402
 from singular.memory_layers.local_json import LocalJsonMemoryBackend  # noqa: E402
 from singular.memory_layers.service import MemoryLayerService  # noqa: E402
+
+
+@pytest.fixture
+def local_sandbox(monkeypatch):
+    """Emulate the trusted worker protocol without starting an OCI container."""
+
+    def execute(code):
+        life_sandbox._validate_ast(ast.parse(code, mode="exec"))
+        namespace = {"__builtins__": vars(builtins)}
+        exec(compile(code, "<unit-sandbox>", "exec"), namespace, namespace)
+        if "result" not in namespace:
+            raise life_sandbox.SandboxError("sandbox code did not set a result")
+        return namespace["result"]
+
+    monkeypatch.setattr(life_sandbox, "run", execute)
+    return execute
 
 
 @pytest.fixture

--- a/tests/test_birth_starter_profiles.py
+++ b/tests/test_birth_starter_profiles.py
@@ -1,5 +1,9 @@
+import pytest
+
 from singular.life.loop import score_code_with_error
 from singular.organisms.birth import _SKILL_TEMPLATES, _resolve_starter_skills
+
+pytestmark = pytest.mark.usefixtures("local_sandbox")
 
 
 def test_resolve_starter_skills_falls_back_to_assistant_profile() -> None:
@@ -13,7 +17,9 @@ def test_resolve_starter_skills_falls_back_to_assistant_profile() -> None:
     assert resolved == ["summary"]
 
 
-def test_starter_skill_templates_satisfy_sandbox_scoring_contract() -> None:
+def test_starter_skill_templates_satisfy_sandbox_scoring_contract(
+    local_sandbox,
+) -> None:
     for skill_name, source in _SKILL_TEMPLATES.items():
         score = score_code_with_error(source)
 

--- a/tests/test_life_loop_targeted.py
+++ b/tests/test_life_loop_targeted.py
@@ -17,6 +17,8 @@ from singular.life.reproduction_flow import ReproductionDecisionPolicy, decide_r
 from singular.life.sandbox_scoring import score_code_with_error
 from singular.resource_manager import CapabilityStatus, ResourceManager
 
+pytestmark = pytest.mark.usefixtures("local_sandbox")
+
 
 def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:
     for node in ast.walk(tree):

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -10,6 +10,9 @@ from pathlib import Path
 import ast
 
 import logging
+import pytest
+
+pytestmark = pytest.mark.usefixtures("local_sandbox")
 
 root_dir = Path(__file__).resolve().parents[1]
 sys.path.append(str(root_dir))
@@ -28,7 +31,7 @@ from singular.life.reproduction import ReproductionDecisionPolicy  # noqa: E402
 from singular.events import EventBus  # noqa: E402
 
 
-def test_repository_addition_skill_satisfies_sandbox_scoring_contract():
+def test_repository_addition_skill_satisfies_sandbox_scoring_contract(local_sandbox):
     assert (
         life_loop.score_code_with_error(Path("skills/addition.py").read_text()).ok
         is True
@@ -51,7 +54,7 @@ def test_float_conversion_skill_satisfies_sandbox_scoring_contract(monkeypatch):
     ) == life_loop.SandboxScore(score=2.5)
 
 
-def test_score_code_with_error_returns_structured_sandbox_score():
+def test_score_code_with_error_returns_structured_sandbox_score(local_sandbox):
     ok = life_loop.score_code_with_error("result = 3")
     assert ok == life_loop.SandboxScore(score=3.0)
     assert ok.ok is True

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -17,6 +17,8 @@ def isolated_runtime(monkeypatch):
     def fake_run(command, **kwargs):
         if command[1] == "info":
             return subprocess.CompletedProcess(command, 0, '["name=seccomp"]', "")
+        if command[1:3] == ["image", "inspect"]:
+            return subprocess.CompletedProcess(command, 0, "[]", "")
         code = kwargs["input"]
         if "while True" in code:
             raise subprocess.TimeoutExpired(command, kwargs["timeout"])
@@ -44,6 +46,19 @@ def isolated_runtime(monkeypatch):
         return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
 
     monkeypatch.setattr(sandbox.subprocess, "run", fake_run)
+
+
+@pytest.fixture
+def oci_runtime():
+    """Return a verified runtime or clearly skip for an infrastructure gap."""
+
+    config = SandboxConfig.from_environment()
+    try:
+        runtime = sandbox._runtime(config.runtime)
+        sandbox._ensure_image_available(runtime, config.image)
+    except SandboxError as exc:
+        pytest.skip(f"OCI sandbox infrastructure unavailable: {exc}")
+    return runtime, config
 
 
 @pytest.mark.parametrize(
@@ -159,6 +174,31 @@ def test_container_has_all_required_system_isolation(isolated_runtime, monkeypat
     assert any(
         value.startswith("--tmpfs=/tmp:rw,noexec,nosuid,nodev") for value in command
     )
+    assert "--pull=never" in command
+
+
+def test_missing_configured_image_is_reported_clearly(monkeypatch):
+    monkeypatch.setattr(sandbox.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+    def probe(command, **kwargs):
+        if command[1] == "info":
+            return subprocess.CompletedProcess(command, 0, '["name=seccomp"]', "")
+        return subprocess.CompletedProcess(command, 1, "", "No such image")
+
+    monkeypatch.setattr(sandbox.subprocess, "run", probe)
+    with pytest.raises(SandboxError, match="not available locally.*implicit pulls"):
+        run("result = 1", config=SandboxConfig(image="singular:test-missing"))
+
+
+@pytest.mark.sandbox_oci
+def test_oci_image_executes_worker_protocol(oci_runtime):
+    assert run("result = sum(range(5))") == 10
+
+
+@pytest.mark.sandbox_oci
+def test_oci_image_returns_worker_errors_as_json(oci_runtime):
+    with pytest.raises(SandboxError, match="ZeroDivisionError"):
+        run("result = 1 / 0")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,4 +1,14 @@
+import pytest
+
+from singular.life import sandbox
 from singular.life.score import score
+from singular.life.sandbox_scoring import (
+    SandboxScore,
+    _sandbox_failure_category,
+    score_code_with_error,
+)
+
+pytestmark = pytest.mark.usefixtures("local_sandbox")
 
 
 def test_score_single_run_variance_zero():
@@ -14,15 +24,8 @@ def test_complexity_penalty_increases_score():
     complex_score, _ = score(complex_code, runs=1, alpha=100.0)
     assert complex_score > simple_score
 
-from singular.life import sandbox
-from singular.life.sandbox_scoring import (
-    SandboxScore,
-    _sandbox_failure_category,
-    score_code_with_error,
-)
 
-
-def test_sandbox_score_finite_result_is_comparable():
+def test_sandbox_score_finite_result_is_comparable(local_sandbox):
     result = score_code_with_error("result = 2.5")
 
     assert result.ok is True
@@ -32,7 +35,7 @@ def test_sandbox_score_finite_result_is_comparable():
     assert result.is_infrastructure_failure is False
 
 
-def test_sandbox_score_non_finite_result_is_candidate_failure():
+def test_sandbox_score_non_finite_result_is_candidate_failure(local_sandbox):
     result = score_code_with_error("result = 1e309")
 
     assert result.ok is False


### PR DESCRIPTION
### Motivation

- Distinguish tests that actually require an OCI runtime and a configured image from fast unit tests that can simulate the sandbox protocol.
- Prevent implicit image pulls from test runs by keeping `--pull=never` and require explicit CI preparation of `SINGULAR_SANDBOX_IMAGE`.
- Provide clear diagnostics when runtime/seccomp/image are missing so infra gaps are not confused with regressions.

### Description

- Added a new pytest marker `sandbox_oci` and registered it in `pytest.ini` for tests that need Linux + Podman/Docker, seccomp and the configured image.
- Implemented `_ensure_image_available(runtime, image)` in `src/singular/life/sandbox.py` and call it from `run()` so execution fails fast with a clear message if the image is not locally present; left `--pull=never` in `_command()` to avoid implicit pulls.
- Introduced a `local_sandbox` fixture in `tests/conftest.py` that validates the AST then executes the worker protocol in-process for unit tests (monkeypatches `sandbox.run`), and updated relevant tests to use it so unit tests simulate the runtime and verify commands, policies, JSON responses and error mappings without launching containers.
- Updated `tests/test_sandbox.py` to add an `oci_runtime` fixture (which skips with a clear message on missing infra), to assert `--pull=never`, to check missing-image diagnostics, and to add a couple of `@pytest.mark.sandbox_oci` tests exercising worker protocol and error reporting.
- Added a dedicated CI job `sandbox-oci` in `.github/workflows/ci.yml` that verifies presence of `docker`, checks `seccomp` is reported by the daemon, prepares (`docker pull`) the configured `SINGULAR_SANDBOX_IMAGE`, inspects it locally, and then runs only tests with `-m sandbox_oci`.

### Testing

- Ran unit test suite excluding OCI tests with `pytest -m "not sandbox_oci"`, and the unit-level runs passed: `56 passed, 2 deselected` (non-OCI tests); unit tests simulate the runtime via `local_sandbox`.
- Executed lints/formatters: `ruff` and `black` completed and files were formatted as needed.
- Validated CI workflow YAML parsing (`ruby` YAML load in CI run) and updated `.github/workflows/ci.yml` successfully.
- Running `pytest -m sandbox_oci` in the local environment produced clear skips due to missing Docker/seccomp/image (the CI job explicitly prepares the image and will fail early with readable diagnostics if runtime/seccomp/image are unavailable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76b5738400832a9e35c65dbd9f0cbc)