### PR TITLE
Improve quest spec error handling and concise CLI errors

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -93,28 +93,22 @@ def _extract_talk_life_alias(argv: list[str] | None) -> str | None:
     return None
 
 
-def _normalize_legacy_quest_argv(
-    argv: list[str] | None,
-) -> tuple[list[str] | None, bool]:
-    """Translate ``quest SPEC`` to the documented ``quest create SPEC`` grammar."""
+def _normalize_quest_help_argv(argv: list[str] | None) -> list[str] | None:
+    """Allow the convenient top-level ``quest --example/--schema`` spellings."""
 
     if argv is None:
-        return None, False
+        return None
     normalized = list(argv)
     try:
         index = normalized.index("quest")
     except ValueError:
-        return normalized, False
+        return normalized
     following = normalized[index + 1 :]
     if not following or following[0] in {"create", "list", "-h", "--help"}:
-        return normalized, False
+        return normalized
     if following[0] in {"--example", "--schema"}:
         normalized.insert(index + 1, "create")
-        return normalized, True
-    if not following[0].startswith("-"):
-        normalized.insert(index + 1, "create")
-        return normalized, True
-    return normalized, False
+    return normalized
 
 
 def _add_local_life_argument(parser: argparse.ArgumentParser) -> None:
@@ -1649,7 +1643,11 @@ def main(argv: list[str] | None = None) -> int:
         _implicit_registry_root_from_env_or_default().resolve()
     )
     raw_argv = list(argv) if argv is not None else sys.argv[1:]
-    argv_list, legacy_quest = _normalize_legacy_quest_argv(raw_argv)
+    legacy_quest_help = any(
+        raw_argv[index : index + 2] in (["quest", "--example"], ["quest", "--schema"])
+        for index in range(max(0, len(raw_argv) - 1))
+    )
+    argv_list = _normalize_quest_help_argv(raw_argv)
     _preparse_environment(argv_list)
 
     from .lives import (
@@ -1681,10 +1679,9 @@ def main(argv: list[str] | None = None) -> int:
                 print(suggestion, file=sys.stderr)
         raise
 
-    if legacy_quest:
+    if legacy_quest_help:
         print(
-            "⚠️ `singular quest <spec>` est déprécié. "
-            "Utilisez `singular quest create <spec>`.",
+            "Information: `quest create --example/--schema` est aussi disponible.",
             file=sys.stderr,
         )
 
@@ -1916,10 +1913,19 @@ def main(argv: list[str] | None = None) -> int:
             parser.error(
                 "quest create requires a spec path unless --example or --schema is used"
             )
+        from .life.quest import QuestSpecError
         from .organisms.quest import quest
 
         _ensure_active_life(resolve_life, args.life)
-        quest(spec=args.spec)
+        try:
+            quest(spec=args.spec)
+        except QuestSpecError as exc:
+            print(
+                f"Erreur: {exc}. Syntaxe: singular quest create <spec>. "
+                "Aide: singular quest --example ou singular quest --schema.",
+                file=sys.stderr,
+            )
+            return 2
 
     elif args.command == "social":
         from .social.graph import SocialGraph

--- a/src/singular/life/quest.py
+++ b/src/singular/life/quest.py
@@ -8,7 +8,23 @@ from typing import Any, List
 import json
 
 
-class SpecValidationError(ValueError):
+class QuestSpecError(ValueError):
+    """Base class for ordinary, user-correctable specification errors."""
+
+
+class SpecNotFoundError(QuestSpecError):
+    """Raised when the specification path does not exist."""
+
+
+class SpecUnreadableError(QuestSpecError):
+    """Raised when the specification path cannot be read."""
+
+
+class SpecJSONError(QuestSpecError):
+    """Raised when the specification is not valid JSON."""
+
+
+class SpecValidationError(QuestSpecError):
     """Raised when a specification fails validation."""
 
 
@@ -113,7 +129,36 @@ class Spec:
 def load(path: Path) -> Spec:
     """Parse *path* as a JSON spec and return a :class:`Spec`."""
 
-    data = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise SpecNotFoundError(f"spécification introuvable: {path}") from exc
+    except (OSError, UnicodeError) as exc:
+        raise SpecUnreadableError(f"spécification illisible: {path}") from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SpecJSONError(
+            f"JSON invalide dans {path} (ligne {exc.lineno}, colonne {exc.colno})"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise SpecValidationError(
+            f"spécification sémantiquement invalide dans {path}: "
+            "la racine JSON doit être un objet"
+        )
+
+    try:
+        return _load_data(data)
+    except SpecValidationError as exc:
+        raise SpecValidationError(
+            f"spécification sémantiquement invalide dans {path}: {exc}"
+        ) from exc
+
+
+def _load_data(data: dict[str, Any]) -> Spec:
+    """Validate already-decoded quest data."""
 
     name = data.get("name")
     if not isinstance(name, str) or not name.strip():

--- a/tests/test_cli_quest.py
+++ b/tests/test_cli_quest.py
@@ -34,7 +34,7 @@ def test_quest_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     life_path = resolve_life(None)
     assert life_path is not None
 
-    main(["--root", str(root), "quest", str(spec_path)])
+    main(["--root", str(root), "quest", "create", str(spec_path)])
 
     life_path = resolve_life(None)
     assert life_path is not None
@@ -75,7 +75,7 @@ def test_quest_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     assert life_path is not None
 
     with pytest.raises(RuntimeError):
-        main(["--root", str(root), "quest", str(spec_path)])
+        main(["--root", str(root), "quest", "create", str(spec_path)])
 
     assert not (life_path / "skills" / "badskill.py").exists()
     skills_data = read_skills(life_path / "mem" / "skills.json")
@@ -136,9 +136,82 @@ def test_quest_invalid_spec_does_not_create_files(
     assert life_path is not None
     before = {path.relative_to(life_path) for path in life_path.rglob("*")}
 
-    with pytest.raises(ValueError, match="examples"):
-        main(["--root", str(root), "quest", str(spec_path)])
+    assert main(["--root", str(root), "quest", "create", str(spec_path)]) == 2
 
     after = {path.relative_to(life_path) for path in life_path.rglob("*")}
     assert after == before
     assert not (life_path / "skills" / "broken.py").exists()
+
+
+@pytest.mark.parametrize(
+    ("filename", "contents", "message"),
+    [
+        ("missing.json", None, "introuvable"),
+        ("broken.json", "{not json", "JSON invalide"),
+    ],
+)
+def test_quest_reports_file_input_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    filename: str,
+    contents: str | None,
+    message: str,
+) -> None:
+    root = tmp_path / "world"
+    path = tmp_path / filename
+    if contents is not None:
+        path.write_text(contents, encoding="utf-8")
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    main(["--root", str(root), "birth", "--name", "Input Errors"])
+    capsys.readouterr()
+
+    assert main(["--root", str(root), "quest", "create", str(path)]) == 2
+
+    error = capsys.readouterr().err
+    assert str(path) in error
+    assert message in error
+    assert "quest create <spec>" in error
+    assert "quest --example" in error
+    assert "quest --schema" in error
+
+
+def test_quest_reports_unreadable_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "world"
+    path = tmp_path / "unreadable.json"
+    path.write_text("{}", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def deny_read(target: Path, *args: object, **kwargs: object) -> str:
+        if target == path:
+            raise PermissionError("permission denied")
+        return original_read_text(target, *args, **kwargs)
+
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.delenv("SINGULAR_ROOT", raising=False)
+    main(["--root", str(root), "birth", "--name", "Unreadable Input"])
+    capsys.readouterr()
+    monkeypatch.setattr(Path, "read_text", deny_read)
+
+    assert main(["--root", str(root), "quest", "create", str(path)]) == 2
+    assert f"spécification illisible: {path}" in capsys.readouterr().err
+
+
+def test_quest_spec_cannot_be_confused_with_subcommand(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "spec.json"
+    _write_spec(path, "skill", [{"input": [1], "output": 1}])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(["quest", str(path)])
+
+    assert exc_info.value.code == 2
+    error = capsys.readouterr().err
+    assert "invalid choice" in error
+    assert "create" in error and "list" in error


### PR DESCRIPTION
### Motivation

- Provide clear, user-facing diagnostics that distinguish a missing spec file, unreadable path, invalid JSON and semantically invalid quest specifications so users can fix input errors without seeing tracebacks.
- Reserve the first-level `quest` positional namespace for the explicit `create`/`list` subcommands while preserving convenient `quest --example`/`--schema` help shorthands.

### Description

- Add a small hierarchy of user-correctable exceptions in `src/singular/life/quest.py`: `QuestSpecError`, `SpecNotFoundError`, `SpecUnreadableError`, `SpecJSONError` and make `load` surface file/path/JSON/semantic errors with the spec path in messages. 
- Split validation into `_load_data` for semantic validation and update `load` to map IO/JSON failures to the new exception classes. 
- Update CLI behavior in `src/singular/cli.py` to normalize `quest --example/--schema` help shorthands, require `quest create <spec>` for spec input, and catch `QuestSpecError` to print a concise error message referencing the offending path, the expected syntax `singular quest create <spec>`, and the help commands `quest --example` / `quest --schema`, returning exit code `2` without a traceback. 
- Update tests in `tests/test_cli_quest.py` to call the explicit `create` subcommand and add coverage for missing file, invalid JSON, unreadable file, semantic validation and confusion between a path and a subcommand.

### Testing

- Ran targeted CLI tests with `pytest -q tests/test_cli_quest.py -k "file_input_errors or unreadable or confused or invalid_spec or example or schema"` and they passed. 
- Ran `pytest -q tests/test_cli_visible_paths.py` and it passed. 
- Ran lint/quality checks with `ruff check src/singular/cli.py src/singular/life/quest.py tests/test_cli_quest.py` and `git diff --check`, both succeeded.
- Note: an earlier full run that included synthesising/running generated-skill validation failed in this ephemeral environment due to a missing secure sandbox (Podman/Docker) required by the skill verification step, which is an external environment limitation rather than a regression in these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7753540bc4832ab7afd209065f3671)