### PR TITLE
Prevent OS perception imports from shadowing stdlib environment access

### DIFF
--- a/src/singular/perception/__init__.py
+++ b/src/singular/perception/__init__.py
@@ -12,7 +12,7 @@ publishes normalized perception events on the :class:`~singular.events.EventBus`
 
 from __future__ import annotations
 
-import os
+import os as stdlib_os
 import random
 import time
 from dataclasses import dataclass, field
@@ -33,7 +33,7 @@ from singular.sensors import (
 
 def _read_optional_file() -> dict[str, Any]:
     """Read data from ``SINGULAR_SENSOR_FILE`` if available."""
-    path = os.getenv("SINGULAR_SENSOR_FILE")
+    path = stdlib_os.getenv("SINGULAR_SENSOR_FILE")
     if not path:
         return {}
     try:
@@ -44,13 +44,13 @@ def _read_optional_file() -> dict[str, Any]:
 
 def _query_optional_weather_api() -> dict[str, Any]:
     """Query ``SINGULAR_WEATHER_API`` for weather data if possible."""
-    url = os.getenv("SINGULAR_WEATHER_API")
+    url = stdlib_os.getenv("SINGULAR_WEATHER_API")
     if not url:
         return {}
     try:  # pragma: no cover - network failures are expected
         import requests  # type: ignore[import-untyped]
 
-        timeout_str = os.getenv("SINGULAR_HTTP_TIMEOUT", "5")
+        timeout_str = stdlib_os.getenv("SINGULAR_HTTP_TIMEOUT", "5")
         try:
             timeout = float(timeout_str)
         except ValueError:
@@ -64,7 +64,7 @@ def _query_optional_weather_api() -> dict[str, Any]:
 
 def _resolve_sandbox_root(path: str | Path | None) -> Path:
     if path is None:
-        path = os.getenv("SINGULAR_SANDBOX_ROOT", "sandbox")
+        path = stdlib_os.getenv("SINGULAR_SANDBOX_ROOT", "sandbox")
     candidate = Path(path).resolve()
     if not candidate.exists() or not candidate.is_dir():
         return candidate
@@ -188,7 +188,9 @@ def _collect_host_signals() -> dict[str, float | None] | None:
         if not policy.allow_sensor("host_metrics"):
             return None
         metrics = collect_host_metrics()
-        opt_in = os.getenv("SINGULAR_SENSOR_SENSITIVE_OPT_IN", "").strip().lower() in {
+        opt_in = stdlib_os.getenv(
+            "SINGULAR_SENSOR_SENSITIVE_OPT_IN", ""
+        ).strip().lower() in {
             "1",
             "true",
             "yes",

--- a/tests/perception/test_os_pipeline.py
+++ b/tests/perception/test_os_pipeline.py
@@ -11,6 +11,7 @@ from singular.perception.os.capture import (
     OSSnapshotProvider,
 )
 from singular.perception.os.pipeline import OSPerceptionPipeline
+import singular.perception as perception
 
 
 @dataclass
@@ -19,6 +20,22 @@ class StaticSnapshotProvider(OSSnapshotProvider):
 
     def collect_snapshot(self) -> OSSnapshot:
         return self.snapshot
+
+
+def test_loading_os_pipeline_does_not_shadow_standard_library_os(
+    tmp_path, monkeypatch
+) -> None:
+    sensor_file = tmp_path / "sensor.txt"
+    sensor_file.write_text("pipeline-safe", encoding="utf-8")
+    monkeypatch.setenv("SINGULAR_SENSOR_FILE", str(sensor_file))
+    monkeypatch.delenv("SINGULAR_WEATHER_API", raising=False)
+
+    # Importing the pipeline installs the public ``perception.os`` package
+    # attribute; environment access must still use the standard library alias.
+    assert perception.os.__name__ == "singular.perception.os"
+    signals = perception.capture_signals(sandbox_root=tmp_path)
+
+    assert signals["file"] == "pipeline-safe"
 
 
 def test_os_pipeline_emits_raw_and_semantic_events() -> None:


### PR DESCRIPTION
### Motivation

- Prevent the `singular.perception.os` subpackage from shadowing access to the standard-library `os` APIs used to read environment variables.
- Add a regression that proves importing the public OS perception pipeline no longer interferes with `getenv` calls used by `capture_signals`.

### Description

- Import the standard-library `os` module under a non-conflicting alias with `import os as stdlib_os` in `src/singular/perception/__init__.py`.
- Replace all environment reads in that module to use `stdlib_os.getenv(...)` (sensor file, weather API url and timeout, sandbox root, and sensitive-opt-in flag).
- Add a regression test `test_loading_os_pipeline_does_not_shadow_standard_library_os` in `tests/perception/test_os_pipeline.py` that imports the OS pipeline and then calls `singular.perception.capture_signals()` with controlled environment variables to assert `getenv` still works.
- Preserve the `src/singular/perception/os/` subpackage and its public imports unchanged.

### Testing

- Ran `pytest -q tests/perception/test_os_pipeline.py tests/test_perception.py` and both completed successfully with `14 passed`.
- Ran `python -m ruff check src/singular/perception/__init__.py tests/perception/test_os_pipeline.py` and `git diff --check`, both passed with no issues.
- Ran broader test families (perception/loop/talk/orchestrator/multi-organisms) which showed `129 passed, 7 failed`; the failures are unrelated preexisting test failures surfaced after fixing the environment-shadowing issue and do not concern the perception getenv regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76c5429e70832a881e9d1dafbdad21)