### PR TITLE
Relier les résultats incarnés à la mémoire décisionnelle

### DIFF
--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict, deque
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Callable, Protocol
 
@@ -15,6 +15,7 @@ from singular.embodiment import Acknowledgement, Command, EmergencyStop, Observa
 from singular.morals import MoralAction, MoralDecisionEngine
 from singular.morals import MoralContextBuilder
 from singular.identity.core import IdentityCoreService
+from singular.memory_layers.embodiment_pipeline import EmbodimentOutcomePipeline
 
 DEFAULT_SCHEMA_VERSION = "1.0"
 
@@ -146,6 +147,7 @@ class AgentRuntime:
         resource_gate: Callable[[ActionRequest], bool | tuple[bool, str]] | None = None,
         emergency_stop: EmergencyStop | None = None,
         self_observation: SelfObservationService | None = None,
+        outcome_pipeline: EmbodimentOutcomePipeline | None = None,
     ) -> None:
         self.perception = perception
         self.mind = mind
@@ -172,6 +174,12 @@ class AgentRuntime:
         self.self_observation = self_observation or SelfObservationService(
             get_mem_dir() / "self_model.json"
         )
+        self.outcome_pipeline = outcome_pipeline
+        if outcome_pipeline is not None:
+            self.event_bus.subscribe(
+                "embodiment.action.result", outcome_pipeline.consume
+            )
+            self.event_bus.subscribe("causal.trace", outcome_pipeline.consume)
 
     @property
     def disabled(self) -> bool:
@@ -215,6 +223,18 @@ class AgentRuntime:
             self._ensure_schema_version(percept.schema_version)
             self.event_bus.publish("perception.received", percept)
 
+            if self.outcome_pipeline is not None:
+                recalled = self.outcome_pipeline.decision_context()
+                if recalled["outcomes"]:
+                    percept = replace(
+                        percept,
+                        payload={
+                            **percept.payload,
+                            "embodied_memory_context": recalled,
+                        },
+                    )
+                    self.event_bus.publish("decision.memory.injected", recalled)
+
             intent = self.mind.propose_intent(percept)
             if intent is None:
                 self.event_bus.publish("mind.intent.skipped", {"percept": percept})
@@ -229,7 +249,9 @@ class AgentRuntime:
             self._ensure_schema_version(request.schema_version)
             self.event_bus.publish("action.requested", request)
 
-            action = MoralAction(request.action_type, request.parameters, intent.rationale)
+            action = MoralAction(
+                request.action_type, request.parameters, intent.rationale
+            )
             moral_context = self.moral_context_builder.build(
                 action, request.parameters.get("moral_context", {})
             )
@@ -579,6 +601,14 @@ class AgentRuntime:
             "dry_run": getattr(decision, "dry_run", None),
         }
         gain_loss = 1.0 if result.success else -1.0
+        dry_run = bool(policy_details["dry_run"])
+        executed = bool(result.actual.get("executed", result.success and not dry_run))
+        refused = not result.success and not executed
+        cost = result.audit.get("cost", result.actual.get("cost", 0.0))
+        try:
+            cost_value = float(cost)
+        except (TypeError, ValueError):
+            cost_value = 0.0
         trace = CausalTrace(
             trace_id=uuid4().hex,
             input={
@@ -620,7 +650,21 @@ class AgentRuntime:
             "decision": trace.decision,
             "action": trace.action,
             "result": trace.result,
+            "embodied_outcome": True,
+            "objective": intent.goal,
+            "confidence": max(0.0, min(1.0, float(intent.confidence))),
+            "importance": 1.0 if refused or cost_value > 0 else 0.75,
+            "dry_run": dry_run,
+            "costly": cost_value > 0,
+            "outcome_status": (
+                "refused" if refused else ("success" if result.success else "failure")
+            ),
+            "summary": (
+                f"{request.action_type} pour {intent.goal}: "
+                f"{result.message or result.error or ('réussi' if result.success else 'échoué')}"
+            ),
         }
+        self.event_bus.publish("embodiment.action.result", payload)
         add_causal_trace(payload)
         add_episode({"event": "embodiment.action.result", **payload})
         # The persisted trace id is the evidence anchor; never learn from an

--- a/src/singular/identity/consolidation_coordinator.py
+++ b/src/singular/identity/consolidation_coordinator.py
@@ -65,12 +65,12 @@ class ConsolidationCoordinator:
     def _stage_items(stage: str, episodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
         keys = {
             "semantic_memory": ("user_fact", "preference", "constraint", "fact"),
-            "autobiographical_memory": ("user_fact", "autobiographical_fact", "achievement", "failure"),
+            "autobiographical_memory": ("user_fact", "autobiographical_fact", "achievement", "failure", "embodied_outcome"),
             "metacognitive_self_model": ("strategy", "error", "bias", "failure_condition"),
             "models_of_others": ("individual_id", "other_id", "person"),
-            "probabilistic_beliefs": ("belief", "hypothesis", "success", "reward"),
+            "probabilistic_beliefs": ("belief", "hypothesis", "success", "reward", "embodied_outcome"),
             "imitation_learning": ("demonstration", "observations", "actions", "skill"),
-            "narrative_projection": ("narrative", "heading", "achievement", "failure"),
+            "narrative_projection": ("narrative", "heading", "achievement", "failure", "embodied_outcome"),
         }[stage]
         return [episode for episode in episodes if any(key in episode for key in keys)]
 
@@ -83,7 +83,7 @@ class ConsolidationCoordinator:
         counts["seen"] = len(items)
         now = _now()
         for episode in items:
-            provenance = str(episode.get("id") or episode.get("event_id") or _key(episode))
+            provenance = str(episode.get("trace_id") or episode.get("id") or episode.get("event_id") or _key(episode))
             content = next(
                 (episode[key] for key in (
                     "value", "user_fact", "autobiographical_fact", "preference",
@@ -91,7 +91,7 @@ class ConsolidationCoordinator:
                     "strategy", "error", "bias", "skill", "individual_id",
                     "other_id", "person",
                 ) if episode.get(key) is not None),
-                episode,
+                episode.get("summary", episode),
             )
             normalized = str(content).strip().casefold()
             item_id = _key([stage, normalized])
@@ -128,6 +128,9 @@ class ConsolidationCoordinator:
                     "obsolete": bool(episode.get("obsolete")),
                     "first_seen": str(episode.get("ts") or now),
                     "last_seen": str(episode.get("ts") or now), "contradicts": contradictions,
+                    "trace_id": episode.get("trace_id"), "objective": episode.get("objective"),
+                    "result": episode.get("result"), "confidence": episode.get("confidence"),
+                    "importance": episode.get("importance"),
                 }
                 counts["rejected"] += int(rejected)
         # Obsolete evidence can leave active memory, but critical records and the

--- a/src/singular/memory_layers/__init__.py
+++ b/src/singular/memory_layers/__init__.py
@@ -3,6 +3,7 @@ from .local_json import LocalJsonMemoryBackend
 from .service import MemoryLayerService
 from .retrieval import MemoryRetrievalService, RetrievalResult
 from .vector_adapter import build_backend
+from .embodiment_pipeline import EmbodimentOutcomePipeline
 
 __all__ = [
     "MemoryBackend",
@@ -12,4 +13,5 @@ __all__ = [
     "MemoryRetrievalService",
     "RetrievalResult",
     "build_backend",
+    "EmbodimentOutcomePipeline",
 ]

--- a/src/singular/memory_layers/embodiment_pipeline.py
+++ b/src/singular/memory_layers/embodiment_pipeline.py
@@ -1,0 +1,60 @@
+"""Common projection pipeline for measured embodied action outcomes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from singular.identity.consolidation_coordinator import ConsolidationCoordinator
+from singular.self_narrative import update_from_signals
+
+from .service import MemoryLayerService
+
+
+class EmbodimentOutcomePipeline:
+    """Deduplicate, consolidate and recall outcomes using causal provenance."""
+
+    def __init__(
+        self,
+        memory: MemoryLayerService,
+        coordinator: ConsolidationCoordinator,
+        narrative_path: Path | str,
+    ) -> None:
+        self.memory = memory
+        self.coordinator = coordinator
+        self.narrative_path = Path(narrative_path)
+        self._seen: set[str] = set()
+
+    def consume(self, event: Any) -> dict[str, Any] | None:
+        payload = getattr(event, "payload", event)
+        if not isinstance(payload, Mapping):
+            return None
+        trace_id = str(payload.get("trace_id", ""))
+        if not trace_id or trace_id in self._seen or payload.get("dry_run"):
+            return None
+        self._seen.add(trace_id)
+        outcome = dict(payload)
+        self.memory.ingest_embodied_outcome(outcome)
+        self.coordinator.run([outcome])
+        status = str(outcome.get("outcome_status", ""))
+        summary = str(outcome.get("summary", ""))
+        narrative_signals: dict[str, list[str]] = {}
+        if status == "success":
+            narrative_signals["significant_successes"] = [summary]
+        elif status == "refused":
+            narrative_signals["significant_failures"] = [summary]
+        if outcome.get("costly"):
+            narrative_signals["costly_incidents"] = [summary]
+        update_from_signals(
+            {"embodied_actions": [outcome], "regrets_and_pride": narrative_signals},
+            self.narrative_path,
+        )
+        return outcome
+
+    def decision_context(self, *, objective: str = "") -> dict[str, Any]:
+        memories = self.memory.embodied_outcomes(objective=objective)
+        return {
+            "provenance": [row["provenance"] for row in memories],
+            "outcomes": memories,
+            "summary": " | ".join(str(row["summary"]) for row in memories),
+        }

--- a/src/singular/memory_layers/service.py
+++ b/src/singular/memory_layers/service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import hashlib
 import json
-from pathlib import Path
 from typing import Any
 
 from .base import MemoryBackend, MemoryRecord
@@ -56,6 +55,44 @@ class MemoryLayerService:
             metadata={"kind": "mutation", "ts": now, **result},
         )
         self.backend.put(_PROCEDURAL_LAYER, record)
+
+    def ingest_embodied_outcome(self, outcome: dict[str, Any]) -> None:
+        """Store an executed/refused embodied outcome with its evidence anchor."""
+
+        if outcome.get("dry_run"):
+            return
+        self.ingest_episode(outcome)
+
+    def embodied_outcomes(
+        self, *, objective: str = "", limit: int = 5
+    ) -> list[dict[str, Any]]:
+        """Retrieve outcomes by explicit causal provenance, not inferred similarity."""
+
+        matches: list[dict[str, Any]] = []
+        for layer in (_SHORT_TERM_LAYER, _LONG_TERM_LAYER):
+            for record in self.backend.search(layer, query="", limit=10000):
+                metadata = record.metadata
+                if metadata.get("kind") != "episode" or not metadata.get("trace_id"):
+                    continue
+                if objective and str(metadata.get("objective")) != objective:
+                    continue
+                matches.append(
+                    {
+                        "provenance": f"causal:{metadata['trace_id']}",
+                        "trace_id": metadata["trace_id"],
+                        "objective": metadata.get("objective"),
+                        "result": metadata.get("result"),
+                        "confidence": metadata.get("confidence", 0.0),
+                        "importance": metadata.get("importance", 0.0),
+                        "summary": metadata.get("summary", record.text),
+                    }
+                )
+        deduplicated = {row["trace_id"]: row for row in matches}
+        return sorted(
+            deduplicated.values(),
+            key=lambda row: float(row.get("importance", 0.0)),
+            reverse=True,
+        )[: max(0, limit)]
 
     def consolidate(self) -> None:
         recent = self.backend.search(_SHORT_TERM_LAYER, query="", limit=10000)

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -452,6 +452,13 @@ class OrchestratorService:
             for ep in recent_episodes
             if ep.get("status") == "failure"
         ]
+        embodied_actions = [
+            dict(ep)
+            for ep in recent_episodes
+            if ep.get("event") == "embodiment.action.result"
+            and ep.get("embodied_outcome")
+            and not ep.get("dry_run")
+        ]
 
         quest_changes = self._refresh_generated_quests(
             psyche_state=psyche_state,
@@ -535,6 +542,7 @@ class OrchestratorService:
                         str(event.get("phase")) for event in last_events[-3:]
                     ],
                 },
+                "embodied_actions": embodied_actions,
             },
             self.mem_dir / "self_narrative.json",
             clock=self.clock,

--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -941,6 +941,29 @@ def update_from_signals(
             regrets_signals.get("costly_incidents"),
         )
 
+    # Embodied evidence is classified here rather than at each caller so a
+    # refusal or an expensive success is narrated consistently. Simulations are
+    # audit evidence only and must never become lived autobiographical evidence.
+    embodied_actions = signals.get("embodied_actions")
+    if isinstance(embodied_actions, list):
+        for action in embodied_actions:
+            if not isinstance(action, Mapping) or action.get("dry_run"):
+                continue
+            summary = str(action.get("summary") or "").strip()
+            if not summary:
+                continue
+            status = str(action.get("outcome_status") or "")
+            if status == "success":
+                _extend_unique(
+                    narrative.regrets_and_pride.significant_successes, [summary]
+                )
+            elif status == "refused":
+                _extend_unique(
+                    narrative.regrets_and_pride.significant_failures, [summary]
+                )
+            if action.get("costly"):
+                _extend_unique(narrative.regrets_and_pride.costly_incidents, [summary])
+
     save(
         narrative,
         path,

--- a/tests/test_embodiment_runtime.py
+++ b/tests/test_embodiment_runtime.py
@@ -10,6 +10,13 @@ from singular.embodiment import (
     ErrorCode,
     ScriptedSensor,
 )
+from singular.core.agent_runtime import AgentRuntime, Intent
+from singular.identity.consolidation_coordinator import ConsolidationCoordinator
+from singular.memory_layers import (
+    EmbodimentOutcomePipeline,
+    LocalJsonMemoryBackend,
+    MemoryLayerService,
+)
 
 
 def test_multiple_sensors_effectors_and_measured_feedback() -> None:
@@ -115,3 +122,79 @@ def test_cli_runs_simulated_configuration_and_writes_audit(tmp_path, capsys) -> 
     ]
     assert records[-1]["event"] == "embodiment.closed"
     assert records[-1]["state"]["closed"] is True
+
+
+def test_embodied_outcome_is_consolidated_narrated_and_influences_next_decision(
+    tmp_path,
+) -> None:
+    class Perception:
+        def collect(self):
+            from singular.embodiment import Observation
+
+            return [Observation("range", {"distance": 1}, "range-sensor")]
+
+    class Mind:
+        contexts = []
+
+        def propose_intent(self, percept):
+            context = percept.payload.get("embodied_memory_context")
+            self.contexts.append(context)
+            goal = "avoid-obstacle" if context else "approach-obstacle"
+            return Intent(goal=goal, rationale="measured feedback", confidence=0.9)
+
+        def propose_action(self, intent, percept):
+            return Command(
+                "motor.stop" if intent.goal == "avoid-obstacle" else "motor.move",
+                {"distance": percept.payload["distance"]},
+                intent_goal=intent.goal,
+            )
+
+    class Action:
+        def execute(self, request):
+            from singular.embodiment import Acknowledgement
+
+            return Acknowledgement(
+                request.action_type,
+                True,
+                "obstacle reached",
+                command_id=request.command_id,
+                actual={"executed": True, "distance": 1},
+            )
+
+    mem = tmp_path / "mem"
+    memory = MemoryLayerService(LocalJsonMemoryBackend(mem / "layers"))
+    pipeline = EmbodimentOutcomePipeline(
+        memory, ConsolidationCoordinator(mem), mem / "self_narrative.json"
+    )
+    mind = Mind()
+    runtime = AgentRuntime(
+        perception=Perception(), mind=mind, action=Action(), outcome_pipeline=pipeline
+    )
+
+    first = runtime.step()[0]
+    second = runtime.step()[0]
+
+    assert first.action_type == "motor.move" and first.success
+    assert second.action_type == "motor.stop" and second.success
+    assert mind.contexts[0] is None
+    assert mind.contexts[1]["provenance"][0].startswith("causal:")
+    trace_id = mind.contexts[1]["outcomes"][0]["trace_id"]
+    assert trace_id
+    narrative = json.loads((mem / "self_narrative.json").read_text())
+    assert any(
+        "motor.move" in item
+        for item in narrative["regrets_and_pride"]["significant_successes"]
+    )
+    audit = json.loads((mem / "consolidation_audit.json").read_text())
+    assert any(trace_id in row["provenance"] for row in audit.values())
+
+
+def test_dry_run_trace_is_not_learned_as_executed_outcome(tmp_path) -> None:
+    memory = MemoryLayerService(LocalJsonMemoryBackend(tmp_path / "layers"))
+    pipeline = EmbodimentOutcomePipeline(
+        memory, ConsolidationCoordinator(tmp_path), tmp_path / "self_narrative.json"
+    )
+
+    assert pipeline.consume({"trace_id": "simulation", "dry_run": True}) is None
+    assert memory.embodied_outcomes() == []
+    assert not (tmp_path / "self_narrative.json").exists()


### PR DESCRIPTION
### Motivation
- Fournir un pipeline unifié pour capter les résultats d'actions incarnées (exécutions réelles, refus, actions coûteuses) et en faire des souvenirs utilisables lors de la décision suivante.
- Empêcher l'apprentissage à partir de simulations (`dry_run`) tout en conservant leur auditabilité.

### Description
- Ajout d'un pipeline `EmbodimentOutcomePipeline` abonné aux événements `embodiment.action.result` et `causal.trace` qui déduplique, ingère via les couches mémoire et déclenche la consolidation et la projection narrative (nouveau fichier `src/singular/memory_layers/embodiment_pipeline.py`).
- Enrichissement de l'enregistrement de trace produit par `AgentRuntime` avec `trace_id`, `objective`, `confidence`, `importance`, `costly`, `outcome_status`, `summary` et publication de l'événement `embodiment.action.result` (modifications dans `src/singular/core/agent_runtime.py`).
- Extension du service de couches mémoire pour ingérer et restituer explicitement les outcomes incarnés par provenance causale (`ingest_embodied_outcome` et `embodied_outcomes` dans `src/singular/memory_layers/service.py`) et export du pipeline depuis le package `memory_layers`.
- Mise à jour du coordinateur de consolidation pour inclure `embodied_outcome` comme type traitable et préserver provenance, trace et métadonnées utiles (`src/singular/identity/consolidation_coordinator.py`).
- Extension de `update_from_signals` et intégration orchestrateur pour classifier et narrer succès, refus et incidents coûteux issus des outcomes incarnés tout en ignorant les `dry_run` (`src/singular/self_narrative.py`, `src/singular/orchestrator/service.py`).
- Injection contextuelle des souvenirs incarnés dans la charge utile de perception avant décision pour influencer la proposition d'intention (modification de `AgentRuntime` pour appeler `decision_context`).
- Ajout de tests unitaires et d'un test bout en bout couvrant la chaîne perception → décision → commande → acknowledgement → consolidation → mise à jour narrative → décision suivante influencée, et un test assurant que les `dry_run` ne sont pas appris (`tests/test_embodiment_runtime.py`).

### Testing
- Exécution de la vérification de style: `ruff check` sur les modules modifiés et reformattage par `black` où nécessaire, sans erreurs résiduelles.
- Exécution des suites ciblées: `pytest -q tests/test_embodiment_runtime.py tests/test_core_agent_runtime.py tests/test_self_narrative.py tests/test_memory_layers.py tests/test_consolidation_coordinator.py tests/test_orchestrator_service.py` et commandes associées; la batterie de tests automatisés a réussi (tous les tests exécutés sont passés).
- Vérifications additionnelles: `git diff --check` et contrôles d'intégrité avant commit ont été exécutés et sont passés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a788672bc38832aa70375b3692a4995)