### PR TITLE
Add transactional IdentitySynchronizationService to atomically sync Psyche and SelfNarrative

### DIFF
--- a/src/singular/identity/synchronization.py
+++ b/src/singular/identity/synchronization.py
@@ -1,0 +1,232 @@
+"""Transactional synchronization of the mutable psyche and its narrative."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Mapping
+from uuid import uuid4
+
+from singular.events import EventBus
+from singular.io_utils import append_jsonl_line, atomic_write_text, file_lock
+from singular.psyche import Mood, Psyche
+from singular.self_narrative import TraitTrend, load, save, timeline_path
+
+_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")
+
+
+@dataclass(frozen=True)
+class SynchronizationResult:
+    event_id: str
+    psyche_version: int
+    narrative_version: int
+    source: str
+    deltas: dict[str, float]
+    recovered: bool = False
+
+
+class IdentitySynchronizationService:
+    """Apply and durably project identity events through a recoverable journal.
+
+    The journal is the commit intent.  It is removed only after both JSON
+    projections and the timeline record exist, so startup can finish a partial
+    transaction.  Publication happens strictly after that commit point.
+    """
+
+    def __init__(
+        self, life_home: Path | str = ".", *, bus: EventBus | None = None
+    ) -> None:
+        self.home = Path(life_home)
+        self.mem = self.home / "mem"
+        self.psyche_path = self.mem / "psyche.json"
+        self.narrative_path = self.mem / "self_narrative.json"
+        self.journal_path = self.mem / "identity_sync.pending.json"
+        self.lock_path = self.mem / "identity_sync"
+        self.bus = bus
+        self.mem.mkdir(parents=True, exist_ok=True)
+        self.recover()
+
+    @staticmethod
+    def _payload(psyche: Psyche) -> dict[str, Any]:
+        # Psyche owns its serialization rules; writing to an in-memory-shaped
+        # temporary sibling also keeps future fields centralized there.
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "psyche.json"
+            psyche.save_state(path)
+            return json.loads(path.read_text(encoding="utf-8"))
+
+    def apply_event(
+        self,
+        event: Mapping[str, Any],
+        *,
+        psyche: Psyche | None = None,
+        publish: bool = True,
+    ) -> SynchronizationResult:
+        with file_lock(self.lock_path):
+            self._recover_locked()
+            current = psyche or Psyche.load_state(self.psyche_path)
+            event_id = str(event.get("event_id") or uuid4())
+            source = str(event.get("source") or "unknown")
+            if current.last_identity_event_id == event_id:
+                narrative = load(self.narrative_path)
+                return SynchronizationResult(
+                    event_id,
+                    current.psyche_version,
+                    narrative.narrative_version,
+                    source,
+                    {},
+                )
+
+            before = {key: float(getattr(current, key)) for key in _TRAITS}
+            requested = event.get("deltas", {})
+            if isinstance(requested, Mapping):
+                for key in _TRAITS:
+                    if key in requested:
+                        setattr(
+                            current,
+                            key,
+                            max(0.0, min(1.0, before[key] + float(requested[key]))),
+                        )
+            mood = event.get("mood")
+            if mood:
+                current.feel(mood if isinstance(mood, Mood) else Mood(str(mood)))
+            deltas = {
+                key: round(float(getattr(current, key)) - before[key], 12)
+                for key in _TRAITS
+                if float(getattr(current, key)) != before[key]
+            }
+            current.psyche_version += 1
+            current.last_identity_event_id = event_id
+
+            narrative = load(self.narrative_path)
+            narrative.narrative_version += 1
+            narrative.psyche_version = current.psyche_version
+            narrative.last_event_id = event_id
+            narrative.last_source = source
+            narrative.last_deltas = deltas
+            for key in _TRAITS:
+                value = float(getattr(current, key))
+                previous = narrative.trait_trends.get(key, TraitTrend()).value
+                narrative.trait_trends[key] = TraitTrend(
+                    value=value,
+                    trend="up"
+                    if value > previous
+                    else "down"
+                    if value < previous
+                    else "stable",
+                )
+            if isinstance(event.get("current_heading"), str):
+                narrative.current_heading = str(event["current_heading"])
+
+            stamp = datetime.now(timezone.utc).isoformat()
+            psyche_payload = self._payload(current)
+            narrative_payload = narrative.to_dict()
+            record = {
+                "recorded_at": stamp,
+                "schema_version": narrative.schema_version,
+                "record_type": "identity_sync",
+                "event_id": event_id,
+                "source": source,
+                "psyche_version": current.psyche_version,
+                "narrative_version": narrative.narrative_version,
+                "deltas": deltas,
+                "narrative": narrative_payload,
+            }
+            intent = {
+                "psyche": psyche_payload,
+                "narrative": narrative_payload,
+                "timeline": record,
+            }
+            atomic_write_text(
+                self.journal_path, json.dumps(intent, ensure_ascii=False, indent=2)
+            )
+            self._commit_intent(intent)
+            self.journal_path.unlink(missing_ok=True)
+            result = SynchronizationResult(
+                event_id,
+                current.psyche_version,
+                narrative.narrative_version,
+                source,
+                deltas,
+            )
+        if publish and self.bus is not None:
+            self.bus.publish(
+                "self_narrative.updated",
+                {"event_type": "self_narrative.updated", **result.__dict__},
+                payload_version=2,
+            )
+        return result
+
+    def _commit_intent(self, intent: Mapping[str, Any]) -> None:
+        atomic_write_text(
+            self.psyche_path, json.dumps(intent["psyche"], ensure_ascii=False, indent=2)
+        )
+        atomic_write_text(
+            self.narrative_path,
+            json.dumps(intent["narrative"], ensure_ascii=False, indent=2),
+        )
+        event_id = str(intent["timeline"]["event_id"])
+        existing = (
+            timeline_path(self.narrative_path).read_text(encoding="utf-8")
+            if timeline_path(self.narrative_path).exists()
+            else ""
+        )
+        recorded_ids: set[str] = set()
+        for line in existing.splitlines():
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, Mapping) and parsed.get("event_id"):
+                recorded_ids.add(str(parsed["event_id"]))
+        if event_id not in recorded_ids:
+            append_jsonl_line(
+                timeline_path(self.narrative_path), dict(intent["timeline"])
+            )
+
+    def recover(self) -> SynchronizationResult | None:
+        with file_lock(self.lock_path):
+            return self._recover_locked()
+
+    def _recover_locked(self) -> SynchronizationResult | None:
+        if self.journal_path.exists():
+            intent = json.loads(self.journal_path.read_text(encoding="utf-8"))
+            self._commit_intent(intent)
+            self.journal_path.unlink(missing_ok=True)
+            item = intent["timeline"]
+            return SynchronizationResult(
+                str(item["event_id"]),
+                int(item["psyche_version"]),
+                int(item["narrative_version"]),
+                str(item["source"]),
+                dict(item.get("deltas", {})),
+                True,
+            )
+        self.verify_and_repair()
+        return None
+
+    def verify_and_repair(self) -> bool:
+        """Repair an old/divergent narrative from the authoritative psyche."""
+        psyche = Psyche.load_state(self.psyche_path)
+        narrative = load(self.narrative_path)
+        if narrative.psyche_version == psyche.psyche_version:
+            return False
+        narrative.psyche_version = psyche.psyche_version
+        narrative.narrative_version = max(
+            narrative.narrative_version, psyche.psyche_version
+        )
+        narrative.last_event_id = psyche.last_identity_event_id
+        for key in _TRAITS:
+            narrative.trait_trends[key] = TraitTrend(
+                value=float(getattr(psyche, key)), trend="stable"
+            )
+        save(narrative, self.narrative_path, record_snapshot=False)
+        return True
+
+
+# Concise alias for call sites and integrations.
+IdentitySyncService = IdentitySynchronizationService

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -23,6 +23,7 @@ from singular.events import (
 from singular.goals import IntrinsicGoals
 from singular.cognition.self_observation import SelfObservationService
 from singular.identity import ConsolidationCoordinator, ConsolidationPipeline
+from singular.identity.synchronization import IdentitySynchronizationService
 from singular.governance.policy import MutationGovernancePolicy
 from singular.life.coevolution_flow import LivingTestPool
 from singular.life.loop import WorldState, run_tick
@@ -146,6 +147,9 @@ class OrchestratorService:
         self.state = self._load_state()
         self.resource_manager = ResourceManager(path=self.resources_path)
         self.psyche = Psyche.load_state()
+        self.identity_sync = IdentitySynchronizationService(
+            self.mem_dir.parent, bus=self.bus
+        )
         self.quest_runtime = QuestRuntime(base_dir=self.base_dir, mem_dir=self.mem_dir)
         self.skill_runtime = SkillRuntime(
             skills_dir=self.skills_dir,
@@ -197,6 +201,16 @@ class OrchestratorService:
             }
         )
         self._pending_events = self._pending_events[-50:]
+        if event.event_type in {"mutation.applied", "mutation.rejected"}:
+            self.identity_sync.apply_event(
+                {
+                    "event_id": event.payload.get("event_id")
+                    or f"{event.event_type}:{event.emitted_at}",
+                    "source": f"event_bus:{event.event_type}",
+                    "type": "mutation",
+                },
+                psyche=self.psyche,
+            )
 
     def _load_state(self) -> OrchestratorState:
         if not self.state_path.exists():
@@ -719,7 +733,14 @@ class OrchestratorService:
                 self._push_event(phase, {"skipped": True, "reason": "frequency_gate"})
                 return
             mood = self.psyche.update_from_resource_manager(self.resource_manager)
-            self.psyche.save_state()
+            self.identity_sync.apply_event(
+                {
+                    "event_id": f"introspection:{self._tick_count}:{self._introspection_tick_count}",
+                    "source": "orchestrator.introspection",
+                },
+                psyche=self.psyche,
+                publish=False,
+            )
             narrative_update = self._refresh_self_narrative()
             metacognitive_model = self.self_observation.observe_episodes(
                 read_episodes()

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -21,6 +21,7 @@ from ..memory import (
 from ..memory_layers import MemoryRetrievalService, build_backend
 from ..perception import capture_signals
 from ..psyche import Mood, Psyche
+from ..identity.synchronization import IdentitySynchronizationService
 from ..self_narrative import load as load_self_narrative, summarize_short
 from ..providers import (
     FallbackLLMClient,
@@ -194,6 +195,7 @@ def talk(
     psyche_file = mem_dir / "psyche.json"
     narrative_file = mem_dir / "self_narrative.json"
     ensure_memory_structure(mem_dir)
+    identity_sync = IdentitySynchronizationService(life_root)
 
     # Human dialogue is eligible for teaching only through a separate,
     # structured and explicitly consented demonstration payload.
@@ -523,7 +525,15 @@ def talk(
             path=causal_file,
         )
         psyche.gain()
-        psyche.save_state(psyche_file)
+        identity_sync.apply_event(
+            {
+                "event_id": f"conversation-{uuid4()}",
+                "source": "organisms.talk",
+                "type": "conversation",
+                "summary": "Interaction utilisateur traitée",
+            },
+            psyche=psyche,
+        )
         return response
 
     if prompt is not None:

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -78,7 +78,9 @@ class PsycheActionDecision:
     scores: dict[str, float] = field(default_factory=dict)
 
 
-def _numeric_signal(signals: Mapping[str, Any], key: str, default: float = 0.0) -> float:
+def _numeric_signal(
+    signals: Mapping[str, Any], key: str, default: float = 0.0
+) -> float:
     """Return ``key`` from ``signals`` as a float, falling back on ``default``."""
     try:
         return float(signals.get(key, default))
@@ -86,7 +88,9 @@ def _numeric_signal(signals: Mapping[str, Any], key: str, default: float = 0.0) 
         return default
 
 
-def _social_loneliness_signal(social_states: Mapping[str, Mapping[str, float]]) -> float:
+def _social_loneliness_signal(
+    social_states: Mapping[str, Mapping[str, float]],
+) -> float:
     """Estimate social isolation from low loyalty/gratitude and high resentment."""
     if not social_states:
         return 0.5
@@ -97,7 +101,9 @@ def _social_loneliness_signal(social_states: Mapping[str, Mapping[str, float]]) 
         gratitude = _clamp(float(state.get("gratitude", 0.5)))
         loyalty = _clamp(float(state.get("loyalty", 0.5)))
         resentment = _clamp(float(state.get("resentment", 0.5)))
-        signals.append(_clamp(1.0 - ((gratitude + loyalty) / 2.0) + (resentment * 0.25)))
+        signals.append(
+            _clamp(1.0 - ((gratitude + loyalty) / 2.0) + (resentment * 0.25))
+        )
     if not signals:
         return 1.0
     return _clamp(sum(signals) / len(signals))
@@ -105,7 +111,11 @@ def _social_loneliness_signal(social_states: Mapping[str, Mapping[str, float]]) 
 
 def _objective_pressure(psyche: "Psyche") -> tuple[float, float, float]:
     """Return exploration, safety, and resource pressure from objectives."""
-    axes = getattr(psyche, "weighted_objective_axes", lambda: {"long_term": 0.33, "sandbox": 0.33, "resource": 0.34})()
+    axes = getattr(
+        psyche,
+        "weighted_objective_axes",
+        lambda: {"long_term": 0.33, "sandbox": 0.33, "resource": 0.34},
+    )()
     exploration = _clamp(float(axes.get("long_term", 0.33)))
     safety = _clamp(float(axes.get("sandbox", 0.33)))
     resources = _clamp(float(axes.get("resource", 0.34)))
@@ -155,7 +165,9 @@ def choose_action_from_psyche(
     competition = _clamp(_numeric_signal(signals, "competition_pressure", 0.0))
     opportunity = _clamp(_numeric_signal(signals, "opportunity", 0.5))
     fallback_action = signals.get("fallback_action")
-    exploration_pressure, safety_pressure, resource_pressure = _objective_pressure(psyche)
+    exploration_pressure, safety_pressure, resource_pressure = _objective_pressure(
+        psyche
+    )
     loneliness = max(
         _social_loneliness_signal(getattr(psyche, "social_states", {})),
         _clamp(_numeric_signal(signals, "social_isolation", 0.0)),
@@ -200,7 +212,9 @@ def choose_action_from_psyche(
         reason_parts.append("loneliness favors cooperation")
     if risk >= 0.75:
         add("avoid_threat", 2.0)
-        reason_parts.append(f"high environmental risk({risk:.2f}) favors avoiding threat")
+        reason_parts.append(
+            f"high environmental risk({risk:.2f}) favors avoiding threat"
+        )
     if rarity >= 0.70 and effective_energy >= 35.0:
         add("forage", 1.3)
         reason_parts.append(f"scarcity({rarity:.2f}) favors foraging")
@@ -210,7 +224,9 @@ def choose_action_from_psyche(
         reason_parts.append(
             "balanced objective/environment scoring selected the highest-scoring action"
         )
-    reason = "; ".join(reason_parts) + f"; selected={action}; score={scores[action]:.3f}"
+    reason = (
+        "; ".join(reason_parts) + f"; selected={action}; score={scores[action]:.3f}"
+    )
     return PsycheActionDecision(action=action, reason=reason, scores=scores)
 
 
@@ -241,6 +257,9 @@ class Psyche:
         }
     )
     identity_wounds: float = 0.0
+    # Monotonic identity revision (distinct from the JSON schema version).
+    psyche_version: int = 0
+    last_identity_event_id: str | None = None
 
     # ``last_mood`` is updated every time :meth:`feel` is called and can be
     # queried by other subsystems (interaction and mutation policies).
@@ -472,7 +491,9 @@ class Psyche:
         self.social_states[target_life] = normalized
         return normalized
 
-    def apply_social_interaction(self, target_life: str, interaction: str) -> Dict[str, float]:
+    def apply_social_interaction(
+        self, target_life: str, interaction: str
+    ) -> Dict[str, float]:
         """Apply interaction-triggered social deltas for one target life."""
 
         state = self.social_state(target_life)
@@ -493,7 +514,9 @@ class Psyche:
         )
         return _clamp((0.6 * trait_base) + (0.4 * _clamp(0.5 + social_signal)))
 
-    def reproduction_arbitration_score(self, base_score: float, target_life: str) -> float:
+    def reproduction_arbitration_score(
+        self, base_score: float, target_life: str
+    ) -> float:
         """Modulate reproduction arbitration score using social emotions."""
 
         state = self.social_state(target_life)
@@ -736,6 +759,8 @@ class Psyche:
             },
             "identity_commitments": self.identity_commitments,
             "identity_wounds": float(self.identity_wounds),
+            "psyche_version": self.psyche_version,
+            "last_identity_event_id": self.last_identity_event_id,
         }
         if self.objectives:
             state["objectives"] = {
@@ -808,18 +833,33 @@ class Psyche:
             },
             social_states={
                 str(target): {
-                    key: _clamp(float(values.get(key, 0.5)))
-                    for key in cls._SOCIAL_KEYS
+                    key: _clamp(float(values.get(key, 0.5))) for key in cls._SOCIAL_KEYS
                 }
                 for target, values in social_payload.items()
                 if isinstance(values, dict)
             },
             mood_history=[str(entry) for entry in mood_history[-256:]],
             identity_commitments={
-                "values": [str(v) for v in data.get("identity_commitments", {}).get("values", ["coherence", "safety", "utility"])],
-                "red_lines": [str(v) for v in data.get("identity_commitments", {}).get("red_lines", ["harm_user", "silent_data_loss"])],
+                "values": [
+                    str(v)
+                    for v in data.get("identity_commitments", {}).get(
+                        "values", ["coherence", "safety", "utility"]
+                    )
+                ],
+                "red_lines": [
+                    str(v)
+                    for v in data.get("identity_commitments", {}).get(
+                        "red_lines", ["harm_user", "silent_data_loss"]
+                    )
+                ],
             },
             identity_wounds=_clamp(float(data.get("identity_wounds", 0.0))),
+            psyche_version=max(0, int(data.get("psyche_version", 0) or 0)),
+            last_identity_event_id=(
+                str(data["last_identity_event_id"])
+                if data.get("last_identity_event_id")
+                else None
+            ),
         )
         mood_val = data.get("last_mood")
         psyche.last_mood = Mood(mood_val) if mood_val else None

--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -87,6 +87,12 @@ class SelfNarrative:
     objective_trends: dict[str, TraitTrend] = field(default_factory=dict)
     life_id: str = "default"
     entries: list[NarrativeEntry] = field(default_factory=list)
+    # Transaction revisions used to prove that psyche and projection agree.
+    psyche_version: int = 0
+    narrative_version: int = 0
+    last_event_id: str | None = None
+    last_source: str | None = None
+    last_deltas: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
@@ -271,7 +277,9 @@ def infer_trend(
     return (
         "up"
         if projected_delta >= minimum_delta
-        else "down" if projected_delta <= -minimum_delta else "stable"
+        else "down"
+        if projected_delta <= -minimum_delta
+        else "stable"
     )
 
 
@@ -416,6 +424,19 @@ def _materialize(payload: Mapping[str, Any]) -> SelfNarrative:
         },
         life_id=str(payload.get("life_id", "default")),
         entries=entries,
+        psyche_version=max(0, int(payload.get("psyche_version", 0) or 0)),
+        narrative_version=max(0, int(payload.get("narrative_version", 0) or 0)),
+        last_event_id=(
+            str(payload["last_event_id"]) if payload.get("last_event_id") else None
+        ),
+        last_source=(
+            str(payload["last_source"]) if payload.get("last_source") else None
+        ),
+        last_deltas=(
+            dict(payload.get("last_deltas", {}))
+            if isinstance(payload.get("last_deltas"), Mapping)
+            else {}
+        ),
     )
     narrative.identity.logical_age = _compute_logical_age(narrative.identity.born_at)
     return narrative

--- a/tests/test_identity_coherence.py
+++ b/tests/test_identity_coherence.py
@@ -1,7 +1,12 @@
 import json
+import pytest
 from pathlib import Path
 
-from singular.identity import IdentityCoherenceGuard, IdentityInvariants, detect_contradictions
+from singular.identity import (
+    IdentityCoherenceGuard,
+    IdentityInvariants,
+    detect_contradictions,
+)
 
 
 def test_detect_contradictions_between_beliefs_goals_and_history() -> None:
@@ -40,11 +45,17 @@ def test_guard_blocks_invariant_violation_and_audits_gap(tmp_path: Path) -> None
     assert decision.accepted is False
     assert decision.status == "blocked"
     assert "life_name_mismatch" in decision.invariant_violations
-    assert any("cardinal_values_missing" in item for item in decision.invariant_violations)
-    assert any("long_term_commitment_negated" in item for item in decision.invariant_violations)
+    assert any(
+        "cardinal_values_missing" in item for item in decision.invariant_violations
+    )
+    assert any(
+        "long_term_commitment_negated" in item for item in decision.invariant_violations
+    )
 
     audit_path = tmp_path / "mem" / "identity_coherence_audit.jsonl"
-    entries = [json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()]
+    entries = [
+        json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()
+    ]
     assert len(entries) == 1
     assert entries[0]["status"] == "blocked"
     assert entries[0]["accepted"] is False
@@ -91,3 +102,57 @@ def test_guard_recovers_after_drift_with_compliant_decision(tmp_path: Path) -> N
     audit_path = tmp_path / "mem" / "identity_coherence_audit.jsonl"
     lines = audit_path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
+
+
+def test_identity_sync_projects_multi_event_versions(tmp_path):
+    from singular.identity.synchronization import IdentitySynchronizationService
+
+    service = IdentitySynchronizationService(tmp_path)
+    first = service.apply_event(
+        {"event_id": "one", "source": "test", "deltas": {"optimism": 0.1}}
+    )
+    second = service.apply_event(
+        {"event_id": "two", "source": "test", "deltas": {"patience": -0.1}}
+    )
+
+    psyche = json.loads((tmp_path / "mem" / "psyche.json").read_text())
+    narrative = json.loads((tmp_path / "mem" / "self_narrative.json").read_text())
+    assert (first.psyche_version, second.psyche_version) == (1, 2)
+    assert narrative["psyche_version"] == psyche["psyche_version"] == 2
+    assert narrative["narrative_version"] == 2
+    assert narrative["last_event_id"] == "two"
+
+
+def test_identity_sync_recovers_partial_write_without_publishing(monkeypatch, tmp_path):
+    import singular.identity.synchronization as sync_module
+    from singular.events import EventBus
+    from singular.identity.synchronization import IdentitySynchronizationService
+
+    events = []
+    bus = EventBus()
+    bus.subscribe("self_narrative.updated", lambda event: events.append(event.payload))
+    service = IdentitySynchronizationService(tmp_path, bus=bus)
+    original = sync_module.atomic_write_text
+    failed = False
+
+    def fail_narrative(path, data, *args, **kwargs):
+        nonlocal failed
+        if str(path).endswith("self_narrative.json") and not failed:
+            failed = True
+            raise OSError("simulated narrative failure")
+        return original(path, data, *args, **kwargs)
+
+    monkeypatch.setattr(sync_module, "atomic_write_text", fail_narrative)
+    with pytest.raises(OSError):
+        service.apply_event(
+            {"event_id": "partial", "source": "test", "deltas": {"curiosity": 0.1}}
+        )
+    assert events == []
+    assert service.journal_path.exists()
+
+    monkeypatch.setattr(sync_module, "atomic_write_text", original)
+    recovered = service.recover()
+    assert recovered is not None and recovered.recovered
+    psyche = json.loads(service.psyche_path.read_text())
+    narrative = json.loads(service.narrative_path.read_text())
+    assert psyche["psyche_version"] == narrative["psyche_version"] == 1


### PR DESCRIPTION
### Motivation

- Garantir une mise à jour atomique et traçable des traits de `Psyche` et de la projection narrative en associant à chaque modification un `event_id`, une version de psyché, une version narrative, la source et les deltas appliqués.
- Prévenir la publication d'événements `self_narrative.updated` si l’écriture d’un des états échoue, et fournir une reprise après écriture partielle.
- Centraliser les appels dispersés (orchestrateur, talk, mutations) derrière un service unique de synchronisation pour garder l’invariant de cohérence entre `mem/psyche.json`, `mem/self_narrative.json` et la timeline append-only.

### Description

- Ajout du service transactionnel `IdentitySynchronizationService` (alias `IdentitySyncService`) implémenté dans `src/singular/identity/synchronization.py`, qui écrit d’abord une intention (journal), puis engage atomiquement la psyché, la projection narrative et la timeline, publie l’événement uniquement après succès et déduit/évite les doublons dans la timeline.
- Introduit un journal d’intention `identity_sync.pending.json` et un verrou via `file_lock` pour permettre la reprise et l’achèvement sûr des transactions partielles au démarrage.
- Étendu `Psyche` pour inclure `psyche_version` et `last_identity_event_id` et les persister/restaurer via `save_state`/`load_state`.
- Étendu `SelfNarrative` pour inclure `psyche_version`, `narrative_version`, `last_event_id`, `last_source` et `last_deltas` afin d’enregistrer la provenance et prouver l’accord des versions.
- Intégration du service dans les points pertinents : `src/singular/organisms/talk.py` (remplace la persistance directe après interaction) et `src/singular/orchestrator/service.py` (vérification/reprise au chargement, application sur mutations et introspections).
- Ajout de nouvelles assertions et tests fonctionnels dans `tests/test_identity_coherence.py` couvrant les séquences multi-événements, la progression des versions, la simulation d’échec d’écriture et la reprise sans publication prématurée.
- Diverses petites adaptations de sérialisation et de formatage pour intégrer proprement les nouveaux champs.

Fichiers clés modifiés/ajoutés:
- Ajouté: `src/singular/identity/synchronization.py`
- Modifiés: `src/singular/psyche.py`, `src/singular/self_narrative.py`, `src/singular/organisms/talk.py`, `src/singular/orchestrator/service.py`, `tests/test_identity_coherence.py`

### Testing

- Exécution ciblée des suites modifiées: `pytest -q tests/test_psyche.py tests/test_self_narrative.py tests/test_talk.py tests/test_identity_coherence.py tests/test_orchestrator_service.py` — réussies.
- Exécution étendue: `pytest -q tests/test_narrative_projector.py tests/test_orchestrator_service_targeted.py` — réussies.
- Exécution finale de l’ensemble des tests pertinents et validation de compilation/format: toutes les suites exécutées ont réussi (`75 passed` pour les ensembles lancés dans ce cycle).
- Contrôles supplémentaires: `ruff check/format`, `python -m compileall`, `git diff --check` ont été exécutés et sont verts; un commit a été créé (`Add transactional identity synchronization`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7810b55b2c832aae041f06978d566f)