### PR TITLE
Add favicon, meta tags and brand header with responsive CSS; add static asset tests

### DIFF
--- a/src/singular/dashboard/static/dashboard.css
+++ b/src/singular/dashboard/static/dashboard.css
@@ -40,6 +40,17 @@ h1 {
   text-shadow: 0 0 18px rgba(107, 124, 255, 0.45);
 }
 
+.brand-header {
+  max-width: 100%;
+}
+
+.brand-header img {
+  display: block;
+  width: 350px;
+  max-width: 100%;
+  height: auto;
+}
+
 h2, h3, h4 {
   margin-bottom: 8px;
   color: #d6e4ff;
@@ -541,5 +552,6 @@ body.essential-mode #toggle-essential { border-color: var(--ok); color: var(--ok
 .life-verdict-signals-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; margin-top: 8px; }
 
 @media (max-width: 720px) {
+  .brand-header img { width: min(350px, 100%); }
   .life-verdict-card { grid-column: span 1; }
 }

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -1,10 +1,16 @@
 <html>
 <head>
+  <meta charset='utf-8'/>
+  <meta name='viewport' content='width=device-width, initial-scale=1'/>
+  <meta name='theme-color' content='#060a1a'/>
   <title>Tableau de bord Singular</title>
+  <link rel='icon' href='/static/favicon.svg' type='image/svg+xml'/>
   <link rel='stylesheet' href='/static/dashboard.css'/>
 </head>
 <body>
-<h1>Tableau de bord Singular</h1>
+<h1 class='brand-header'>
+  <img src='/static/singular-logo.svg' alt='Singular — tableau de bord' width='350' height='108'/>
+</h1>
 <nav aria-label='Navigation rapide'>
   <a href='#tab-decider-maintenant'>Décider maintenant</a>
   <a href='#tab-diagnostiquer'>Diagnostiquer</a>

--- a/src/singular/dashboard/templates/mutation_detail.html
+++ b/src/singular/dashboard/templates/mutation_detail.html
@@ -1,4 +1,4 @@
-<html><head><title>Détail mutation</title></head><body>
+<html><head><title>Détail mutation</title><link rel='icon' href='/static/favicon.svg' type='image/svg+xml'/></head><body>
 <h1>Détail mutation · run __RUN_ID__ · index __INDEX__</h1>
 <p><a href='/'>← Retour tableau de bord</a></p>
 <h2>Résumé naturel</h2><pre id='summary'>Chargement...</pre>

--- a/tests/fastapi_stub/testclient.py
+++ b/tests/fastapi_stub/testclient.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 from urllib.parse import parse_qs, urlsplit
+import mimetypes
 
 import asyncio
 import inspect
@@ -15,9 +16,18 @@ from . import HTTPException, WebSocket, WebSocketDisconnect
 class Response:
     """Represents a minimal HTTP response object."""
 
-    def __init__(self, status_code: int, data: Any) -> None:
+    def __init__(
+        self, status_code: int, data: Any, headers: dict[str, str] | None = None
+    ) -> None:
         self.status_code = status_code
         self._data = data
+        self.headers = headers or {}
+
+    @property
+    def text(self) -> str:
+        if isinstance(self._data, bytes):
+            return self._data.decode("utf-8")
+        return str(self._data)
 
     def json(self) -> Any:  # pragma: no cover - trivial
         return self._data
@@ -30,6 +40,19 @@ class TestClient:
         self.app = app
 
     def get(self, path: str) -> Response:
+        for prefix, mount in self.app._mounts.items():
+            if path.startswith(f"{prefix}/"):
+                relative_path = path.removeprefix(f"{prefix}/")
+                static_root = mount["app"].directory.resolve()
+                asset_path = (static_root / relative_path).resolve()
+                if asset_path.is_file() and asset_path.is_relative_to(static_root):
+                    media_type, _ = mimetypes.guess_type(asset_path)
+                    return Response(
+                        200,
+                        asset_path.read_bytes(),
+                        {"content-type": media_type or "application/octet-stream"},
+                    )
+                return Response(404, None)
         handler = self.app._routes[path]
         try:
             data = handler()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -51,6 +51,29 @@ def test_dashboard_endpoints(tmp_path: Path, monkeypatch) -> None:
     assert "last_purge" in retention
 
 
+def test_dashboard_brand_assets_are_referenced_and_served_as_svg(tmp_path: Path) -> None:
+    app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
+    client = TestClient(app)
+
+    dashboard_response = client.get("/")
+    assert dashboard_response.status_code == 200
+    assert "<meta charset='utf-8'/>" in dashboard_response.text
+    assert "name='viewport'" in dashboard_response.text
+    assert "name='theme-color'" in dashboard_response.text
+    assert "href='/static/favicon.svg'" in dashboard_response.text
+    assert "src='/static/singular-logo.svg'" in dashboard_response.text
+    mutation_template = Path(
+        "src/singular/dashboard/templates/mutation_detail.html"
+    ).read_text(encoding="utf-8")
+    assert "href='/static/favicon.svg'" in mutation_template
+
+    for asset_url in ("/static/favicon.svg", "/static/singular-logo.svg"):
+        asset_response = client.get(asset_url)
+        assert asset_response.status_code == 200
+        assert asset_response.headers["content-type"].startswith("image/svg+xml")
+        assert asset_response.text.lstrip().startswith("<svg")
+
+
 def test_dashboard_context_normalizes_object_and_dict_life_metadata(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation

- Ensure the dashboard and mutation detail pages include a coherent brand identity and basic metadata for correct rendering on browsers and mobile devices.
- Prevent the brand logo from overflowing on small viewports while keeping its natural aspect ratio.

### Description

- Add `charset`, `viewport` and `theme-color` meta tags and a favicon link to `src/singular/dashboard/templates/dashboard.html` and add the favicon to `src/singular/dashboard/templates/mutation_detail.html` using `<link rel='icon' href='/static/favicon.svg' type='image/svg+xml'/>`.
- Replace the textual title with a brand header containing the logo image `'/static/singular-logo.svg'` with explicit `alt`, `width`, and `height` attributes in `src/singular/dashboard/templates/dashboard.html`.
- Add responsive CSS rules in `src/singular/dashboard/static/dashboard.css` (`.brand-header` and `.brand-header img`) so the logo preserves its ratio and does not overflow on mobile (`max-width: 100%`, `height: auto`, and a mobile media rule).
- Add `test_dashboard_brand_assets_are_referenced_and_served_as_svg` to `tests/test_dashboard.py` to assert the pages reference the favicon/logo and to verify the static SVG endpoints return `image/svg+xml` content beginning with `<svg`.
- Extend the test `TestClient` stub in `tests/fastapi_stub/testclient.py` to serve mounted static files and expose response `text` and `headers` so tests can assert content and MIME types.

### Testing

- Ran `pytest -q tests/test_dashboard.py::test_dashboard_brand_assets_are_referenced_and_served_as_svg tests/test_dashboard_static_smoke.py` and the suite passed (`12 passed`).
- Ran lint/static checks with `ruff` on the modified test helpers and test file and they passed.
- Verified static asset responses and content-type headers in tests (SVG responses begin with `<svg`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a777102273c832a81a2d022356eb70e)