### PR TITLE
feat: versioned deterministic interaction perception signals

### DIFF
--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import random
 import time
-import re
 import json
 from dataclasses import dataclass, field
 from typing import Mapping, Any, Iterable
@@ -22,6 +21,7 @@ from ..memory import (
 )
 from ..memory_layers import MemoryRetrievalService, build_backend
 from ..perception import capture_signals
+from ..perception.interaction import apply_psyche_deltas, extract_structured_signals
 from ..psyche import Mood, Psyche
 from ..identity.synchronization import IdentitySynchronizationService
 from ..self_narrative import load as load_self_narrative, summarize_short
@@ -181,76 +181,6 @@ def _user_message_for_error(provider: str, err: LLMProviderError) -> str:
     if isinstance(err, ProviderRetryExhaustedError):
         return f"Provider '{provider}' retries exhausted. Using local fallback replies."
     return f"Provider '{provider}' failed unexpectedly. Using local fallback replies."
-
-
-def _extract_structured_signals(text: str) -> dict[str, object]:
-    lowered = text.lower()
-    frustration_tokens = {
-        "bug",
-        "erreur",
-        "error",
-        "frustr",
-        "bloqué",
-        "bloque",
-        "impossible",
-        "nul",
-        "fail",
-        "failed",
-        "wtf",
-    }
-    satisfaction_tokens = {
-        "merci",
-        "super",
-        "parfait",
-        "great",
-        "thanks",
-        "top",
-        "cool",
-        "good",
-        "bien",
-    }
-    urgency_tokens = {
-        "urgent",
-        "asap",
-        "vite",
-        "maintenant",
-        "now",
-        "immédiat",
-        "immediat",
-        "deadline",
-    }
-    token_count = max(1, len(re.findall(r"\w+", lowered)))
-    frustration = min(
-        1.0,
-        sum(1 for token in frustration_tokens if token in lowered)
-        / max(1.0, token_count * 0.2),
-    )
-    satisfaction = min(
-        1.0,
-        sum(1 for token in satisfaction_tokens if token in lowered)
-        / max(1.0, token_count * 0.2),
-    )
-    urgency = min(
-        1.0,
-        0.35 * float("!" in text or "?" in text)
-        + sum(1 for token in urgency_tokens if token in lowered) * 0.35,
-    )
-    theme = "general"
-    for candidate, keywords in (
-        ("bugfix", ("bug", "erreur", "fix", "incident")),
-        ("performance", ("lent", "slow", "optim", "performance", "latence")),
-        ("planning", ("roadmap", "plan", "deadline", "priorit")),
-        ("support", ("help", "aide", "explain", "comprendre")),
-    ):
-        if any(keyword in lowered for keyword in keywords):
-            theme = candidate
-            break
-    return {
-        "frustration": round(frustration, 3),
-        "satisfaction": round(satisfaction, 3),
-        "urgency": round(urgency, 3),
-        "theme": theme,
-    }
 
 
 def _trim_for_budget(text: str, budget: int) -> str:
@@ -427,7 +357,10 @@ def talk(
         self_narrative_summary: str,
         self_narrative_version: int,
     ) -> str:
-        user_signals = _extract_structured_signals(user_input)
+        user_signals = extract_structured_signals(
+            user_input, state_path=mem_dir / "interaction_perception.json"
+        )
+        apply_psyche_deltas(psyche, user_signals)
         theme = str(user_signals.get("theme", "general"))
         retrieval = MemoryRetrievalService(
             life_root, build_backend(root=mem_dir / "layers")

--- a/src/singular/perception/interaction.py
+++ b/src/singular/perception/interaction.py
@@ -1,0 +1,244 @@
+"""Deterministic, auditable perception of human dialogue."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from pathlib import Path
+from typing import Any, Mapping
+
+CONTRACT_VERSION = "interaction-signals/1.0"
+_WORDS = re.compile(r"[^\W_]+", re.UNICODE)
+_NEGATIONS = {
+    "aucun",
+    "aucune",
+    "jamais",
+    "ne",
+    "non",
+    "not",
+    "no",
+    "never",
+    "pas",
+    "sans",
+}
+_INTENSIFIERS = {
+    "tres": 1.5,
+    "vraiment": 1.4,
+    "extremement": 1.8,
+    "very": 1.5,
+    "really": 1.4,
+    "extremely": 1.8,
+}
+_LEXICON = {
+    "frustration": {
+        "bug",
+        "erreur",
+        "error",
+        "frustre",
+        "frustree",
+        "bloque",
+        "impossible",
+        "nul",
+        "fail",
+        "failed",
+        "wtf",
+    },
+    "satisfaction": {
+        "merci",
+        "super",
+        "parfait",
+        "great",
+        "thanks",
+        "top",
+        "cool",
+        "good",
+        "bien",
+    },
+    "urgency": {"urgent", "asap", "vite", "maintenant", "now", "immediat", "deadline"},
+}
+_THEMES = (
+    ("bugfix", {"bug", "erreur", "error", "fix", "incident"}),
+    ("performance", {"lent", "slow", "optimisation", "performance", "latence"}),
+    ("planning", {"roadmap", "plan", "deadline", "priorite"}),
+    ("support", {"help", "aide", "explain", "comprendre"}),
+)
+_MARKING = {"traumatisant", "traumatic", "critique", "critical", "marquant", "landmark"}
+
+
+def _normalize(word: str) -> str:
+    return "".join(
+        c
+        for c in unicodedata.normalize("NFKD", word.casefold())
+        if not unicodedata.combining(c)
+    )
+
+
+def tokenize(text: str) -> list[str]:
+    """Return accent-insensitive Unicode words with real word boundaries."""
+    return [_normalize(word) for word in _WORDS.findall(text)]
+
+
+def _load_state(path: Path | None) -> dict[str, float]:
+    if path is None:
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return {str(k): float(v) for k, v in data.get("accumulators", {}).items()}
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def extract_structured_signals(
+    text: str, *, state_path: Path | None = None
+) -> dict[str, Any]:
+    """Observe, interpret and gate dialogue effects without an LLM.
+
+    The returned versioned contract keeps evidence separate from interpretation
+    and from the trait deltas that crossed the accumulation threshold.
+    """
+    word_matches = list(_WORDS.finditer(text))
+    tokens = [_normalize(match.group()) for match in word_matches]
+    observations: list[dict[str, Any]] = []
+    totals = {name: 0.0 for name in _LEXICON}
+    for index, token in enumerate(tokens):
+        for dimension, vocabulary in _LEXICON.items():
+            if token not in vocabulary:
+                continue
+            start = max(0, index - 3)
+            window = tokens[start:index]
+            for prior in range(index - 1, start - 1, -1):
+                separator = text[
+                    word_matches[prior].end() : word_matches[prior + 1].start()
+                ]
+                if re.search(r"[,;.!?]", separator):
+                    window = tokens[prior + 1 : index]
+                    break
+            negated = any(item in _NEGATIONS for item in window)
+            multiplier = max(
+                (_INTENSIFIERS.get(item, 1.0) for item in window[-2:]), default=1.0
+            )
+            weight = 0.0 if negated else multiplier
+            totals[dimension] += weight
+            observations.append(
+                {
+                    "token": token,
+                    "index": index,
+                    "dimension": dimension,
+                    "negated": negated,
+                    "intensity": multiplier,
+                    "source": "human_message",
+                }
+            )
+
+    scores = {name: round(min(1.0, total * 0.45), 3) for name, total in totals.items()}
+    theme = next(
+        (
+            name
+            for name, words in _THEMES
+            if any(o["token"] in words and not o["negated"] for o in observations)
+        ),
+        "general",
+    )
+    # Themes also use exact normalized tokens, including words not in sentiment lexicons.
+    if theme == "general":
+        negated_indexes = {int(o["index"]) for o in observations if o["negated"]}
+        theme = next(
+            (
+                name
+                for name, words in _THEMES
+                if any(
+                    token in words and index not in negated_indexes
+                    for index, token in enumerate(tokens)
+                )
+            ),
+            "general",
+        )
+    marking = any(token in _MARKING for token in tokens)
+    accumulators = _load_state(state_path)
+    deltas: list[dict[str, Any]] = []
+    for dimension, trait, direction in (
+        ("satisfaction", "optimism", 1.0),
+        ("frustration", "resilience", -1.0),
+        ("urgency", "patience", -1.0),
+    ):
+        score = scores[dimension]
+        previous = accumulators.get(dimension, 0.0)
+        accumulated = max(0.0, previous * 0.8 + (score if score >= 0.3 else 0.0))
+        threshold = 0.4 if marking else 1.2
+        proposed = direction * (
+            0.1 if marking and score >= 0.3 else min(0.04, score * 0.08)
+        )
+        applied = proposed if accumulated >= threshold else 0.0
+        capped = abs(proposed) >= (0.1 if marking else 0.04)
+        if applied:
+            accumulated = 0.0
+        accumulators[dimension] = round(accumulated, 3)
+        deltas.append(
+            {
+                "trait": trait,
+                "proposed": round(proposed, 3),
+                "applied": round(applied, 3),
+                "confidence": score,
+                "justification": (
+                    "explicit_marking_event"
+                    if marking
+                    else (
+                        "repeated_signal_threshold"
+                        if applied
+                        else "neutral_zone_or_accumulation_pending"
+                    )
+                ),
+                "source": "interaction_perception",
+                "capped": capped,
+                "cap": 0.1 if marking else 0.04,
+            }
+        )
+    if state_path is not None:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(
+            json.dumps(
+                {"contract_version": CONTRACT_VERSION, "accumulators": accumulators},
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "raw_observations": {
+            "text": text,
+            "tokens": tokens,
+            "matches": observations,
+            "source": "human_message",
+        },
+        "interpretation": {
+            **scores,
+            "theme": theme,
+            "explicitly_marking": marking,
+            "accumulators": accumulators,
+            "neutral_zone": 0.3,
+            "threshold": 0.4 if marking else 1.2,
+        },
+        "psyche_deltas": deltas,
+        # Compatibility fields for consumers of the original unversioned shape.
+        **scores,
+        "theme": theme,
+    }
+
+
+def apply_psyche_deltas(psyche: object, signals: Mapping[str, Any]) -> None:
+    """Apply only audited deltas from the versioned contract, with a final clamp."""
+    for delta in signals.get("psyche_deltas", []):
+        if not isinstance(delta, Mapping) or not delta.get("applied"):
+            continue
+        trait = str(delta.get("trait"))
+        if hasattr(psyche, trait):
+            setattr(
+                psyche,
+                trait,
+                max(
+                    0.0,
+                    min(1.0, float(getattr(psyche, trait)) + float(delta["applied"])),
+                ),
+            )

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -8,6 +8,62 @@ from singular.events import EventBus
 from singular.governance.policy import load_runtime_policy, save_runtime_policy
 from singular.perception import capture_signals, reset_perception_state
 from singular.memory import add_episode, read_episodes
+from singular.perception.interaction import (
+    CONTRACT_VERSION,
+    apply_psyche_deltas,
+    extract_structured_signals,
+)
+from singular.psyche import Psyche
+
+
+def test_dialogue_perception_handles_boundaries_accents_negations_and_mixed_language():
+    signals = extract_structured_signals(
+        "Très urgent, really great — mais pas urgent et aucune erreur; superbe."
+    )
+
+    assert signals["contract_version"] == CONTRACT_VERSION
+    assert signals["urgency"] > 0
+    assert signals["satisfaction"] > 0
+    assert signals["frustration"] == 0
+    matches = signals["raw_observations"]["matches"]
+    assert any(match["token"] == "urgent" and match["negated"] for match in matches)
+    assert any(match["token"] == "erreur" and match["negated"] for match in matches)
+    # Accidental substrings are not words: neither "superbe" nor "nowhere"
+    # may trigger "super" or "now".
+    accidental = extract_structured_signals("superbe nowhere planification")
+    assert accidental["satisfaction"] == 0
+    assert accidental["urgency"] == 0
+    assert accidental["theme"] == "general"
+
+
+def test_dialogue_perception_accumulates_before_applying_audited_delta(tmp_path):
+    state = tmp_path / "interaction.json"
+    psyche = Psyche()
+    first = extract_structured_signals("Merci, great work", state_path=state)
+    apply_psyche_deltas(psyche, first)
+    assert psyche.optimism == 0.5
+    optimism = next(
+        delta for delta in first["psyche_deltas"] if delta["trait"] == "optimism"
+    )
+    assert optimism["applied"] == 0
+    assert set(optimism) >= {"confidence", "justification", "source", "capped", "cap"}
+
+    second = extract_structured_signals("Thanks, parfait", state_path=state)
+    apply_psyche_deltas(psyche, second)
+    applied = next(
+        delta for delta in second["psyche_deltas"] if delta["trait"] == "optimism"
+    )
+    assert applied["applied"] > 0
+    assert applied["justification"] == "repeated_signal_threshold"
+    assert psyche.optimism > 0.5
+
+    marking = extract_structured_signals("A critical error was traumatic")
+    resilience = next(
+        delta for delta in marking["psyche_deltas"] if delta["trait"] == "resilience"
+    )
+    assert resilience["applied"] == -0.1
+    assert resilience["justification"] == "explicit_marking_event"
+    assert resilience["capped"] is True
 
 
 def test_capture_and_persist_signals(tmp_path, monkeypatch):

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -191,6 +191,34 @@ def test_talk_single_prompt(monkeypatch, tmp_path):
     assert outputs[-1] == expected
 
 
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("Ce n'est pas urgent et il n'y a aucune erreur", (0.0, 0.0)),
+        ("This is not urgent, no error, thanks", (0.0, 0.45)),
+        ("superbe nowhere", (0.0, 0.0)),
+        ("Très urgent but really great", (0.675, 0.63)),
+    ],
+)
+def test_talk_persists_versioned_multilingual_signals(
+    monkeypatch, tmp_path, message, expected
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SINGULAR_HOME", raising=False)
+    monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: None)
+    monkeypatch.setattr("builtins.print", lambda _message: None)
+
+    talk(prompt=message)
+
+    user = next(episode for episode in read_episodes() if episode.get("role") == "user")
+    signals = user["structured_signals"]
+    assert signals["contract_version"] == "interaction-signals/1.0"
+    assert (signals["urgency"], signals["satisfaction"]) == expected
+    assert "raw_observations" in signals
+    assert "interpretation" in signals
+    assert "psyche_deltas" in signals
+
+
 def _run_talk(monkeypatch, tmp_path, seed, run):
     subdir = tmp_path / f"{seed}_{run}"
     subdir.mkdir()
@@ -388,7 +416,9 @@ def test_talk_prompt_keeps_each_life_identity(monkeypatch, tmp_path, name):
     )
     captured = {}
     client = LLMProviderClient(
-        name="openai", generate=lambda prompt, timeout=8.0: captured.setdefault("prompt", prompt) and "ok"
+        name="openai",
+        generate=lambda prompt, timeout=8.0: captured.setdefault("prompt", prompt)
+        and "ok",
     )
     monkeypatch.setattr("singular.organisms.talk.load_llm_client", lambda _name: client)
     monkeypatch.setattr("builtins.print", lambda _msg: None)
@@ -396,13 +426,17 @@ def test_talk_prompt_keeps_each_life_identity(monkeypatch, tmp_path, name):
     talk(provider="openai", prompt="Qui es-tu ?", life_home=root)
 
     assert name in captured["prompt"]
-    assert all(other not in captured["prompt"] for other in {"Ada", "Bob", "Eve"} - {name})
+    assert all(
+        other not in captured["prompt"] for other in {"Ada", "Bob", "Eve"} - {name}
+    )
 
 
 def test_context_drops_whole_facts_but_never_safety_rule():
     result = _build_structured_context(
         [
-            ContextItem("identity", "fait critique indivisible", "identity:1", relevance=1),
+            ContextItem(
+                "identity", "fait critique indivisible", "identity:1", relevance=1
+            ),
             ContextItem("traits", "x" * 500, "trait:oversized", relevance=1),
             ContextItem("safety", "NE JAMAIS INVENTER", "policy:safety", critical=True),
         ],


### PR DESCRIPTION
### Motivation

- Isolate and version the heuristic that extracts structured dialogue signals so perception is deterministic, auditable, and decoupled from `talk`'s orchestration. 
- Replace fragile substring matching with normalized tokenization that respects word boundaries, accents, negations and intensifiers for French and English.
- Prevent single messages from permanently shifting identity traits by adding accumulation, neutral zones and explicit marking to reserve large changes for repeated or marked events.

### Description

- Added a new module `src/singular/perception/interaction.py` that implements a versioned contract `interaction-signals/1.0`, Unicode-aware tokenization, scoped negation detection, intensifier multipliers, theme detection, persistent accumulators, and an auditable `psyche_deltas` structure including `confidence`, `justification`, `source` and `cap` fields. 
- Integrated the new contract into the conversation flow by calling `extract_structured_signals(..., state_path=mem_dir / "interaction_perception.json")` and applying audited changes with `apply_psyche_deltas(psyche, signals)` in `src/singular/organisms/talk.py`.
- Implemented neutral-zone gating and accumulation logic so ordinary single signals do not apply trait deltas immediately; thresholds or explicit marking events trigger capped deltas. 
- Added tests in `tests/test_perception.py` and updates to `tests/test_talk.py` covering French and English formulations, negations (e.g. “pas urgent”, “aucune erreur”), accidental-substring cases, mixed-language messages, accumulation behavior and explicit marking events.

### Testing

- ✅ `pytest -q tests/test_perception.py tests/test_talk.py` — focused unit tests for interaction perception and talk integration all passed (`41 passed`).
- ✅ `ruff check src/singular/perception/interaction.py src/singular/organisms/talk.py tests/test_perception.py tests/test_talk.py` — linting passed on modified files.
- ✅ `git diff --check` — no whitespace/patch errors detected.
- ⚠️ `pytest -q` — full project test run was attempted and revealed many unrelated baseline/environment failures (not caused by these changes), notably a missing/blocked secure sandbox (Podman/Docker) and existing cross-test state; these are reported as environment/fixture issues rather than regressions in the new interaction code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a781b949a20832a9908278fca97b8d4)