### PR TITLE
Unify the dashboard life status contract

### DIFF
--- a/docs/technical_life_status.md
+++ b/docs/technical_life_status.md
@@ -2,14 +2,35 @@
 
 Ce document définit la sémantique officielle du statut d'une **vie** dans Singular.
 
-## Source de vérité
+## Vocabulaire canonique et champs indépendants
 
-La source de vérité est le champ `status` de chaque entrée dans `lives/registry.json`.
+Deux sources de vérité indépendantes sont exposées; un endpoint ne change jamais
+la signification d'un champ:
 
-Valeurs supportées:
+- `registry_status` est l'état administratif du registre: `active`, `archived`,
+  `extinct`, `stopped` ou `unknown`;
+- `life_status` est le verdict biologique: `running`, `budget_exhausted`,
+  `degraded`, `mutation_paused`, `terminal`, `dead`, ou `null` lorsqu'aucun
+  verdict biologique n'a été calculé.
 
-- `active`: la vie est considérée active dans le registre.
-- `extinct`: la vie est marquée comme éteinte dans le registre.
+La table de lecture des anciennes valeurs est explicite:
+
+| ancienne valeur | `registry_status` | `life_status` |
+|---|---|---|
+| `degraded` | `active` | `degraded` |
+| `dead` | `extinct` | `dead` |
+| `archived` | `archived` | `null` |
+| `stopped` | `stopped` | `null` |
+
+`archived` et `stopped` ne constituent donc jamais une preuve de mort. Le code
+canonique et cette table résident dans `singular.life.life_status`.
+
+Chaque ligne de comparaison expose également `operator_actions`, une table de
+booléens calculée côté serveur. Pour un registre `active`, `archive`, `talk` et
+`emergency_stop` sont permis. Ils sont interdits pour tout autre état; les
+actions non exécutantes `lives_use`, `memorial` et `clone` restent permises. Le
+JavaScript consomme cette capacité et ne reconstruit pas ces règles depuis les
+libellés de statut.
 
 Ce statut est porté par `LifeMetadata.status` dans `src/singular/lives.py`, persisté via `save_registry()`, et modifié via `set_life_status()`.
 
@@ -26,7 +47,7 @@ Barème:
 - **Reproduction possible**: 10 points.
 - **Narration cohérente sur N jours**: 15 points, avec `N = thresholds.minimum_narrative_trajectory_days`.
 
-Les critères fondamentaux pour atteindre `alive` sont:
+Les critères fondamentaux pour atteindre `running` sont:
 
 - identité persistante,
 - registre de générations,
@@ -34,56 +55,31 @@ Les critères fondamentaux pour atteindre `alive` sont:
 - objectifs intrinsèques continus,
 - narration cohérente sur la durée minimale configurée.
 
-La reproduction possible contribue au score, mais n'est pas un critère bloquant pour `alive`.
+La reproduction possible contribue au score, mais n'est pas un critère bloquant pour `running`.
 
-## Statuts qualifiés par score
+## Statuts biologiques qualifiés
 
-Les statuts métier exposés par `configs/life_definition.yaml` sont:
-
-- `not_alive_yet`: score insuffisant ou au moins un signal fondamental absent.
-- `fragile`: score intermédiaire mais continuité incomplète.
-- `alive`: score supérieur ou égal au seuil `alive_minimum_score`, critères fondamentaux présents et aucun signal terminal.
-- `dying`: signal terminal présumé ou dégradation forte, mais extinction non confirmée.
-- `extinct`: autopsy présente, registre `extinct` ou événement `death` confirmé.
-
-Ordre de priorité recommandé:
-
-1. `extinct` si une extinction est confirmée (`autopsy.json` présent, registre `extinct`, ou événement `death` confirmé).
-2. `dying` si une dégradation forte est détectée sans confirmation d'extinction.
-3. `alive` si le score atteint le seuil `alive_minimum_score`, les critères fondamentaux sont présents et aucun signal terminal n'est observé.
-4. `fragile` si le score atteint le seuil `fragile_minimum_score`, mais que la continuité reste incomplète.
-5. `not_alive_yet` sinon.
-
-Les signaux terminaux dominent toujours le score: un score élevé ne peut pas produire `alive` si un signal terminal confirmé existe.
+Le calcul émet exclusivement les valeurs canoniques définies ci-dessus.
+L’ordre de priorité est: `dead` pour une extinction confirmée, `terminal` pour
+une terminalité sans preuve de mort, `budget_exhausted` ou `mutation_paused`
+pour ces suspensions explicites, `running` lorsque la checklist contractuelle
+est satisfaite, et `degraded` sinon. Un score élevé ne peut jamais masquer une
+preuve terminale.
 
 ## Distinction des notions
 
-Trois champs décrivent des niveaux différents et ne doivent pas être confondus:
+- `registry_status` décrit uniquement l’administration de la vie.
+- `vital_timeline.state` décrit la dynamique technique observée.
+- `life_status` décrit uniquement le verdict biologique contractuel.
+- `extinction_seen_in_runs` et `run_terminated` restent des observations de run.
 
-- **`registry.status`**: état administratif de la vie dans `lives/registry.json`. Les seules valeurs normatives du registre sont `active` et `extinct`. Ce champ indique si la vie reste administrativement active ou si son extinction a été confirmée et persistée.
-- **`vital_timeline.state`**: état vital déterministe calculé à partir des signaux techniques observables. Les valeurs exposées sont `mature`, `declining`, `terminal` et `extinct`. Ce champ décrit la dynamique vitale courante, sans remplacer la décision contractuelle.
-- **`life_status.status`**: verdict contractuel portable exposé aux interfaces CLI, dashboard et rapports. Les valeurs autorisées sont `not_alive_yet`, `fragile`, `alive`, `dying` et `extinct`. Ce verdict agrège le registre, la timeline vitale et la checklist contractuelle.
-
-Le dashboard distingue également:
-
-- **Vie sélectionnée**: correspond à la clé racine `active` du registre (`registry["active"]`).
-- **Vie active dans le registre**: correspond à `life.status == "active"`.
-- **Run terminé**: information de run-level (ex: dernier événement `death`).
-- **Extinction détectée**: information observée dans les événements de run (présence d'au moins un `event == "death"`).
-
-## Ordre de priorité du verdict contractuel
-
-Le calcul de `life_status.status` applique l'ordre de priorité suivant:
-
-1. **Extinction confirmée domine tout**: si une extinction est confirmée (`autopsy.json` présent, `registry.status == "extinct"` ou événement `death` confirmé), le verdict est `extinct`, quel que soit le score ou l'état vital intermédiaire.
-2. **Terminalité vitale produit `dying`**: si `vital_timeline.state == "terminal"` ou si un signal terminal fort est observé sans extinction confirmée, le verdict est `dying`.
-3. **Checklist contractuelle produit `not_alive_yet`, `fragile` ou `alive`**: en l'absence d'extinction confirmée et de terminalité vitale, les signaux contractuels configurés dans `configs/life_definition.yaml` déterminent le verdict selon les seuils et critères fondamentaux.
+Aucun de ces champs ne prend une autre signification selon l’endpoint.
 
 Exemple complet de payload `life_status`:
 
 ```json
 {
-  "status": "alive",
+  "status": "running",
   "score": 0.91,
   "explanation": "Identité persistante, cycle stable, objectifs intrinsèques et continuité narrative observés. Vital: état mature, risque low.",
   "signals": {

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -17,7 +17,7 @@ from urllib.parse import quote
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.staticfiles import StaticFiles
 from singular.lives import get_registry_root, load_registry, set_life_status
-from singular.life.life_status import compute_life_status
+from singular.life.life_status import compute_life_status, normalize_registry_status
 from singular.life.vital import compute_vital_timeline
 from singular.metrics.autonomy import compute_autonomy_metrics
 from singular.metrics.behavioral_regulation import compute_behavioral_regulation_metrics
@@ -228,7 +228,7 @@ def create_app(
 
     def _life_status(meta: object | None) -> str:
         status = life_meta_get(meta, "status", None)
-        return str(status or "unknown").strip().lower()
+        return normalize_registry_status(status)
 
     def _active_run_locks(life_dir: Path) -> list[str]:
         runs = life_dir / "runs"
@@ -2347,7 +2347,7 @@ def create_app(
         status_reconciliation = [
             {
                 "life": name,
-                "registry_status": payload.get("life_status"),
+                "registry_status": payload.get("registry_status"),
                 "extinction_seen_in_runs": payload.get("extinction_seen_in_runs"),
                 "suggestion": payload.get("status_reconciliation_suggestion"),
             }
@@ -2404,7 +2404,7 @@ def create_app(
                     {
                         "life": life_name,
                         "slug": slug,
-                        "from_status": payload.get("life_status"),
+                        "from_status": payload.get("registry_status"),
                         "to_status": "extinct",
                         "suggestion": suggestion,
                     }
@@ -2946,7 +2946,7 @@ def create_app(
         payload_status: dict[str, object] = {
             "life": target,
             "available": available,
-            "life_status": life_status,
+            "registry_status": life_status,
             "status": status,
             "message": "Utilisez POST avec un corps JSON pour envoyer un message.",
             "timestamp": datetime.now(timezone.utc).isoformat(),

--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -4,6 +4,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Callable
 from urllib.parse import quote
 
+from singular.life.life_status import (
+    legacy_life_status,
+    normalize_registry_status,
+    operator_action_capabilities,
+)
+
 
 _RECENT_ACTIVITY_EVENTS = {
     "mutation",
@@ -199,12 +205,8 @@ def life_trend_rank(trend: str) -> int:
 
 
 def normalize_life_status(value: object) -> str:
-    if not isinstance(value, str):
-        return "unknown"
-    normalized = value.strip().lower()
-    if normalized in {"active", "archived", "extinct", "dead", "stopped", "unknown"}:
-        return normalized
-    return "unknown"
+    """Deprecated compatibility name; registry values are administrative."""
+    return normalize_registry_status(value)
 
 
 def _status_is_dead(status: str) -> bool:
@@ -600,7 +602,13 @@ def aggregate_lives(
             "alerts_count": 0,
             "iterations": 0,
             "selected_life": is_selected,
-            "life_status": registry_status,
+            "registry_status": registry_status,
+            "life_status": legacy_life_status(
+                raw_meta.get("status")
+                if isinstance(raw_meta, dict)
+                else getattr(raw_meta, "status", None)
+            ),
+            "operator_actions": operator_action_capabilities(registry_status),
             "is_registry_active_life": registry_status == "active",
             "has_recent_activity": False,
             "extinction_seen_in_runs": is_extinct,
@@ -711,7 +719,7 @@ def aggregate_lives(
             registry_meta = registry_lives.get(slug)
             registry_status = normalize_life_status(getattr(registry_meta, "status", "active"))
         if registry_status == "unknown" and life_name in comparison:
-            registry_status = str(comparison[life_name].get("life_status", "unknown"))
+            registry_status = str(comparison[life_name].get("registry_status", "unknown"))
         extinction_seen = extinction_seen or _status_is_dead(registry_status)
         run_terminated = run_terminated or _status_is_terminated(registry_status)
         registry_run_status_inconsistency = (
@@ -748,7 +756,17 @@ def aggregate_lives(
             "alerts_count": len(alerts),
             "iterations": len(mutation_records),
             "selected_life": is_selected,
-            "life_status": registry_status,
+            "registry_status": registry_status,
+            "life_status": (
+                "dead"
+                if extinction_seen
+                else legacy_life_status(
+                    raw_meta.get("status")
+                    if isinstance(raw_meta, dict)
+                    else getattr(raw_meta, "status", None)
+                )
+            ),
+            "operator_actions": operator_action_capabilities(registry_status),
             "is_registry_active_life": registry_status == "active",
             "has_recent_activity": last_timestamp is not None,
             "extinction_seen_in_runs": extinction_seen,

--- a/src/singular/dashboard/services/metrics_contract.py
+++ b/src/singular/dashboard/services/metrics_contract.py
@@ -32,8 +32,9 @@ def build_life_counts(lives: dict[str, dict[str, Any]]) -> dict[str, int]:
             recent_activity_lives += 1
 
         life_status = payload.get("life_status")
+        registry_status = payload.get("registry_status")
         extinct_in_runs = bool(payload.get("extinction_seen_in_runs"))
-        if life_status == "extinct" or extinct_in_runs:
+        if life_status == "dead" or registry_status == "extinct" or extinct_in_runs:
             dead_lives += 1
 
     alive_lives = max(total_lives - dead_lives, 0)

--- a/src/singular/dashboard/static/actions.js
+++ b/src/singular/dashboard/static/actions.js
@@ -21,8 +21,6 @@ const selectedOperatorLife=()=>getSelectedLife()||readValue('operator-action-lif
 const operatorMessage=()=>readValue('operator-action-message','action-prompt');
 const birthName=()=>readValue('operator-birth-name','action-life-name');
 const normalizeLifeStatus=value=>String(value||'').trim().toLowerCase();
-const blockedOperatorActionStatuses=new Set(['archived','dead','extinct','stopped']);
-const statusBlocksOperatorAction=status=>blockedOperatorActionStatuses.has(normalizeLifeStatus(status));
 const statusLabel=status=>{
   const normalized=normalizeLifeStatus(status);
   if(normalized==='archived'){return 'archivée';}
@@ -84,6 +82,13 @@ const selectedOperatorLifeStatus=()=>{
   const option=[...select.options].find(candidate=>candidate.value===selected);
   return normalizeLifeStatus(option?.dataset?.lifeStatus);
 };
+const selectedOperatorCapabilities=()=>{
+  const select=operatorLifeSelect();
+  const selected=selectedOperatorLife();
+  if(!select||!selected){return {};}
+  const option=[...select.options].find(candidate=>candidate.value===selected);
+  try{return JSON.parse(option?.dataset?.operatorActions||'{}');}catch(_err){return {};}
+};
 
 export const updateOperatorActionState=()=>{
   syncOperatorSelectToShared();
@@ -91,7 +96,8 @@ export const updateOperatorActionState=()=>{
   const hasSelection=registryState==='valid';
   const selected=selectedOperatorLife();
   const selectedStatus=selectedOperatorLifeStatus();
-  const blocksOperatorActions=hasSelection&&statusBlocksOperatorAction(selectedStatus);
+  const capabilities=selectedOperatorCapabilities();
+  const blocksOperatorActions=hasSelection&&capabilities.talk!==true;
   const help=document.getElementById('operator-action-help');
   const helpMessages={
     loading:'Les données de vies n’ont pas encore chargé',
@@ -125,7 +131,7 @@ export const updateOperatorActionState=()=>{
   ].forEach(([id,action])=>{
     const button=document.getElementById(id);
     if(!button){return;}
-    const blockedByStatus=hasSelection&&requiresRunnableLife(action)&&blocksOperatorActions;
+    const blockedByStatus=hasSelection&&capabilities[action]!==true;
     const disabled=!hasSelection||blockedByStatus;
     button.disabled=disabled;
     button.classList.toggle('is-disabled',disabled);
@@ -187,7 +193,11 @@ export const updateOperatorLifeOptions=(rows=[],{registryState='empty'}={})=>{
   // Never let a failing/partial refresh erase lives learned from another source.
   if(registryState!=='empty'){
     for(const option of select.options){
-      if(option.value){rowByName.set(option.value,{life:option.value,status:option.dataset.lifeStatus});}
+      if(option.value){
+        let operatorActions={};
+        try{operatorActions=JSON.parse(option.dataset.operatorActions||'{}');}catch(_err){operatorActions={};}
+        rowByName.set(option.value,{life:option.value,registry_status:option.dataset.lifeStatus,operator_actions:operatorActions});
+      }
     }
   }
   for(const row of rows||[]){
@@ -206,7 +216,8 @@ export const updateOperatorLifeOptions=(rows=[],{registryState='empty'}={})=>{
     option.value=name;
     option.textContent=name;
     const row=rowByName.get(name);
-    option.dataset.lifeStatus=normalizeLifeStatus(row?.life_status||row?.registry_status||row?.status);
+    option.dataset.lifeStatus=normalizeLifeStatus(row?.registry_status||row?.status);
+    option.dataset.operatorActions=JSON.stringify(row?.operator_actions||{});
     select.appendChild(option);
   }
   const shared=getSelectedLife();
@@ -286,7 +297,7 @@ const validateAction=(action,payload)=>{
     return 'Sélectionnez une vie valide dans le sélecteur opérateur avant de lancer cette action.';
   }
   const selectedStatus=selectedOperatorLifeStatus();
-  if(requiresRunnableLife(action)&&statusBlocksOperatorAction(selectedStatus)){
+  if(requiresRunnableLife(action)&&selectedOperatorCapabilities()[action]!==true){
     return `Action ${action} indisponible: la vie sélectionnée est ${statusLabel(selectedStatus)}.`;
   }
   if(action==='talk'&&!payload.prompt){

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -207,7 +207,7 @@ const extractEnergy=(row,eco)=>{
 };
 
 const hasAnyRun=rows=>(rows||[]).some(row=>row.last_activity||Number(row.iterations||0)>0||row.run_id||row.latest_run_id);
-const isArchived=row=>String(row?.life_status||row?.registry_status||row?.status||'').toLowerCase().includes('archiv');
+const isArchived=row=>String(row?.registry_status||row?.status||'').toLowerCase().includes('archiv');
 const isStaleSummary=()=>staleTimeoutTasks.has('cockpit')||staleTimeoutTasks.has('lives')||staleTimeoutTasks.has('context')||staleTimeoutTasks.has('ecosystem');
 const extractLastMessage=row=>firstDefined(row?.last_message,row?.latest_message,row?.conversation?.last_message,row?.chat?.last_message);
 const activeObjectivesCount=(cockpit,workItems)=>{
@@ -293,7 +293,7 @@ const renderOperatorSummary=()=>{
   const energyLabel=energy===null||energy===undefined?na():formatOneDecimal(energy);
   const trend=focus?.trend||cockpit.trend||na();
   const liveness=firstDefined(focus?.life_liveness_index,cockpit.life_liveness_index,cockpit.liveness_index);
-  const status=isArchived(focus)?'vie archivée':(focus?.life_status||focus?.registry_status||focus?.status||(total>0?'vie créée':'aucune vie créée'));
+  const status=isArchived(focus)?'vie archivée':(focus?.registry_status||focus?.status||(total>0?'vie créée':'aucune vie créée'));
   const health=firstDefined(focus?.current_health_score,cockpit.health_score);
   const objectivesCount=activeObjectivesCount(cockpit,workItems);
   const lastMessage=extractLastMessage(focus)||workItems?.conversations?.items?.[0]?.title||'aucun message';

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -42,6 +42,71 @@ class LifeStatus(str, Enum):
 AUTHORIZED_LIFE_STATUSES: tuple[str, ...] = tuple(status.value for status in LifeStatus)
 
 
+class RegistryStatus(str, Enum):
+    """Administrative states persisted in the lives registry.
+
+    A registry state is deliberately not a biological verdict.  In particular,
+    archiving or stopping a life does not prove that it is dead.
+    """
+
+    ACTIVE = "active"
+    ARCHIVED = "archived"
+    EXTINCT = "extinct"
+    STOPPED = "stopped"
+    UNKNOWN = "unknown"
+
+
+AUTHORIZED_REGISTRY_STATUSES: tuple[str, ...] = tuple(
+    status.value for status in RegistryStatus
+)
+
+# Read-old/write-new conversion table.  Both target columns are present so a
+# caller can never accidentally interpret an administrative value as biology.
+# ``None`` means that the legacy value contains no biological information.
+LEGACY_STATUS_CONVERSIONS: dict[str, dict[str, str | None]] = {
+    "degraded": {"registry_status": "active", "life_status": "degraded"},
+    "dead": {"registry_status": "extinct", "life_status": "dead"},
+    "archived": {"registry_status": "archived", "life_status": None},
+    "stopped": {"registry_status": "stopped", "life_status": None},
+}
+
+OPERATOR_ACTIONS: tuple[str, ...] = (
+    "archive", "talk", "emergency_stop", "lives_use", "memorial", "clone"
+)
+_RUNNABLE_OPERATOR_ACTIONS = frozenset({"archive", "talk", "emergency_stop"})
+
+
+def normalize_registry_status(value: object) -> str:
+    """Normalize registry input without returning a biological status."""
+
+    normalized = str(value or "unknown").strip().lower()
+    if normalized in AUTHORIZED_REGISTRY_STATUSES:
+        return normalized
+    conversion = LEGACY_STATUS_CONVERSIONS.get(normalized)
+    return str(conversion["registry_status"]) if conversion else "unknown"
+
+
+def legacy_life_status(value: object) -> str | None:
+    """Extract a biological verdict only when a legacy value actually has one."""
+
+    normalized = str(value or "").strip().lower()
+    if normalized in AUTHORIZED_LIFE_STATUSES:
+        return normalized
+    conversion = LEGACY_STATUS_CONVERSIONS.get(normalized)
+    return conversion["life_status"] if conversion else None
+
+
+def operator_action_capabilities(registry_status: object) -> dict[str, bool]:
+    """Return the single server-side capability contract consumed by the UI."""
+
+    status = normalize_registry_status(registry_status)
+    runnable = status == RegistryStatus.ACTIVE.value
+    return {
+        action: runnable or action not in _RUNNABLE_OPERATOR_ACTIONS
+        for action in OPERATOR_ACTIONS
+    }
+
+
 def _status_value(status: LifeStatus | str) -> str:
     return status.value if isinstance(status, LifeStatus) else str(status)
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -783,12 +783,12 @@ def test_dashboard_cockpit_life_status_uses_extinct_registry_status(
     client = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
 
     payload = client.get("/api/cockpit").json()
-    assert payload["life_status"] == "extinct"
+    assert payload["life_status"] == "dead"
     assert isinstance(payload["life_status_score"], float)
     assert payload["life_status_signals"].get("extinction") is True
 
     essential_payload = client.get("/api/cockpit/essential").json()
-    assert essential_payload["life_status"] == "extinct"
+    assert essential_payload["life_status"] == "dead"
     assert essential_payload["life_status_score"] == payload["life_status_score"]
 
 
@@ -1492,17 +1492,21 @@ def test_lives_comparison_table_aggregation_filters_and_sorting(
     assert [row["life"] for row in table] == ["life-c", "life-a", "life-b"]
     assert payload["lives"]["life-a"]["trend"] == "dégradation"
     assert payload["lives"]["life-a"]["selected_life"] is False
-    assert payload["lives"]["life-a"]["life_status"] == "active"
+    assert payload["lives"]["life-a"]["registry_status"] == "active"
+    assert payload["lives"]["life-a"]["life_status"] is None
+    assert payload["lives"]["life-a"]["operator_actions"]["talk"] is True
     assert payload["lives"]["life-a"]["is_registry_active_life"] is True
     assert payload["lives"]["life-a"]["extinction_seen_in_runs"] is False
     assert payload["lives"]["life-a"]["iterations"] == 2
     assert isinstance(payload["lives"]["life-a"]["alerts_count"], int)
     assert payload["lives"]["life-b"]["selected_life"] is False
-    assert payload["lives"]["life-b"]["life_status"] == "extinct"
+    assert payload["lives"]["life-b"]["registry_status"] == "extinct"
+    assert payload["lives"]["life-b"]["life_status"] == "dead"
+    assert payload["lives"]["life-b"]["operator_actions"]["talk"] is False
     assert payload["lives"]["life-b"]["is_registry_active_life"] is False
     assert payload["lives"]["life-b"]["extinction_seen_in_runs"] is True
     assert payload["lives"]["life-c"]["selected_life"] is True
-    assert payload["lives"]["life-c"]["life_status"] == "active"
+    assert payload["lives"]["life-c"]["registry_status"] == "active"
     assert payload["lives"]["life-c"]["stability"] == 0.99
 
     active_only = route(active_only=True)["table"]
@@ -2371,7 +2375,8 @@ def test_lives_comparison_get_does_not_reconcile_registry_silently(
 
     assert before == between == after
     assert json.loads(after)["lives"]["alpha"]["status"] == "active"
-    assert first_payload["lives"]["alpha"]["life_status"] == "active"
+    assert first_payload["lives"]["alpha"]["registry_status"] == "active"
+    assert first_payload["lives"]["alpha"]["life_status"] == "dead"
     assert first_payload["lives"]["alpha"]["extinction_seen_in_runs"] is True
     assert first_payload["lives"]["alpha"]["registry_run_status_inconsistency"] is True
     assert first_payload["lives"]["alpha"]["status_reconciliation_suggestion"] == "mark_extinct"
@@ -2473,7 +2478,7 @@ def test_chat_get_reports_status_without_running_chat(
 
     assert response["life"] == "alpha"
     assert response["available"] is True
-    assert response["life_status"] == "active"
+    assert response["registry_status"] == "active"
     assert response["status"] == "ready"
     assert response["message"] == "Utilisez POST avec un corps JSON pour envoyer un message."
 

--- a/tests/test_dashboard_smoke_e2e.py
+++ b/tests/test_dashboard_smoke_e2e.py
@@ -322,11 +322,12 @@ def test_smoke_dashboard_e2e_capacites_critiques(
     assert str(cockpit_payload["run"]).startswith(run_id)
     assert "accepted_mutation_rate" in cockpit_payload
     assert cockpit_payload["life_status"] in {
-        "not_alive_yet",
-        "fragile",
-        "alive",
-        "dying",
-        "extinct",
+        "running",
+        "budget_exhausted",
+        "degraded",
+        "mutation_paused",
+        "terminal",
+        "dead",
     }
     assert isinstance(cockpit_payload["life_status_score"], float)
     assert isinstance(cockpit_payload["life_status_explanation"], str)
@@ -565,11 +566,12 @@ def test_active_tmp_run_feeds_dashboard_endpoints(
     assert cockpit["vital_metrics"]["energy_resources"]["total_energy"] > 0
     assert cockpit["life_metrics_contract"]["counts"]["total_lives"] >= 2
     assert cockpit["life_status"] in {
-        "not_alive_yet",
-        "fragile",
-        "alive",
-        "dying",
-        "extinct",
+        "running",
+        "budget_exhausted",
+        "degraded",
+        "mutation_paused",
+        "terminal",
+        "dead",
     }
     assert isinstance(cockpit["life_status_score"], float)
     assert isinstance(cockpit["life_status_explanation"], str)

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -720,7 +720,7 @@ for (const [label, button] of [['archive', archive], ['talk', talk], ['emergency
 }}
 
 // A context failure must not hide a life supplied by comparison.
-updateOperatorLifeOptions(mergeLifeRows({{}}, {{table: [{{life: 'comparison-life', life_status: 'active'}}]}}, {{}}), {{registryState: 'partial'}});
+updateOperatorLifeOptions(mergeLifeRows({{}}, {{table: [{{life: 'comparison-life', registry_status: 'active', operator_actions: {{archive: true, talk: true, emergency_stop: true, lives_use: true}}}}]}}, {{}}), {{registryState: 'partial'}});
 if (![...elements.get('operator-action-life-select').options].some(option => option.value === 'comparison-life')) {{
   throw new Error('comparison life missing after isolated /dashboard/context failure');
 }}
@@ -822,7 +822,7 @@ globalThis.CustomEvent = class CustomEvent {{ constructor(type, init) {{ this.ty
 
 const {{ updateOperatorLifeOptions }} = await import('{module_path}');
 for (const [life, status, expectedLabel] of [['beta', 'archived', 'vie archivée'], ['gamma', 'dead', 'vie morte'], ['omega', 'extinct', 'vie morte'], ['delta', 'stopped', 'vie arrêtée']]) {{
-  updateOperatorLifeOptions([{{ life, life_status: status, selected_life: true }}]);
+  updateOperatorLifeOptions([{{ life, registry_status: status === 'dead' ? 'extinct' : status, life_status: status === 'dead' ? 'dead' : null, selected_life: true, operator_actions: {{archive: false, talk: false, emergency_stop: false, lives_use: true, memorial: true, clone: true}} }}]);
   for (const [label, button] of [['critical archive', criticalArchive], ['critical talk', criticalTalk], ['critical emergency', criticalEmergency], ['archive', archive], ['talk', talk]]) {{
     if (!button.disabled) {{ throw new Error(`${{label}} should be disabled for ${{status}} life`); }}
     if (button.getAttribute('aria-disabled') !== 'true') {{ throw new Error(`${{label}} aria-disabled missing`); }}

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -6,9 +6,11 @@ import pytest
 from singular.life.life_definition import LifeDefinitionConfig, LifeThresholds
 from singular.life.life_status import (
     AUTHORIZED_LIFE_STATUSES,
+    LEGACY_STATUS_CONVERSIONS,
     LifeStatus,
     LifeStatusResult,
     _failure_streak,
+    operator_action_capabilities,
 )
 
 
@@ -37,6 +39,18 @@ def test_authorized_life_statuses_are_stable_contract() -> None:
         "terminal",
         "dead",
     )
+
+
+def test_legacy_status_conversion_keeps_registry_and_biology_separate() -> None:
+    assert LEGACY_STATUS_CONVERSIONS == {
+        "degraded": {"registry_status": "active", "life_status": "degraded"},
+        "dead": {"registry_status": "extinct", "life_status": "dead"},
+        "archived": {"registry_status": "archived", "life_status": None},
+        "stopped": {"registry_status": "stopped", "life_status": None},
+    }
+    assert operator_action_capabilities("active")["talk"] is True
+    assert operator_action_capabilities("archived")["talk"] is False
+    assert operator_action_capabilities("archived")["memorial"] is True
 
 
 def test_life_status_result_to_payload_serializes_portable_contract() -> None:


### PR DESCRIPTION
### Motivation

- Clarify and canonicalize the distinction between administrative registry state and the biological verdict so the same field never changes meaning across endpoints. 
- Provide an explicit conversion table for legacy `degraded`, `dead`, `archived` and `stopped` values to avoid silent semantic shifts when reading older registries.
- Centralize operator action permissions server-side and expose them in the comparison payload so the UI consumes a single capability contract instead of re-deriving rules in JavaScript.

### Description

- Add canonical registry vocabulary and migration helpers in `src/singular/life/life_status.py` by introducing `RegistryStatus`, `LEGACY_STATUS_CONVERSIONS`, `normalize_registry_status`, `legacy_life_status` and `operator_action_capabilities`.
- Update the lives comparison service in `src/singular/dashboard/services/lives_comparison.py` to emit both `registry_status` and a nullable `life_status` (biological verdict), include `operator_actions` in each life entry, and to use the new normalization/conversion helpers.
- Adjust metrics aggregation in `src/singular/dashboard/services/metrics_contract.py` to count dead lives from the combined signals (`life_status == "dead"` or `registry_status == "extinct"` or extinction seen in runs).
- Make dashboard server code consume canonical registry status via `normalize_registry_status` and expose `registry_status` in endpoints such as `/api/lives/{life}/chat` and status reconciliation flows in `src/singular/dashboard/__init__.py`.
- Change static JS in `src/singular/dashboard/static/actions.js` and `src/singular/dashboard/static/render-cockpit.js` to read `registry_status` and the server-provided `operator_actions` dataset rather than re-inferring permitted actions from textual status labels.
- Update documentation `docs/technical_life_status.md` to describe the two independent fields, the legacy conversion table, and the server-side `operator_actions` contract.
- Update tests to match the unified contract in `tests/test_dashboard.py`, `tests/test_dashboard_smoke_e2e.py`, `tests/test_dashboard_static_smoke.py` and `tests/test_life_status.py`.

### Testing

- Ran a quick bytecode check with `python -m compileall -q src/singular/life/life_status.py src/singular/dashboard` which completed without errors.
- Executed dashboard and life-status test suites: `pytest -q tests/test_life_status.py tests/test_dashboard_static_smoke.py tests/test_dashboard_smoke_e2e.py` (ran successfully: tests passed; small number of tests skipped as expected in that context).
- Executed focused dashboard tests with `pytest -q tests/test_dashboard.py -k "life_status or lives_comparison or chat_get or metrics_contract"` which passed for the modified assertions.
- Verified static JS smoke tests and updated Python tests; the modified tests referencing the new payload fields and operator capability table passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a775e6b8a34832a8dd12f2e609f49aa)