### PR TITLE
Add explicit Ollama provider setup command and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,30 @@ singular report --format plain
 singular dashboard
 ```
 
+### Préparer Ollama explicitement
+
+La conversation ne télécharge jamais de modèle implicitement. Avant d'utiliser
+Ollama, lancez l'assistant dédié; il vérifie le service, affiche les modèles,
+demande confirmation avant le téléchargement et valide une génération courte :
+
+```bash
+ollama serve
+singular config providers setup ollama
+```
+
+Le modèle est résolu depuis `OLLAMA_MODEL`, puis utilise le défaut unique du
+provider (`llama3.2`). En CI, aucune question n'est posée et le téléchargement
+doit être autorisé explicitement :
+
+```bash
+singular config providers setup ollama --non-interactive --pull --model llama3.2
+```
+
+Les échecs distinguent `service_stopped`, `command_missing`, `model_missing`,
+`download_incomplete`, `timeout` et `invalid_generation`; chaque diagnostic
+affiche une commande de remédiation. Sans `--pull`, même l'action de setup reste
+un contrôle sans téléchargement.
+
 ## 📚 Tutoriels et gouvernance
 
 Index complet par type de document : [`docs/README.md`](docs/README.md).

--- a/docs/cli-reference.en.md
+++ b/docs/cli-reference.en.md
@@ -830,7 +830,7 @@ Paths below are relative to the root or `SINGULAR_HOME`. Always back up before d
 <!-- cli-command: config providers -->
 ## `config providers`
 
-**Syntax :** `singular config providers [-h] {doctor} ...`
+**Syntax :** `singular config providers [-h] {doctor,setup} ...`
 
 **Arguments and defaults :** Aucune / None.
 
@@ -1483,3 +1483,24 @@ Paths below are relative to the root or `SINGULAR_HOME`. Always back up before d
 ## Aliases and help
 
 `veille` is an exact alias of `watch`; `talk --live` is a deprecated alias for `talk --life`; `birth` can be disabled with `SINGULAR_ENABLE_BIRTH_ALIAS=0`. `singular <command> --help` remains the executable source for metavar details.
+
+<!-- cli-command: config providers setup -->
+## `config providers setup`
+
+**Syntax :** `singular config providers setup [-h] [--model MODEL] [--non-interactive] [--pull] [--timeout TIMEOUT] {ollama}`
+
+**Arguments and defaults :** provider `ollama` (required); `--model` (`OLLAMA_MODEL`, then provider default); `--non-interactive` (`false`); `--pull` (`false`); `--timeout` (`120.0`).
+
+**Prerequisites :** A reachable `ollama serve`; automated installation must explicitly combine `--non-interactive --pull`.
+
+**Target root and life :** No root or life; only the service selected by `OLLAMA_HOST`.
+
+**Files read or written :** No Singular file; Ollama manages downloaded model data.
+
+**Side effects :** Lists models, optionally runs `ollama pull`, and validates a minimal generation. `talk` never downloads models.
+
+**Minimal example :** `singular config providers setup ollama`
+
+**Advanced example :** `singular config providers setup ollama --non-interactive --pull --model llama3.2`
+
+**Common errors :** `service_stopped`, `command_missing`, `model_missing`, `download_incomplete`, `timeout`, or `invalid_generation`; every failure includes remediation.

--- a/docs/cli-reference.fr.md
+++ b/docs/cli-reference.fr.md
@@ -830,7 +830,7 @@ Les chemins ci-dessous sont relatifs au root ou à `SINGULAR_HOME`. Toujours sau
 <!-- cli-command: config providers -->
 ## `config providers`
 
-**Syntaxe :** `singular config providers [-h] {doctor} ...`
+**Syntaxe :** `singular config providers [-h] {doctor,setup} ...`
 
 **Arguments et défauts :** Aucune / None.
 
@@ -1395,6 +1395,27 @@ Les chemins ci-dessous sont relatifs au root ou à `SINGULAR_HOME`. Toujours sau
 **Exemple avancé :** `singular --root /srv/singular --life ada --format json ecosystem run --life ada --budget-seconds 10`
 
 **Erreurs usuelles :** Vie/provider/config absent, budget/intervalle invalide, capteur indisponible, trop d'erreurs daemon.
+
+<!-- cli-command: config providers setup -->
+## `config providers setup`
+
+**Syntaxe :** `singular config providers setup [-h] [--model MODEL] [--non-interactive] [--pull] [--timeout TIMEOUT] {ollama}`
+
+**Arguments et défauts :** provider `ollama` (requis); `--model` (`OLLAMA_MODEL`, sinon le défaut du provider); `--non-interactive` (`false`); `--pull` (`false`); `--timeout` (`120.0`).
+
+**Prérequis :** service `ollama serve` joignable. La commande affiche `/api/tags`, demande confirmation avant `ollama pull`, puis effectue une génération minimale. `--non-interactive --pull` convient aux installations automatisées; sans `--pull`, le mode non interactif ne télécharge rien.
+
+**Root et vie ciblés :** Aucun root ni vie; utilise uniquement le service défini par `OLLAMA_HOST`.
+
+**Fichiers lus ou écrits :** Aucun fichier Singular; Ollama stocke le modèle téléchargé dans son propre espace.
+
+**Effets de bord :** le téléchargement n'est possible que dans cette action explicite et après confirmation ou `--pull`; `singular talk` ne télécharge jamais de modèle.
+
+**Exemple minimal :** `singular config providers setup ollama`
+
+**Exemple avancé :** `singular config providers setup ollama --non-interactive --pull --model llama3.2`
+
+**Erreurs usuelles :** `service_stopped`, `command_missing`, `model_missing`, `download_incomplete`, `timeout`, `invalid_generation`. Chaque sortie inclut `Remédiation:` avec la commande à exécuter.
 
 <!-- cli-command: beliefs -->
 ## `beliefs`

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -909,6 +909,35 @@ def _doctor_providers(
     return exit_code
 
 
+def _setup_ollama_provider(
+    *, model: str | None, non_interactive: bool, pull: bool, timeout: float
+) -> int:
+    """Guide an explicit Ollama installation; never called by ``talk``."""
+
+    from .providers import llm_ollama
+
+    selected = (model or llm_ollama._model()).strip()
+    result = llm_ollama.setup_status(model=selected, pull=False, timeout=timeout)
+    models = result.get("models")
+    if isinstance(models, list):
+        print("Modèles Ollama disponibles: " + (", ".join(models) or "(aucun)"))
+
+    should_pull = pull
+    if result.get("state") == "model_missing" and not pull and not non_interactive:
+        answer = input(f"Télécharger le modèle {selected} ? [o/N] ")
+        should_pull = answer.strip().lower() in {"o", "oui", "y", "yes"}
+    if result.get("state") == "model_missing" and should_pull:
+        result = llm_ollama.setup_status(model=selected, pull=True, timeout=timeout)
+
+    state = str(result.get("state", "invalid_generation"))
+    if result.get("ok"):
+        print(f"✅ Ollama prêt: modèle={selected}; génération minimale validée.")
+        return 0
+    print(f"❌ Configuration Ollama: {state}.", file=sys.stderr)
+    print(f"Remédiation: {result.get('remediation')}", file=sys.stderr)
+    return 1
+
+
 _POLICY_SETTERS: dict[str, tuple[str, str]] = {
     "memory.preserve_threshold": ("float", "memory_preserve_threshold"),
     "forgetting.enabled": ("bool", "forgetting_enabled"),
@@ -1684,6 +1713,27 @@ def _build_parser() -> argparse.ArgumentParser:
     providers_doctor_parser.add_argument(
         "--credentials-file", help="Fichier d'identifiants séparé"
     )
+    providers_setup_parser = config_providers_subparsers.add_parser(
+        "setup", help="Préparer et valider un provider"
+    )
+    providers_setup_parser.add_argument("provider", choices=("ollama",))
+    providers_setup_parser.add_argument(
+        "--model", help="Modèle Ollama (défaut: OLLAMA_MODEL puis défaut provider)"
+    )
+    providers_setup_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Ne jamais demander de confirmation",
+    )
+    providers_setup_parser.add_argument(
+        "--pull", action="store_true", help="Autoriser explicitement le téléchargement"
+    )
+    providers_setup_parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="Timeout HTTP/téléchargement en secondes",
+    )
     config_root_parser = config_subparsers.add_parser(
         "root", help="Configurer le root de registre persistant"
     )
@@ -2369,6 +2419,13 @@ def main(argv: list[str] | None = None) -> int:
                     ollama_model=args.ollama_model,
                     api_key=args.api_key,
                     credentials_file=args.credentials_file,
+                )
+            if args.config_providers_command == "setup":
+                return _setup_ollama_provider(
+                    model=args.model,
+                    non_interactive=args.non_interactive,
+                    pull=args.pull,
+                    timeout=args.timeout,
                 )
         if args.config_command == "root":
             if args.config_root_command == "set":

--- a/src/singular/providers/llm_ollama.py
+++ b/src/singular/providers/llm_ollama.py
@@ -6,6 +6,8 @@ import ipaddress
 import json
 import os
 import socket
+import shutil
+import subprocess
 import time
 from typing import Any
 from urllib.parse import urlparse
@@ -49,7 +51,9 @@ def _host() -> str:
 
 
 def _network_policy() -> str:
-    policy = (os.getenv("OLLAMA_NETWORK_POLICY") or DEFAULT_NETWORK_POLICY).strip().lower()
+    policy = (
+        (os.getenv("OLLAMA_NETWORK_POLICY") or DEFAULT_NETWORK_POLICY).strip().lower()
+    )
     aliases = {"strict": "local", "none": "disabled", "off": "disabled"}
     policy = aliases.get(policy, policy)
     if policy not in {"disabled", "local", "unrestricted"}:
@@ -75,11 +79,17 @@ def _validate_network_target(url: str) -> None:
     try:
         addresses = {
             item[4][0]
-            for item in socket.getaddrinfo(parsed.hostname, parsed.port, type=socket.SOCK_STREAM)
+            for item in socket.getaddrinfo(
+                parsed.hostname, parsed.port, type=socket.SOCK_STREAM
+            )
         }
     except socket.gaierror as exc:
-        raise ProviderMisconfiguredError("OLLAMA_HOST could not be resolved locally") from exc
-    if not addresses or any(not ipaddress.ip_address(address).is_loopback for address in addresses):
+        raise ProviderMisconfiguredError(
+            "OLLAMA_HOST could not be resolved locally"
+        ) from exc
+    if not addresses or any(
+        not ipaddress.ip_address(address).is_loopback for address in addresses
+    ):
         raise ProviderMisconfiguredError(
             "OLLAMA_HOST must resolve only to loopback addresses in local mode"
         )
@@ -90,7 +100,11 @@ def _model() -> str:
 
 
 def _embed_model() -> str:
-    return (os.getenv("OLLAMA_EMBED_MODEL") or "").strip() or _model() or DEFAULT_OLLAMA_EMBED_MODEL
+    return (
+        (os.getenv("OLLAMA_EMBED_MODEL") or "").strip()
+        or _model()
+        or DEFAULT_OLLAMA_EMBED_MODEL
+    )
 
 
 def _filter(text: str) -> str:
@@ -102,7 +116,9 @@ def _filter(text: str) -> str:
 def _post_json(path: str, payload: dict[str, Any], *, timeout: float) -> dict[str, Any]:
     url = f"{_host()}{path}"
     data = json.dumps(payload).encode("utf-8")
-    request = Request(url, data=data, headers={"Content-Type": "application/json"}, method="POST")
+    request = Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
     try:
         with _urlopen(request, timeout=timeout) as response:
             _validate_network_target(response.geturl())
@@ -113,7 +129,9 @@ def _post_json(path: str, payload: dict[str, Any], *, timeout: float) -> dict[st
         raise ProviderTimeoutError("Ollama request timed out") from exc
     except HTTPError as exc:
         message = exc.reason or exc.read().decode("utf-8", errors="replace")
-        raise ProviderExecutionError(f"Ollama HTTP error {exc.code}: {message}") from exc
+        raise ProviderExecutionError(
+            f"Ollama HTTP error {exc.code}: {message}"
+        ) from exc
     except URLError as exc:
         reason = getattr(exc, "reason", exc)
         if isinstance(reason, TimeoutError | socket.timeout):
@@ -131,6 +149,183 @@ def _post_json(path: str, payload: dict[str, Any], *, timeout: float) -> dict[st
     return parsed
 
 
+def _get_json(path: str, *, timeout: float) -> dict[str, Any]:
+    """Read an Ollama API object while preserving the provider error taxonomy."""
+
+    request = Request(f"{_host()}{path}", method="GET")
+    try:
+        with _urlopen(request, timeout=timeout) as response:
+            _validate_network_target(response.geturl())
+            raw = response.read().decode("utf-8")
+    except (TimeoutError, socket.timeout) as exc:
+        raise ProviderTimeoutError("Ollama request timed out") from exc
+    except URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        if isinstance(reason, (TimeoutError, socket.timeout)):
+            raise ProviderTimeoutError("Ollama request timed out") from exc
+        raise ProviderUnavailableError("Unable to connect to Ollama") from exc
+    except OSError as exc:
+        raise ProviderUnavailableError("Unable to connect to Ollama") from exc
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ProviderExecutionError("Ollama response is not valid JSON") from exc
+    if not isinstance(result, dict):
+        raise ProviderExecutionError("Ollama response schema error: expected object")
+    return result
+
+
+def available_models(*, timeout: float = 2.0) -> list[str]:
+    """Return model names advertised by ``/api/tags``."""
+
+    models = _get_json("/api/tags", timeout=timeout).get("models")
+    if not isinstance(models, list):
+        raise ProviderExecutionError("Ollama response schema error: missing models")
+    return [
+        item["name"]
+        for item in models
+        if isinstance(item, dict) and isinstance(item.get("name"), str)
+    ]
+
+
+def setup_status(
+    *, model: str | None = None, pull: bool = False, timeout: float = 120.0
+) -> dict[str, object]:
+    """Inspect, optionally install, and validate one Ollama model.
+
+    This is deliberately separate from ``generate``: normal conversation never
+    invokes the Ollama executable and therefore never downloads a model.
+    """
+
+    selected = (model or _model()).strip()
+    pull_command = f"ollama pull {selected}"
+    try:
+        models = available_models(timeout=min(timeout, 5.0))
+    except ProviderTimeoutError:
+        return {
+            "ok": False,
+            "state": "timeout",
+            "model": selected,
+            "remediation": "ollama serve",
+        }
+    except ProviderUnavailableError:
+        return {
+            "ok": False,
+            "state": "service_stopped",
+            "model": selected,
+            "remediation": "ollama serve",
+        }
+    except ProviderExecutionError:
+        return {
+            "ok": False,
+            "state": "invalid_generation",
+            "model": selected,
+            "remediation": "ollama serve",
+        }
+
+    aliases = {name for name in models} | {
+        name.removesuffix(":latest") for name in models
+    }
+    if selected not in aliases:
+        if not pull:
+            return {
+                "ok": False,
+                "state": "model_missing",
+                "model": selected,
+                "models": models,
+                "remediation": pull_command,
+            }
+        executable = shutil.which("ollama")
+        if executable is None:
+            return {
+                "ok": False,
+                "state": "command_missing",
+                "model": selected,
+                "models": models,
+                "remediation": "curl -fsSL https://ollama.com/install.sh | sh",
+            }
+        try:
+            completed = subprocess.run(
+                [executable, "pull", selected], check=False, timeout=timeout
+            )
+        except subprocess.TimeoutExpired:
+            return {
+                "ok": False,
+                "state": "timeout",
+                "model": selected,
+                "models": models,
+                "remediation": pull_command,
+            }
+        if completed.returncode != 0:
+            return {
+                "ok": False,
+                "state": "download_incomplete",
+                "model": selected,
+                "models": models,
+                "remediation": pull_command,
+            }
+        try:
+            models = available_models(timeout=min(timeout, 5.0))
+        except (ProviderTimeoutError, ProviderUnavailableError, ProviderExecutionError):
+            return {
+                "ok": False,
+                "state": "download_incomplete",
+                "model": selected,
+                "models": models,
+                "remediation": pull_command,
+            }
+        aliases = set(models) | {name.removesuffix(":latest") for name in models}
+        if selected not in aliases:
+            return {
+                "ok": False,
+                "state": "download_incomplete",
+                "model": selected,
+                "models": models,
+                "remediation": pull_command,
+            }
+
+    previous = os.environ.get("OLLAMA_MODEL")
+    os.environ["OLLAMA_MODEL"] = selected
+    try:
+        reply = generate("Réponds uniquement: ok", timeout=min(timeout, 8.0))
+    except ProviderTimeoutError:
+        return {
+            "ok": False,
+            "state": "timeout",
+            "model": selected,
+            "models": models,
+            "remediation": f"ollama run {selected}",
+        }
+    except (ProviderExecutionError, ProviderUnavailableError):
+        return {
+            "ok": False,
+            "state": "invalid_generation",
+            "model": selected,
+            "models": models,
+            "remediation": f"ollama run {selected}",
+        }
+    finally:
+        if previous is None:
+            os.environ.pop("OLLAMA_MODEL", None)
+        else:
+            os.environ["OLLAMA_MODEL"] = previous
+    if not reply.strip():
+        return {
+            "ok": False,
+            "state": "invalid_generation",
+            "model": selected,
+            "models": models,
+            "remediation": f"ollama run {selected}",
+        }
+    return {
+        "ok": True,
+        "state": "ready",
+        "model": selected,
+        "models": models,
+        "remediation": f"OLLAMA_MODEL={selected} singular talk",
+    }
+
+
 def generate(prompt: str, *, timeout: float = 8.0) -> str:
     """Generate a reply with Ollama's local ``/api/generate`` endpoint."""
 
@@ -145,7 +340,9 @@ def generate(prompt: str, *, timeout: float = 8.0) -> str:
 
     text = response.get("response")
     if not isinstance(text, str):
-        raise ProviderExecutionError("Ollama response schema error: missing response text")
+        raise ProviderExecutionError(
+            "Ollama response schema error: missing response text"
+        )
 
     filtered = _filter(text)
     LAST_METRICS.input_tokens = len(prompt.split())
@@ -168,16 +365,28 @@ def embed(text: str, *, timeout: float = 8.0) -> list[float]:
     try:
         return [float(value) for value in values]
     except (TypeError, ValueError) as exc:
-        raise ProviderExecutionError("Ollama response schema error: invalid embedding values") from exc
+        raise ProviderExecutionError(
+            "Ollama response schema error: invalid embedding values"
+        ) from exc
 
 
 def healthcheck() -> dict[str, object]:
     """Return provider configuration and whether the local Ollama API responds."""
 
     try:
-        _post_json("/api/generate", {"model": _model(), "prompt": "", "stream": False}, timeout=1.0)
+        _post_json(
+            "/api/generate",
+            {"model": _model(), "prompt": "", "stream": False},
+            timeout=1.0,
+        )
     except Exception as exc:  # healthchecks report instead of raising
-        return {"ok": False, "provider": "ollama", "host": _host(), "model": _model(), "error": str(exc)}
+        return {
+            "ok": False,
+            "provider": "ollama",
+            "host": _host(),
+            "model": _model(),
+            "error": str(exc),
+        }
     return {"ok": True, "provider": "ollama", "host": _host(), "model": _model()}
 
 

--- a/tests/providers/test_llm_ollama.py
+++ b/tests/providers/test_llm_ollama.py
@@ -16,7 +16,9 @@ from singular.providers import llm_ollama
 
 
 class FakeHTTPResponse:
-    def __init__(self, payload: dict[str, object], url: str = "http://127.0.0.1:11434/api"):
+    def __init__(
+        self, payload: dict[str, object], url: str = "http://127.0.0.1:11434/api"
+    ):
         self.payload = payload
         self.url = url
 
@@ -40,7 +42,9 @@ def test_generate_reply_posts_to_configured_ollama_host(monkeypatch):
     monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "unrestricted")
 
     def fake_urlopen(request, timeout):
-        calls.append((request.full_url, json.loads(request.data.decode("utf-8")), timeout))
+        calls.append(
+            (request.full_url, json.loads(request.data.decode("utf-8")), timeout)
+        )
         return FakeHTTPResponse({"response": "bonjour\x00"})
 
     monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
@@ -60,7 +64,9 @@ def test_embed_uses_configured_embedding_model(monkeypatch):
     monkeypatch.setenv("OLLAMA_EMBED_MODEL", " nomic-embed-text ")
 
     def fake_urlopen(request, timeout):
-        calls.append((request.full_url, json.loads(request.data.decode("utf-8")), timeout))
+        calls.append(
+            (request.full_url, json.loads(request.data.decode("utf-8")), timeout)
+        )
         return FakeHTTPResponse({"embedding": [1, "2.5", 3.0]})
 
     monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
@@ -116,7 +122,9 @@ def test_cost_estimate_is_zero_for_local_ollama():
     assert llm_ollama.cost_estimate("prompt", "completion") == 0.0
 
 
-@pytest.mark.parametrize("host", ["http://127.0.0.1:11434", "http://[::1]:11434", "http://localhost:11434"])
+@pytest.mark.parametrize(
+    "host", ["http://127.0.0.1:11434", "http://[::1]:11434", "http://localhost:11434"]
+)
 def test_local_policy_accepts_loopback(monkeypatch, host):
     monkeypatch.setenv("OLLAMA_HOST", host)
     monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "local")
@@ -135,7 +143,9 @@ def test_local_policy_rejects_http_redirect_to_public_host(monkeypatch):
     monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "local")
 
     def fake_urlopen(_request, timeout):
-        return FakeHTTPResponse({"response": "unsafe"}, "https://203.0.113.10/api/generate")
+        return FakeHTTPResponse(
+            {"response": "unsafe"}, "https://203.0.113.10/api/generate"
+        )
 
     monkeypatch.setattr(llm_ollama, "_urlopen", fake_urlopen)
     with pytest.raises(ProviderMisconfiguredError, match="loopback"):
@@ -146,3 +156,48 @@ def test_disabled_policy_refuses_even_loopback(monkeypatch):
     monkeypatch.setenv("OLLAMA_NETWORK_POLICY", "disabled")
     with pytest.raises(ProviderMisconfiguredError, match="disabled"):
         llm_ollama.generate("hello")
+
+
+def test_setup_reports_stopped_service_with_remediation(monkeypatch):
+    monkeypatch.setattr(
+        llm_ollama,
+        "available_models",
+        lambda **_kwargs: (_ for _ in ()).throw(ProviderUnavailableError("offline")),
+    )
+    result = llm_ollama.setup_status()
+    assert (result["state"], result["remediation"]) == (
+        "service_stopped",
+        "ollama serve",
+    )
+
+
+def test_setup_pulls_missing_model_and_validates_http_generation(monkeypatch):
+    responses = iter([[], ["llama3.2:latest"]])
+    monkeypatch.setattr(
+        llm_ollama, "available_models", lambda **_kwargs: next(responses)
+    )
+    monkeypatch.setattr(llm_ollama.shutil, "which", lambda _name: "/usr/bin/ollama")
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return type("Completed", (), {"returncode": 0})()
+
+    monkeypatch.setattr(llm_ollama.subprocess, "run", fake_run)
+    monkeypatch.setattr(llm_ollama, "generate", lambda prompt, timeout: "ok")
+    result = llm_ollama.setup_status(pull=True)
+    assert result["state"] == "ready"
+    assert calls[0][0] == ["/usr/bin/ollama", "pull", llm_ollama.DEFAULT_OLLAMA_MODEL]
+
+
+def test_setup_reports_incomplete_download_process(monkeypatch):
+    monkeypatch.setattr(llm_ollama, "available_models", lambda **_kwargs: [])
+    monkeypatch.setattr(llm_ollama.shutil, "which", lambda _name: "/bin/ollama")
+    monkeypatch.setattr(
+        llm_ollama.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type("Completed", (), {"returncode": 1})(),
+    )
+    result = llm_ollama.setup_status(model="missing", pull=True)
+    assert result["state"] == "download_incomplete"
+    assert result["remediation"] == "ollama pull missing"

--- a/tests/test_cli_ollama_setup.py
+++ b/tests/test_cli_ollama_setup.py
@@ -1,0 +1,57 @@
+from singular import cli
+from singular.providers import llm_ollama
+
+
+def test_cli_ollama_setup_noninteractive_never_pulls_implicitly(monkeypatch, capsys):
+    calls = []
+
+    def fake_setup_status(**kwargs):
+        calls.append(kwargs)
+        return {
+            "ok": False,
+            "state": "model_missing",
+            "models": [],
+            "remediation": "ollama pull llama3.2",
+        }
+
+    monkeypatch.setattr(llm_ollama, "setup_status", fake_setup_status)
+    assert (
+        cli.main(["config", "providers", "setup", "ollama", "--non-interactive"]) == 1
+    )
+    assert calls == [
+        {"model": llm_ollama.DEFAULT_OLLAMA_MODEL, "pull": False, "timeout": 120.0}
+    ]
+    assert "Remédiation: ollama pull llama3.2" in capsys.readouterr().err
+
+
+def test_cli_ollama_setup_ci_explicit_pull(monkeypatch):
+    calls = []
+
+    def fake_setup_status(**kwargs):
+        calls.append(kwargs)
+        if kwargs["pull"]:
+            return {"ok": True, "state": "ready", "models": ["ci-model"]}
+        return {
+            "ok": False,
+            "state": "model_missing",
+            "models": [],
+            "remediation": "ollama pull ci-model",
+        }
+
+    monkeypatch.setattr(llm_ollama, "setup_status", fake_setup_status)
+    assert (
+        cli.main(
+            [
+                "config",
+                "providers",
+                "setup",
+                "ollama",
+                "--model",
+                "ci-model",
+                "--non-interactive",
+                "--pull",
+            ]
+        )
+        == 0
+    )
+    assert [call["pull"] for call in calls] == [False, True]


### PR DESCRIPTION
### Motivation

- Provide an explicit, auditable flow to prepare Ollama models (check service, list models, optionally pull, validate a minimal generation) instead of letting `talk` implicitly download models. 
- Reuse the single source of truth for the Ollama model resolution to avoid divergent defaults between provider code and CLI. 
- Surface clear, distinct failure states with remediation commands so users and CI can recover deterministically. 

### Description

- Add HTTP inspection and model listing helpers `available_models` and `_get_json` and a dedicated `setup_status` flow in `src/singular/providers/llm_ollama.py` that implements `service_stopped`, `command_missing`, `model_missing`, `download_incomplete`, `timeout` and `invalid_generation` outcomes and returns remediation hints. 
- Add CLI glue `_setup_ollama_provider` and a `config providers setup` subcommand (choices: `ollama`) in `src/singular/cli.py` to present models, prompt for confirmation (or run non-interactive CI mode with `--non-interactive --pull`) and validate a minimal generation. 
- Ensure the provider reuses `DEFAULT_OLLAMA_MODEL` / `OLLAMA_MODEL` via the existing `_model()` helper so defaults do not diverge. 
- Add unit tests for the provider and CLI (`tests/providers/test_llm_ollama.py` updates and new `tests/test_cli_ollama_setup.py`) and update documentation (`README.md`, `docs/cli-reference.fr.md`, `docs/cli-reference.en.md`) to describe the explicit setup flow and states. 

### Testing

- `python -m pytest -q tests/providers/test_llm_ollama.py tests/test_cli_ollama_setup.py tests/test_cli_provider_doctor.py tests/test_cli_reference.py` executed and passed (23 passed). 
- `ruff check src/singular/cli.py src/singular/providers/llm_ollama.py tests/providers/test_llm_ollama.py tests/test_cli_ollama_setup.py` executed and passed. 
- A full `python -m pytest -q` run was attempted and revealed many preexisting or environment-dependent failures (OCI/sandbox and broader integration tests); these are unrelated to the new Ollama setup flow and are reported as environment-dependent warnings. 
- Formatting and linting were applied where needed prior to tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77fa994218832a951039f501d2ad8e)