### PR TITLE
Add `doctor --autonomous` readiness checks and shared diagnostics module

### DIFF
--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -1812,6 +1812,16 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Try to add user Scripts directory to user Path on Windows",
     )
+    doctor_parser.add_argument(
+        "--autonomous",
+        action="store_true",
+        help="Vérifie l'aptitude à fonctionner en autonomie",
+    )
+    doctor_parser.add_argument(
+        "--generate",
+        action="store_true",
+        help="Ajoute une génération LLM minimale au diagnostic autonome",
+    )
     config_parser = subparsers.add_parser("config", help="Configure providers and env")
     config_subparsers = config_parser.add_subparsers(
         dest="config_command", required=True
@@ -2553,6 +2563,22 @@ def main(argv: list[str] | None = None) -> int:
             return _retention_config_show()
 
     elif args.command == "doctor":
+        if args.autonomous:
+            from .diagnostics.autonomous import autonomous_diagnostics
+
+            report = autonomous_diagnostics(run_generation=args.generate)
+            if args.output_format == "json":
+                print(json.dumps(report, ensure_ascii=False, indent=2))
+            else:
+                print(f"Diagnostic autonomie: {report['status']}")
+                print("check_id | sévérité | état | preuve | correction")
+                for check in report["checks"]:
+                    print(
+                        f"{check['check_id']} | {check['severity']} | {check['state']} | "
+                        f"{json.dumps(check['evidence'], ensure_ascii=False, sort_keys=True)} | "
+                        f"{check['remediation_command'] or '-'}"
+                    )
+            return int(report["exit_code"])
         _doctor(fix=args.fix)
         _doctor_providers()
 

--- a/src/singular/diagnostics/autonomous.py
+++ b/src/singular/diagnostics/autonomous.py
@@ -1,0 +1,286 @@
+"""Shared, structured readiness diagnostics for autonomous operation."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+READY = 0
+DEGRADED = 1
+BLOCKED = 2
+SCHEMA_VERSION = 1
+
+
+def _check(
+    check_id: str,
+    severity: str,
+    state: str,
+    evidence: dict[str, Any],
+    remediation: str | None,
+) -> dict[str, Any]:
+    return {
+        "check_id": check_id,
+        "severity": severity,
+        "state": state,
+        "evidence": evidence,
+        "remediation_command": remediation,
+    }
+
+
+def _safe_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _mutation_evidence(home: Path) -> dict[str, Any] | None:
+    newest: tuple[float, dict[str, Any]] | None = None
+    for path in (home / "runs").glob("**/*.jsonl") if (home / "runs").is_dir() else ():
+        try:
+            rows = path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in rows:
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            event = str(row.get("event") or row.get("event_type") or "")
+            if "mutation" not in event:
+                continue
+            stamp = path.stat().st_mtime
+            proof = {
+                "event": event,
+                "timestamp": row.get("ts") or row.get("timestamp"),
+                "accepted": row.get("accepted", row.get("ok")),
+            }
+            if newest is None or stamp >= newest[0]:
+                newest = (stamp, proof)
+    return newest[1] if newest else None
+
+
+def _systemd_check(root: Path, home: Path) -> dict[str, Any]:
+    if not shutil.which("systemctl"):
+        return _check(
+            "systemd_consistency",
+            "warning",
+            "degraded",
+            {"available": False},
+            "singular config root install-systemd",
+        )
+    try:
+        result = subprocess.run(
+            [
+                "systemctl",
+                "show",
+                "singular.service",
+                "--property=Environment",
+                "--value",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        result = None
+    output = result.stdout if result is not None else ""
+    consistent = (
+        result is not None
+        and result.returncode == 0
+        and str(root) in output
+        and str(home) in output
+    )
+    return _check(
+        "systemd_consistency",
+        "warning",
+        "ready" if consistent else "degraded",
+        {"unit": "singular.service", "context_matches": consistent},
+        None if consistent else "singular config root install-systemd",
+    )
+
+
+def autonomous_diagnostics(*, run_generation: bool = False) -> dict[str, Any]:
+    """Run ordered autonomous-readiness checks and return a stable payload."""
+
+    from singular.governance.policy import load_circuit_state
+    from singular.lives import load_registry
+    from singular.providers import doctor_providers
+    from singular.root_config import diagnose_registry_root
+
+    checks: list[dict[str, Any]] = []
+    root_info = diagnose_registry_root()
+    root = root_info["root"]
+    root_ok = root.is_dir()
+    checks.append(
+        _check(
+            "root_resolution",
+            "critical",
+            "ready" if root_ok else "blocked",
+            {"source": root_info["source"], "exists": root_ok, "path": str(root)},
+            None if root_ok else f"mkdir -p {root}",
+        )
+    )
+
+    try:
+        registry = load_registry()
+    except (OSError, ValueError, json.JSONDecodeError):
+        registry = {"active": None, "lives": {}}
+    active = registry.get("active")
+    meta = registry.get("lives", {}).get(active) if active else None
+    home = Path(
+        os.environ.get("SINGULAR_HOME")
+        or getattr(meta, "path", root / "lives" / str(active or ""))
+    )
+    life_ok = bool(active and home.is_dir())
+    checks.append(
+        _check(
+            "active_life",
+            "critical",
+            "ready" if life_ok else "blocked",
+            {"configured": bool(active), "exists": home.is_dir(), "life": active},
+            None if life_ok else "singular lives use <vie>",
+        )
+    )
+
+    required = [home / "mem", home / "runs"]
+    writable = life_ok and all(
+        path.is_dir() and os.access(path, os.W_OK | os.X_OK) for path in required
+    )
+    checks.append(
+        _check(
+            "directory_permissions",
+            "critical",
+            "ready" if writable else "blocked",
+            {"required": [p.name for p in required], "writable": writable},
+            None
+            if writable
+            else f"mkdir -p {home / 'mem'} {home / 'runs'} && chmod u+rwx {home / 'mem'} {home / 'runs'}",
+        )
+    )
+    checks.append(_systemd_check(root, home))
+
+    configured_name = (os.environ.get("LLM_PROVIDER") or "").strip()
+    configured = bool(configured_name)
+    checks.append(
+        _check(
+            "provider_configured",
+            "critical",
+            "ready" if configured else "blocked",
+            {"configured": configured, "provider": configured_name or None},
+            None if configured else "singular config providers doctor",
+        )
+    )
+    provider_result = doctor_providers([configured_name])[0] if configured else None
+    model_ready = bool(
+        provider_result
+        and provider_result.get("ok")
+        and provider_result.get("llm_real")
+    )
+    checks.append(
+        _check(
+            "model_available",
+            "critical",
+            "ready" if model_ready else "blocked",
+            {
+                "provider": configured_name or None,
+                "reachable": bool(provider_result and provider_result.get("reachable")),
+                "category": provider_result.get("error_category")
+                if provider_result
+                else "not_configured",
+            },
+            None
+            if model_ready
+            else (provider_result or {}).get("configuration_command")
+            or "singular config providers doctor",
+        )
+    )
+
+    generated = False
+    generation_error: str | None = None
+    if run_generation and model_ready:
+        try:
+            from singular.providers import _load_provider_contract
+
+            contract = _load_provider_contract(configured_name)
+            generated = bool(
+                contract and contract.generate("Répondez uniquement: ok", timeout=2.0)
+            )
+        except (
+            Exception
+        ) as exc:  # diagnostic boundary: expose category, never message/secrets
+            generation_error = type(exc).__name__
+    generation_state = "ready" if (not run_generation or generated) else "degraded"
+    checks.append(
+        _check(
+            "minimal_generation",
+            "warning",
+            generation_state,
+            {
+                "requested": run_generation,
+                "succeeded": generated if run_generation else None,
+                "error_category": generation_error,
+            },
+            None if generation_state == "ready" else "singular config providers doctor",
+        )
+    )
+
+    circuit = load_circuit_state(home)
+    closed = circuit.get("state") == "closed"
+    checks.append(
+        _check(
+            "circuit_breaker",
+            "critical",
+            "ready" if closed else "blocked",
+            {"state": circuit.get("state"), "updated_at": circuit.get("updated_at")},
+            None
+            if closed
+            else "singular governance recover --operator <nom> --justification <raison>",
+        )
+    )
+    mutation = _mutation_evidence(home)
+    checks.append(
+        _check(
+            "last_mutation",
+            "warning",
+            "ready" if mutation else "degraded",
+            mutation or {"found": False},
+            None if mutation else "singular loop --budget-seconds 60",
+        )
+    )
+
+    psyche = _safe_json(home / "mem" / "psyche.json")
+    narrative = _safe_json(home / "mem" / "self_narrative.json")
+    pv, nv = psyche.get("psyche_version"), narrative.get("psyche_version")
+    coherent = bool(psyche and narrative and pv == nv)
+    checks.append(
+        _check(
+            "psyche_narrative_coherence",
+            "critical",
+            "ready" if coherent else "blocked",
+            {
+                "psyche_present": bool(psyche),
+                "narrative_present": bool(narrative),
+                "versions_match": pv == nv if psyche and narrative else False,
+            },
+            None if coherent else "singular self-narrative summarize",
+        )
+    )
+
+    status = (
+        "blocked"
+        if any(c["state"] == "blocked" for c in checks)
+        else ("degraded" if any(c["state"] == "degraded" for c in checks) else "ready")
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": status,
+        "exit_code": {"ready": READY, "degraded": DEGRADED, "blocked": BLOCKED}[status],
+        "checks": checks,
+    }

--- a/src/singular/root_config.py
+++ b/src/singular/root_config.py
@@ -89,6 +89,24 @@ def load_configured_registry_root(cwd: Path | None = None) -> Path | None:
     )
 
 
+def diagnose_registry_root(cwd: Path | None = None) -> dict[str, Any]:
+    """Return the effective registry root and its non-secret provenance.
+
+    This is deliberately a data-only helper so installers, the CLI and the web
+    dashboard can present the exact same root-resolution decision.
+    """
+
+    env_root = os.environ.get("SINGULAR_ROOT")
+    configured = load_configured_registry_root(cwd)
+    if env_root:
+        root, source = _safe_path(env_root).expanduser().resolve(), "environment"
+    elif configured is not None:
+        root, source = configured.resolve(), "configuration"
+    else:
+        root, source = default_registry_root().resolve(), "default"
+    return {"root": root, "source": source, "exists": root.is_dir()}
+
+
 def set_configured_registry_root(
     value: str, *, scope: str, cwd: Path | None = None
 ) -> tuple[Path, Path]:
@@ -97,11 +115,15 @@ def set_configured_registry_root(
     if scope not in {"global", "project"}:
         raise ValueError("scope must be 'global' or 'project'")
 
-    config_path = global_config_path() if scope == "global" else project_config_path(cwd)
+    config_path = (
+        global_config_path() if scope == "global" else project_config_path(cwd)
+    )
     payload = _load_json(config_path)
     payload[_REGISTRY_ROOT_KEY] = value
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    config_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
     resolved = _decode_registry_root(value, base_dir=config_path.parent)
     if resolved is None:

--- a/tests/providers/test_provider_doctor.py
+++ b/tests/providers/test_provider_doctor.py
@@ -125,3 +125,22 @@ def test_doctor_distinguishes_missing_ollama_model(monkeypatch):
     assert result["installed"] is True
     assert result["configured"] is False
     assert result["reachable"] is False
+
+
+def test_provider_diagnostics_exposes_all_three_dashboard_states(monkeypatch):
+    monkeypatch.setattr(
+        providers,
+        "doctor_providers",
+        lambda _names=None: [{"state": "unavailable"}],
+    )
+    assert provider_diagnostics()["state"] == "unavailable"
+    monkeypatch.setattr(
+        providers,
+        "doctor_providers",
+        lambda _names=None: [{"state": "degraded_dummy"}],
+    )
+    assert provider_diagnostics()["state"] == "degraded_dummy"
+    monkeypatch.setattr(
+        providers, "doctor_providers", lambda _names=None: [{"state": "ready"}]
+    )
+    assert provider_diagnostics()["state"] == "ready"

--- a/tests/test_cli_diagnose_sandbox.py
+++ b/tests/test_cli_diagnose_sandbox.py
@@ -5,6 +5,18 @@ from pathlib import Path
 import singular.cli as cli
 
 
+def test_autonomous_generation_is_explicitly_optional(monkeypatch, tmp_path) -> None:
+    from singular.diagnostics import autonomous
+
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    report = autonomous.autonomous_diagnostics(run_generation=False)
+    generation = next(
+        c for c in report["checks"] if c["check_id"] == "minimal_generation"
+    )
+    assert generation["state"] == "ready"
+    assert generation["evidence"]["requested"] is False
+
+
 def _write_skill(home: Path, name: str, source: str) -> None:
     skills = home / "skills"
     skills.mkdir(parents=True, exist_ok=True)

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -5,6 +5,66 @@ import singular.cli as cli
 from singular.lives import load_registry
 
 
+def test_autonomous_doctor_json_has_stable_order_and_blocked_exit(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path / "missing"))
+
+    exit_code = cli.main(["--format", "json", "doctor", "--autonomous"])
+
+    import json
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert payload["schema_version"] == 1
+    assert payload["status"] == "blocked"
+    assert [item["check_id"] for item in payload["checks"]] == [
+        "root_resolution",
+        "active_life",
+        "directory_permissions",
+        "systemd_consistency",
+        "provider_configured",
+        "model_available",
+        "minimal_generation",
+        "circuit_breaker",
+        "last_mutation",
+        "psyche_narrative_coherence",
+    ]
+    assert all("remediation_command" in item for item in payload["checks"])
+
+
+def test_autonomous_doctor_fully_ready(monkeypatch, tmp_path) -> None:
+    from singular.diagnostics import autonomous
+
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+    cli.main(["lives", "create", "--name", "Ready"])
+    home = Path(load_registry()["lives"][load_registry()["active"]].path)
+    (home / "mem" / "psyche.json").write_text('{"psyche_version": 4}')
+    (home / "mem" / "self_narrative.json").write_text('{"psyche_version": 4}')
+    run = home / "runs" / "ready"
+    run.mkdir(parents=True)
+    (run / "events.jsonl").write_text('{"event":"mutation.applied","ok":true}\n')
+    monkeypatch.setenv("LLM_PROVIDER", "local")
+    monkeypatch.setattr(
+        "singular.providers.doctor_providers",
+        lambda names: [{"ok": True, "llm_real": True, "reachable": True}],
+    )
+    monkeypatch.setattr(autonomous.shutil, "which", lambda _name: "/bin/systemctl")
+    monkeypatch.setattr(
+        autonomous.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(
+            returncode=0, stdout=f"{tmp_path} {home}"
+        ),
+    )
+
+    report = autonomous.autonomous_diagnostics()
+
+    assert report["status"] == "ready"
+    assert report["exit_code"] == 0
+    assert all(item["state"] == "ready" for item in report["checks"])
+
+
 def test_doctor_reports_status_and_powershell_fix(monkeypatch, capsys) -> None:
     scripts_dir = Path("/tmp/singular-user-scripts")
     monkeypatch.setattr(cli.sys, "executable", "/tmp/python/bin/python")
@@ -100,7 +160,9 @@ def test_doctor_fix_windows_user_path_is_idempotent(monkeypatch, capsys) -> None
     assert "déjà présent" in out
 
 
-def test_quickstart_creates_life_without_prompt_when_not_tty(monkeypatch, tmp_path) -> None:
+def test_quickstart_creates_life_without_prompt_when_not_tty(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
     monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
 

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -9,15 +9,15 @@ def test_decode_relative_windows_separators_against_config_directory(
     base_dir = tmp_path / ".singular"
     monkeypatch.setattr(root_config.os, "name", "nt")
 
-    decoded = root_config._decode_registry_root(
-        r"roots\\project", base_dir=base_dir
-    )
+    decoded = root_config._decode_registry_root(r"roots\\project", base_dir=base_dir)
 
     assert decoded == (base_dir / "roots" / "project").resolve()
     assert isinstance(decoded, PosixPath)
 
 
-def test_decode_absolute_windows_path_on_simulated_windows(monkeypatch, tmp_path) -> None:
+def test_decode_absolute_windows_path_on_simulated_windows(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setattr(root_config.os, "name", "nt")
 
     decoded = root_config._decode_registry_root(
@@ -32,12 +32,14 @@ def test_decode_relative_path_is_based_on_global_or_project_config(tmp_path) -> 
     global_dir = tmp_path / "home" / ".singular"
     project_dir = tmp_path / "workspace" / ".singular"
 
-    assert root_config._decode_registry_root("registry", base_dir=global_dir) == (
-        global_dir / "registry"
-    ).resolve()
-    assert root_config._decode_registry_root("registry", base_dir=project_dir) == (
-        project_dir / "registry"
-    ).resolve()
+    assert (
+        root_config._decode_registry_root("registry", base_dir=global_dir)
+        == (global_dir / "registry").resolve()
+    )
+    assert (
+        root_config._decode_registry_root("registry", base_dir=project_dir)
+        == (project_dir / "registry").resolve()
+    )
 
 
 def test_decode_posix_absolute_path_is_not_rebased(tmp_path) -> None:
@@ -46,3 +48,15 @@ def test_decode_posix_absolute_path_is_not_rebased(tmp_path) -> None:
     assert root_config._decode_registry_root(
         str(absolute), base_dir=tmp_path / "config"
     ) == Path(absolute)
+
+
+def test_diagnose_registry_root_reports_env_provenance(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
+
+    diagnostic = root_config.diagnose_registry_root()
+
+    assert diagnostic == {
+        "root": tmp_path.resolve(),
+        "source": "environment",
+        "exists": True,
+    }


### PR DESCRIPTION
### Motivation

- Provide a single, structured readiness check for autonomous operation that the CLI, installer and dashboard can reuse instead of duplicating logic. 
- Expose a stable machine-readable JSON contract and distinct exit codes for automation and dashboards (ready / degraded / blocked). 

### Description

- Add a new diagnostics module `src/singular/diagnostics/autonomous.py` implementing ordered checks (root resolution, active life, directory permissions, systemd consistency, provider configured, model availability, optional minimal generation, circuit breaker, latest mutation and psyche–narrative coherence) and returning structured items with `check_id`, `severity`, `state`, `evidence` and `remediation_command` plus an overall `status` and numeric `exit_code` mapping (`0` ready, `1` degraded, `2` blocked). 
- Extend `src/singular/root_config.py` with `diagnose_registry_root()` to return the effective root and non-sensitive provenance (environment/configuration/default) for reuse by CLI and dashboard. 
- Add CLI flags `--autonomous` and `--generate` to `singular doctor` in `src/singular/cli.py` and wire the textual and JSON outputs of the autonomous report into the existing `doctor` command. 
- Add and update unit tests to validate the JSON contract, stable ordering of checks, optional generation behaviour, provider three-state logic and root provenance in `tests/test_cli_doctor.py`, `tests/providers/test_provider_doctor.py`, `tests/test_cli_diagnose_sandbox.py` and `tests/test_root_config.py`.

### Testing

- Ran the focused test suite: `pytest -q tests/test_cli_doctor.py tests/providers/test_provider_doctor.py tests/test_root_config.py tests/test_cli_diagnose_sandbox.py::test_autonomous_generation_is_explicitly_optional`, then full set for the modified tests; final automated result: `21 passed`. 
- Static/format checks passed: `ruff format` / `ruff check` completed with no remaining issues after formatting. 
- Early sandbox-related failures were observed while iterating (missing sandbox runtime in the environment), and were addressed; final automated test runs for the modified tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a781eee9260832ab0874ac0889c2c6f)