### PR TITLE
Integrate generated quests into introspection and persist quest lifecycle

### DIFF
--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -22,6 +22,7 @@ from singular.events import (
     get_global_event_bus,
 )
 from singular.goals import IntrinsicGoals
+from singular.goals.quest_generation import generate_quests
 from singular.cognition.self_observation import SelfObservationService
 from singular.identity import ConsolidationCoordinator, ConsolidationPipeline
 from singular.identity.synchronization import IdentitySynchronizationService
@@ -121,6 +122,7 @@ class OrchestratorConfig:
     help_request_failure_threshold: int = 3
     max_consecutive_tick_failures: int = 10
     tick_failure_backoff_seconds: float = 0.2
+    max_active_generated_quests: int = 3
 
 
 class OrchestratorService:
@@ -451,6 +453,12 @@ class OrchestratorService:
             if ep.get("status") == "failure"
         ]
 
+        quest_changes = self._refresh_generated_quests(
+            psyche_state=psyche_state,
+            successes=len(successes),
+            failures=len(failures),
+        )
+
         def _trait_value(name: str) -> float:
             try:
                 return float(psyche_state.get(name, 0.5))
@@ -544,6 +552,7 @@ class OrchestratorService:
             "run_events_loaded": len(run_events),
             "short_summary": summary_short,
             "long_summary": summary_long,
+            "generated_quests": quest_changes,
         }
         self.bus.publish("self_narrative.updated", payload, payload_version=1)
         self.state.last_events.append(
@@ -555,6 +564,75 @@ class OrchestratorService:
         )
         self.state.last_events = self.state.last_events[-100:]
         return payload
+
+    def _refresh_generated_quests(
+        self, *, psyche_state: dict[str, Any], successes: int, failures: int
+    ) -> dict[str, list[str]]:
+        """Generate and durably reconcile intrinsic quests during introspection."""
+
+        resources = {
+            "energy": self.resource_manager.energy,
+            "food": self.resource_manager.food,
+            "warmth": self.resource_manager.warmth,
+        }
+        world_resources = self.world_state.world_resources
+        world = {
+            "delayed_crisis_pressure": self._latest_signals.get(
+                "delayed_crisis_pressure", 0.0
+            ),
+            "opportunity_pressure": self._latest_signals.get(
+                "opportunity_pressure", 0.0
+            ),
+            "cpu_budget": world_resources.cpu_budget,
+            "mutation_slots": world_resources.mutation_slots,
+            "attention_score": world_resources.attention_score,
+        }
+        surprise = {
+            key: self._latest_signals.get(key, 0.0)
+            for key in (
+                "surprise",
+                "frustration",
+                "curiosity",
+                "operator_family_failure_pressure",
+            )
+        }
+        candidates = generate_quests(
+            psyche_traits=psyche_state,
+            outcomes_history={
+                "recent_successes": successes,
+                "recent_failures": failures,
+            },
+            value_performance_tension=self._latest_signals.get(
+                "value_performance_tension", 0.0
+            ),
+            world_state=world,
+            resources=resources,
+            surprise_signals=surprise,
+        )
+        context_payload = {
+            "life_id": canonical_life_id(self.base_dir),
+            "source": "introspection",
+        }
+        context = json.dumps(context_payload, sort_keys=True, separators=(",", ":"))
+        terminal = bool(
+            self._latest_signals.get("terminal")
+            or self._latest_signals.get("terminal_lifecycle_state")
+        )
+        degraded = bool(
+            self._latest_signals.get("degraded")
+            or self._latest_signals.get("degraded_mode")
+        )
+        circuit_open = self._latest_signals.get("circuit_breaker_status") in {
+            "open",
+            "ouvert",
+        } or bool(self._latest_signals.get("circuit_breaker_open"))
+        return self.quest_runtime.reconcile_generated(
+            candidates,
+            context=context,
+            recent_successes=successes,
+            max_active=max(0, int(self.config.max_active_generated_quests)),
+            restrict_costly=terminal or degraded or circuit_open,
+        )
 
     def _run_phase(self, phase: LifecyclePhase) -> None:
         if phase is LifecyclePhase.VEILLE:

--- a/src/singular/quests.py
+++ b/src/singular/quests.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
+
+from singular.goals.quest_generation import GeneratedQuest
 
 from singular.life.quest import Spec, load as load_spec
 from singular.memory import _atomic_write_text, add_episode, get_mem_dir
@@ -23,6 +26,13 @@ class QuestRecord:
     completed_at: str | None = None
     reason: str | None = None
     history: list[dict[str, Any]] = field(default_factory=list)
+    id: str | None = None
+    priority: float = 0.0
+    context: str = ""
+    objective: str | None = None
+    created_at: str | None = None
+    progress: float = 0.0
+    success_criterion: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -30,6 +40,7 @@ class QuestRuntimeState:
     active: list[QuestRecord] = field(default_factory=list)
     paused: list[QuestRecord] = field(default_factory=list)
     completed: list[QuestRecord] = field(default_factory=list)
+    failed: list[QuestRecord] = field(default_factory=list)
     cooldowns: dict[str, str] = field(default_factory=dict)
 
 
@@ -49,24 +60,50 @@ class ObjectiveArbitrator:
         health_score: float | None,
         load_score: float | None,
     ) -> dict[str, float | str]:
-        reward_signal = float(len(spec.reward)) + float(spec.reward.get("psyche_energy", 0.0) or 0.0) / 15.0
-        penalty_signal = float(len(spec.penalty)) + abs(float(spec.penalty.get("psyche_energy", 0.0) or 0.0)) / 12.0
-        expected_utility = self._clamp((reward_signal + (0.2 if spec.origin == "intrinsic" else 0.1)) / (reward_signal + penalty_signal + 1.0))
+        reward_signal = (
+            float(len(spec.reward))
+            + float(spec.reward.get("psyche_energy", 0.0) or 0.0) / 15.0
+        )
+        penalty_signal = (
+            float(len(spec.penalty))
+            + abs(float(spec.penalty.get("psyche_energy", 0.0) or 0.0)) / 12.0
+        )
+        expected_utility = self._clamp(
+            (reward_signal + (0.2 if spec.origin == "intrinsic" else 0.1))
+            / (reward_signal + penalty_signal + 1.0)
+        )
 
         failures = sum(1 for event in record.history if event.get("to") == "failure")
         pauses = sum(1 for event in record.history if event.get("to") == "paused")
-        emotional_cost = self._clamp((failures * 0.35) + (pauses * 0.18) + (0.2 if record.reason == "timeout" else 0.0))
+        emotional_cost = self._clamp(
+            (failures * 0.35)
+            + (pauses * 0.18)
+            + (0.2 if record.reason == "timeout" else 0.0)
+        )
 
-        resources_score = self._clamp((resources.energy + resources.food + resources.warmth) / 300.0)
-        health_capacity = self._clamp(float(health_score if isinstance(health_score, (int, float)) else 100.0) / 100.0)
-        load_capacity = 1.0 - self._clamp(float(load_score if isinstance(load_score, (int, float)) else 0.0))
+        resources_score = self._clamp(
+            (resources.energy + resources.food + resources.warmth) / 300.0
+        )
+        health_capacity = self._clamp(
+            float(health_score if isinstance(health_score, (int, float)) else 100.0)
+            / 100.0
+        )
+        load_capacity = 1.0 - self._clamp(
+            float(load_score if isinstance(load_score, (int, float)) else 0.0)
+        )
         capacity = max(0.0, min(resources_score, health_capacity, load_capacity))
 
-        arbitration = (expected_utility * 0.55) + (capacity * 0.45) - (emotional_cost * 0.5)
+        arbitration = (
+            (expected_utility * 0.55) + (capacity * 0.45) - (emotional_cost * 0.5)
+        )
         transition = "keep"
         if record.status == "active":
             if capacity < 0.18 or arbitration < 0.05:
-                transition = "abandoned" if (emotional_cost > 0.78 or (pauses >= 2 and arbitration < 0.0)) else "paused"
+                transition = (
+                    "abandoned"
+                    if (emotional_cost > 0.78 or (pauses >= 2 and arbitration < 0.0))
+                    else "paused"
+                )
         elif record.status == "paused":
             if arbitration > 0.35 and capacity > 0.4:
                 transition = "resumed"
@@ -115,19 +152,56 @@ class QuestRuntime:
                 name = item.get("name")
                 status = item.get("status")
                 started_at = item.get("started_at")
-                if not all(isinstance(v, str) and v for v in (name, status, started_at)):
+                if not all(
+                    isinstance(v, str) and v for v in (name, status, started_at)
+                ):
                     continue
                 raw_origin = item.get("origin")
-                origin = raw_origin if raw_origin in {"intrinsic", "external"} else "external"
+                origin = (
+                    raw_origin
+                    if raw_origin in {"intrinsic", "external"}
+                    else "external"
+                )
                 out.append(
                     QuestRecord(
                         name=name,
                         status=status,
                         started_at=started_at,
                         origin=origin,
-                        completed_at=item.get("completed_at") if isinstance(item.get("completed_at"), str) else None,
-                        reason=item.get("reason") if isinstance(item.get("reason"), str) else None,
-                        history=item.get("history") if isinstance(item.get("history"), list) else [],
+                        completed_at=(
+                            item.get("completed_at")
+                            if isinstance(item.get("completed_at"), str)
+                            else None
+                        ),
+                        reason=(
+                            item.get("reason")
+                            if isinstance(item.get("reason"), str)
+                            else None
+                        ),
+                        history=(
+                            item.get("history")
+                            if isinstance(item.get("history"), list)
+                            else []
+                        ),
+                        id=item.get("id") if isinstance(item.get("id"), str) else None,
+                        priority=float(item.get("priority", 0.0) or 0.0),
+                        context=str(item.get("context", "")),
+                        objective=(
+                            item.get("objective")
+                            if isinstance(item.get("objective"), str)
+                            else None
+                        ),
+                        created_at=(
+                            item.get("created_at")
+                            if isinstance(item.get("created_at"), str)
+                            else started_at
+                        ),
+                        progress=float(item.get("progress", 0.0) or 0.0),
+                        success_criterion=(
+                            item.get("success_criterion")
+                            if isinstance(item.get("success_criterion"), dict)
+                            else {}
+                        ),
                     )
                 )
             return out
@@ -142,6 +216,7 @@ class QuestRuntime:
             active=_records(raw.get("active", [])),
             paused=_records(raw.get("paused", [])),
             completed=_records(raw.get("completed", [])),
+            failed=_records(raw.get("failed", [])),
             cooldowns=cooldowns,
         )
 
@@ -150,10 +225,171 @@ class QuestRuntime:
             "active": [asdict(item) for item in self.state.active],
             "paused": [asdict(item) for item in self.state.paused],
             "completed": [asdict(item) for item in self.state.completed[-200:]],
+            "failed": [asdict(item) for item in self.state.failed[-200:]],
             "cooldowns": self.state.cooldowns,
             "updated_at": self._now().isoformat(),
         }
-        _atomic_write_text(self.state_path, json.dumps(payload, ensure_ascii=False, indent=2))
+        _atomic_write_text(
+            self.state_path, json.dumps(payload, ensure_ascii=False, indent=2)
+        )
+
+    @staticmethod
+    def _generated_id(name: str, context: str) -> str:
+        return hashlib.sha256(f"{name}\0{context}".encode("utf-8")).hexdigest()[:24]
+
+    def reconcile_generated(
+        self,
+        quests: list[GeneratedQuest],
+        *,
+        context: str,
+        recent_successes: int,
+        max_active: int,
+        restrict_costly: bool = False,
+    ) -> dict[str, list[str]]:
+        """Persist generated quests and reconcile their lifecycle on every cycle."""
+
+        changed: dict[str, list[str]] = {
+            "created": [],
+            "paused": [],
+            "completed": [],
+            "failed": [],
+        }
+        candidates = {self._generated_id(q.name, context): q for q in quests}
+        for terminal_record in (*self.state.completed, *self.state.failed):
+            if terminal_record.id:
+                candidates.pop(terminal_record.id, None)
+        records = [*self.state.active, *self.state.paused]
+
+        for record in list(records):
+            if not record.id:
+                continue
+            if (
+                recent_successes > 0
+                and record.success_criterion.get("type") == "recent_success"
+            ):
+                source = (
+                    self.state.active
+                    if record in self.state.active
+                    else self.state.paused
+                )
+                source.remove(record)
+                previous = record.status
+                record.status = "completed"
+                record.progress = 1.0
+                record.completed_at = self._now().isoformat()
+                self._append_transition(
+                    record=record,
+                    from_status=previous,
+                    to_status="completed",
+                    reason="success_criterion_met",
+                )
+                self.state.completed.append(record)
+                changed["completed"].append(record.name)
+                candidates.pop(record.id, None)
+                continue
+            failure_limit = record.success_criterion.get("failure_limit")
+            if (
+                isinstance(failure_limit, int)
+                and recent_successes == 0
+                and recent_failures >= failure_limit
+            ):
+                source = (
+                    self.state.active
+                    if record in self.state.active
+                    else self.state.paused
+                )
+                source.remove(record)
+                previous = record.status
+                record.status = "failed"
+                record.reason = "failure_limit_reached"
+                self._append_transition(
+                    record=record,
+                    from_status=previous,
+                    to_status="failed",
+                    reason="failure_limit_reached",
+                )
+                self.state.failed.append(record)
+                changed["failed"].append(record.name)
+                candidates.pop(record.id, None)
+                continue
+            quest = candidates.pop(record.id, None)
+            if quest is not None:
+                record.priority = round(float(quest.priority), 3)
+                if (
+                    record in self.state.paused
+                    and len(self.state.active) < max_active
+                    and not (restrict_costly and quest.difficulty > 0.5)
+                ):
+                    self.state.paused.remove(record)
+                    record.status = "active"
+                    self._append_transition(
+                        record=record,
+                        from_status="paused",
+                        to_status="active",
+                        reason="active_quest_budget_available",
+                    )
+                    self.state.active.append(record)
+
+        eligible = [
+            q
+            for q in candidates.values()
+            if not (restrict_costly and q.difficulty > 0.5)
+        ]
+        eligible.sort(key=lambda q: q.priority, reverse=True)
+        capacity = max(0, max_active - len(self.state.active))
+        for quest in eligible[:capacity]:
+            now = self._now().isoformat()
+            record = QuestRecord(
+                id=self._generated_id(quest.name, context),
+                name=quest.name,
+                status="active",
+                started_at=now,
+                created_at=now,
+                origin=quest.origin,
+                priority=round(float(quest.priority), 3),
+                context=context,
+                objective=quest.objective,
+                progress=0.0,
+                success_criterion={
+                    "type": "recent_success",
+                    "minimum": 1,
+                    "failure_limit": 10,
+                },
+                history=[
+                    {
+                        "at": now,
+                        "from": "inactive",
+                        "to": "active",
+                        "reason": "generated_during_introspection",
+                    }
+                ],
+            )
+            self.state.active.append(record)
+            changed["created"].append(record.name)
+
+        generated_ids = {self._generated_id(q.name, context) for q in quests}
+        generated_active = sorted(
+            [r for r in self.state.active if r.id and r.id in generated_ids],
+            key=lambda r: r.priority,
+            reverse=True,
+        )
+        allowed_generated = max(
+            0, max_active - len([r for r in self.state.active if not r.id])
+        )
+        overflow = generated_active[allowed_generated:]
+        for record in overflow:
+            self.state.active.remove(record)
+            record.status = "paused"
+            self._append_transition(
+                record=record,
+                from_status="active",
+                to_status="paused",
+                reason="active_quest_budget",
+            )
+            self.state.paused.append(record)
+            changed["paused"].append(record.name)
+        self._save_state()
+        return changed
 
     def _append_transition(
         self,
@@ -229,7 +465,9 @@ class QuestRuntime:
             return float(value) <= float(trigger["lte"])
         if "contains" in trigger:
             needle = trigger.get("contains")
-            return isinstance(value, str) and isinstance(needle, str) and needle in value
+            return (
+                isinstance(value, str) and isinstance(needle, str) and needle in value
+            )
         return False
 
     def evaluate_triggers(self, signals: dict[str, Any]) -> list[str]:
@@ -269,7 +507,9 @@ class QuestRuntime:
             self._save_state()
         return activated
 
-    def _resource_criteria_met(self, criteria: dict[str, Any], rm: ResourceManager) -> bool:
+    def _resource_criteria_met(
+        self, criteria: dict[str, Any], rm: ResourceManager
+    ) -> bool:
         rules = criteria.get("resource_min")
         if not isinstance(rules, dict):
             return True
@@ -391,11 +631,15 @@ class QuestRuntime:
                 continue
             criteria = spec.success
             success = self._resource_criteria_met(criteria, resource_manager)
-            timeout = criteria.get("timeout_seconds") if isinstance(criteria, dict) else None
+            timeout = (
+                criteria.get("timeout_seconds") if isinstance(criteria, dict) else None
+            )
             timed_out = False
             if isinstance(timeout, (int, float)):
                 started = self._parse_iso(record.started_at)
-                if started is not None and (self._now() - started).total_seconds() > float(timeout):
+                if started is not None and (
+                    self._now() - started
+                ).total_seconds() > float(timeout):
                     timed_out = True
 
             if success:

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -77,9 +77,7 @@ def test_orchestrator_sleep_consolidates_identity_memory(
     service = OrchestratorService(
         config=OrchestratorConfig(
             dry_run=True,
-            phase_behaviors={
-                "sommeil": {"allowed_actions": ["memory_consolidation"]}
-            },
+            phase_behaviors={"sommeil": {"allowed_actions": ["memory_consolidation"]}},
         ),
         bus=EventBus(),
     )
@@ -128,9 +126,7 @@ def test_orchestrator_sleep_retries_after_interrupted_consolidation(
     service = OrchestratorService(
         config=OrchestratorConfig(
             dry_run=True,
-            phase_behaviors={
-                "sommeil": {"allowed_actions": ["memory_consolidation"]}
-            },
+            phase_behaviors={"sommeil": {"allowed_actions": ["memory_consolidation"]}},
         ),
         bus=EventBus(),
     )
@@ -151,8 +147,7 @@ def test_orchestrator_sleep_retries_after_interrupted_consolidation(
     failed = next(
         item
         for item in persisted["last_events"]
-        if item.get("details", {}).get("event_type")
-        == "memory.consolidation_failed"
+        if item.get("details", {}).get("event_type") == "memory.consolidation_failed"
     )
     assert "InterruptedError" in failed["details"]["errors"][0]
     assert persisted["last_consolidated_episode_id"] is None
@@ -183,21 +178,31 @@ def test_orchestrator_detects_external_stimulus(monkeypatch, tmp_path: Path) -> 
     assert service._external_stimulus_detected() is True
 
 
-def test_recent_run_events_exclude_other_and_unattributed_lives(monkeypatch, tmp_path: Path) -> None:
+def test_recent_run_events_exclude_other_and_unattributed_lives(
+    monkeypatch, tmp_path: Path
+) -> None:
     life = tmp_path / "Ada"
     (life / "skills").mkdir(parents=True)
     (life / "runs").mkdir()
     monkeypatch.setenv("SINGULAR_HOME", str(life))
     events = life / "runs" / "mixed.jsonl"
     events.write_text(
-        '\n'.join(json.dumps(item) for item in (
-            {"life_id": "ADA", "summary": "ada"},
-            {"life_id": "Bob", "summary": "bob"},
-            {"summary": "ambiguous"},
-        )) + '\n', encoding="utf-8"
+        "\n".join(
+            json.dumps(item)
+            for item in (
+                {"life_id": "ADA", "summary": "ada"},
+                {"life_id": "Bob", "summary": "bob"},
+                {"summary": "ambiguous"},
+            )
+        )
+        + "\n",
+        encoding="utf-8",
     )
-    service = OrchestratorService(config=OrchestratorConfig(dry_run=True), bus=EventBus())
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=True), bus=EventBus()
+    )
     assert [item["summary"] for item in service._load_recent_run_events()] == ["ada"]
+
 
 def test_orchestrator_triggers_and_settles_quest(monkeypatch, tmp_path: Path) -> None:
     life = tmp_path / "life"
@@ -658,6 +663,48 @@ def test_orchestrator_introspection_frequency_uses_introspection_ticks(
     service.state.current_phase = LifecyclePhase.INTROSPECTION.value
     service.tick()
     assert len(events) == 1
+
+
+def test_introspection_generates_recovery_quest_but_stable_state_does_not(
+    monkeypatch, tmp_path: Path
+) -> None:
+    life = tmp_path / "life"
+    (life / "skills").mkdir(parents=True)
+    (life / "mem").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life))
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=True), bus=EventBus()
+    )
+
+    service.state.current_phase = LifecyclePhase.INTROSPECTION.value
+    service.tick()
+    assert (
+        not (life / "mem" / "quests_state.json").exists()
+        or not json.loads(
+            (life / "mem" / "quests_state.json").read_text(encoding="utf-8")
+        )["active"]
+    )
+
+    (life / "mem" / "episodic.jsonl").write_text(
+        "".join(
+            f'{{"event":"attempt-{index}","status":"failure"}}\n' for index in range(4)
+        ),
+        encoding="utf-8",
+    )
+    service.state.current_phase = LifecyclePhase.INTROSPECTION.value
+    service.tick()
+
+    state = json.loads((life / "mem" / "quests_state.json").read_text(encoding="utf-8"))
+    recovery = next(
+        item
+        for item in state["active"]
+        if item["name"] == "recover_execution_reliability"
+    )
+    assert recovery["id"] and recovery["priority"] > 0
+    assert recovery["origin"] == "intrinsic"
+    assert recovery["created_at"] and recovery["status"] == "active"
+    assert recovery["progress"] == 0.0
+    assert recovery["success_criterion"]["type"] == "recent_success"
 
 
 def test_run_life_daemon_resolves_life_and_writes_checkpoint_logs(

--- a/tests/test_targeted_lifecycle_narrative_trajectory.py
+++ b/tests/test_targeted_lifecycle_narrative_trajectory.py
@@ -14,6 +14,12 @@ from singular.life import loop as life_loop
 from singular.life.loop import load_checkpoint
 from singular.organisms.birth import birth
 from singular.organisms.status import status
+from singular.events import EventBus
+from singular.orchestrator.service import (
+    LifecyclePhase,
+    OrchestratorConfig,
+    OrchestratorService,
+)
 from singular.self_narrative import SCHEMA_VERSION, load, update_from_signals
 
 
@@ -27,7 +33,50 @@ class _DummyPsyche:
 
 
 def _read_jsonl(path: Path) -> list[dict[str, object]]:
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_recovery_success_closes_generated_quest(tmp_path: Path, monkeypatch) -> None:
+    life_home = tmp_path / "life"
+    (life_home / "skills").mkdir(parents=True)
+    (life_home / "mem").mkdir(parents=True)
+    monkeypatch.setenv("SINGULAR_HOME", str(life_home))
+    episodes = life_home / "mem" / "episodic.jsonl"
+    episodes.write_text(
+        "".join(
+            f'{{"event":"attempt-{index}","status":"failure"}}\n' for index in range(4)
+        ),
+        encoding="utf-8",
+    )
+    service = OrchestratorService(
+        config=OrchestratorConfig(dry_run=True), bus=EventBus()
+    )
+    service.state.current_phase = LifecyclePhase.INTROSPECTION.value
+    service.tick()
+
+    with episodes.open("a", encoding="utf-8") as handle:
+        handle.write('{"event":"repair","status":"success"}\n')
+    service.state.current_phase = LifecyclePhase.INTROSPECTION.value
+    service.tick()
+
+    state = json.loads(
+        (life_home / "mem" / "quests_state.json").read_text(encoding="utf-8")
+    )
+    assert not any(
+        item["name"] == "recover_execution_reliability" for item in state["active"]
+    )
+    completed = next(
+        item
+        for item in state["completed"]
+        if item["name"] == "recover_execution_reliability"
+    )
+    assert completed["status"] == "completed"
+    assert completed["progress"] == 1.0
+    assert completed["completed_at"]
 
 
 def test_targeted_lifecycle_birth_introspection_goals_world_action_death(
@@ -95,7 +144,9 @@ def test_targeted_lifecycle_birth_introspection_goals_world_action_death(
     assert reason == "too many failures"
 
 
-def test_narrative_files_persist_and_reload_with_fixed_seed(tmp_path: Path, monkeypatch) -> None:
+def test_narrative_files_persist_and_reload_with_fixed_seed(
+    tmp_path: Path, monkeypatch
+) -> None:
     life_home = tmp_path / "life"
     monkeypatch.setenv("SINGULAR_HOME", str(life_home))
     birth(seed=7, home=life_home)
@@ -115,12 +166,16 @@ def test_narrative_files_persist_and_reload_with_fixed_seed(tmp_path: Path, monk
     assert reloaded.current_heading == "Documenter une trajectoire explicable."
     assert reloaded.life_periods[-1].title == "Boot"
 
-    biography_payload = json.loads((life_home / "mem" / "biography.json").read_text(encoding="utf-8"))
+    biography_payload = json.loads(
+        (life_home / "mem" / "biography.json").read_text(encoding="utf-8")
+    )
     assert biography_payload["birth_certificate"]["event_type"] == "birth_certificate"
     assert biography_payload["self_summaries"]
 
 
-def test_schema_invariants_and_migrations_for_narrative_and_checkpoint(tmp_path: Path) -> None:
+def test_schema_invariants_and_migrations_for_narrative_and_checkpoint(
+    tmp_path: Path,
+) -> None:
     narrative_path = tmp_path / "mem" / "self_narrative.json"
     narrative_path.parent.mkdir(parents=True, exist_ok=True)
     narrative_path.write_text(


### PR DESCRIPTION
### Motivation

- Appeler `singular.goals.quest_generation.generate_quests` pendant la phase d’introspection pour proposer quêtes pertinentes à partir des traits, résultats récents, ressources, état du monde et signaux de surprise. 
- Persister les quêtes proposées afin d’assurer un identifiant stable, priorisation, origine, date de création, état, progression et critère de réussite entre cycles d’exécution. 
- Gérer la déduplication, la réévaluation de priorité à chaque cycle et les transitions `active`, `paused`, `completed` et `failed` tout en respectant des budgets et des gardes de sécurité (terminal / mode dégradé / circuit breaker). 
- Couvrir par des tests d’intégration les cas clefs : série d’échecs crée une quête de récupération, un état stable n’en crée pas et la réussite clôt la quête.

### Description

- L’introspection appelle désormais la génération de quêtes via `generate_quests` et réconcilie les candidats en ajoutant la méthode `_refresh_generated_quests` dans `OrchestratorService`, avec prise en compte du contexte de vie et des flags `terminal`, `degraded` et `circuit_breaker`. 
- Ajout de la configuration `max_active_generated_quests` dans `OrchestratorConfig` pour limiter le nombre de quêtes actives générées. 
- Refactor du runtime de quêtes (`src/singular/quests.py`) pour enrichir `QuestRecord` (id stable, `priority`, `context`, `created_at`, `progress`, `success_criterion`), ajouter une liste `failed` et implémenter `reconcile_generated` qui persiste, déduplique, met à jour priorités, active/pauses selon budget, clôture sur réussite et marque `failed` après dépassement du `failure_limit`. 
- Ajout de tests d’intégration : `tests/test_orchestrator_service.py::test_introspection_generates_recovery_quest_but_stable_state_does_not` et `tests/test_targeted_lifecycle_narrative_trajectory.py::test_recovery_success_closes_generated_quest` vérifiant création, absence en état stable et clôture après succès.

### Testing

- ✅ Exécution ciblée des tests modifiés avec `pytest -q tests/test_orchestrator_service.py tests/test_targeted_lifecycle_narrative_trajectory.py`, qui ont passé (tests ciblés réussis).
- ✅ Vérification de formatage avec `python -m black --check src/singular/quests.py src/singular/orchestrator/service.py tests/test_orchestrator_service.py tests/test_targeted_lifecycle_narrative_trajectory.py` et application de `black` avant le commit.
- ⚠️ Tentative d’exécution de la suite complète `pytest -q` interrompue par de nombreuses failures non liées aux changements (dont l’absence de Podman/Docker pour la sandbox sécurisée et d’autres dépendances d’environnement), ces échecs sont hors du périmètre des modifications apportées ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7822680894832ab81830a1626f8603)