### PR TITLE
Use GitHub-friendly logo PNG in README and update branding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/branding/singular-logo.svg" alt="Singular" width="760">
+  <img src="docs/assets/branding/singular-logo-github.png" alt="Singular" width="700" height="215">
 </p>
 
 # 🌱 Singular — Un organisme numérique vivant interactif

--- a/docs/assets/branding/BRAND.md
+++ b/docs/assets/branding/BRAND.md
@@ -13,7 +13,8 @@ Dégradé principal : `#0A1BFF → #2D6BFF → #00A7FF → #00E0D1`.
 
 ## Fichiers
 
-- `singular-logo.svg` : logo horizontal principal, recommandé pour le README et la documentation.
+- `singular-logo.svg` : source vectorielle canonique du logo horizontal, recommandée pour la documentation et le dashboard.
+- `singular-logo-github.png` : export horizontal à placer dans ce dossier, en 1 400 × 430 px (affiché à 700 × 215 px, soit 2×), sur fond blanc explicite pour préserver la lisibilité dans les thèmes clair et sombre ; variante recommandée pour les README rendus par GitHub.
 - `singular-logo-stacked.svg` : version verticale.
 - `singular-icon.svg` : symbole seul, recommandé pour favicon, app icon et espaces compacts.
 


### PR DESCRIPTION
### Motivation
- Replace the README SVG with a GitHub-optimized PNG to ensure consistent rendering and legibility across GitHub renderers and light/dark themes and to document the new asset.

### Description
- Update `README.md` to reference `docs/assets/branding/singular-logo-github.png` with explicit `width`/`height` attributes, and update `docs/assets/branding/BRAND.md` to add and document the `singular-logo-github.png` export while clarifying the canonical `singular-logo.svg` description.

### Testing
- No automated tests were modified or required for this documentation change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a777340fc70832abe9a10664ecce2cc)