### PR TITLE
Expose explicit LLM provider availability states (ready / degraded_dummy / unavailable)

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -686,12 +686,17 @@ def _doctor_providers() -> int:
         ok = bool(result.get("ok"))
         if not ok:
             exit_code = 1
-        status = "✅ ok" if ok else "⚠️ indisponible"
+        provider_state = str(result.get("state") or ("ready" if ok else "unavailable"))
+        status = {
+            "ready": "✅ ready",
+            "degraded_dummy": "⚠️ degraded_dummy (réponse déterministe/factice)",
+            "unavailable": "⚠️ unavailable",
+        }.get(provider_state, f"⚠️ {provider_state}")
         provider = result.get("provider", "inconnu")
         llm_real = str(bool(result.get("llm_real"))).lower()
         error_category = result.get("error_category") or "none"
         details = []
-        for key in ("model", "host", "error"):
+        for key in ("model", "host", "cause", "error"):
             value = result.get(key)
             if value:
                 details.append(f"{key}={value}")
@@ -699,6 +704,9 @@ def _doctor_providers() -> int:
         print(
             f"- {provider}: {status} | llm_real={llm_real} | error_category={error_category}{suffix}"
         )
+        command = result.get("configuration_command")
+        if command:
+            print(f"  Configuration: `{command}`")
     return exit_code
 
 

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -23,6 +23,7 @@ from singular.metrics.autonomy import compute_autonomy_metrics
 from singular.metrics.behavioral_regulation import compute_behavioral_regulation_metrics
 from singular.memory import read_causal_timeline, read_episodes, read_skills
 from singular.storage_retention import retention_status_snapshot
+from singular.providers import provider_diagnostics
 
 from singular.dashboard.actions import DashboardActionService
 from singular.governance.policy import load_runtime_policy
@@ -2024,6 +2025,7 @@ def create_app(
             "policy_impact": policy.impact_summary(),
             "skills_lifecycle": _skill_lifecycle_summary(),
             "retention": retention,
+            "llm_providers": provider_diagnostics(),
         }
 
     @app.get("/api/retention/status")

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -424,6 +424,20 @@ export const loadContext=()=>Promise.all([
   setText('ctx-root',ctx.singular_root||na());
   setText('ctx-home',ctx.singular_home||na());
   setText('ctx-lives-count',String(ctx.registry_lives_count||0));
+  const providerDiagnostic=ctx.llm_providers||{};
+  const providerAlert=byId('llm-provider-alert');
+  if(providerAlert){
+    const state=String(providerDiagnostic.state||'unavailable');
+    if(state==='ready'){
+      providerAlert.classList.add('panel-hidden');providerAlert.textContent='';
+    }else{
+      const details=(providerDiagnostic.providers||[]).map(item=>`${item.provider}: ${item.cause||item.state}${item.configuration_command?` — ${item.configuration_command}`:''}`).join(' · ');
+      providerAlert.textContent=state==='degraded_dummy'
+        ? `LLM degraded_dummy : les réponses sont déterministes/factices. ${details}`
+        : `LLM unavailable : aucun fournisseur de langage n'est disponible. ${details}`;
+      providerAlert.classList.remove('panel-hidden');
+    }
+  }
   const policy=ctx.policy||{};
   const autonomy=policy.autonomy||{};
   const permissions=policy.permissions||{};

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -71,6 +71,7 @@
 <div id='critical-action-result' class='critical-action-result' role='status' aria-live='polite'>Aucune action critique exécutée.</div>
 
 <div id='stale-data-banner' class='stale-banner panel-hidden' role='status' aria-live='polite'></div>
+<div id='llm-provider-alert' class='stale-banner panel-hidden' role='status' aria-live='polite'></div>
 
 <section id='tab-decider-maintenant' class='tab-pane' role='tabpanel' aria-labelledby='tab-btn-decider'>
   <div class='intro-box'>

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -30,6 +30,7 @@ from ..providers import (
     ProviderRetryExhaustedError,
     ProviderTimeoutError,
     ProviderUnavailableError,
+    PROVIDER_CONFIGURATION_COMMANDS,
     describe_client,
     load_llm_client,
     provider_is_real,
@@ -49,7 +50,7 @@ def _default_reply(prompt: str, rng: random.Random) -> str:
         "You said",
         "Echoing",
     ]
-    return f"{rng.choice(options)}: {prompt}"
+    return f"[RÉPONSE DÉTERMINISTE/FACTICE — aucun LLM réel] {rng.choice(options)}: {prompt}"
 
 
 def _user_message_for_error(provider: str, err: LLMProviderError) -> str:
@@ -182,7 +183,11 @@ def talk(
 ) -> str | None:
     """Handle the ``talk`` subcommand."""
 
-    life_root = Path(life_home) if life_home is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    life_root = (
+        Path(life_home)
+        if life_home is not None
+        else Path(os.environ.get("SINGULAR_HOME", "."))
+    )
     mem_dir = life_root / "mem"
     episodic_file = mem_dir / "episodic.jsonl"
     causal_file = mem_dir / "causal_timeline.jsonl"
@@ -193,10 +198,9 @@ def talk(
     # Human dialogue is eligible for teaching only through a separate,
     # structured and explicitly consented demonstration payload.
     if demonstration is not None:
-        (
-            imitation_engine
-            or ImitationEngine(life_root)
-        ).ingest_interaction(demonstration, source="human:talk")
+        (imitation_engine or ImitationEngine(life_root)).ingest_interaction(
+            demonstration, source="human:talk"
+        )
 
     rng = random.Random(seed)
 
@@ -225,9 +229,9 @@ def talk(
 
     psyche = Psyche.load_state(psyche_file)
 
-    def gather_context() -> tuple[
-        str | None, dict | None, dict | None, str | None, str | None
-    ]:
+    def gather_context() -> (
+        tuple[str | None, dict | None, dict | None, str | None, str | None]
+    ):
         signals = capture_signals()
         add_episode({"event": "perception", **signals}, path=episodic_file)
         psyche.consume()
@@ -317,7 +321,8 @@ def talk(
                     "query": user_input,
                     "memories": recalled_memories,
                     "summary": recall_summary,
-                }, path=episodic_file
+                },
+                path=episodic_file,
             )
             add_episode(
                 {
@@ -326,9 +331,13 @@ def talk(
                     "decision": "assistant_reply",
                     "memories": recalled_memories,
                     "summary": recall_summary,
-                }, path=episodic_file
+                },
+                path=episodic_file,
             )
-        add_episode({"role": "user", "text": user_input, "structured_signals": user_signals}, path=episodic_file)
+        add_episode(
+            {"role": "user", "text": user_input, "structured_signals": user_signals},
+            path=episodic_file,
+        )
         mood = psyche.feel(Mood.NEUTRAL)
         mood_report = mood_event or mood.value
         system_preamble = _build_system_preamble(
@@ -344,6 +353,7 @@ def talk(
         error_category: str | None = "provider_missing" if client is None else None
         active_provider = str(provider_status["active_provider"])
         llm_real = bool(provider_status["llm_real"]) and not fallback_used
+        provider_state = "unavailable" if client is None else "ready"
 
         if client is None:
             print(
@@ -358,6 +368,7 @@ def talk(
                 fallback_used = True
                 llm_real = False
                 error_category = getattr(err, "category", "provider_error")
+                provider_state = "unavailable"
                 print(_user_message_for_error(provider_selection, err))
                 print(
                     f"LLM status: active={active_provider} fallback=true "
@@ -378,6 +389,24 @@ def talk(
                     fallback_used = False
                     error_category = None
                 llm_real = provider_is_real(active_provider)
+                if not llm_real:
+                    provider_state = "degraded_dummy"
+                    reply = f"[RÉPONSE DÉTERMINISTE/FACTICE — provider dummy] {reply}"
+                    fallback_used = True
+                    print(
+                        "Aucun fournisseur LLM réel n'est disponible; le provider "
+                        "dummy produit uniquement un écho factice."
+                    )
+                if isinstance(client, FallbackLLMClient):
+                    for failure in client.last_errors:
+                        command = PROVIDER_CONFIGURATION_COMMANDS.get(
+                            failure["provider"]
+                        )
+                        print(
+                            f"Cause {failure['provider']}: {failure['category']} — "
+                            f"{failure['error']}"
+                            + (f" | Configuration: `{command}`" if command else "")
+                        )
                 print(
                     f"LLM status: active={active_provider} "
                     f"fallback={str(fallback_used).lower()} "
@@ -422,6 +451,7 @@ def talk(
                 "active_provider": active_provider,
                 "fallback_used": fallback_used,
                 "error_category": error_category,
+                "provider_state": provider_state,
                 "structured_signals": user_signals,
                 "context": {
                     "self_narrative_version": self_narrative_version,
@@ -431,14 +461,17 @@ def talk(
                     "recalled_memories": recalled_memories,
                     "recalled_memory_summary": recall_summary,
                 },
-            }, path=episodic_file
+            },
+            path=episodic_file,
         )
         gain_estimate = round(
             float(user_signals.get("satisfaction", 0.0))
             - float(user_signals.get("frustration", 0.0)),
             3,
         )
-        cognitive_success = llm_real and not fallback_used
+        # A real provider reached through the fallback chain is still real;
+        # dummy/echo output, however, must never improve cognitive metrics.
+        cognitive_success = llm_real
         cognitive_gain = gain_estimate if cognitive_success else 0.0
         add_causal_trace(
             {
@@ -459,6 +492,7 @@ def talk(
                     "fallback_used": fallback_used,
                     "error_category": error_category,
                     "llm_real": llm_real,
+                    "provider_state": provider_state,
                     "mood": mood_report,
                     "recalled_memory_summary": recall_summary,
                     "recalled_memories": recalled_memories,
@@ -476,7 +510,8 @@ def talk(
                         "impact": cognitive_gain,
                     },
                 },
-            }, path=causal_file
+            },
+            path=causal_file,
         )
         psyche.gain()
         psyche.save_state(psyche_file)

--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -15,6 +15,13 @@ DEFAULT_PROVIDER_MAX_RETRIES = 2
 # local backend, before trying the remote OpenAI service and deterministic dummy.
 DEFAULT_FALLBACK_CHAIN = ("ollama", "local", "openai", "dummy")
 
+PROVIDER_CONFIGURATION_COMMANDS = {
+    "openai": "singular config openai",
+    "ollama": "ollama serve",
+    "local": "singular config providers doctor",
+    "dummy": "singular config providers doctor",
+}
+
 
 class LLMProviderError(RuntimeError):
     """Base class for provider-facing errors."""
@@ -202,22 +209,29 @@ def describe_client(
         if isinstance(client, FallbackLLMClient)
         else ([client.name] if client else [])
     )
+    has_real = (
+        any(provider_is_real(name) for name in chain)
+        if chain
+        else provider_is_real(active)
+    )
+    state = (
+        "ready"
+        if has_real
+        else ("degraded_dummy" if active.lower() == "dummy" else "unavailable")
+    )
     return {
         "requested_provider": requested,
         "active_provider": active,
         "provider_chain": chain,
-        "llm_real": (
-            any(provider_is_real(name) for name in chain)
-            if chain
-            else provider_is_real(active)
-        ),
+        "llm_real": has_real,
+        "state": state,
     }
 
 
 def doctor_providers(names: list[str] | None = None) -> list[dict[str, Any]]:
     """Healthcheck configured providers without issuing a conversational success signal."""
 
-    provider_names = names or ["openai", "ollama", "local"]
+    provider_names = names or ["openai", "ollama", "local", "dummy"]
     results: list[dict[str, Any]] = []
     for name in provider_names:
         try:
@@ -229,18 +243,43 @@ def doctor_providers(names: list[str] | None = None) -> list[dict[str, Any]]:
                         "ok": False,
                         "llm_real": provider_is_real(name),
                         "error_category": "provider_missing",
+                        "state": "unavailable",
+                        "configuration_command": PROVIDER_CONFIGURATION_COMMANDS.get(
+                            name
+                        ),
+                        "cause": "provider implementation not installed",
                     }
                 )
                 continue
             status = contract.healthcheck()
             ok = bool(status.get("ok"))
+            real = provider_is_real(name)
+            state = (
+                "ready" if ok and real else ("degraded_dummy" if ok else "unavailable")
+            )
+            error = status.get("error")
+            category = (
+                None
+                if ok
+                else (
+                    "misconfigured"
+                    if isinstance(error, str)
+                    and (
+                        "missing" in error.lower() or "not configured" in error.lower()
+                    )
+                    else "unavailable"
+                )
+            )
             results.append(
                 {
                     **status,
                     "provider": str(status.get("provider") or name),
                     "ok": ok,
-                    "llm_real": provider_is_real(name),
-                    "error_category": None if ok else "unavailable",
+                    "llm_real": real,
+                    "error_category": category,
+                    "state": state,
+                    "configuration_command": PROVIDER_CONFIGURATION_COMMANDS.get(name),
+                    "cause": None if ok else str(error or "healthcheck failed"),
                 }
             )
         except LLMProviderError as exc:
@@ -251,9 +290,43 @@ def doctor_providers(names: list[str] | None = None) -> list[dict[str, Any]]:
                     "llm_real": provider_is_real(name),
                     "error_category": getattr(exc, "category", "provider_error"),
                     "error": str(exc),
+                    "state": "unavailable",
+                    "configuration_command": PROVIDER_CONFIGURATION_COMMANDS.get(name),
+                    "cause": str(exc),
+                }
+            )
+        except Exception as exc:  # defensive: diagnostics must report every provider
+            results.append(
+                {
+                    "provider": name,
+                    "ok": False,
+                    "llm_real": False,
+                    "error_category": "unavailable",
+                    "error": str(exc),
+                    "state": "unavailable",
+                    "configuration_command": PROVIDER_CONFIGURATION_COMMANDS.get(name),
+                    "cause": str(exc),
                 }
             )
     return results
+
+
+def provider_diagnostics(names: list[str] | None = None) -> dict[str, Any]:
+    """Return provider details and the effective three-state LLM availability."""
+
+    providers = doctor_providers(names)
+    if any(item["state"] == "ready" for item in providers):
+        state = "ready"
+    elif any(item["state"] == "degraded_dummy" for item in providers):
+        state = "degraded_dummy"
+    else:
+        state = "unavailable"
+    return {
+        "state": state,
+        "llm_real": state == "ready",
+        "deterministic_fake": state == "degraded_dummy",
+        "providers": providers,
+    }
 
 
 def _invoke_provider(fn: Callable[..., Any], **kwargs: Any) -> Any:

--- a/tests/providers/test_provider_doctor.py
+++ b/tests/providers/test_provider_doctor.py
@@ -1,5 +1,10 @@
 import singular.providers as providers
-from singular.providers import LLMProviderContract, doctor_providers, provider_is_real
+from singular.providers import (
+    LLMProviderContract,
+    doctor_providers,
+    provider_diagnostics,
+    provider_is_real,
+)
 
 
 def test_provider_is_real_excludes_offline_stubs():
@@ -15,14 +20,10 @@ def test_doctor_providers_reports_missing_provider_category(monkeypatch):
 
     results = doctor_providers(["openai"])
 
-    assert results == [
-        {
-            "provider": "openai",
-            "ok": False,
-            "llm_real": True,
-            "error_category": "provider_missing",
-        }
-    ]
+    assert results[0]["provider"] == "openai"
+    assert results[0]["state"] == "unavailable"
+    assert results[0]["error_category"] == "provider_missing"
+    assert results[0]["configuration_command"] == "singular config openai"
 
 
 def test_doctor_providers_normalizes_healthcheck_failures(monkeypatch):
@@ -41,3 +42,69 @@ def test_doctor_providers_normalizes_healthcheck_failures(monkeypatch):
     assert result["ok"] is False
     assert result["llm_real"] is True
     assert result["error_category"] == "unavailable"
+    assert result["state"] == "unavailable"
+    assert result["cause"] == "offline"
+
+
+def test_diagnostics_distinguish_dummy_and_real_provider_restoration(monkeypatch):
+    contracts = {
+        "dummy": LLMProviderContract(
+            name="dummy",
+            generate=lambda prompt: prompt,
+            embed=lambda text: [1.0],
+            healthcheck=lambda: {"ok": True, "provider": "dummy"},
+            cost_estimate=lambda prompt, completion="": 0.0,
+        ),
+        "openai": LLMProviderContract(
+            name="openai",
+            generate=lambda prompt: prompt,
+            embed=lambda text: [1.0],
+            healthcheck=lambda: {"ok": True, "provider": "openai"},
+            cost_estimate=lambda prompt, completion="": 0.0,
+        ),
+    }
+    monkeypatch.setattr(
+        providers, "_load_provider_contract", lambda name: contracts.get(name)
+    )
+
+    assert provider_diagnostics(["dummy"])["state"] == "degraded_dummy"
+    restored = provider_diagnostics(["dummy", "openai"])
+    assert restored["state"] == "ready"
+    assert restored["llm_real"] is True
+
+
+def test_doctor_reports_missing_openai_key_and_ollama_timeout(monkeypatch):
+    contracts = {
+        "openai": LLMProviderContract(
+            name="openai",
+            generate=lambda prompt: prompt,
+            embed=lambda text: [1.0],
+            healthcheck=lambda: {
+                "ok": False,
+                "provider": "openai",
+                "error": "missing OPENAI_API_KEY",
+            },
+            cost_estimate=lambda prompt, completion="": 0.0,
+        ),
+        "ollama": LLMProviderContract(
+            name="ollama",
+            generate=lambda prompt: prompt,
+            embed=lambda text: [1.0],
+            healthcheck=lambda: {
+                "ok": False,
+                "provider": "ollama",
+                "error": "Ollama request timed out",
+            },
+            cost_estimate=lambda prompt, completion="": 0.0,
+        ),
+    }
+    monkeypatch.setattr(providers, "_load_provider_contract", contracts.get)
+    openai, ollama = doctor_providers(["openai", "ollama"])
+    assert (openai["state"], openai["error_category"]) == (
+        "unavailable",
+        "misconfigured",
+    )
+    assert (ollama["state"], ollama["cause"]) == (
+        "unavailable",
+        "Ollama request timed out",
+    )

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -2540,3 +2540,23 @@ def test_dashboard_cockpit_exposes_used_memories(tmp_path: Path, monkeypatch: py
 
     assert payload["memory_metrics"]["has_memory_signal"] is True
     assert payload["memory_metrics"]["used_memories"][0]["summary"] == "bug prioritaire rappelé"
+
+
+
+def test_dashboard_context_exposes_degraded_dummy_diagnostic(tmp_path, monkeypatch):
+    diagnostic = {
+        "state": "degraded_dummy",
+        "llm_real": False,
+        "deterministic_fake": True,
+        "providers": [{
+            "provider": "openai",
+            "state": "unavailable",
+            "cause": "missing OPENAI_API_KEY",
+            "configuration_command": "singular config openai",
+        }],
+    }
+    monkeypatch.setattr(dashboard_module, "provider_diagnostics", lambda: diagnostic)
+
+    context = create_app(psyche_file=tmp_path / "psyche.json")._routes["/dashboard/context"]()
+
+    assert context["llm_providers"] == diagnostic


### PR DESCRIPTION
### Motivation

- Clarifier et exposer l’état effectif des fournisseurs LLM (réel, fallback dummy déterministe ou indisponible) pour éviter que des échos factices soient comptés comme succès cognitifs.
- Fournir diagnostics actionnables (cause + commande de configuration) pour accélérer la mise en service ou la réparation des backends (OpenAI, Ollama, local, dummy).
- Afficher un signal non bloquant dans le Dashboard pour informer les opérateurs que les réponses sont déterministes/factices ou qu’aucun LLM réel n’est disponible.

### Description

- Ajout d’un dictionnaire `PROVIDER_CONFIGURATION_COMMANDS` et d’une nouvelle API agrégée `provider_diagnostics()` exposant un état global à trois valeurs (`ready`, `degraded_dummy`, `unavailable`) et la liste détaillée des fournisseurs avec cause et commande de configuration (fichier modifié: `src/singular/providers/__init__.py`).
- `describe_client` normalise et expose désormais `state` et `llm_real`; `doctor_providers()` renvoie la cause, l’état et la commande de configuration par fournisseur et inclut désormais `dummy` dans la liste vérifiée (fichier modifié: `src/singular/providers/__init__.py`).
- `talk` marque explicitement les réponses factices/echo par un préfixe visible, n’incrémente plus les métriques cognitives quand la réponse est dummy, enrichit épisodes et traces avec `provider_state` et imprime les causes + commandes de configuration quand la chaîne a échoué (fichier modifié: `src/singular/organisms/talk.py`).
- Le sous‑commande `doctor` de la CLI affiche l’état agrégé lisible, la cause, `llm_real` et la commande de configuration pour chaque fournisseur (fichier modifié: `src/singular/cli.py`).
- Exposition du diagnostic dans le contexte Dashboard (`/dashboard/context`) et ajout d’une alerte non bloquante côté UI pour indiquer `degraded_dummy` ou `unavailable` (fichiers modifiés: `src/singular/dashboard/__init__.py`, `src/singular/dashboard/templates/dashboard.html`, `src/singular/dashboard/static/render-cockpit.js`).
- Tests ajoutés/actualisés pour couvrir: clé OpenAI manquante, timeout Ollama, fallback dummy dégradé et restauration d’un fournisseur réel, ainsi que l’exposition du diagnostic dans `dashboard/context` (fichiers modifiés: `tests/providers/test_provider_doctor.py`, `tests/test_dashboard.py`).

### Testing

- Exécutions ciblées de tests unitaires et d’intégration réalisées via `pytest` sur les modules affectés; suites principales lancées: `tests/providers`, `tests/test_cli_provider_doctor.py`, cas `talk` ciblés et checks Dashboard.
- Résultat final des tests automatiques exécutés dans l’environnement CI local: all relevant tests passed (final run: 56 passed, 1 skipped); précédemment des échecs temporaires ont été résolus pendant le développement.
- `git diff --check` a été exécuté sans erreur de style / vérification finale et les modifications ont été commitées sous le message: "Expose explicit LLM provider availability states".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77621a0aa0832ab1cbc9dbeb248d6e)