### PR TITLE
Define consistent CLI journey grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ Pour découvrir le format sans modifier le disque ni sélectionner de vie active
 utilisez les sorties intégrées :
 
 ```bash
-singular quest --example
-singular quest --schema
+singular quest create --example
+singular quest create --schema
 ```
 
 Un exemple complet versionné est également disponible dans

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Index de la documentation
 
+La [grammaire des parcours CLI de recette](cli-visible-paths.fr.md) décrit les
+groupes `skills`, `quest`, `social`, `self-narrative` et `cognition`, ainsi que
+le placement cohérent de `--life` et la migration des anciennes syntaxes.
+
 Cet index est le point d'entrée canonique de la documentation Singular. Les
 documents de planification et les spécifications cibles sont volontairement
 séparés des fonctions utilisables afin qu'une intention ne soit pas interprétée

--- a/docs/cli-reference.en.md
+++ b/docs/cli-reference.en.md
@@ -158,7 +158,7 @@ Paths below are relative to the root or `SINGULAR_HOME`. Always back up before d
 <!-- cli-command: quest -->
 ## `quest`
 
-**Syntax :** `singular quest [-h] [--example] [--schema] [spec]`
+**Syntax :** `singular quest create [-h] [--example] [--schema] [--life LIFE] [spec]`
 
 **Arguments and defaults :** `spec` (`None`); `--example` (`false`); `--schema` (`false`)
 
@@ -170,11 +170,221 @@ Paths below are relative to the root or `SINGULAR_HOME`. Always back up before d
 
 **Side effects :** Creates/changes artifacts; `rollback` atomically replaces active state.
 
-**Minimal example :** `singular quest --example`
+**Minimal example :** `singular quest create --example`
 
-**Advanced example :** `singular --root /srv/singular --life ada --format json quest --example`
+**Advanced example :** `singular --root /srv/singular --life ada --format json quest create --example`
 
 **Common errors :** Missing/invalid input, unknown generation, existing or unwritable output.
+
+<!-- cli-command: skills -->
+## `skills`
+
+**Syntax :** `singular skills ACTION`
+
+**Arguments and defaults :** `ACTION` (requis/required)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular skills list`
+
+**Advanced example :** `singular --root /srv/singular --life ada skills list`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: skills list -->
+## `skills list`
+
+**Syntax :** `singular skills list [--life LIFE]`
+
+**Arguments and defaults :** `--life` (`None`)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular skills list --life ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada skills list --life ada`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: quest create -->
+## `quest create`
+
+**Syntax :** `singular quest create [--example] [--schema] [--life LIFE] [spec]`
+
+**Arguments and defaults :** `spec` (`None`); options (`false`)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular quest create --example`
+
+**Advanced example :** `singular --root /srv/singular --life ada quest create --example`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: quest list -->
+## `quest list`
+
+**Syntax :** `singular quest list [--life LIFE]`
+
+**Arguments and defaults :** `--life` (`None`)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular quest list --life ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada quest list --life ada`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: social -->
+## `social`
+
+**Syntax :** `singular social ACTION`
+
+**Arguments and defaults :** `ACTION` (requis/required)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular social interact bob cooperation`
+
+**Advanced example :** `singular --root /srv/singular --life ada social interact bob cooperation`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: social interact -->
+## `social interact`
+
+**Syntax :** `singular social interact TARGET EVENT [--life LIFE]`
+
+**Arguments and defaults :** `TARGET`, `EVENT` (requis/required); `--life` (`None`)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular social interact bob cooperation --life ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada social interact bob cooperation --life ada`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: self-narrative -->
+## `self-narrative`
+
+**Syntax :** `singular self-narrative ACTION`
+
+**Arguments and defaults :** `ACTION` (requis/required)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular self-narrative summarize`
+
+**Advanced example :** `singular --root /srv/singular --life ada self-narrative summarize`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: self-narrative summarize -->
+## `self-narrative summarize`
+
+**Syntax :** `singular self-narrative summarize [--long] [--life LIFE]`
+
+**Arguments and defaults :** `--long` (`false`); `--life` (`None`)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular self-narrative summarize --life ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada self-narrative summarize --life ada`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: cognition -->
+## `cognition`
+
+**Syntax :** `singular cognition ACTION`
+
+**Arguments and defaults :** `ACTION` (requis/required)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular cognition self-observe`
+
+**Advanced example :** `singular --root /srv/singular --life ada cognition self-observe`
+
+**Common errors :** Missing subcommand/argument or unknown life.
+
+<!-- cli-command: cognition self-observe -->
+## `cognition self-observe`
+
+**Syntax :** `singular cognition self-observe [--life LIFE]`
+
+**Arguments and defaults :** `--life` (`None`)
+
+**Prerequisites :** An active life for actions.
+
+**Target root and life :** Global or local `--life`; the local option takes precedence.
+
+**Files read or written :** Reads or writes active-life artifacts.
+
+**Side effects :** The action may update life memory.
+
+**Minimal example :** `singular cognition self-observe --life ada`
+
+**Advanced example :** `singular --root /srv/singular --life ada cognition self-observe --life ada`
+
+**Common errors :** Missing subcommand/argument or unknown life.
 
 <!-- cli-command: synthesize -->
 ## `synthesize`

--- a/docs/cli-reference.fr.md
+++ b/docs/cli-reference.fr.md
@@ -158,7 +158,7 @@ Les chemins ci-dessous sont relatifs au root ou à `SINGULAR_HOME`. Toujours sau
 <!-- cli-command: quest -->
 ## `quest`
 
-**Syntaxe :** `singular quest [-h] [--example] [--schema] [spec]`
+**Syntaxe :** `singular quest create [-h] [--example] [--schema] [--life LIFE] [spec]`
 
 **Arguments et défauts :** `spec` (`None`); `--example` (`false`); `--schema` (`false`)
 
@@ -170,11 +170,221 @@ Les chemins ci-dessous sont relatifs au root ou à `SINGULAR_HOME`. Toujours sau
 
 **Effets de bord :** Crée/modifie des artefacts; `rollback` remplace atomiquement l'état actif.
 
-**Exemple minimal :** `singular quest --example`
+**Exemple minimal :** `singular quest create --example`
 
-**Exemple avancé :** `singular --root /srv/singular --life ada --format json quest --example`
+**Exemple avancé :** `singular --root /srv/singular --life ada --format json quest create --example`
 
 **Erreurs usuelles :** Entrée absente/invalide, génération inconnue, sortie existante ou non inscriptible.
+
+<!-- cli-command: skills -->
+## `skills`
+
+**Syntaxe :** `singular skills ACTION`
+
+**Arguments et défauts :** `ACTION` (requis/required)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular skills list`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada skills list`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: skills list -->
+## `skills list`
+
+**Syntaxe :** `singular skills list [--life LIFE]`
+
+**Arguments et défauts :** `--life` (`None`)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular skills list --life ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada skills list --life ada`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: quest create -->
+## `quest create`
+
+**Syntaxe :** `singular quest create [--example] [--schema] [--life LIFE] [spec]`
+
+**Arguments et défauts :** `spec` (`None`); options (`false`)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular quest create --example`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada quest create --example`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: quest list -->
+## `quest list`
+
+**Syntaxe :** `singular quest list [--life LIFE]`
+
+**Arguments et défauts :** `--life` (`None`)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular quest list --life ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada quest list --life ada`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: social -->
+## `social`
+
+**Syntaxe :** `singular social ACTION`
+
+**Arguments et défauts :** `ACTION` (requis/required)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular social interact bob cooperation`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada social interact bob cooperation`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: social interact -->
+## `social interact`
+
+**Syntaxe :** `singular social interact TARGET EVENT [--life LIFE]`
+
+**Arguments et défauts :** `TARGET`, `EVENT` (requis/required); `--life` (`None`)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular social interact bob cooperation --life ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada social interact bob cooperation --life ada`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: self-narrative -->
+## `self-narrative`
+
+**Syntaxe :** `singular self-narrative ACTION`
+
+**Arguments et défauts :** `ACTION` (requis/required)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular self-narrative summarize`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada self-narrative summarize`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: self-narrative summarize -->
+## `self-narrative summarize`
+
+**Syntaxe :** `singular self-narrative summarize [--long] [--life LIFE]`
+
+**Arguments et défauts :** `--long` (`false`); `--life` (`None`)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular self-narrative summarize --life ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada self-narrative summarize --life ada`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: cognition -->
+## `cognition`
+
+**Syntaxe :** `singular cognition ACTION`
+
+**Arguments et défauts :** `ACTION` (requis/required)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular cognition self-observe`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada cognition self-observe`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
+
+<!-- cli-command: cognition self-observe -->
+## `cognition self-observe`
+
+**Syntaxe :** `singular cognition self-observe [--life LIFE]`
+
+**Arguments et défauts :** `--life` (`None`)
+
+**Prérequis :** Une vie active pour les actions.
+
+**Root et vie ciblés :** `--life` global ou local; l'option locale est prioritaire.
+
+**Fichiers lus ou écrits :** Lit ou écrit les artefacts de la vie active.
+
+**Effets de bord :** L'action peut actualiser la mémoire de la vie.
+
+**Exemple minimal :** `singular cognition self-observe --life ada`
+
+**Exemple avancé :** `singular --root /srv/singular --life ada cognition self-observe --life ada`
+
+**Erreurs usuelles :** Sous-commande/argument manquant ou vie introuvable.
 
 <!-- cli-command: synthesize -->
 ## `synthesize`

--- a/docs/cli-visible-paths.fr.md
+++ b/docs/cli-visible-paths.fr.md
@@ -1,0 +1,30 @@
+# Grammaire des parcours CLI de recette
+
+Les parcours fonctionnels visibles suivent tous la forme `singular [options globales]
+<groupe> <action> [arguments]`. Les syntaxes prises en charge sont :
+
+```text
+singular [--life VIE] skills list [--life VIE]
+singular [--life VIE] quest create SPEC [--life VIE]
+singular [--life VIE] quest list [--life VIE]
+singular [--life VIE] social interact CIBLE ÉVÉNEMENT [--life VIE]
+singular [--life VIE] self-narrative summarize [--long] [--life VIE]
+singular [--life VIE] cognition self-observe [--life VIE]
+```
+
+`--life` placé sur l'action est prioritaire sur `--life` placé avant le groupe. La
+résolution est unique : une vie inconnue produit `Vie introuvable: <nom>` et aucune
+commande n'est exécutée. Par exemple, les deux commandes suivantes ciblent Ada :
+
+```console
+singular --root ~/.singular --life ada skills list
+singular --root ~/.singular skills list --life ada
+```
+
+## Migration de l'ancienne quête
+
+`singular quest SPEC` reste temporairement accepté et délègue exactement à
+`singular quest create SPEC`, avec un avertissement de migration sur stderr. Les
+formes d'inspection deviennent `singular quest create --example` et
+`singular quest create --schema`.
+

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -93,6 +93,41 @@ def _extract_talk_life_alias(argv: list[str] | None) -> str | None:
     return None
 
 
+def _normalize_legacy_quest_argv(
+    argv: list[str] | None,
+) -> tuple[list[str] | None, bool]:
+    """Translate ``quest SPEC`` to the documented ``quest create SPEC`` grammar."""
+
+    if argv is None:
+        return None, False
+    normalized = list(argv)
+    try:
+        index = normalized.index("quest")
+    except ValueError:
+        return normalized, False
+    following = normalized[index + 1 :]
+    if not following or following[0] in {"create", "list", "-h", "--help"}:
+        return normalized, False
+    if following[0] in {"--example", "--schema"}:
+        normalized.insert(index + 1, "create")
+        return normalized, True
+    if not following[0].startswith("-"):
+        normalized.insert(index + 1, "create")
+        return normalized, True
+    return normalized, False
+
+
+def _add_local_life_argument(parser: argparse.ArgumentParser) -> None:
+    """Add the uniform command-local spelling without shadowing global ``life``."""
+
+    parser.add_argument(
+        "--life",
+        dest="local_life",
+        default=None,
+        help="Life slug/name (overrides the global --life option)",
+    )
+
+
 def _build_life_suggestion_message(unknown: str) -> str | None:
     """Return a targeted suggestion when an unknown argument looks like a life slug."""
 
@@ -1118,20 +1153,64 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Alias de compatibilité déprécié pour `talk --life`",
     )
 
-    quest_parser = subparsers.add_parser(
-        "quest", help="Generate a skill from a specification"
+    skills_parser = subparsers.add_parser("skills", help="Inspect life skills")
+    skills_subparsers = skills_parser.add_subparsers(
+        dest="skills_command", required=True
     )
-    quest_parser.add_argument(
+    skills_list = skills_subparsers.add_parser("list", help="List available skills")
+    _add_local_life_argument(skills_list)
+
+    quest_parser = subparsers.add_parser("quest", help="Manage life quests")
+    quest_subparsers = quest_parser.add_subparsers(dest="quest_command", required=True)
+    quest_create = quest_subparsers.add_parser(
+        "create", help="Generate a skill from a quest specification"
+    )
+    quest_create.add_argument(
         "spec", nargs="?", type=Path, help="Path to specification JSON"
     )
-    quest_parser.add_argument(
+    quest_create.add_argument(
         "--example",
         action="store_true",
         help="Print a complete quest JSON example and exit",
     )
-    quest_parser.add_argument(
+    quest_create.add_argument(
         "--schema", action="store_true", help="Print the quest JSON schema and exit"
     )
+    _add_local_life_argument(quest_create)
+    quest_list = quest_subparsers.add_parser("list", help="List quest specifications")
+    _add_local_life_argument(quest_list)
+
+    social_parser = subparsers.add_parser("social", help="Manage social interactions")
+    social_subparsers = social_parser.add_subparsers(
+        dest="social_command", required=True
+    )
+    social_interact = social_subparsers.add_parser(
+        "interact", help="Record an interaction with another life"
+    )
+    social_interact.add_argument("target", help="Other life identifier")
+    social_interact.add_argument("event", help="Observed interaction event")
+    _add_local_life_argument(social_interact)
+
+    narrative_parser = subparsers.add_parser(
+        "self-narrative", help="Inspect the active life's narrative"
+    )
+    narrative_subparsers = narrative_parser.add_subparsers(
+        dest="narrative_command", required=True
+    )
+    narrative_summarize = narrative_subparsers.add_parser(
+        "summarize", help="Summarize the self narrative"
+    )
+    narrative_summarize.add_argument("--long", action="store_true")
+    _add_local_life_argument(narrative_summarize)
+
+    cognition_parser = subparsers.add_parser("cognition", help="Inspect cognition")
+    cognition_subparsers = cognition_parser.add_subparsers(
+        dest="cognition_command", required=True
+    )
+    cognition_observe = cognition_subparsers.add_parser(
+        "self-observe", help="Display evidence-bound self observations"
+    )
+    _add_local_life_argument(cognition_observe)
 
     synth_parser = subparsers.add_parser("synthesize", help="Synthesize results")
     synth_parser.add_argument("code", help="Code snippet to store in memory")
@@ -1569,7 +1648,8 @@ def main(argv: list[str] | None = None) -> int:
     implicit_root_before_override = (
         _implicit_registry_root_from_env_or_default().resolve()
     )
-    argv_list = list(argv) if argv is not None else None
+    raw_argv = list(argv) if argv is not None else sys.argv[1:]
+    argv_list, legacy_quest = _normalize_legacy_quest_argv(raw_argv)
     _preparse_environment(argv_list)
 
     from .lives import (
@@ -1601,6 +1681,13 @@ def main(argv: list[str] | None = None) -> int:
                 print(suggestion, file=sys.stderr)
         raise
 
+    if legacy_quest:
+        print(
+            "⚠️ `singular quest <spec>` est déprécié. "
+            "Utilisez `singular quest create <spec>`.",
+            file=sys.stderr,
+        )
+
     if args.command == "loop":
         if args.budget_seconds is None and args.ticks is not None:
             parser.error(
@@ -1624,6 +1711,12 @@ def main(argv: list[str] | None = None) -> int:
             if selected_life is None:
                 selected_life = args.talk_life_legacy
         args.life = selected_life if selected_life is not None else args.life
+
+    # Every local --life uses a separate parser destination; resolution happens
+    # exactly once here and local syntax consistently takes precedence.
+    local_life = getattr(args, "local_life", None)
+    if local_life is not None:
+        args.life = local_life
 
     _print_registry_context_message_if_needed(
         args.root,
@@ -1786,8 +1879,21 @@ def main(argv: list[str] | None = None) -> int:
         _ensure_active_life(resolve_life, args.life)
         talk(provider=args.provider, seed=args.seed, prompt=args.prompt)
 
+    elif args.command == "skills":
+        from .life.skill_catalog import refresh_skill_catalog
+
+        life_dir = _ensure_active_life(resolve_life, args.life)
+        catalog = refresh_skill_catalog(
+            skills_dir=life_dir / "skills", mem_dir=life_dir / "mem"
+        )
+        if args.output_format == "json":
+            print(json.dumps(catalog, ensure_ascii=False, indent=2))
+        else:
+            for name in sorted(catalog):
+                print(name)
+
     elif args.command == "quest":
-        if args.example or args.schema:
+        if getattr(args, "example", False) or getattr(args, "schema", False):
             from .life.quest import FULL_SPEC_EXAMPLE, QUEST_SCHEMA
 
             print(
@@ -1797,15 +1903,50 @@ def main(argv: list[str] | None = None) -> int:
                     indent=2,
                 )
             )
-            return
+            return 0
+        if args.quest_command == "list":
+            life_dir = _ensure_active_life(resolve_life, args.life)
+            names = sorted(path.stem for path in (life_dir / "quests").glob("*.json"))
+            if args.output_format == "json":
+                print(json.dumps(names, ensure_ascii=False))
+            else:
+                print("\n".join(names))
+            return 0
         if args.spec is None:
             parser.error(
-                "quest requires a spec path unless --example or --schema is used"
+                "quest create requires a spec path unless --example or --schema is used"
             )
         from .organisms.quest import quest
 
         _ensure_active_life(resolve_life, args.life)
         quest(spec=args.spec)
+
+    elif args.command == "social":
+        from .social.graph import SocialGraph
+
+        life_dir = _ensure_active_life(resolve_life, args.life)
+        observer = args.life or life_dir.name
+        result = SocialGraph(life_dir / "mem" / "social_graph.json").record_interaction(
+            observer, args.target, args.event
+        )
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+
+    elif args.command == "self-narrative":
+        from .self_narrative import summarize_long, summarize_short
+
+        life_dir = _ensure_active_life(resolve_life, args.life)
+        narrative_path = life_dir / "mem" / "self_narrative.json"
+        summarize = summarize_long if args.long else summarize_short
+        print(summarize(path=narrative_path))
+
+    elif args.command == "cognition":
+        from .cognition.self_observation import SelfObservationService
+
+        life_dir = _ensure_active_life(resolve_life, args.life)
+        model = SelfObservationService(
+            life_dir / "mem" / "self_model.json"
+        ).store.read()
+        print(json.dumps(model.get("metacognition", {}), ensure_ascii=False, indent=2))
 
     elif args.command == "synthesize":
         from .runs.synthesize import synthesize

--- a/tests/test_cli_visible_paths.py
+++ b/tests/test_cli_visible_paths.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from singular.cli import main
+
+
+@pytest.fixture
+def life_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    root = tmp_path / "root"
+    main(["--root", str(root), "lives", "create", "--name", "Ada"])
+    # Register values that the CLI itself assigned so monkeypatch restores the
+    # process environment after this in-process CLI test.
+    monkeypatch.setenv("SINGULAR_ROOT", str(root))
+    monkeypatch.setenv("SINGULAR_HOME", str(root / "lives" / "ada"))
+    return root
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["skills", "list"],
+        ["quest", "list"],
+        ["self-narrative", "summarize"],
+        ["cognition", "self-observe"],
+        ["social", "interact", "bob", "cooperation"],
+    ],
+)
+def test_visible_paths_accept_global_and_local_life(
+    life_root: Path, command: list[str]
+) -> None:
+    assert main(["--root", str(life_root), "--life", "ada", *command]) in (None, 0)
+    assert main(["--root", str(life_root), *command, "--life", "ada"]) in (None, 0)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["skills", "list"],
+        ["quest", "list"],
+        ["self-narrative", "summarize"],
+        ["cognition", "self-observe"],
+        ["social", "interact", "bob", "cooperation"],
+    ],
+)
+def test_visible_paths_reject_unknown_life(life_root: Path, command: list[str]) -> None:
+    with pytest.raises(SystemExit, match="Vie introuvable: missing"):
+        main(["--root", str(life_root), *command, "--life", "missing"])
+
+
+@pytest.mark.parametrize(
+    "group", ["skills", "quest", "social", "self-narrative", "cognition"]
+)
+def test_visible_groups_require_an_action(group: str) -> None:
+    with pytest.raises(SystemExit) as error:
+        main([group])
+    assert error.value.code == 2
+
+
+def test_deprecated_quest_alias_reports_migration(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    main(["quest", "--example"])
+    assert "quest create" in capsys.readouterr().err
+
+
+def test_quest_create_documented_inspection_syntax(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["quest", "create", "--example"]) == 0
+    assert '"name"' in capsys.readouterr().out


### PR DESCRIPTION
### Motivation

- Rendre explicite et cohérente la grammaire CLI pour les parcours de recette visibles (par ex. inspection de skills, génération de quests, interactions sociales, narration et observation cognitive). 
- Uniformiser l'utilisation de l'option `--life` pour autoriser une option globale avant la commande et une option locale après la sous-commande sans destinations contradictoires. 
- Maintenir une compatibilité de transition avec l'ancien usage `quest <spec>` tout en guidant la migration vers la nouvelle syntaxe.

### Description

- Ajout des groupes de commandes et sous-commandes : `skills list`, `quest create/list`, `social interact`, `self-narrative summarize` et `cognition self-observe` dans `src/singular/cli.py`, en déléguant aux modules existants (`life.skill_catalog`, `organisms.quest`, `social.graph`, `self_narrative`, `cognition.self_observation`).
- Introduit les utilitaires ` _normalize_legacy_quest_argv` et `_add_local_life_argument` et une destination locale `--life` par sous-commande pour permettre une option locale non conflictuelle ; la résolution effective de la vie est centralisée pour que l’option locale prévaille si fournie.
- Transforme `quest` en groupe à sous-commandes `create`/`list` tout en acceptant temporairement l’ancien `singular quest SPEC` comme alias qui réémet un avertissement de migration sur stderr.
- Ajout de documentation de référence descriptive `docs/cli-visible-paths.fr.md` et mises à jour des références CLI (FR/EN + README) pour refléter la grammaire retenue.
- Ajout de tests `tests/test_cli_visible_paths.py` couvrant : acceptation des syntaxes avec `--life` global et local, rejet d’une vie inexistante, erreur sur groupe sans action, syntaxe de `quest create --example` et message de migration pour l’alias déprécié.

### Testing

- `pytest -q tests/test_cli_visible_paths.py tests/test_cli_reference.py` — passed (new visible-paths and reference parity checks succeed).
- `pytest -q tests/test_cli_visible_paths.py tests/test_cli_quest.py -k 'not quest_success'` — passed (quest inspection/related CLI behavior OK; the sandbox-backed quest success case remains environment-dependent).
- Formatting and byte-compile checks: `python -m black --check src/singular/cli.py tests/test_cli_visible_paths.py` and `python -m compileall -q src/singular/cli.py` were run; formatting was applied and compilation succeeded.
- A broader test run (`pytest -q tests/test_cli_*.py tests/test_talk.py`) showed many unrelated tests passing but a set of failures remain (environment-sensitive): missing secure sandbox backend (Podman/Docker) causes sandbox/quest generation checks to fail, and a few tests depending on platform-specific path semantics or global environment state also failed; these failures are external to the CLI grammar changes and reflect test environment limitations rather than regressions in the new command routing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a774bacc9ec832abf58441ccc433f84)