### PR TITLE
Isolate self narratives by canonical life id

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -2928,7 +2928,7 @@ def create_app(
                 details={"active_run_locks": locks},
             )
 
-        from singular.lives import resolve_life
+        from singular.lives import canonical_life_id, resolve_life
         from singular.organisms.talk import talk
 
         resolved_life = resolve_life(target)
@@ -2951,7 +2951,7 @@ def create_app(
                 life_home=resolved_life,
             )
             return {
-                "life": target,
+                "life": canonical_life_id(resolved_life),
                 "path": str(resolved_life),
                 "response": response or "",
             }

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -470,7 +470,7 @@ class DashboardActionService:
         if seed is not None and not isinstance(seed, int):
             raise ValueError("seed must be an integer")
 
-        from singular.lives import resolve_life
+        from singular.lives import canonical_life_id, resolve_life
         from singular.organisms.talk import talk
 
         life = resolve_life(name)
@@ -480,7 +480,7 @@ class DashboardActionService:
         def _run() -> dict[str, Any]:
             response = talk(provider=provider, seed=seed, prompt=prompt, life_home=life)
             return {
-                "life": str(life),
+                "life": canonical_life_id(life),
                 "name": name,
                 "prompt": prompt,
                 "response": response,

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -446,6 +446,15 @@ def _slugify(name: str) -> str:
     return slug or "life"
 
 
+def canonical_life_id(value: str | Path) -> str:
+    """Return the single canonical (registry slug) representation of a life id."""
+
+    raw = Path(value).name if isinstance(value, Path) else str(value)
+    if not raw.strip():
+        raise ValueError("life_id must not be empty")
+    return _slugify(raw)
+
+
 def _resolve_life_metadata(name: str) -> tuple[dict[str, Any], str, LifeMetadata]:
     registry = load_registry()
     lives: dict[str, LifeMetadata] = registry.setdefault("lives", {})

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -27,7 +27,7 @@ from singular.identity.synchronization import IdentitySynchronizationService
 from singular.governance.policy import MutationGovernancePolicy
 from singular.life.coevolution_flow import LivingTestPool
 from singular.life.loop import WorldState, run_tick
-from singular.lives import resolve_life
+from singular.lives import canonical_life_id, resolve_life
 from singular.memory import (
     _atomic_write_text,
     get_base_dir,
@@ -371,6 +371,8 @@ class OrchestratorService:
         return self._wake_requested or run_changed or watch_changed
 
     def _load_recent_run_events(self, *, limit: int = 20) -> list[dict[str, Any]]:
+        """Load only events attributable to this life before narrative aggregation."""
+
         runs_dir = self.base_dir / "runs"
         if not runs_dir.exists():
             return []
@@ -393,8 +395,16 @@ class OrchestratorService:
                     payload = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if isinstance(payload, dict):
-                    collected.append(payload)
+                if not isinstance(payload, dict):
+                    continue
+                raw_life_id = payload.get("life_id")
+                # Unattributed legacy records are deliberately excluded.  They can
+                # only enter a narrative through an explicit migration tool.
+                if not isinstance(raw_life_id, str) or not raw_life_id.strip():
+                    continue
+                if canonical_life_id(raw_life_id) != canonical_life_id(self.base_dir):
+                    continue
+                collected.append(payload)
         return collected[-limit:]
 
     def _refresh_self_narrative(self) -> dict[str, Any]:
@@ -448,7 +458,10 @@ class OrchestratorService:
         now = self.clock()
         if now.tzinfo is None:
             now = now.replace(tzinfo=timezone.utc)
-        snapshots = load_snapshots(self.mem_dir / "self_narrative.json")
+        current_life_id = canonical_life_id(self.base_dir)
+        snapshots = load_snapshots(
+            self.mem_dir / "self_narrative.json", life_id=current_life_id
+        )
 
         def _history_values(
             group: str, name: str, current: float
@@ -515,6 +528,7 @@ class OrchestratorService:
             },
             self.mem_dir / "self_narrative.json",
             clock=self.clock,
+            life_id=current_life_id,
         )
         summary_short = summarize_short(narrative=narrative)
         summary_long = summarize_long(narrative=narrative)

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -23,6 +23,7 @@ from ..perception import capture_signals
 from ..psyche import Mood, Psyche
 from ..identity.synchronization import IdentitySynchronizationService
 from ..self_narrative import load as load_self_narrative, summarize_short
+from ..lives import canonical_life_id
 from ..providers import (
     FallbackLLMClient,
     LLMProviderError,
@@ -194,6 +195,7 @@ def talk(
     causal_file = mem_dir / "causal_timeline.jsonl"
     psyche_file = mem_dir / "psyche.json"
     narrative_file = mem_dir / "self_narrative.json"
+    life_id = canonical_life_id(life_root)
     ensure_memory_structure(mem_dir)
     identity_sync = IdentitySynchronizationService(life_root)
 
@@ -235,7 +237,7 @@ def talk(
         str | None, dict | None, dict | None, str | None, str | None
     ]:
         signals = capture_signals()
-        add_episode({"event": "perception", **signals}, path=episodic_file)
+        add_episode({"event": "perception", "life_id": life_id, **signals}, path=episodic_file)
         psyche.consume()
         episodes = read_episodes(episodic_file)
         episodes_by_role = {
@@ -319,6 +321,7 @@ def talk(
             add_episode(
                 {
                     "event": "memory.recalled",
+                    "life_id": life_id,
                     "source": "talk",
                     "query": user_input,
                     "memories": recalled_memories,
@@ -329,6 +332,7 @@ def talk(
             add_episode(
                 {
                     "event": "memory.used_for_decision",
+                    "life_id": life_id,
                     "source": "talk",
                     "decision": "assistant_reply",
                     "memories": recalled_memories,
@@ -337,7 +341,7 @@ def talk(
                 path=episodic_file,
             )
         add_episode(
-            {"role": "user", "text": user_input, "structured_signals": user_signals},
+            {"role": "user", "life_id": life_id, "text": user_input, "structured_signals": user_signals},
             path=episodic_file,
         )
         mood = psyche.feel(Mood.NEUTRAL)
@@ -447,6 +451,7 @@ def talk(
         add_episode(
             {
                 "role": "assistant",
+                "life_id": life_id,
                 "text": response,
                 "raw_reply": reply,
                 "mood": mood.value,
@@ -538,7 +543,7 @@ def talk(
 
     if prompt is not None:
         context = gather_context()
-        self_narrative = load_self_narrative(narrative_file)
+        self_narrative = load_self_narrative(narrative_file, life_id=life_id)
         return respond(
             prompt,
             *context,
@@ -549,7 +554,7 @@ def talk(
 
     while True:
         context = gather_context()
-        self_narrative = load_self_narrative(narrative_file)
+        self_narrative = load_self_narrative(narrative_file, life_id=life_id)
         try:
             user_input = input("you: ")
         except EOFError:

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -16,6 +16,7 @@ import os
 from typing import Any, Mapping
 
 from ..storage_retention import run_retention_service
+from ..lives import canonical_life_id
 from ..storage import (
     ProviderEventsRepository,
     RunsRepository,
@@ -133,6 +134,7 @@ class RunLogger:
     root: Path | None = None
     psyche: Psyche = field(default_factory=Psyche.load_state)
     reputation_update_every: int = DEFAULT_REPUTATION_UPDATE_EVERY
+    life_id: str | None = None
 
     def __post_init__(self) -> None:
         self.root = (
@@ -141,6 +143,8 @@ class RunLogger:
             else Path(os.environ.get("SINGULAR_HOME", ".")) / "runs"
         )
         self.root.mkdir(parents=True, exist_ok=True)
+        inferred_life = self.life_id or self.root.parent.name or "default"
+        self.life_id = canonical_life_id(inferred_life)
 
         self.run_dir = self.root / self.run_id
         self.run_dir.mkdir(parents=True, exist_ok=True)
@@ -305,17 +309,20 @@ class RunLogger:
         return {name: dict(stats) for name, stats in self._skill_reputation.items()}
 
     def _write_record(self, record: dict[str, Any]) -> None:
+        record["life_id"] = canonical_life_id(record.get("life_id") or self.life_id or "default")
         self._file.write(json.dumps(record) + "\n")
         self._file.flush()
         os.fsync(self._file.fileno())
         self._runs_repository.add_event(self.run_id, record)
 
     def _write_event(self, event_type: str, payload: dict[str, Any], ts: str) -> None:
+        payload["life_id"] = canonical_life_id(payload.get("life_id") or self.life_id or "default")
         event = {
             "version": EVENT_SCHEMA_VERSION,
             "event_type": event_type,
             "ts": ts,
             "payload": payload,
+            "life_id": self.life_id,
         }
         self._events_file.write(json.dumps(event) + "\n")
         self._events_file.flush()

--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -11,6 +11,7 @@ import hashlib
 
 from singular.identity.coherence import detect_contradictions
 from singular.io_utils import append_jsonl_line, atomic_write_text
+from singular.lives import canonical_life_id
 
 SCHEMA_VERSION = 3
 TIMELINE_SUFFIX = ".timeline.jsonl"
@@ -221,12 +222,51 @@ def timeline_path(path: Path | str | None = None) -> Path:
     return current.with_name(current.stem + TIMELINE_SUFFIX)
 
 
-def load_snapshots(path: Path | str | None = None) -> list[dict[str, Any]]:
+def load_snapshots(path: Path | str | None = None, *, life_id: str | None = None) -> list[dict[str, Any]]:
     """Read valid snapshots without letting a damaged line hide later history."""
 
-    return sorted(
-        _load_timeline_records(path), key=lambda item: str(item["recorded_at"])
-    )
+    records = _load_timeline_records(path)
+    if life_id is not None:
+        wanted = canonical_life_id(life_id)
+        records = [item for item in records if _record_life_id(item) == wanted]
+    return sorted(records, key=lambda item: str(item["recorded_at"]))
+
+
+def _record_life_id(record: Mapping[str, Any]) -> str | None:
+    candidates = [record.get("life_id")]
+    for key in ("entry", "narrative", "resulting_narrative"):
+        nested = record.get(key)
+        if isinstance(nested, Mapping):
+            candidates.append(nested.get("life_id"))
+    attributed = {
+        canonical_life_id(value)
+        for value in candidates
+        if isinstance(value, str) and value.strip()
+    }
+    return next(iter(attributed)) if len(attributed) == 1 else None
+
+
+def diagnose_timeline(path: Path | str | None = None) -> dict[str, Any]:
+    """Detect cross-life/missing attribution and propose safe per-life rebuilds."""
+
+    records = _load_timeline_records(path)
+    attributable: dict[str, int] = {}
+    ambiguous: list[int] = []
+    for index, record in enumerate(records, start=1):
+        life = _record_life_id(record)
+        if life is None:
+            ambiguous.append(index)
+        else:
+            attributable[life] = attributable.get(life, 0) + 1
+    return {
+        "contaminated": len(attributable) > 1 or bool(ambiguous),
+        "lives": attributable,
+        "ambiguous_record_lines": ambiguous,
+        "reconstruction_proposals": [
+            {"life_id": life, "command": f"rebuild_from_timeline(path, life_id={life!r})"}
+            for life in sorted(attributable)
+        ],
+    }
 
 
 def _load_timeline_records(path: Path | str | None = None) -> list[dict[str, Any]]:
@@ -451,12 +491,20 @@ def _migrate(payload: Mapping[str, Any]) -> SelfNarrative:
     return narrative
 
 
-def load(path: Path | str | None = None) -> SelfNarrative:
+def _quarantine_entries(path: Path, entries: Sequence[Mapping[str, Any]], reason: str) -> None:
+    quarantine = path.with_name(path.stem + ".quarantine.jsonl")
+    for entry in entries:
+        append_jsonl_line(quarantine, {"quarantined_at": _iso_now(), "reason": reason, "entry": dict(entry)})
+
+
+def load(path: Path | str | None = None, *, life_id: str | None = None) -> SelfNarrative:
     """Load narrative from disk with graceful fallback for missing/corrupt file."""
 
     file_path = _path_or_default(path)
     if not file_path.exists():
         narrative = _default_narrative()
+        if life_id is not None:
+            narrative.life_id = canonical_life_id(life_id)
         save(narrative, file_path, record_snapshot=False)
         return narrative
 
@@ -470,7 +518,7 @@ def load(path: Path | str | None = None) -> SelfNarrative:
             file_path.rename(backup)
         except OSError:
             pass
-        narrative = rebuild_from_timeline(file_path, persist=False)
+        narrative = rebuild_from_timeline(file_path, life_id=life_id, persist=False)
         save(narrative, file_path, record_snapshot=False)
         return narrative
 
@@ -479,7 +527,39 @@ def load(path: Path | str | None = None) -> SelfNarrative:
         save(narrative, file_path, record_snapshot=False)
         return narrative
 
-    narrative = _migrate(payload)
+    expected = canonical_life_id(life_id) if life_id is not None else None
+    raw_life = payload.get("life_id")
+    owner = canonical_life_id(raw_life) if isinstance(raw_life, str) and raw_life.strip() else expected
+    # Explicit bootstrap migration: an untouched, entry-free default projection
+    # may be claimed by the first concrete life that opens its own path.
+    if expected is not None and owner == "default" and not payload.get("entries"):
+        owner = expected
+    if expected is not None and owner is not None and owner != expected:
+        raise ValueError("narrative path belongs to a different life")
+    owner = owner or "default"
+    clean_payload = dict(payload)
+    clean_payload["life_id"] = owner
+    accepted: list[Mapping[str, Any]] = []
+    rejected: list[Mapping[str, Any]] = []
+    for item in payload.get("entries", []) if isinstance(payload.get("entries"), list) else []:
+        if not isinstance(item, Mapping):
+            continue
+        raw_entry_life = item.get("life_id")
+        # Explicit legacy rule: schema < 3 entries inherit an explicit projection owner.
+        if raw_entry_life is None and int(payload.get("schema_version", 0) or 0) < 3 and raw_life:
+            migrated = dict(item)
+            migrated["life_id"] = owner
+            accepted.append(migrated)
+        elif isinstance(raw_entry_life, str) and raw_entry_life.strip() and canonical_life_id(raw_entry_life) == owner:
+            canonical = dict(item)
+            canonical["life_id"] = owner
+            accepted.append(canonical)
+        else:
+            rejected.append(item)
+    clean_payload["entries"] = accepted
+    if rejected:
+        _quarantine_entries(file_path, rejected, "missing_or_foreign_life_id")
+    narrative = _migrate(clean_payload)
     save(narrative, file_path, record_snapshot=False)
     return narrative
 
@@ -495,6 +575,12 @@ def save(
     """Persist narrative JSON and return canonicalized object."""
 
     file_path = _path_or_default(path)
+    narrative.life_id = canonical_life_id(narrative.life_id)
+    foreign = [entry for entry in narrative.entries if canonical_life_id(entry.life_id) != narrative.life_id]
+    if foreign:
+        raise ValueError("cannot save narrative entries belonging to another life")
+    for entry in narrative.entries:
+        entry.life_id = narrative.life_id
     file_path.parent.mkdir(parents=True, exist_ok=True)
     narrative.schema_version = SCHEMA_VERSION
     narrative.identity.logical_age = _compute_logical_age(narrative.identity.born_at)
@@ -578,6 +664,8 @@ def _event_identifier(event: Mapping[str, Any]) -> str:
 
 
 def _apply_entry(narrative: SelfNarrative, entry: NarrativeEntry) -> bool:
+    entry.life_id = canonical_life_id(entry.life_id)
+    narrative.life_id = canonical_life_id(narrative.life_id)
     if entry.life_id != narrative.life_id:
         return False
     if any(current.entry_id == entry.entry_id for current in narrative.entries):
@@ -594,7 +682,7 @@ def rebuild_from_timeline(
 ) -> SelfNarrative:
     """Rebuild a projection from valid append-only records, skipping damage."""
 
-    wanted_life = life_id
+    wanted_life = canonical_life_id(life_id) if life_id is not None else None
     narrative = _default_narrative()
     if wanted_life is not None:
         narrative.life_id = wanted_life
@@ -602,13 +690,22 @@ def rebuild_from_timeline(
         projection = record.get("narrative")
         if isinstance(projection, Mapping) and not record.get("entry"):
             candidate = _migrate(projection)
+            candidate.life_id = canonical_life_id(candidate.life_id)
+            candidate.entries = [
+                entry
+                for entry in candidate.entries
+                if entry.life_id and canonical_life_id(entry.life_id) == candidate.life_id
+            ]
             if wanted_life is None or candidate.life_id == wanted_life:
                 narrative = candidate
             continue
         raw_entry = record.get("entry")
         if not isinstance(raw_entry, Mapping):
             continue
-        record_life = str(raw_entry.get("life_id", "default"))
+        raw_record_life = raw_entry.get("life_id")
+        if not isinstance(raw_record_life, str) or not raw_record_life.strip():
+            continue
+        record_life = canonical_life_id(raw_record_life)
         if wanted_life is None and not narrative.entries:
             narrative.life_id = record_life
         if record_life != narrative.life_id:
@@ -620,6 +717,12 @@ def rebuild_from_timeline(
         resulting = record.get("resulting_narrative")
         if isinstance(resulting, Mapping):
             candidate = _migrate(resulting)
+            candidate.life_id = canonical_life_id(candidate.life_id)
+            candidate.entries = [
+                entry
+                for entry in candidate.entries
+                if entry.life_id and canonical_life_id(entry.life_id) == candidate.life_id
+            ]
             if candidate.life_id == narrative.life_id:
                 narrative = candidate
     if persist:
@@ -643,7 +746,8 @@ def project_event(
     if event_type not in SIGNIFICANT_EVENT_TYPES:
         raise ValueError(f"unsupported narrative event type: {event_type or 'missing'}")
     file_path = _path_or_default(path)
-    projected = load(file_path)
+    life_id = canonical_life_id(life_id)
+    projected = load(file_path, life_id=life_id)
     if projected.entries and projected.life_id != life_id:
         # A path is the storage boundary of one life; never mix identities.
         raise ValueError("narrative path belongs to a different life")
@@ -758,10 +862,11 @@ def update_from_signals(
     path: Path | str | None = None,
     *,
     clock: Callable[[], datetime] | None = None,
+    life_id: str | None = None,
 ) -> SelfNarrative:
     """Update persisted narrative from external signals and return it."""
 
-    narrative = load(path)
+    narrative = load(path, life_id=life_id)
 
     identity_patch = signals.get("identity")
     if isinstance(identity_patch, Mapping):

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -73,6 +73,16 @@ def test_multi_organisms_independent(tmp_path: Path, monkeypatch):
     assert world.organisms["org2"].last_score == val2
 
 
+def test_run_logger_canonicalizes_three_life_identifiers(tmp_path: Path) -> None:
+    from singular.runs.logger import RunLogger
+
+    for raw, expected in (("Ada", "ada"), ("BOB", "bob"), ("Eve Smith", "eve-smith")):
+        with RunLogger(raw, root=tmp_path / raw / "runs", life_id=raw) as logger:
+            logger.log_event("contradictory", summary=raw)
+        record = json.loads((tmp_path / raw / "runs" / raw / "events.jsonl").read_text().splitlines()[0])
+        assert record["life_id"] == expected
+        assert record["payload"]["life_id"] == expected
+
 def test_multi_organism_events_and_dashboard(tmp_path: Path, monkeypatch) -> None:
     org1 = tmp_path / "org1" / "skills"
     org2 = tmp_path / "org2" / "skills"

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -183,6 +183,22 @@ def test_orchestrator_detects_external_stimulus(monkeypatch, tmp_path: Path) -> 
     assert service._external_stimulus_detected() is True
 
 
+def test_recent_run_events_exclude_other_and_unattributed_lives(monkeypatch, tmp_path: Path) -> None:
+    life = tmp_path / "Ada"
+    (life / "skills").mkdir(parents=True)
+    (life / "runs").mkdir()
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+    events = life / "runs" / "mixed.jsonl"
+    events.write_text(
+        '\n'.join(json.dumps(item) for item in (
+            {"life_id": "ADA", "summary": "ada"},
+            {"life_id": "Bob", "summary": "bob"},
+            {"summary": "ambiguous"},
+        )) + '\n', encoding="utf-8"
+    )
+    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+    assert [item["summary"] for item in service._load_recent_run_events()] == ["ada"]
+
 def test_orchestrator_triggers_and_settles_quest(monkeypatch, tmp_path: Path) -> None:
     life = tmp_path / "life"
     (life / "skills").mkdir(parents=True)

--- a/tests/test_self_narrative.py
+++ b/tests/test_self_narrative.py
@@ -7,6 +7,9 @@ from singular.self_narrative import (
     summarize_long,
     summarize_short,
     update_from_signals,
+    diagnose_timeline,
+    project_event,
+    rebuild_from_timeline,
 )
 
 
@@ -25,6 +28,23 @@ def test_load_creates_default_file_when_missing(tmp_path: Path) -> None:
         "optimism",
         "resilience",
     }
+
+
+def test_contaminated_timeline_rebuilds_ada_bob_and_eve_separately(tmp_path: Path) -> None:
+    path = tmp_path / "shared.json"
+    for life, claim in (("Ada", "succès"), ("Bob", "échec"), ("Eve", "incident")):
+        own = tmp_path / f"{life}.json"
+        project_event({"event_type": "incident", "event_id": life, "summary": claim}, own, life_id=life)
+        with path.with_name("shared.timeline.jsonl").open("a", encoding="utf-8") as target:
+            target.write(own.with_name(f"{life}.timeline.jsonl").read_text(encoding="utf-8"))
+
+    report = diagnose_timeline(path)
+    assert report["contaminated"] is True
+    assert set(report["lives"]) == {"ada", "bob", "eve"}
+    rebuilt = {life: rebuild_from_timeline(path, life_id=life, persist=False) for life in report["lives"]}
+    assert {entry.summary for entry in rebuilt["ada"].entries} == {"succès"}
+    assert {entry.summary for entry in rebuilt["bob"].entries} == {"échec"}
+    assert {entry.summary for entry in rebuilt["eve"].entries} == {"incident"}
 
 
 def test_load_fallback_on_corrupted_file(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Prevent cross-life contamination of self-narrative state by ensuring all pipeline stages agree on a single canonical life identifier and by refusing to merge or accept events that are unattributed or belong to another life without an explicit migration rule.

### Description
- Introduce a canonical life id helper `canonical_life_id` and use it across the codebase to normalise life identifiers. (added in `src/singular/lives.py`).
- Filter run events early in the orchestrator: `_load_recent_run_events()` now ignores events that lack a `life_id` or whose canonical life id does not match the current life before any narrative aggregation (changes in `src/singular/orchestrator/service.py`).
- Harden `SelfNarrative` invariants: `load()` accepts an explicit `life_id`, quarantines or rejects entries that are missing or belong to a different life, ensures saved narratives contain only entries for their canonical life, supports loading/rebuilding snapshots filtered by life, and adds `diagnose_timeline()` to detect contaminated timelines and propose per-life rebuilds (`src/singular/self_narrative.py`).
- Ensure provenance and logging use the canonical format: `RunLogger` writes canonical `life_id` into run records and events, and `talk`, dashboard actions and the orchestrator use canonical ids when annotating episodes or returning responses (`src/singular/runs/logger.py`, `src/singular/organisms/talk.py`, `src/singular/dashboard/actions.py`, `src/singular/dashboard/__init__.py`).
- Secure timeline-based reconstruction to only accept projections and resulting narratives that match the target life id and quarantine ambiguous/foreign entries (`src/singular/self_narrative.py`).
- Add multi-life tests covering timeline contamination and reconstruction and tests to verify that logger output is canonicalised (`tests/test_self_narrative.py`, `tests/test_orchestrator_service.py`, `tests/test_multi_organisms.py`).

### Testing
- Executed targeted pytest runs for the modified areas: the new multi-life unit tests and orchestrator/self-narrative checks passed; added tests exercise Ada/Bob/Eve separation and RunLogger canonicalisation (new/updated tests in `tests/test_self_narrative.py`, `tests/test_orchestrator_service.py`, `tests/test_multi_organisms.py`).
- Ran the requested-file suite and linters: `ruff` checks and `git diff --check` reported no issues; the full requested-file pytest suite completed with the new multi-life tests passing, while two pre-existing timing-sensitive multi-organism tests remained failing (`test_multi_organisms_independent` and `test_ecosystem_rules_and_reputation_influence_crossover`), which are unrelated to the multi-life invariants introduced here.
- Summary of automated runs: subset runs with the newly added tests succeeded; full suite run: 30 tests passed and 2 timing-sensitive multi-organism tests failed (investigation of those timing-sensitive failures is outside the scope of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7813ea1484832aac897f43aecbd2a2)