### PR TITLE
Conserver les vies opérateur lors d'échecs partiels du dashboard

### DIFF
--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -47,8 +47,9 @@ const hasValidSelectedLife=()=>{
 const operatorRegistryState=()=>{
   const select=operatorLifeSelect();
   if(!select){return 'loading';}
-  if(select.dataset.registryState!=='loaded'){return 'loading';}
-  if(validOperatorLives().size===0){return 'empty';}
+  const state=select.dataset.registryState||'loading';
+  if(state==='loading'||state==='error'){return state;}
+  if(validOperatorLives().size===0){return state==='empty'?'empty':'error';}
   return hasValidSelectedLife()?'valid':'invalid';
 };
 
@@ -94,6 +95,7 @@ export const updateOperatorActionState=()=>{
   const help=document.getElementById('operator-action-help');
   const helpMessages={
     loading:'Les données de vies n’ont pas encore chargé',
+    error:'Registre des vies indisponible : aucune source (/dashboard/context, comparaison des vies ou cockpit essentiel) n’a pu être chargée.',
     empty:'Aucune vie détectée dans le registre',
     invalid:'Sélectionnez une vie valide dans le registre pour activer “Supprimer/archiver” et “Parler”.',
     valid:blocksOperatorActions
@@ -146,7 +148,7 @@ const mergeDefined=(base,extra)=>{
   return merged;
 };
 
-export const mergeLifeRows=(context={},comparison={})=>{
+export const mergeLifeRows=(context={},comparison={},essential={})=>{
   const rowsByLife=new Map();
   const pushRow=(life,row)=>{
     const key=String(life||'').trim();
@@ -172,20 +174,28 @@ export const mergeLifeRows=(context={},comparison={})=>{
     const life=candidates.find(candidate=>rowsByLife.has(candidate))||candidates[0]||lifeRowName(row);
     pushRow(life,row);
   }
+  const selectedLife=String(essential?.selected_life||'').trim();
+  if(selectedLife){pushRow(selectedLife,{life:selectedLife,selected_life:true});}
   return [...rowsByLife.values()];
 };
 
-export const updateOperatorLifeOptions=(rows=[])=>{
+export const updateOperatorLifeOptions=(rows=[],{registryState='empty'}={})=>{
   const select=operatorLifeSelect();
   if(!select){return;}
   const previous=select.value;
-  select.dataset.registryState='loaded';
   const rowByName=new Map();
+  // Never let a failing/partial refresh erase lives learned from another source.
+  if(registryState!=='empty'){
+    for(const option of select.options){
+      if(option.value){rowByName.set(option.value,{life:option.value,status:option.dataset.lifeStatus});}
+    }
+  }
   for(const row of rows||[]){
     const name=String(lifeRowName(row)||'').trim();
     if(name&&!rowByName.has(name)){rowByName.set(name,row);}
   }
   const names=[...rowByName.keys()].sort((a,b)=>a.localeCompare(b));
+  select.dataset.registryState=names.length?(registryState==='error'?'partial':registryState):registryState;
   select.innerHTML='';
   const placeholder=document.createElement('option');
   placeholder.value='';

--- a/src/singular/dashboard/static/dashboard-data.js
+++ b/src/singular/dashboard/static/dashboard-data.js
@@ -19,8 +19,18 @@ export const fetchSharedDashboardContext=()=>cachedJson('/dashboard/context');
 export const fetchSharedLivesComparison=()=>cachedJson(withScope('/lives/comparison?sort_by=last_activity&sort_order=desc'));
 export const fetchSharedCockpitEssential=()=>cachedJson(withScope('/api/cockpit/essential'));
 
-export const fetchSharedDashboardData=()=>Promise.all([
+export const fetchSharedDashboardData=()=>Promise.allSettled([
   fetchSharedDashboardContext(),
   fetchSharedLivesComparison(),
   fetchSharedCockpitEssential(),
-]).then(([context,comparison,essential])=>({context,comparison,essential}));
+]).then(results=>{
+  const [contextResult,comparisonResult,essentialResult]=results;
+  return {
+    context:contextResult.status==='fulfilled'?contextResult.value:{},
+    comparison:comparisonResult.status==='fulfilled'?comparisonResult.value:{table:[]},
+    essential:essentialResult.status==='fulfilled'?essentialResult.value:{},
+    registryState:results.every(result=>result.status==='rejected')?'error':(
+      results.some(result=>result.status==='rejected')?'partial':'ready'
+    ),
+  };
+});

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -567,7 +567,18 @@ export const loadCockpit=()=>Promise.allSettled([
   operatorSummaryState.cockpit={trend,liveness_index:livenessIndex,life_liveness_index:d.life_liveness_index,health_score:d.health_score,selected_life:essentialPayload.selected_life};
   const comparisonAvailable=livesResult.status==='fulfilled'&&isComparisonPayload(livesResult.value);
   if(comparisonAvailable){operatorSummaryState.lives=lives;}
-  updateOperatorLifeOptions(mergeLifeRows(ctx,comparisonAvailable?lives:{}));
+  const registryResults=[ctxResult,livesResult,essentialResult];
+  const successfulRegistrySources=registryResults.filter(result=>result.status==='fulfilled').length;
+  const registryState=successfulRegistrySources===0?'error':(
+    successfulRegistrySources<registryResults.length?'partial':(
+      mergeLifeRows(ctx,lives,essentialPayload).length?'ready':'empty'
+    )
+  );
+  updateOperatorLifeOptions(mergeLifeRows(
+    ctx,
+    comparisonAvailable?lives:{},
+    essentialResult.status==='fulfilled'?essentialPayload:{},
+  ),{registryState});
   renderOperatorSummary();
   setText('kpi-health',healthValue);
   setText('kpi-trend',trend);

--- a/src/singular/dashboard/static/render-lives.js
+++ b/src/singular/dashboard/static/render-lives.js
@@ -1,6 +1,6 @@
 import {fetchJson} from './api.js';
 import {fetchSharedDashboardData} from './dashboard-data.js';
-import {updateOperatorLifeOptions} from './actions.js';
+import {mergeLifeRows,updateOperatorLifeOptions} from './actions.js';
 import {BADGE_TONE,liveState,livesTableState,na,scopeState,setPanelState,setSelectedLife} from './state.js';
 
 const byId=id=>document.getElementById(id);
@@ -377,7 +377,7 @@ export const loadLivesBoard=()=>{
   const presetKey=document.getElementById('filter-sort-preset')?.value||'watch';
   const preset=SORT_PRESETS[presetKey]||SORT_PRESETS.watch;
   const timeWindow=byId('filter-time-window')?.value||'all';
-  return fetchSharedDashboardData().then(({context,comparison,essential})=>{
+  return fetchSharedDashboardData().then(({context,comparison,essential,registryState})=>{
     const d=comparison||{};
     let mappedRows=(d.table||[]).map(row=>{
       const risk=rowRiskSummary(row);
@@ -403,7 +403,10 @@ export const loadLivesBoard=()=>{
     if(livesUiState.focus==='at_risk'){tableRows=tableRows.filter(row=>(row.__riskLevel||0)>=1);}
     clientSteps.push({step:'client_focus',label:`Après focus ${livesUiState.focus}`,applied:livesUiState.focus!=='all',count:tableRows.length});
     livesUiState.rowsByLife=new Map(mappedRows.map(row=>[row.life,row]));
-    updateOperatorLifeOptions(mappedRows);
+    const operatorRows=mergeLifeRows(context,comparison,essential);
+    updateOperatorLifeOptions(operatorRows,{
+      registryState:registryState==='ready'&&!operatorRows.length?'empty':registryState,
+    });
     renderLivesBuckets(Object.entries(d.lives||{}).map(([life,payload])=>({life,...payload})),d.life_metrics_contract);
     renderLivesTable(tableRows);
     if(livesUiState.selectedLife&&livesUiState.rowsByLife.has(livesUiState.selectedLife)){showLifeDetails(livesUiState.selectedLife);}

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -705,7 +705,7 @@ globalThis.document = {{
 globalThis.window = {{ dispatchEvent() {{}} }};
 globalThis.CustomEvent = class CustomEvent {{ constructor(type, init) {{ this.type = type; this.detail = init?.detail; }} }};
 
-const {{ updateOperatorLifeOptions }} = await import('{module_path}');
+const {{ mergeLifeRows, updateOperatorLifeOptions }} = await import('{module_path}');
 const emptyComparison = {{ table: [] }};
 updateOperatorLifeOptions(emptyComparison.table);
 
@@ -717,6 +717,33 @@ if (birth.classList.contains('is-disabled')) {{ throw new Error('Créer une vie 
 for (const [label, button] of [['archive', archive], ['talk', talk], ['emergency_stop', emergency]]) {{
   if (!button.disabled) {{ throw new Error(`${{label}} should be disabled without a valid life`); }}
   if (button.getAttribute('aria-disabled') !== 'true') {{ throw new Error(`${{label}} aria-disabled missing`); }}
+}}
+
+// A context failure must not hide a life supplied by comparison.
+updateOperatorLifeOptions(mergeLifeRows({{}}, {{table: [{{life: 'comparison-life', life_status: 'active'}}]}}, {{}}), {{registryState: 'partial'}});
+if (![...elements.get('operator-action-life-select').options].some(option => option.value === 'comparison-life')) {{
+  throw new Error('comparison life missing after isolated /dashboard/context failure');
+}}
+elements.get('operator-action-life-select').value = 'comparison-life';
+updateOperatorLifeOptions(mergeLifeRows({{}}, {{}}, {{selected_life: 'essential-life'}}), {{registryState: 'partial'}});
+if (![...elements.get('operator-action-life-select').options].some(option => option.value === 'comparison-life')) {{
+  throw new Error('known comparison option was erased by an isolated comparison failure');
+}}
+if (![...elements.get('operator-action-life-select').options].some(option => option.value === 'essential-life')) {{
+  throw new Error('cockpit essential selected_life was not added');
+}}
+for (const [label, button] of [['archive', archive], ['talk', talk], ['emergency_stop', emergency]]) {{
+  if (button.disabled) {{ throw new Error(`${{label}} should remain enabled with one successful life source`); }}
+}}
+
+// Once all sources fail, creation remains independent while life actions are blocked.
+updateOperatorLifeOptions([], {{registryState: 'empty'}});
+updateOperatorLifeOptions([], {{registryState: 'error'}});
+if (!elements.get('operator-action-help').textContent.includes('Registre des vies indisponible')) {{
+  throw new Error('explicit all-source registry error missing');
+}}
+if (birth.disabled || !archive.disabled || !talk.disabled || !emergency.disabled) {{
+  throw new Error('incorrect exact action state when every registry source is unavailable');
 }}
 """,
         encoding="utf-8",


### PR DESCRIPTION
### Motivation
- Veiller à ce que le sélecteur opérateur agrège les vies depuis toutes les sources disponibles (`/dashboard/context`, comparaison des vies et `selected_life` du cockpit essentiel) et ne perde pas des options déjà connues lorsqu’un endpoint secondaire échoue.
- Remplacer l’état binaire `loading/loaded` par des états plus fins (initial, partiel, vide confirmé, erreur) pour afficher des aides et bloquer uniquement les actions réellement dépendantes d’une vie valide.

### Description
- Agrégation des sources : `mergeLifeRows` accepte désormais aussi le payload `essential` et fusionne `context.registry_lives`, `comparison.table` et `essential.selected_life` pour produire les lignes alimentant le sélecteur (`actions.js`).
- États de registre distingués : le dataset `registryState` est utilisé pour représenter `loading`, `partial`, `ready`, `empty` et `error`, et un message d’aide explicite `error` s’affiche quand toutes les sources échouent (`actions.js`).
- Conservation des options connues : `updateOperatorLifeOptions` préserve les options déjà présentes quand une actualisation partielle/erronée arrive, afin qu’un endpoint défaillant ne supprime pas les options apprises précédemment (`actions.js`).
- Chargements résilients : passage à `Promise.allSettled` pour les fetch partagés et calcul d’un `registryState` agrégé afin de propager l’état (ready/partial/error) aux vues (`dashboard-data.js`).
- Propagation côté vues : `render-cockpit.js` et `render-lives.js` calculent et transmettent `registryState` à `updateOperatorLifeOptions` et intègrent la vie sélectionnée du cockpit essentiel lors du merge (`render-cockpit.js`, `render-lives.js`).
- Tests étendus : `tests/test_dashboard_static_smoke.py` renforce les scénarios smoke pour simuler des pannes isolées de `/dashboard/context`, de la comparaison et de `/api/cockpit/essential`, et vérifie la conservation des options et l’état précis des boutons/actions.
- Fichiers modifiés : `src/singular/dashboard/static/actions.js`, `src/singular/dashboard/static/dashboard-data.js`, `src/singular/dashboard/static/render-cockpit.js`, `src/singular/dashboard/static/render-lives.js`, et `tests/test_dashboard_static_smoke.py`.

### Testing
- Exécution des tests smoke : `pytest -q tests/test_dashboard_static_smoke.py` — 11 passed (tous verts).
- Les modifications ont été exercées via les scénarios qui simulent échecs isolés des endpoints et la combinaison de sources, et les assertions couvrent la présence des options, l’ajout de la `selected_life` essentielle et l’état des boutons selon l’état agrégé du registre.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7754c02078832aab2dd1e9204b1bf3)