### PR TITLE
Make simulated Windows path handling host-safe and decouple platform policy for OpenAI persistence

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -43,10 +43,17 @@ _PATH_UNSUPPORTED_ERRORS = _path_unsupported_errors()
 def _safe_path(raw: str) -> Path:
     """Build a path safely across host/path-flavor mismatches."""
 
-    try:
-        return Path(raw)
-    except _PATH_UNSUPPORTED_ERRORS:
-        return _HOST_PATH_CLS(raw)
+    return _HOST_PATH_CLS(raw)
+
+
+def _is_windows_platform(platform_name: str | None = None) -> bool:
+    """Return whether Windows-specific persistence should be used.
+
+    ``platform_name`` makes platform policy independently testable without
+    changing ``os.name`` and therefore pathlib's choice of concrete path class.
+    """
+
+    return (os.name if platform_name is None else platform_name) == "nt"
 
 
 def _birth_alias_enabled() -> bool:
@@ -610,7 +617,13 @@ def _append_export_to_shell_profile(profile_path: Path, api_key: str) -> bool:
     return True
 
 
-def _configure_openai(api_key: str, *, shell_profile: str | None, test: bool) -> int:
+def _configure_openai(
+    api_key: str,
+    *,
+    shell_profile: str | None,
+    test: bool,
+    platform_name: str | None = None,
+) -> int:
     """Configure OPENAI_API_KEY for current platform and optionally test it."""
 
     warnings = _validate_openai_api_key(api_key)
@@ -624,13 +637,13 @@ def _configure_openai(api_key: str, *, shell_profile: str | None, test: bool) ->
     masked_key = _mask_api_key(api_key)
     print(f"✅ Clé OpenAI chargée (masquée): {masked_key}")
 
-    if os.name == "nt":
+    if _is_windows_platform(platform_name):
         _set_windows_user_env_var("OPENAI_API_KEY", api_key)
         print("✅ OPENAI_API_KEY enregistrée dans HKCU\\Environment.")
         print("➡️ Veuillez redémarrer PowerShell pour recharger l'environnement.")
     else:
         if shell_profile:
-            profile_path = Path(shell_profile)
+            profile_path = _safe_path(shell_profile)
             answer = input(
                 f"Confirmer l'écriture dans {profile_path.expanduser()} ? "
                 "Tapez OUI pour confirmer: "

--- a/src/singular/root_config.py
+++ b/src/singular/root_config.py
@@ -4,41 +4,37 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path, PosixPath
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 
 _CONFIG_DIRNAME = ".singular"
 _CONFIG_FILENAME = "config.json"
 _REGISTRY_ROOT_KEY = "registry_root"
+_HOST_PATH_CLS = type(Path())
 
 
 def _safe_path(raw: str) -> Path:
-    try:
-        return Path(raw)
-    except NotImplementedError:
-        # Handles tests that monkeypatch os.name to "nt" on non-Windows hosts.
-        return PosixPath(str(raw).replace("\\", "/"))
+    """Build a path with the native class selected when this module loaded."""
+
+    # pathlib selects Path's concrete class from os.name at call time.  Tests
+    # and embedders may simulate a platform, but that policy change must not
+    # cause construction of a path class unsupported by the actual host.
+    normalized = str(raw).replace("\\", "/") if os.name == "nt" else str(raw)
+    return _HOST_PATH_CLS(normalized)
 
 
 def default_registry_root() -> Path:
     """Return the documented fallback registry root."""
 
-    try:
-        home = Path.home()
-    except NotImplementedError:
-        home = _safe_path(os.path.expanduser("~"))
+    home = _HOST_PATH_CLS.home()
     return home / _CONFIG_DIRNAME
 
 
 def global_config_path() -> Path:
     """Return the global config file path."""
 
-    root = default_registry_root()
-    try:
-        return root / _CONFIG_FILENAME
-    except NotImplementedError:
-        return _safe_path(f"{root}/{_CONFIG_FILENAME}")
+    return default_registry_root() / _CONFIG_FILENAME
 
 
 def project_config_path(cwd: Path | None = None) -> Path:
@@ -47,14 +43,8 @@ def project_config_path(cwd: Path | None = None) -> Path:
     if cwd is not None:
         base = cwd
     else:
-        try:
-            base = Path.cwd()
-        except NotImplementedError:
-            base = _safe_path(os.getcwd())
-    try:
-        return base / _CONFIG_DIRNAME / _CONFIG_FILENAME
-    except NotImplementedError:
-        return _safe_path(f"{base}/{_CONFIG_DIRNAME}/{_CONFIG_FILENAME}")
+        base = _HOST_PATH_CLS.cwd()
+    return base / _CONFIG_DIRNAME / _CONFIG_FILENAME
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -68,8 +58,13 @@ def _load_json(path: Path) -> dict[str, Any]:
 def _decode_registry_root(raw: Any, *, base_dir: Path) -> Path | None:
     if not isinstance(raw, str) or not raw.strip():
         return None
-    configured = Path(raw).expanduser()
-    if not configured.is_absolute():
+    configured = _safe_path(raw).expanduser()
+    # When ``os.name`` is simulated as ``nt`` on a POSIX host, ``_safe_path``
+    # deliberately returns a host-native path.  Preserve the meaning of an
+    # absolute Windows value even though PosixPath does not recognise its
+    # drive/root syntax.
+    is_absolute = configured.is_absolute() or PureWindowsPath(raw).is_absolute()
+    if not is_absolute:
         configured = (base_dir / configured).resolve()
     return configured
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -40,7 +40,6 @@ def test_config_openai_empty_key_returns_error(monkeypatch, capsys) -> None:
 
 
 def test_config_openai_windows_writes_hkcu_environment(monkeypatch, capsys) -> None:
-    monkeypatch.setattr(cli.os, "name", "nt")
     store: dict[str, str] = {}
 
     class _FakeKey:
@@ -63,8 +62,11 @@ def test_config_openai_windows_writes_hkcu_environment(monkeypatch, capsys) -> N
     monkeypatch.setitem(cli.sys.modules, "winreg", fake_winreg)
 
     raw_key = "sk-win-secret-123456"
-    exit_code = cli.main(
-        ["--home", "/tmp/singular-life", "config", "openai", "--api-key", raw_key]
+    exit_code = cli._configure_openai(
+        raw_key,
+        shell_profile=None,
+        test=False,
+        platform_name="nt",
     )
 
     out = capsys.readouterr().out
@@ -73,6 +75,22 @@ def test_config_openai_windows_writes_hkcu_environment(monkeypatch, capsys) -> N
     assert "HKCU\\Environment" in out
     assert "redémarrer PowerShell" in out
     assert raw_key not in out
+
+
+def test_config_openai_simulated_windows_does_not_construct_windows_path(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(cli, "_set_windows_user_env_var", lambda *_args: None)
+
+    exit_code = cli._configure_openai(
+        "sk-win-secret-123456",
+        shell_profile=r"C:\\Users\\Ada\\profile",
+        test=False,
+        platform_name="nt",
+    )
+
+    assert exit_code == 0
+    assert "HKCU\\Environment" in capsys.readouterr().out
 
 
 def test_config_openai_shell_profile_append_with_confirmation(
@@ -178,7 +196,8 @@ def test_implicit_registry_root_windows_uses_path_for_env_value(monkeypatch) -> 
     root = cli._implicit_registry_root_from_env_or_default()
 
     assert isinstance(root, Path)
-    assert root == Path(r"C:\tmp\singular").expanduser()
+    assert root == cli._HOST_PATH_CLS(r"C:\tmp\singular").expanduser()
+    assert type(root) is cli._HOST_PATH_CLS
 
 
 def test_safe_path_windows_fallback_handles_unsupported_operation(monkeypatch) -> None:

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -1,0 +1,48 @@
+from pathlib import Path, PosixPath
+
+import singular.root_config as root_config
+
+
+def test_decode_relative_windows_separators_against_config_directory(
+    monkeypatch, tmp_path
+) -> None:
+    base_dir = tmp_path / ".singular"
+    monkeypatch.setattr(root_config.os, "name", "nt")
+
+    decoded = root_config._decode_registry_root(
+        r"roots\\project", base_dir=base_dir
+    )
+
+    assert decoded == (base_dir / "roots" / "project").resolve()
+    assert isinstance(decoded, PosixPath)
+
+
+def test_decode_absolute_windows_path_on_simulated_windows(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(root_config.os, "name", "nt")
+
+    decoded = root_config._decode_registry_root(
+        r"C:\\registry\\singular", base_dir=tmp_path / ".singular"
+    )
+
+    assert decoded == PosixPath("C:/registry/singular")
+    assert isinstance(decoded, PosixPath)
+
+
+def test_decode_relative_path_is_based_on_global_or_project_config(tmp_path) -> None:
+    global_dir = tmp_path / "home" / ".singular"
+    project_dir = tmp_path / "workspace" / ".singular"
+
+    assert root_config._decode_registry_root("registry", base_dir=global_dir) == (
+        global_dir / "registry"
+    ).resolve()
+    assert root_config._decode_registry_root("registry", base_dir=project_dir) == (
+        project_dir / "registry"
+    ).resolve()
+
+
+def test_decode_posix_absolute_path_is_not_rebased(tmp_path) -> None:
+    absolute = tmp_path / "registry"
+
+    assert root_config._decode_registry_root(
+        str(absolute), base_dir=tmp_path / "config"
+    ) == Path(absolute)


### PR DESCRIPTION
### Motivation

- Empêcher la construction de `WindowsPath` sur un hôte POSIX lorsque des tests ou des embedders simulent `os.name == "nt"` et conserver la résolution correcte des chemins relatifs par rapport aux fichiers de configuration.
- Séparer la décision d’utilisation des mécanismes de persistance Windows (HKCU) de la classe `pathlib.Path` en rendant la politique de plateforme testable et inject able.

### Description

- Capture la classe de chemin native à l’import (`_HOST_PATH_CLS`) et remplace les constructions directes de `Path(raw)` par des appels à `_safe_path` qui utilisent la classe hôte afin d’éviter d’instancier une classe de chemin incompatible avec l’hôte (fichiers modifiés: `src/singular/root_config.py`, `src/singular/cli.py`).
- Améliore `_decode_registry_root` pour normaliser les séparateurs Windows, utiliser `_safe_path(...).expanduser()` et reconnaître les chemins absolus Windows via `PureWindowsPath(raw).is_absolute()` tout en préservant le comportement de rebasing relatif vers le répertoire du fichier de config.
- Injecte une politique de plateforme testable pour la persistance OpenAI via la nouvelle fonction `_is_windows_platform(platform_name: str | None)` et un paramètre `platform_name` sur `_configure_openai`, et fait passer les chemins de profil shell par `_safe_path` avant toute écriture.
- Audite et adapte les helpers de résolution de configuration globale/projet pour utiliser la classe de chemin hôte pour `home` et `cwd`, évitant ainsi les constructions non natives lors d’une simulation de plateforme.
- Ajoute des tests couvrant les cas simulés Windows sans instancier `WindowsPath`, la reconnaissance des séparateurs Windows relatifs et absolus, et la logique de persistance OpenAI basée sur la plateforme (nouveau fichier `tests/test_root_config.py` et ajustements/tests supplémentaires dans `tests/test_cli_config.py`).

### Testing

- Exécuté: `pytest -q tests/test_cli_config.py tests/test_root_config.py` et tous les tests ciblés ont réussi (`19 passed`).
- Exécuté: contrôle de style `ruff` et vérification de diff/checks (vérifications locales de cohérence) qui sont passés sans signaler problèmes sur les fichiers modifiés.
- Tentative d’exécution de la suite complète `pytest -q` démarrée mais interrompue/produisant des échecs massifs non liés à ces changements (p. ex. sandbox sécurisé indisponible faute de Podman/Docker et états inter-tests préexistants), donc ces échecs sont hors-scope pour cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a775c0dc254832abfc8a94641eede81)