### PR TITLE
Ajouter un gouverneur de dérive de viabilité (hystérésis) et son exposition au cockpit

### DIFF
--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -801,6 +801,31 @@ def create_app(
             "events": events[-10:],
         }
 
+    def _summarize_viability_governance(records: list[dict[str, object]]) -> dict[str, object]:
+        """Expose the latest preventive drift state separately from sandbox policy."""
+        names = {
+            "governance.viability_drift_detected",
+            "mutation_paused",
+            "checkpoint.restored",
+            "governance.viability_recovered",
+        }
+        events = [record for record in records if _record_event_name(record) in names]
+        latest = events[-1] if events else {}
+        latest_name = _record_event_name(latest) if latest else None
+        state = latest.get("action", "normal") if latest else "normal"
+        if latest_name == "governance.viability_recovered":
+            state = "normal"
+        return {
+            "state": state,
+            "mutations_enabled": state in {"normal", "throttled"},
+            "operator_intervention_required": state == "operator",
+            "latest_event": latest_name,
+            "metrics": latest.get("metrics", {}),
+            "thresholds": latest.get("thresholds", {}),
+            "windows": latest.get("windows", {}),
+            "events": events[-20:],
+        }
+
     def _summarize_memory(records: list[dict[str, object]]) -> dict[str, object]:
         """Build a compact memory summary for cockpit and smoke checks."""
         memory_records = [
@@ -1121,6 +1146,7 @@ def create_app(
                 "accepted_mutation_rate": None,
                 "critical_alerts": [],
                 "sandbox_governance": _summarize_sandbox_governance([]),
+                "viability_governance": _summarize_viability_governance([]),
                 "governance_policy": _governance_policy_diagnostics(),
                 "last_notable_mutation": None,
                 "next_action": "Aucune donnée: démarrer un run pour remplir le cockpit.",
@@ -1418,6 +1444,7 @@ def create_app(
             "accepted_mutation_rate": accepted_rate,
             "critical_alerts": critical_alerts,
             "sandbox_governance": sandbox_governance,
+            "viability_governance": _summarize_viability_governance(records),
             "governance_policy": _governance_policy_diagnostics(),
             "last_notable_mutation": last_notable_mutation,
             "next_action": next_action,

--- a/src/singular/life/checkpointing.py
+++ b/src/singular/life/checkpointing.py
@@ -20,6 +20,7 @@ class Checkpoint:
     stats: Dict[str, Dict[str, float]] = field(default_factory=dict)
     health_history: list[dict[str, float | int]] = field(default_factory=list)
     health_counters: dict[str, float | int] = field(default_factory=dict)
+    viability_governance: dict[str, object] = field(default_factory=dict)
 
 
 def _migrate_checkpoint_data(data: Mapping[str, object]) -> dict[str, object]:

--- a/src/singular/life/health.py
+++ b/src/singular/life/health.py
@@ -1,9 +1,142 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from typing import Any, Iterable, Literal
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Literal, Mapping
 
 HealthState = Literal["amélioration", "plateau", "dégradation"]
+ViabilityAction = Literal["normal", "throttled", "paused", "restored", "operator"]
+
+
+@dataclass(frozen=True)
+class ViabilityDriftConfig:
+    """Thresholds for the multi-window, hysteretic viability governor."""
+
+    short_window: int = 3
+    medium_window: int = 6
+    long_window: int = 12
+    degrade_cycles: int = 2
+    stable_cycles: int = 4
+    drift_threshold: float = 0.12
+    recovery_threshold: float = 0.05
+    critical_score: float = 0.38
+
+
+@dataclass
+class ViabilityDriftDetector:
+    """Escalate preventive controls before sandbox policy is violated.
+
+    Every observation combines health, risk, resources, failure rate, trait
+    continuity, useful-skill retention and mutation fitness.  Both a short vs
+    long trend and a medium-window absolute level must agree; consequently one
+    anomalous sample cannot change the governance state.
+    """
+
+    config: ViabilityDriftConfig = field(default_factory=ViabilityDriftConfig)
+    action: ViabilityAction = "normal"
+    degraded_cycles: int = 0
+    stable_cycles: int = 0
+    samples: list[dict[str, float]] = field(default_factory=list)
+
+    _LEVELS = ("normal", "throttled", "paused", "restored", "operator")
+    _BENEFICIAL = ("health", "resources", "traits", "useful_skills", "fitness")
+    _ADVERSE = ("risk", "failure_rate")
+
+    @classmethod
+    def from_state(cls, state: Mapping[str, object] | None) -> "ViabilityDriftDetector":
+        detector = cls()
+        if not isinstance(state, Mapping):
+            return detector
+        action = state.get("action")
+        if action in cls._LEVELS:
+            detector.action = action  # type: ignore[assignment]
+        detector.degraded_cycles = int(state.get("degraded_cycles", 0))
+        detector.stable_cycles = int(state.get("stable_cycles", 0))
+        raw = state.get("samples", [])
+        if isinstance(raw, list):
+            detector.samples = [
+                {str(k): float(v) for k, v in item.items() if isinstance(v, (int, float))}
+                for item in raw[-detector.config.long_window :]
+                if isinstance(item, Mapping)
+            ]
+        return detector
+
+    def to_state(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "degraded_cycles": self.degraded_cycles,
+            "stable_cycles": self.stable_cycles,
+            "samples": self.samples[-self.config.long_window :],
+            "diagnostics": self.diagnostics(),
+        }
+
+    @staticmethod
+    def _mean(items: list[dict[str, float]], key: str) -> float:
+        values = [item[key] for item in items if key in item]
+        return sum(values) / len(values) if values else 0.0
+
+    def _score(self, item: Mapping[str, float]) -> float:
+        good = sum(_clamp(float(item.get(k, 1.0))) for k in self._BENEFICIAL)
+        adverse = sum(1.0 - _clamp(float(item.get(k, 0.0))) for k in self._ADVERSE)
+        return (good + adverse) / (len(self._BENEFICIAL) + len(self._ADVERSE))
+
+    def observe(self, metrics: Mapping[str, float]) -> tuple[ViabilityAction, str | None]:
+        normalized = {key: _clamp(float(metrics.get(key, 0.0))) for key in (*self._BENEFICIAL, *self._ADVERSE)}
+        normalized["score"] = self._score(normalized)
+        self.samples.append(normalized)
+        self.samples = self.samples[-self.config.long_window :]
+        if len(self.samples) < self.config.medium_window:
+            return self.action, None
+
+        short = self.samples[-self.config.short_window :]
+        medium = self.samples[-self.config.medium_window :]
+        long = self.samples
+        short_score = self._mean(short, "score")
+        medium_score = self._mean(medium, "score")
+        long_score = self._mean(long, "score")
+        drift = long_score - short_score
+        degrading = drift >= self.config.drift_threshold and medium_score < long_score
+        critical = short_score <= self.config.critical_score
+        recovering = abs(short_score - long_score) <= self.config.recovery_threshold and short_score > self.config.critical_score
+
+        if degrading or critical:
+            self.degraded_cycles += 1
+            self.stable_cycles = 0
+            if self.degraded_cycles >= self.config.degrade_cycles:
+                previous = self.action
+                index = min(self._LEVELS.index(self.action) + 1, len(self._LEVELS) - 1)
+                self.action = self._LEVELS[index]  # type: ignore[assignment]
+                self.degraded_cycles = 0
+                if self.action != previous:
+                    return self.action, "drift"
+        elif recovering:
+            self.stable_cycles += 1
+            self.degraded_cycles = 0
+            if self.stable_cycles >= self.config.stable_cycles and self.action != "normal":
+                self.action = "normal"
+                self.stable_cycles = 0
+                return self.action, "recovered"
+        else:
+            self.degraded_cycles = 0
+            self.stable_cycles = 0
+        return self.action, None
+
+    def diagnostics(self) -> dict[str, object]:
+        short = self.samples[-self.config.short_window :]
+        long = self.samples[-self.config.long_window :]
+        return {
+            "state": self.action,
+            "mutations_enabled": self.action in {"normal", "throttled"},
+            "mutation_interval": 2 if self.action == "throttled" else (1 if self.action == "normal" else None),
+            "degraded_cycles": self.degraded_cycles,
+            "stable_cycles": self.stable_cycles,
+            "samples": len(self.samples),
+            "metrics": self.samples[-1] if self.samples else {},
+            "windows": {
+                "short": self._mean(short, "score"),
+                "long": self._mean(long, "score"),
+            },
+            "thresholds": asdict(self.config),
+        }
 
 
 def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -66,7 +66,7 @@ from singular.multiagent.runtime import LifeTickContext, MultiAgentRuntime
 from singular.life.ecosystem import ARCHETYPES, EcosystemRulesConfig, compute_population_metrics, draw_global_event
 
 from .death import DeathMonitor
-from .health import HealthTracker
+from .health import HealthTracker, ViabilityDriftDetector
 from singular.governance.policy import (
     MutationGovernancePolicy,
     classify_sandbox_error_type,
@@ -1037,6 +1037,8 @@ def run(
         logger_kwargs["root"] = life_root / "runs"
     with RunLogger(run_id, **logger_kwargs) as logger:
         health_tracker = HealthTracker.from_state(state.health_counters)
+        viability_detector = ViabilityDriftDetector.from_state(state.viability_governance)
+        healthy_checkpoint_path = checkpoint_path.with_suffix(checkpoint_path.suffix + ".healthy")
         delayed: list[tuple[float, str, Path]] = []
         tick_count = 0
 
@@ -1078,6 +1080,25 @@ def run(
                 continue
 
             resource_manager.metabolize()
+            # Preventive viability governance is deliberately independent from
+            # sandbox violations. Throttling still permits sampled mutations;
+            # all later levels remain mutation-free until hysteretic recovery.
+            if viability_detector.action == "throttled" and state.iteration % 2:
+                logger.log_interaction(
+                    "mutation_paused", iteration=state.iteration,
+                    reason="viability_throttled", governance=viability_detector.diagnostics(),
+                )
+                _persist_consumed_tick()
+                continue
+            if viability_detector.action in {"paused", "restored", "operator"}:
+                logger.log_interaction(
+                    "mutation_paused", iteration=state.iteration,
+                    reason=f"viability_{viability_detector.action}",
+                    operator_intervention_required=viability_detector.action == "operator",
+                    governance=viability_detector.diagnostics(),
+                )
+                _persist_consumed_tick()
+                continue
             try:
                 signals = capture_signals(bus=event_bus)
             except TypeError:
@@ -2511,6 +2532,44 @@ def run(
             state.health_history.append(health_snapshot.to_dict())
             state.health_history = _retain_health_history(state.health_history)
             state.health_counters = health_tracker.to_state()
+
+            viability_metrics = {
+                "health": health_snapshot.score / 100.0,
+                "risk": post_mutation_snapshot["vital_risk"],
+                "resources": post_mutation_snapshot["resources"],
+                "failure_rate": health_snapshot.failure_frequency,
+                "traits": post_mutation_snapshot["identity_continuity"],
+                "useful_skills": post_mutation_snapshot["useful_skills_retention"],
+                "fitness": _clamp01((fitness_decision.fitness_after + 1.0) / 2.0),
+            }
+            viability_action, viability_transition = viability_detector.observe(viability_metrics)
+            state.viability_governance = viability_detector.to_state()
+            viability_payload = {
+                "iteration": state.iteration,
+                "action": viability_action,
+                "metrics": viability_metrics,
+                "thresholds": asdict(viability_detector.config),
+                "windows": viability_detector.diagnostics()["windows"],
+                "sandbox_violation_streak": org.sandbox_violation_streak,
+            }
+            if viability_transition == "drift":
+                logger.log_interaction("governance.viability_drift_detected", **viability_payload)
+                event_bus.publish("governance.viability_drift_detected", viability_payload, payload_version=1)
+                if viability_action == "paused":
+                    logger.log_interaction("mutation_paused", reason="viability_drift", **viability_payload)
+                elif viability_action == "restored":
+                    healthy = load_checkpoint(healthy_checkpoint_path)
+                    if healthy_checkpoint_path.exists():
+                        state.stats = healthy.stats
+                        state.health_history = healthy.health_history
+                        state.health_counters = healthy.health_counters
+                    logger.log_interaction("checkpoint.restored", checkpoint=str(healthy_checkpoint_path), **viability_payload)
+                    event_bus.publish("checkpoint.restored", viability_payload, payload_version=1)
+            elif viability_transition == "recovered":
+                logger.log_interaction("governance.viability_recovered", **viability_payload)
+                event_bus.publish("governance.viability_recovered", viability_payload, payload_version=1)
+            if viability_action == "normal":
+                save_checkpoint(healthy_checkpoint_path, state)
 
             logger.log_interaction(
                 INTERACTION_RESOURCE_COMPETITION,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -13,6 +13,24 @@ from singular.dashboard.services.trajectory import build_trajectory
 from singular.lives import LifeMetadata, create_life
 
 
+def test_dashboard_exposes_viability_drift_diagnostics(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    (runs_dir / "drift.jsonl").write_text(json.dumps({
+        "ts": "2026-08-09T10:00:00+00:00", "event": "interaction",
+        "interaction": "mutation_paused", "action": "paused",
+        "metrics": {"health": .35, "risk": .7, "fitness": .2},
+        "thresholds": {"drift_threshold": .12},
+        "windows": {"short": .35, "long": .62},
+    }) + "\n", encoding="utf-8")
+    payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get("/api/cockpit").json()
+    governance = payload["viability_governance"]
+    assert governance["state"] == "paused"
+    assert governance["mutations_enabled"] is False
+    assert governance["metrics"]["risk"] == .7
+    assert governance["thresholds"]["drift_threshold"] == .12
+
+
 def test_trajectory_contract_joins_records_by_correlation_id(tmp_path: Path) -> None:
     records = [
         {"ts": "2026-08-09T10:00:00+00:00", "event": "sandbox_violation", "correlation_id": "corr-1", "category": "forbidden_name", "life_id": "life-a"},

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from singular.life.health import HealthTracker, detect_health_state
+from singular.life.health import HealthTracker, ViabilityDriftDetector, detect_health_state
 from singular.life.loop import _retain_health_history
 from singular.runs import report as report_mod
 
@@ -68,6 +68,18 @@ def test_health_tracker_regression() -> None:
 
     assert scores[-1] < scores[49]
     assert detect_health_state(scores, short_window=10, long_window=50) == "dégradation"
+
+
+def test_viability_drift_state_round_trips_with_metrics_and_thresholds() -> None:
+    detector = ViabilityDriftDetector()
+    metrics = {"health": .8, "risk": .1, "resources": .7, "failure_rate": .1,
+               "traits": .9, "useful_skills": .8, "fitness": .75}
+    for _ in range(7):
+        detector.observe(metrics)
+    diagnostics = ViabilityDriftDetector.from_state(detector.to_state()).diagnostics()
+    assert diagnostics["metrics"]["useful_skills"] == .8
+    assert diagnostics["thresholds"]["stable_cycles"] == 4
+    assert diagnostics["windows"]["short"] > .7
 
 
 def test_report_prints_health_state(tmp_path: Path, capsys) -> None:

--- a/tests/test_vital_transitions.py
+++ b/tests/test_vital_transitions.py
@@ -1,4 +1,23 @@
 from singular.life.vital import compute_vital_timeline
+from singular.life.health import ViabilityDriftDetector
+
+
+def test_viability_drift_escalates_and_recovers_with_hysteresis() -> None:
+    detector = ViabilityDriftDetector()
+    healthy = {"health": .9, "risk": .05, "resources": .9, "failure_rate": .05,
+               "traits": .9, "useful_skills": .9, "fitness": .9}
+    degraded = {"health": .1, "risk": .9, "resources": .1, "failure_rate": .9,
+                "traits": .2, "useful_skills": .2, "fitness": .1}
+    transitions = []
+    for metrics in [healthy] * 12 + [degraded] * 14 + [healthy] * 30:
+        action, transition = detector.observe(metrics)
+        if transition:
+            transitions.append((action, transition))
+    assert transitions == [
+        ("throttled", "drift"), ("paused", "drift"),
+        ("restored", "drift"), ("operator", "drift"),
+        ("normal", "recovered"),
+    ]
 
 
 def test_vital_transition_to_declining_on_age_threshold() -> None:


### PR DESCRIPTION
### Motivation

- Prévenir les dégradations silencieuses en détectant les tendances multi‑signal (santé, risque, ressources, échecs, traits, compétences utiles, fitness) et en escaladant des actions préventives avant violation sandbox.

### Description

- Ajout d’un détecteur `ViabilityDriftDetector` avec configuration multi‑fenêtres, hystérésis et niveaux d’escalade `normal → throttled → paused → restored → operator` dans `src/singular/life/health.py`.
- Persistance de l’état du détecteur dans le checkpoint (`viability_governance`) via `src/singular/life/checkpointing.py` afin de conserver fenêtres et compteurs entre exécutions.
- Intégration dans la boucle de vie (`run`) pour appliquer réduction de cadence, pause préventive des mutations, restauration depuis le dernier checkpoint sain et signaler la nécessité d’une intervention opérateur, sans attendre une violation sandbox, dans `src/singular/life/loop.py`.
- Journalisation et publication d’événements explicites : `governance.viability_drift_detected`, `mutation_paused`, `checkpoint.restored`, `governance.viability_recovered` avec métriques, fenêtres et seuils déclencheurs.
- Exposition d’un résumé de gouvernance de viabilité séparé dans le cockpit/dashboard (`viability_governance`) et agrégation des diagnostics côté UI dans `src/singular/dashboard/__init__.py`.
- Ajout de tests couvrant la séquence dégradation → pause → restauration → reprise et la sérialisation des diagnostics dans `tests/test_vital_transitions.py`, `tests/test_health.py` et `tests/test_dashboard.py`.

### Testing

- Compilation statique : `python -m py_compile src/singular/life/health.py src/singular/life/loop.py src/singular/dashboard/__init__.py` — OK.
- Tests ciblés de viabilité : `pytest -q tests/test_health.py tests/test_vital_transitions.py tests/test_dashboard.py -k "viability_drift or health_tracker or vital_transition"` — 10 passed (viability‑focused tests green).
- Tests plus larges (suite élargie comprenant `tests/test_loop.py` etc.) ont montré échecs indépendants liés à états partagés et valeurs par défaut de politique sandbox existantes; ces échecs sont hors du périmètre du gouverneur de dérive et n’ont pas été modifiés intentionnellement par cette PR.
- Vérifications git/format : `git diff --check` et commit réalisé (`Add hysteretic viability drift governance`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7826420898832ab51338c10e2433e1)