### PR TITLE
Handle dashboard WebSocket cancellation cleanly

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections import Counter
 import json
+import inspect
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import os
@@ -172,6 +173,7 @@ def create_app(
     )
     ws_clients = 0
     ws_clients_lock = threading.Lock()
+    app.state.ws_clients = ws_clients
     ws_max_clients = max(
         1, int(os.environ.get("SINGULAR_DASHBOARD_WS_MAX_CLIENTS", "32"))
     )
@@ -3065,14 +3067,26 @@ def create_app(
                 await ws.close(code=1013)
                 return
             ws_clients += 1
-        await ws.accept()
+            app.state.ws_clients = ws_clients
         last_psyche_mtime_ns: int | None = None
         last_quests_mtime_ns: int | None = None
         log_cursors: dict[str, _LogCursor] = {}
 
         async def _send(payload: dict[str, object]) -> None:
             """Disconnect slow consumers instead of accumulating unbounded writes."""
-            await asyncio.wait_for(ws.send_json(payload), timeout=ws_send_timeout)
+            try:
+                await asyncio.wait_for(
+                    ws.send_json(payload), timeout=ws_send_timeout
+                )
+            except asyncio.CancelledError:
+                # ``wait_for`` must not turn application shutdown into a send failure.
+                raise
+
+        async def _close() -> None:
+            """Best-effort close compatible with Starlette and the test WebSocket."""
+            result = ws.close()
+            if inspect.isawaitable(result):
+                await result
 
         def _read_changed_json(
             path: Path, previous_mtime_ns: int | None
@@ -3160,6 +3174,7 @@ def create_app(
             }
 
         try:
+            await ws.accept()
             while True:
                 for source, path, previous_mtime in (
                     ("psyche", psyche_path, last_psyche_mtime_ns),
@@ -3231,12 +3246,23 @@ def create_app(
 
                 for event in incremental_events:
                     await _send(event)
-                await asyncio.sleep(ws_poll_interval)
-        except (WebSocketDisconnect, asyncio.TimeoutError, asyncio.CancelledError):
+                try:
+                    await asyncio.sleep(ws_poll_interval)
+                except asyncio.CancelledError:
+                    # Keep cancellation distinct from an ordinary stream error.
+                    raise
+        except asyncio.CancelledError:
+            try:
+                await _close()
+            except (WebSocketDisconnect, RuntimeError, OSError):
+                pass
+            raise
+        except (WebSocketDisconnect, asyncio.TimeoutError):
             pass
         finally:
             with ws_clients_lock:
                 ws_clients -= 1
+                app.state.ws_clients = ws_clients
 
     @app.get("/", response_class=HTMLResponse)
     def index() -> str:

--- a/tests/fastapi_stub/__init__.py
+++ b/tests/fastapi_stub/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, Callable, Dict
 from dataclasses import dataclass, field
 from queue import Queue
+from types import SimpleNamespace
 
 
 class HTTPException(Exception):
@@ -49,6 +50,7 @@ class FastAPI:
     """Minimal application object supporting GET and WebSocket routes."""
 
     def __init__(self) -> None:
+        self.state = SimpleNamespace()
         self._routes: Dict[str, Callable[[], Any]] = {}
         self._post_routes: Dict[str, Callable[[], Any]] = {}
         self._ws_routes: Dict[str, Callable[[WebSocket], Any]] = {}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1993,8 +1993,36 @@ def test_websocket_slow_discovery_does_not_block_http_or_disconnect(
         assert await asyncio.to_thread(started.wait, 1)
         assert "<html>" in app._routes["/"]().lower()
         websocket_task.cancel()
-        await asyncio.wait_for(websocket_task, timeout=0.25)
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(websocket_task, timeout=0.25)
         release.set()
+
+    asyncio.run(exercise())
+    assert "CancelledError" not in capsys.readouterr().err
+
+
+def test_websocket_application_shutdown_closes_client_and_releases_slot(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "missing.json")
+
+    async def exercise() -> None:
+        ws = dashboard_module.WebSocket()
+        websocket_task = asyncio.create_task(app._ws_routes["/ws"](ws))
+
+        async def client_is_connected() -> None:
+            while app.state.ws_clients != 1:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(client_is_connected(), timeout=0.25)
+
+        # ASGI servers cancel connection tasks while shutting the application down.
+        websocket_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(websocket_task, timeout=0.25)
+
+        assert ws.closed
+        assert app.state.ws_clients == 0
 
     asyncio.run(exercise())
     assert "CancelledError" not in capsys.readouterr().err


### PR DESCRIPTION
### Motivation

- Traiter `asyncio.CancelledError` dans le endpoint WebSocket comme une demande d'arrêt afin de fermer le socket au mieux, laisser le bloc `finally` décrémenter le compteur de clients et préserver la sémantique d'annulation sans produire un traceback d'erreur de flux.
- Empêcher que les annulations issues de `asyncio.wait_for(ws.send_json(...))` ou `asyncio.sleep(...)` soient converties en erreurs de flux ordinaires.

### Description

- Préservation explicite de `asyncio.CancelledError` lors des envois bornés en ajoutant un `try/except` autour de `asyncio.wait_for(ws.send_json(...))` et en re-propageant l'annulation.
- Séparation des chemins d'annulation pour le `await asyncio.sleep(ws_poll_interval)` afin que l'annulation reste distincte d'une `TimeoutError` ou d'un `WebSocketDisconnect`.
- Ajout d'une fonction `async def _close()` qui effectue une fermeture best-effort du WebSocket et qui attend la fermeture si `ws.close()` est awaitable.
- Synchronisation et exposition du compteur de clients WebSocket via `app.state.ws_clients` lors des connexions et déconnexions pour permettre des assertions de cycle de vie fiables.
- Mise à jour du stub de test FastAPI (`tests/fastapi_stub`) pour fournir `app.state` et ajout d'un test de cycle de vie `test_websocket_application_shutdown_closes_client_and_releases_slot` qui ouvre `/ws`, déclenche l'arrêt (annulation), vérifie la fermeture du client et que le compteur repasse à zéro, et qui s'assure qu'aucun traceback `CancelledError` inattendu n'est imprimé.

### Testing

- Exécution ciblée des tests WebSocket avec `pytest -q tests/test_dashboard.py -k websocket`, résultat : 4 tests réussis.
- Exécution ciblée du scénario d'arrêt et découverte lente avec `pytest -q tests/test_dashboard.py -k 'websocket_application_shutdown or websocket_slow_discovery'`, résultat : 2 tests réussis.
- Exécution complète du fichier de tests du tableau de bord avec `pytest -q tests/test_dashboard.py`, résultat : 50 tests réussis et 3 échecs existants non liés à cette modification (attentes de valeurs de gouvernance / statut de vie), ces échecs proviennent de valeurs de configuration/attentes préexistantes et n'ont pas été introduits par ce changement.
- Vérification de style : `python -m ruff check src/singular/dashboard/__init__.py tests/test_dashboard.py tests/fastapi_stub/__init__.py` a réussi, et `python -m black --check ...` signale que 3 fichiers seraient reformattés (vérification Black échouée pour ces fichiers).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77441f5908832a98fc3ea449fc905a)