### PR TITLE
Add correlated causal dashboard timeline

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -568,6 +568,12 @@ def create_app(
             "cooldown_seconds": record.get("cooldown_seconds"),
             "open_until": record.get("open_until"),
             "corrective_action": record.get("corrective_action"),
+            "correlation_id": record.get("correlation_id"),
+            "cause": record.get("initial_cause", record.get("category", record.get("source_error_type"))),
+            "decision": record.get("decision_reason", record.get("reason")),
+            "consequence": record.get("human_summary", record.get("result")),
+            "life": _record_life(record),
+            "mutation_path": record.get("impacted_file", record.get("path")),
             "last_sandbox_diagnostics": record.get("last_sandbox_diagnostics"),
         }
 

--- a/src/singular/dashboard/services/trajectory.py
+++ b/src/singular/dashboard/services/trajectory.py
@@ -102,6 +102,34 @@ def build_trajectory(
             }
         )
 
+    # Correlation IDs are deliberately the primary join key: a breaker alert
+    # can therefore lead to its sandbox cause, mutation and impacted path even
+    # when these were emitted by different subsystems.
+    correlated: dict[str, list[dict[str, object]]] = {}
+    for record in records:
+        correlation_id = record.get("correlation_id")
+        if not isinstance(correlation_id, str) or not correlation_id:
+            continue
+        event = record.get("event") or record.get("event_type") or (
+            "mutation" if any(key in record for key in ("op", "operator", "diff")) else "record"
+        )
+        item = {
+            "correlation_id": correlation_id,
+            "timestamp": record.get("ts", record.get("timestamp")),
+            "event": event,
+            "cause": record.get("initial_cause", record.get("category", record.get("source_error_type"))),
+            "decision": record.get("decision_reason", record.get("reason", record.get("accepted"))),
+            "consequence": record.get("human_summary", record.get("result", record.get("self_narrative_event"))),
+            "life": record.get("life_id", record.get("life", record.get("organism"))),
+            "corrective_action": record.get("corrective_action"),
+            "mutation": record.get("operator", record.get("op")),
+            "path": record.get("impacted_file", record.get("path")),
+            "run": record_run_id(record),
+        }
+        correlated.setdefault(correlation_id, []).append(item)
+    chronology = [item for group in correlated.values() for item in group]
+    chronology.sort(key=lambda item: str(item.get("timestamp") or ""))
+
     return {
         "objectives": {
             "counts": {
@@ -115,4 +143,6 @@ def build_trajectory(
         },
         "priority_changes": priority_changes[-40:],
         "objective_narrative_links": links[-40:],
+        "causal_chronology": chronology[-100:],
+        "correlations": {key: value for key, value in correlated.items()},
     }

--- a/src/singular/dashboard/static/render-cockpit.js
+++ b/src/singular/dashboard/static/render-cockpit.js
@@ -667,13 +667,13 @@ export const loadCockpit=()=>Promise.allSettled([
   const energyResources=vitalMetrics.energy_resources||{};
   const codeGeneration=vitalMetrics.code_generation||{};
   const risks=vitalMetrics.risks||[];
-  setText('kpi-vital-age',String(vital.age??0));
+  setText('kpi-vital-age',String(vital.age??na()));
   setText('kpi-vital-risk',String(vital.risk_level||na()));
   setText('kpi-vital-terminal',vital.terminal===true?'oui':'non');
   setText('kpi-vital-causes',(vital.causes||[]).join(', ')||na());
   setText('kpi-circadian-phase',String((vitalMetrics.circadian_cycle||{}).phase||na()));
-  setText('kpi-active-objectives-count',String(objectives.count||0));
-  setText('kpi-quests-progress',`${objectives.count||0} actifs`);
+  setText('kpi-active-objectives-count',String(objectives.count??na()));
+  setText('kpi-quests-progress',objectives.count==null?'Données absentes':`${objectives.count} actifs`);
   setText('kpi-energy-total',fmtNum(energyResources.total_energy));
   setText('kpi-resources-total',fmtNum(energyResources.total_resources));
   setText('kpi-code-progression',String(codeGeneration.progression||na()));

--- a/src/singular/dashboard/static/render-conversations.js
+++ b/src/singular/dashboard/static/render-conversations.js
@@ -10,6 +10,10 @@ const conversationState={
 };
 
 const FLOW_STYLES={
+  'sain':'summary-ok',
+  'mode dégradé':'summary-warning',
+  'bloqué':'summary-critical',
+  'données absentes':'summary-muted',
   'en écoute':'summary-ok',
   'en réflexion':'summary-warning',
   'indisponible':'summary-muted',
@@ -76,6 +80,10 @@ const setFlowState=(flow)=>{
 
 const inferFlow=(meta)=>{
   const chatStatus=String(meta?.chat_status||'').toLowerCase();
+  if(!chatStatus&&!meta?.status){return 'données absentes';}
+  if(chatStatus==='ok'){return 'sain';}
+  if(chatStatus.includes('fallback')||chatStatus.includes('degraded')){return 'mode dégradé';}
+  if(chatStatus.includes('blocked')||chatStatus.includes('breaker')){return 'bloqué';}
   if(STATUS_LABELS[chatStatus]){return STATUS_LABELS[chatStatus];}
   const status=String(meta?.status||'').toLowerCase();
   if(status.includes('archiv')){return 'archivée';}

--- a/src/singular/dashboard/static/render-timeline.js
+++ b/src/singular/dashboard/static/render-timeline.js
@@ -35,6 +35,20 @@ const showGovernanceBreakerDetail=(item)=>{
   diff.textContent='';
 };
 
+const addCorrelationLinks=(row,item,items,runId)=>{
+  if(!item.correlation_id){return;}
+  row.dataset.correlationId=item.correlation_id;
+  const mutation=items.find(candidate=>candidate.correlation_id===item.correlation_id&&candidate.event==='mutation');
+  const path=item.mutation_path||mutation?.mutation_path;
+  if(mutation){
+    const button=document.createElement('button');
+    button.type='button';button.className='timeline-link';button.textContent='Mutation déclenchante';
+    button.onclick=()=>showMutationDetail(runId,items.filter(entry=>entry.event==='mutation').indexOf(mutation));
+    row.appendChild(button);
+  }
+  if(path){const code=document.createElement('code');code.className='timeline-path';code.textContent=path;row.appendChild(code);}
+};
+
 export const loadTimeline=()=>fetchJson(withScope('/runs/latest')).then(meta=>{
   if(!meta.run){return {run_id:null,items:[]};}
   return fetchJson(`/api/runs/${meta.run}/timeline?page=1&page_size=120`);
@@ -58,6 +72,7 @@ export const loadTimeline=()=>fetchJson(withScope('/runs/latest')).then(meta=>{
       btn.onclick=()=>showGovernanceBreakerDetail(item);
     }
     row.appendChild(btn);
+    addCorrelationLinks(row,item,data.items||[],data.run_id);
     if(item.event==='mutation'&&data.run_id){
       const currentIndex=mutationIndex;
       mutationIndex+=1;

--- a/src/singular/dashboard/templates/dashboard.html
+++ b/src/singular/dashboard/templates/dashboard.html
@@ -325,6 +325,7 @@
     <h2>Timeline des événements</h2>
     <p class='section-help'>Timeline + détail mutation pour expliquer rapidement un changement.</p>
     <div id='timeline' class='timeline-strip'></div>
+    <p class='section-help'>Chaque événement corrélé expose cause, décision, conséquence, vie, action corrective, mutation et chemin concernés.</p>
     <h3 class='technical-only'>Ce qui a changé grâce à quoi</h3>
     <ul id='causal-timeline-list' class='list-tight-top technical-only'>
       <li>Aucune trace causale disponible.</li>

--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -10,6 +10,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Mapping
+from uuid import uuid4
 
 from .values import ValueWeights
 
@@ -760,6 +761,7 @@ def audit_circuit_transition(
     new_state: str,
     emergency: bool = False,
     evidence: Mapping[str, Any] | None = None,
+    correlation_id: str | None = None,
 ) -> None:
     """Append a mandatory, attributable state transition audit record."""
 
@@ -777,6 +779,7 @@ def audit_circuit_transition(
         "new_state": new_state,
         "emergency": emergency,
         "evidence": dict(evidence or {}),
+        "correlation_id": correlation_id or uuid4().hex,
     }
     with path.open("a", encoding="utf-8") as stream:
         stream.write(json.dumps(record, ensure_ascii=False) + "\n")
@@ -1077,13 +1080,18 @@ class MutationGovernancePolicy:
         severity: str | None = None,
         closure: Mapping[str, Any] | None = None,
         probe: Mapping[str, Any] | None = None,
+        correlation_id: str | None = None,
     ) -> None:
         if self._circuit_state_file is None:
             return
         home = self._circuit_state_file.parent.parent
         payload = load_circuit_state(home)
         now = self._now().isoformat()
-        payload.update({"state": state, "updated_at": now})
+        payload.update({
+            "state": state,
+            "updated_at": now,
+            "correlation_id": correlation_id or payload.get("correlation_id") or uuid4().hex,
+        })
         if cause:
             violations = payload["violations"]
             violations["total"] = int(violations.get("total", 0)) + 1

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -10,6 +10,7 @@ import json
 import logging
 import signal
 import time
+from uuid import uuid4
 from pathlib import Path
 from typing import Any, Callable
 
@@ -180,6 +181,7 @@ class OrchestratorService:
         self._host_thresholds = load_host_sensor_thresholds()
         self._started_at = datetime.now(timezone.utc)
         self._behavioral_metrics: dict[str, Any] = {}
+        self._correlation_id = uuid4().hex
 
         self._subscribe_external_stimuli()
 
@@ -534,6 +536,7 @@ class OrchestratorService:
         summary_long = summarize_long(narrative=narrative)
         payload = {
             "event_type": "self_narrative.updated",
+            "correlation_id": self._correlation_id,
             "tick": self._tick_count,
             "introspection_tick": self._introspection_tick_count,
             "episodes_loaded": len(recent_episodes),

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -357,6 +357,9 @@ def talk(
         self_narrative_summary: str,
         self_narrative_version: int,
     ) -> str:
+        # One identifier joins the human turn, every provider attempt, the
+        # resulting narrative evidence and the causal trace.
+        correlation_id = uuid4().hex
         user_signals = extract_structured_signals(
             user_input, state_path=mem_dir / "interaction_perception.json"
         )
@@ -504,6 +507,7 @@ def talk(
             active_provider=active_provider,
             life_root=life_root,
             context_metrics=context_result.metrics,
+            correlation_id=correlation_id,
         )
 
         parts = [reply]
@@ -525,6 +529,7 @@ def talk(
         add_episode(
             {
                 "role": "assistant",
+                "correlation_id": correlation_id,
                 "life_id": life_id,
                 "text": response,
                 "raw_reply": reply,
@@ -564,6 +569,7 @@ def talk(
             {
                 "ts": datetime.now(timezone.utc).isoformat(),
                 "trace_id": uuid4().hex,
+                "correlation_id": correlation_id,
                 "pipeline": "interaction.talk",
                 "input": {
                     "kind": "human_message",
@@ -608,7 +614,8 @@ def talk(
         psyche.gain()
         identity_sync.apply_event(
             {
-                "event_id": f"conversation-{uuid4()}",
+                "event_id": f"conversation-{correlation_id}",
+                "correlation_id": correlation_id,
                 "source": "organisms.talk",
                 "type": "conversation",
                 "summary": "Interaction utilisateur traitée",

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import json
 import logging
 import os
+from uuid import uuid4
 from typing import Any, Mapping
 
 from ..storage_retention import run_retention_service
@@ -83,6 +84,7 @@ def log_provider_event(
     active_provider: str | None = None,
     life_root: Path | str | None = None,
     context_metrics: Mapping[str, Any] | None = None,
+    correlation_id: str | None = None,
 ) -> None:
     """Emit a structured provider log entry."""
 
@@ -94,6 +96,7 @@ def log_provider_event(
         "fallback": fallback,
         "error_category": error_category,
         "llm_real": llm_real,
+        "correlation_id": correlation_id or uuid4().hex,
     }
     if context_metrics is not None:
         # Metrics contain only sizes, counts and opaque provenance identifiers;
@@ -140,8 +143,10 @@ class RunLogger:
     psyche: Psyche = field(default_factory=Psyche.load_state)
     reputation_update_every: int = DEFAULT_REPUTATION_UPDATE_EVERY
     life_id: str | None = None
+    correlation_id: str | None = None
 
     def __post_init__(self) -> None:
+        self.correlation_id = self.correlation_id or uuid4().hex
         self.root = (
             Path(self.root)
             if self.root is not None
@@ -314,6 +319,7 @@ class RunLogger:
         return {name: dict(stats) for name, stats in self._skill_reputation.items()}
 
     def _write_record(self, record: dict[str, Any]) -> None:
+        record.setdefault("correlation_id", self.correlation_id)
         record["life_id"] = canonical_life_id(record.get("life_id") or self.life_id or "default")
         self._file.write(json.dumps(record) + "\n")
         self._file.flush()
@@ -321,6 +327,7 @@ class RunLogger:
         self._runs_repository.add_event(self.run_id, record)
 
     def _write_event(self, event_type: str, payload: dict[str, Any], ts: str) -> None:
+        payload.setdefault("correlation_id", self.correlation_id)
         payload["life_id"] = canonical_life_id(payload.get("life_id") or self.life_id or "default")
         event = {
             "version": EVENT_SCHEMA_VERSION,
@@ -361,6 +368,7 @@ class RunLogger:
                 "energy": energy,
             },
             "success": success,
+            "correlation_id": self.correlation_id,
         }
         self._consciousness_file.write(json.dumps(record) + "\n")
         self._consciousness_file.flush()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -9,7 +9,22 @@ from fastapi_stub import TestClient
 
 import singular.dashboard as dashboard_module
 from singular.dashboard import create_app, run
+from singular.dashboard.services.trajectory import build_trajectory
 from singular.lives import LifeMetadata, create_life
+
+
+def test_trajectory_contract_joins_records_by_correlation_id(tmp_path: Path) -> None:
+    records = [
+        {"ts": "2026-08-09T10:00:00+00:00", "event": "sandbox_violation", "correlation_id": "corr-1", "category": "forbidden_name", "life_id": "life-a"},
+        {"ts": "2026-08-09T10:00:01+00:00", "event": "mutation", "correlation_id": "corr-1", "op": "replace", "impacted_file": "skills/a.py", "accepted": False},
+        {"ts": "2026-08-09T10:00:02+00:00", "event": "governance.circuit_breaker_opened", "correlation_id": "corr-1", "corrective_action": "halt mutations"},
+    ]
+    payload = build_trajectory(records, tmp_path / "missing.json", lambda _: "run-a")
+    assert [item["event"] for item in payload["correlations"]["corr-1"]] == [
+        "sandbox_violation", "mutation", "governance.circuit_breaker_opened"
+    ]
+    assert payload["correlations"]["corr-1"][1]["path"] == "skills/a.py"
+    assert payload["causal_chronology"][2]["corrective_action"] == "halt mutations"
 
 
 def _receive_with_timeout(ws: TestClient._WSConnection, timeout: float = 2.0) -> dict[str, object]:

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -20,6 +20,17 @@ AUDITED_JS = [
 CANONICAL_BRANDING = Path("docs/assets/branding")
 
 
+def test_timeline_static_exposes_correlation_navigation() -> None:
+    timeline = (DASHBOARD_STATIC / "render-timeline.js").read_text(encoding="utf-8")
+    conversations = (DASHBOARD_STATIC / "render-conversations.js").read_text(encoding="utf-8")
+    template = DASHBOARD_TEMPLATE.read_text(encoding="utf-8")
+    assert "correlation_id" in timeline
+    assert "Mutation déclenchante" in timeline
+    assert "timeline-path" in timeline
+    assert all(label in conversations for label in ("données absentes", "sain", "mode dégradé", "bloqué"))
+    assert "cause, décision, conséquence, vie, action corrective" in template
+
+
 @pytest.mark.parametrize(
     ("canonical_name", "dashboard_name"),
     [


### PR DESCRIPTION
### Motivation

- Faciliter le suivi causal des incidents en joignant un identifiant de corrélation unique aux tentatives provider, mutations, violations sandbox, transitions du circuit-breaker, mises à jour narratives et conversations afin de permettre une navigation directe entre l'alerte, la mutation déclenchante et le fichier impacté.
- Rendre le tableau de bord plus explicite sur l'état des conversations et des métriques en différenciant données absentes, état sain, mode dégradé et état bloqué et en évitant de représenter une métrique inconnue comme zéro.

### Description

- Propagation d'un identifiant de corrélation via `correlation_id` dans les enregistrements de run et événements provider en ajoutant/consistant `correlation_id` dans `src/singular/runs/logger.py` et la fonction `log_provider_event`.
- Génération et propagation du même identifiant depuis les interactions conversationnelles dans `src/singular/organisms/talk.py` (injection dans les épisodes, traces causales et événements d'identité). 
- Persistance et audit enrichis côté gouvernance avec `correlation_id` dans `src/singular/governance/policy.py` pour l'audit de transition et le snapshot du circuit.
- Orchestrateur inclut un `correlation_id` de contexte dans le payload de mise à jour narrative via `src/singular/orchestrator/service.py`.
- Construction d'une vue chronologique corrélée dans `src/singular/dashboard/services/trajectory.py` exposant `causal_chronology` et un mapping `correlations` (cause, décision, conséquence, vie, action corrective, mutation, chemin, run) pour joindre événements émis par des sous-systèmes distincts.
- Enrichissement du contract d'affichage du dashboard (`src/singular/dashboard/__init__.py`) pour exposer `correlation_id`, `cause`, `decision`, `consequence`, `life` et `mutation_path` dans les entrées de timeline.
- Ajout de navigation front-end pour passer d'une alerte breaker à la mutation et au chemin concernés dans `src/singular/dashboard/static/render-timeline.js` et affichage amélioré des états et valeurs manquantes dans `src/singular/dashboard/static/render-cockpit.js` et `src/singular/dashboard/static/render-conversations.js` ainsi que un message explicatif dans `src/singular/dashboard/templates/dashboard.html`.
- Ajout de tests: contrat d'agrégation `tests/test_dashboard.py::test_trajectory_contract_joins_records_by_correlation_id` et test statique de rendu `tests/test_dashboard_static_smoke.py::test_timeline_static_exposes_correlation_navigation`.

### Testing

- Exécution ciblée des nouveaux tests et suites relationnées: `pytest tests/test_dashboard.py::test_trajectory_contract_joins_records_by_correlation_id tests/test_dashboard_static_smoke.py::test_timeline_static_exposes_correlation_navigation tests/test_runs_logger.py` — tous les tests ciblés ont réussi (suite complète ciblée indiquant 12 passed).
- Compilation statique du code source via `python -m compileall -q src/singular` — réussie.
- Vérifications additionnelles automatiques (`git diff --check` / checks locaux) — sans erreurs détectées pour les modifications apportées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a781d8c6f10832aa5912608908327cf)