### PR TITLE
Keep dashboard WebSocket polling responsive

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -3074,6 +3074,37 @@ def create_app(
             """Disconnect slow consumers instead of accumulating unbounded writes."""
             await asyncio.wait_for(ws.send_json(payload), timeout=ws_send_timeout)
 
+        def _read_changed_json(
+            path: Path, previous_mtime_ns: int | None
+        ) -> tuple[int | None, object | None, Exception | None]:
+            """Read one changed snapshot without doing unbounded work on the event loop."""
+            max_bytes = run_repository._limit(
+                "SINGULAR_DASHBOARD_MAX_EVENT_BYTES", 1024 * 1024
+            )
+            try:
+                initial_stat = path.stat()
+                if initial_stat.st_mtime_ns == previous_mtime_ns:
+                    return previous_mtime_ns, None, None
+                with path.open("rb") as handle:
+                    opened_stat = os.fstat(handle.fileno())
+                    raw = handle.read(max_bytes + 1)
+            except FileNotFoundError:
+                return None, None, None
+            except OSError as exc:
+                return previous_mtime_ns, None, exc
+            if len(raw) > max_bytes:
+                return opened_stat.st_mtime_ns, None, ValueError("snapshot too large")
+            try:
+                return opened_stat.st_mtime_ns, json.loads(raw.decode("utf-8")), None
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                return opened_stat.st_mtime_ns, None, exc
+
+        def _list_run_files() -> tuple[list[Path], Exception | None]:
+            try:
+                return _iter_run_files(), None
+            except OSError as exc:
+                return [], exc
+
         def _read_new_entries(
             file: Path, cursor: _LogCursor | None
         ) -> tuple[list[bytes], _LogCursor, bool]:
@@ -3130,58 +3161,39 @@ def create_app(
 
         try:
             while True:
-                if psyche_path.exists():
-                    mtime_ns = psyche_path.stat().st_mtime_ns
-                    if mtime_ns != last_psyche_mtime_ns:
+                for source, path, previous_mtime in (
+                    ("psyche", psyche_path, last_psyche_mtime_ns),
+                    ("quests", quests_path, last_quests_mtime_ns),
+                ):
+                    mtime_ns, data, error = await asyncio.to_thread(
+                        _read_changed_json, path, previous_mtime
+                    )
+                    if source == "psyche":
                         last_psyche_mtime_ns = mtime_ns
-                        try:
-                            data = json.loads(psyche_path.read_text())
-                        except (
-                            OSError,
-                            UnicodeDecodeError,
-                            json.JSONDecodeError,
-                        ) as exc:
-                            await _send(
-                                {
-                                    "type": "stream_error",
-                                    "source": "psyche",
-                                    "error": type(exc).__name__,
-                                }
-                            )
-                        else:
-                            await _send({"type": "psyche", "data": data})
-
-                if quests_path.exists():
-                    mtime_ns = quests_path.stat().st_mtime_ns
-                    if mtime_ns != last_quests_mtime_ns:
+                    else:
                         last_quests_mtime_ns = mtime_ns
-                        try:
-                            data = json.loads(quests_path.read_text())
-                        except (
-                            OSError,
-                            UnicodeDecodeError,
-                            json.JSONDecodeError,
-                        ) as exc:
-                            await _send(
-                                {
-                                    "type": "stream_error",
-                                    "source": "quests",
-                                    "error": type(exc).__name__,
-                                }
-                            )
-                        else:
-                            await _send({"type": "quests", "data": data})
+                    if error is not None:
+                        await _send({"type": "stream_error", "source": source, "error": type(error).__name__})
+                    elif data is not None:
+                        await _send({"type": source, "data": data})
 
                 incremental_events: list[dict[str, object]] = []
-                run_files = _iter_run_files()
+                run_files, discovery_error = await asyncio.to_thread(_list_run_files)
+                if discovery_error is not None:
+                    incremental_events.append({"type": "stream_error", "source": "runs", "error": type(discovery_error).__name__})
+                    run_files = [Path(name) for name in log_cursors]
                 if run_files:
                     current_files: set[str] = set()
                     for file in run_files:
                         key = str(file)
                         current_files.add(key)
-                        entries, next_cursor, rotated = await asyncio.to_thread(
-                            _read_new_entries, file, log_cursors.get(key)
-                        )
+                        try:
+                            entries, next_cursor, rotated = await asyncio.to_thread(
+                                _read_new_entries, file, log_cursors.get(key)
+                            )
+                        except (FileNotFoundError, OSError):
+                            log_cursors.pop(key, None)
+                            continue
                         log_cursors[key] = next_cursor
                         if rotated:
                             incremental_events.append(
@@ -3220,7 +3232,7 @@ def create_app(
                 for event in incremental_events:
                     await _send(event)
                 await asyncio.sleep(ws_poll_interval)
-        except (WebSocketDisconnect, asyncio.TimeoutError):
+        except (WebSocketDisconnect, asyncio.TimeoutError, asyncio.CancelledError):
             pass
         finally:
             with ws_clients_lock:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,6 +1,8 @@
+import asyncio
 import json
 from pathlib import Path
 from queue import Empty
+import threading
 
 import pytest
 from fastapi_stub import TestClient
@@ -1967,6 +1969,35 @@ def test_websocket_multiple_clients_receive_the_same_bounded_stream(tmp_path: Pa
     assert first_event == second_event
     assert first_event["type"] == "run_event"
     assert first_event["run_id"] == "shared"
+
+
+def test_websocket_slow_discovery_does_not_block_http_or_disconnect(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_iter_run_files(self, current_life_only: bool = False):
+        started.set()
+        release.wait(timeout=5)
+        return []
+
+    monkeypatch.setattr(
+        dashboard_module.RunRecordsRepository, "iter_run_files", slow_iter_run_files
+    )
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "missing.json")
+
+    async def exercise() -> None:
+        ws = dashboard_module.WebSocket()
+        websocket_task = asyncio.create_task(app._ws_routes["/ws"](ws))
+        assert await asyncio.to_thread(started.wait, 1)
+        assert "<html>" in app._routes["/"]().lower()
+        websocket_task.cancel()
+        await asyncio.wait_for(websocket_task, timeout=0.25)
+        release.set()
+
+    asyncio.run(exercise())
+    assert "CancelledError" not in capsys.readouterr().err
 
 
 


### PR DESCRIPTION
### Motivation

- Empêcher que les lectures bloquantes de snapshots (`psyche_path`, `quests_path`) et l’énumération des fichiers de run monopolisent la boucle événementielle WebSocket et bloquent d’autres endpoints ou provoquent des cascades de `CancelledError` lors d’un arrêt.

### Description

- Déplacé la lecture conditionnelle de `psyche_path` et `quests_path` dans une fonction synchrone bornée `_read_changed_json()` exécutée via `asyncio.to_thread`, avec une limite de bytes basée sur `SINGULAR_DASHBOARD_MAX_EVENT_BYTES`.
- Externalisé l’énumération des fichiers de run dans `_list_run_files()` exécutée aussi via `asyncio.to_thread`, et isolé les erreurs de découverte pour éviter qu’une erreur sur une source interrompe tout le flux.
- Conservé les limites de batch et d’événement existantes, toléré la rotation/suppression d’un fichier entre `stat` et lecture, et traité `FileNotFoundError`/OSError pendant la lecture comme comportements normaux (pas d’exception remontée).
- Suppressé le bruit d’annulation en gérant `asyncio.CancelledError` avec les autres exceptions de déconnexion et ajouté test(s) pour vérifier la réactivité HTTP et l’absence de cascade `CancelledError` lors d’une découverte lente.

### Testing

- Ajouté `tests/test_dashboard.py::test_websocket_slow_discovery_does_not_block_http_or_disconnect` qui simule une énumération lente et vérifie qu’un endpoint HTTP reste servi et que l’annulation WebSocket n’engendre pas de `CancelledError`; test ajouté et réussi.
- Exécuté les tests ciblés via `python -m pytest tests/test_dashboard.py -q -k 'websocket_slow_discovery or websocket_stream_incremental or websocket_multiple or psyche_missing or dashboard_quests_endpoint'` — 5 tests passés.
- Vérification statique et formatage avec `ruff` et `black` effectués et passés, et `git diff --check` sans erreurs.
- Remarque : une exécution précédente non liée de la suite complète de `tests/test_dashboard.py` a rapporté 3 échecs préexistants (valeurs de politique/governance et libellé d’état de vie) qui ne sont pas liés à ces modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a773f679324832a8dc95ff3b5a6f33f)