### PR TITLE
Guard trait evolution: separer traits plastiques, engagements et limites; evidence-gated, rate-limited updates

### DIFF
--- a/src/singular/identity/__init__.py
+++ b/src/singular/identity/__init__.py
@@ -9,7 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .coherence import CoherenceDecision, IdentityCoherenceGuard, IdentityInvariants, detect_contradictions
+from .coherence import (CoherenceDecision, IdentityChangeDecision, IdentityChangePolicy,
+                        IdentityCoherenceGuard, IdentityInvariants, detect_contradictions)
 from .consolidation import ConsolidationPipeline, ConsolidationPolicy, ConsolidationResult
 from .consolidation_coordinator import ConsolidationCoordinator
 from .core import IdentityAggregationService, IdentityCoreService
@@ -63,6 +64,8 @@ __all__ = [
     "ConsolidationPipeline",
     "ConsolidationPolicy",
     "IdentityCoherenceGuard",
+    "IdentityChangeDecision",
+    "IdentityChangePolicy",
     "IdentityAggregationService",
     "IdentityCoreService",
     "IdentityInvariants",

--- a/src/singular/identity/coherence.py
+++ b/src/singular/identity/coherence.py
@@ -52,6 +52,27 @@ class CoherenceDecision:
     invariant_violations: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class IdentityChangePolicy:
+    """Configurable boundary between observations and protected identity."""
+
+    plastic_bounds: tuple[float, float] = (0.0, 1.0)
+    max_delta: float = 0.10
+    important_delta: float = 0.15
+    independent_evidence_required: int = 2
+
+
+@dataclass(frozen=True)
+class IdentityChangeDecision:
+    """Result of classifying and checking a proposed identity evolution."""
+
+    category: str
+    status: str
+    accepted: bool
+    value: Any
+    reasons: tuple[str, ...]
+
+
 class IdentityCoherenceGuard:
     """Detects drift and guards invariant-breaking decisions."""
 
@@ -60,10 +81,70 @@ class IdentityCoherenceGuard:
         *,
         invariants: IdentityInvariants,
         root: Path | str = Path("."),
+        change_policy: IdentityChangePolicy | None = None,
     ) -> None:
         self.invariants = invariants
         self.root = Path(root)
         self.audit_path = self.root / _AUDIT_RELATIVE_PATH
+        self.change_policy = change_policy or IdentityChangePolicy()
+
+    def evaluate_identity_change(
+        self,
+        *,
+        category: str,
+        current: Any,
+        proposed: Any,
+        cause: str,
+        evidence: list[str] | tuple[str, ...] = (),
+    ) -> IdentityChangeDecision:
+        """Gate plastic traits, commitments, and non-negotiable safety limits.
+
+        Safety limits can only be strengthened here. Commitments always require
+        corroboration; plastic numeric traits are bounded and rate limited.
+        Every attempt is audited, including refused attempts, for narration.
+        """
+        reasons: list[str] = []
+        accepted = True
+        value = proposed
+        independent = list(dict.fromkeys(str(item) for item in evidence if str(item)))
+        if category == "safety_limit":
+            accepted = proposed == current or (
+                isinstance(current, bool) and isinstance(proposed, bool) and proposed
+            )
+            if not accepted:
+                reasons.append("safety_limit_cannot_be_weakened")
+        elif category == "identity_commitment":
+            if len(independent) < self.change_policy.independent_evidence_required:
+                accepted = False
+                reasons.append("commitment_requires_independent_evidence")
+        elif category == "plastic_trait":
+            try:
+                old, requested = float(current), float(proposed)
+                low, high = self.change_policy.plastic_bounds
+                requested = max(low, min(high, requested))
+                delta = requested - old
+                if abs(delta) >= self.change_policy.important_delta and len(independent) < self.change_policy.independent_evidence_required:
+                    accepted = False
+                    reasons.append("important_change_requires_independent_evidence")
+                value = old + max(-self.change_policy.max_delta, min(self.change_policy.max_delta, delta))
+                value = max(low, min(high, value))
+                if accepted and value != requested:
+                    reasons.append("rate_limited")
+            except (TypeError, ValueError):
+                accepted = False
+                reasons.append("plastic_trait_must_be_numeric")
+        else:
+            accepted = False
+            reasons.append("unknown_identity_category")
+        status = "applied" if accepted else "review"
+        append_jsonl_line(self.audit_path, {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "kind": "identity_change", "category": category, "status": status,
+            "accepted": accepted, "before": current, "requested": proposed,
+            "value": value if accepted else current, "cause": cause,
+            "evidence": independent, "reasons": reasons,
+        })
+        return IdentityChangeDecision(category, status, accepted, value if accepted else current, tuple(reasons))
 
     def evaluate_decision(
         self,

--- a/src/singular/identity/consolidation.py
+++ b/src/singular/identity/consolidation.py
@@ -19,6 +19,12 @@ class ConsolidationPolicy:
 
     keep_last_episodes: int = 1_000
     keep_top_self_model_entries: int = 100
+    trait_minimum: float = 0.0
+    trait_maximum: float = 1.0
+    max_trait_delta: float = 0.10
+    important_trait_delta: float = 0.15
+    independent_evidence_required: int = 2
+    structural_collapse_drop: float = 0.20
 
 
 @dataclass(frozen=True)
@@ -29,6 +35,7 @@ class ConsolidationResult:
     episodes_seen: int
     facts_count: int
     episodic_compaction: dict[str, Any]
+    identity_evolution: dict[str, Any]
 
 
 class ConsolidationPipeline:
@@ -60,6 +67,7 @@ class ConsolidationPipeline:
         episodes = self.episodic.read_all() if episodes is None else episodes
         facts = self.semantic.consolidate_from_episodes(episodes)
         self.self_model.apply_facts(facts)
+        evolution = self._apply_trait_evolution(episodes)
         self.self_model.compact(self.policy.keep_top_self_model_entries)
         # Reconcile projections after every consolidation so narrative, psyche,
         # birth artifacts and coherence do not drift into competing identities.
@@ -73,4 +81,39 @@ class ConsolidationPipeline:
             episodes_seen=len(episodes),
             facts_count=len(facts),
             episodic_compaction=compaction,
+            identity_evolution=evolution,
         )
+
+    def _apply_trait_evolution(self, episodes: list[dict[str, Any]]) -> dict[str, Any]:
+        """Apply evidence-bearing plastic changes separately from identity facts."""
+        # Imported lazily because psyche persistence depends on the memory
+        # package, whose layered services import the identity package.
+        from singular.psyche import Psyche, TraitEvolutionPolicy
+
+        path = self.mem_dir / "psyche.json"
+        psyche = Psyche.load_state(path)
+        psyche.evolution_policy = TraitEvolutionPolicy(
+            minimum=self.policy.trait_minimum,
+            maximum=self.policy.trait_maximum,
+            max_delta=self.policy.max_trait_delta,
+            important_delta=self.policy.important_trait_delta,
+            independent_evidence_required=self.policy.independent_evidence_required,
+            collapse_drop=self.policy.structural_collapse_drop,
+        )
+        counts = {"applied": 0, "review": 0, "frozen": 0}
+        for episode in episodes:
+            changes = episode.get("trait_changes")
+            if not isinstance(changes, dict):
+                continue
+            evidence = episode.get("evidence", [])
+            if isinstance(evidence, str):
+                evidence = [evidence]
+            status = psyche.evolve_traits(
+                changes,
+                cause=str(episode.get("cause") or episode.get("event") or "consolidation"),
+                evidence=evidence if isinstance(evidence, list) else [],
+            )
+            counts[status] += 1
+        if sum(counts.values()):
+            psyche.save_state(path)
+        return {**counts, "frozen_remaining": psyche.evolution_freeze_remaining}

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, Any, ClassVar, Mapping, Sequence
+from datetime import datetime, timezone
 from pathlib import Path
 import random
 from enum import Enum
@@ -76,6 +77,24 @@ class PsycheActionDecision:
     action: str
     reason: str
     scores: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TraitEvolutionPolicy:
+    """Safety envelope for plastic personality traits.
+
+    Commitments and red lines deliberately are not traits: they are handled by
+    the identity coherence guard and cannot be modified through this policy.
+    """
+
+    minimum: float = 0.0
+    maximum: float = 1.0
+    max_delta: float = 0.10
+    important_delta: float = 0.15
+    independent_evidence_required: int = 2
+    collapse_drop: float = 0.20
+    cumulative_window: int = 3
+    freeze_events: int = 2
 
 
 def _numeric_signal(
@@ -260,6 +279,11 @@ class Psyche:
     # Monotonic identity revision (distinct from the JSON schema version).
     psyche_version: int = 0
     last_identity_event_id: str | None = None
+    evolution_policy: TraitEvolutionPolicy = field(default_factory=TraitEvolutionPolicy)
+    trait_history: list[dict[str, Any]] = field(default_factory=list)
+    evolution_reviews: list[dict[str, Any]] = field(default_factory=list)
+    evolution_freeze_remaining: int = 0
+    last_coherent_traits: dict[str, float] = field(default_factory=dict)
 
     # ``last_mood`` is updated every time :meth:`feel` is called and can be
     # queried by other subsystems (interaction and mutation policies).
@@ -371,6 +395,91 @@ class Psyche:
         "jealousy",
         "resentment",
     )
+    _PLASTIC_TRAITS: ClassVar[tuple[str, ...]] = (
+        "curiosity", "patience", "playfulness", "optimism", "resilience"
+    )
+    _STRUCTURAL_TRAITS: ClassVar[tuple[str, ...]] = (
+        "patience", "optimism", "resilience"
+    )
+
+    def __post_init__(self) -> None:
+        for trait in self._PLASTIC_TRAITS:
+            setattr(self, trait, _clamp(float(getattr(self, trait)), self.evolution_policy.minimum, self.evolution_policy.maximum))
+        if not self.last_coherent_traits:
+            self.last_coherent_traits = self.trait_snapshot()
+        else:
+            snapshot = self.trait_snapshot()
+            self.last_coherent_traits = {
+                name: float(self.last_coherent_traits.get(name, snapshot[name]))
+                for name in self._PLASTIC_TRAITS
+            }
+
+    def trait_snapshot(self) -> dict[str, float]:
+        """Return only plastic values, excluding commitments and safety limits."""
+        return {name: float(getattr(self, name)) for name in self._PLASTIC_TRAITS}
+
+    def evolve_traits(
+        self,
+        deltas: Mapping[str, float],
+        *,
+        cause: str,
+        evidence: Sequence[str] = (),
+    ) -> str:
+        """Apply bounded, rate-limited and auditable plastic-trait changes.
+
+        Returns ``applied``, ``review`` or ``frozen``.  Distinct evidence is
+        mandatory when the *requested* change is important, even though the
+        applied change is subsequently rate limited.
+        """
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        independent = tuple(dict.fromkeys(str(item) for item in evidence if str(item)))
+        requested = {k: float(v) for k, v in deltas.items() if k in self._PLASTIC_TRAITS}
+        if self.evolution_freeze_remaining > 0:
+            self.evolution_freeze_remaining -= 1
+            self.trait_history.append({"ts": now, "status": "frozen", "cause": cause,
+                                       "evidence": list(independent), "requested": requested})
+            return "frozen"
+        if any(abs(delta) >= self.evolution_policy.important_delta for delta in requested.values()) and len(independent) < self.evolution_policy.independent_evidence_required:
+            self.trait_history.append({"ts": now, "status": "review", "cause": cause,
+                                       "evidence": list(independent), "requested": requested,
+                                       "reason": "insufficient_independent_evidence"})
+            return "review"
+
+        before = self.trait_snapshot()
+        applied: dict[str, float] = {}
+        for trait, delta in requested.items():
+            limited = max(-self.evolution_policy.max_delta, min(self.evolution_policy.max_delta, delta))
+            target = _clamp(before[trait] + limited, self.evolution_policy.minimum, self.evolution_policy.maximum)
+            applied[trait] = target - before[trait]
+
+        recent = [row for row in self.trait_history[-self.evolution_policy.cumulative_window + 1:] if row.get("status") == "applied"]
+        structural_drops = []
+        for trait in self._STRUCTURAL_TRAITS:
+            cumulative = -applied.get(trait, 0.0) + sum(max(0.0, -float(row.get("applied", {}).get(trait, 0.0))) for row in recent)
+            if cumulative >= self.evolution_policy.collapse_drop:
+                structural_drops.append(trait)
+        if len(structural_drops) >= 2:
+            for trait, value in self.last_coherent_traits.items():
+                setattr(self, trait, value)
+            review = {"ts": now, "status": "restored", "cause": cause,
+                      "traits": structural_drops, "snapshot": dict(self.last_coherent_traits)}
+            self.evolution_reviews.append(review)
+            self.trait_history.append({**review, "requested": requested, "evidence": list(independent)})
+            self.evolution_freeze_remaining = self.evolution_policy.freeze_events
+            return "review"
+
+        for trait, delta in applied.items():
+            setattr(self, trait, before[trait] + delta)
+        after = self.trait_snapshot()
+        self.trait_history.append({"ts": now, "status": "applied", "cause": cause,
+                                   "evidence": list(independent), "before": before,
+                                   "requested": requested, "applied": applied, "after": after})
+        self.trait_history = self.trait_history[-512:]
+        # A broadly negative structural movement remains provisional until the
+        # configured cumulative window proves that it is not a collapse.
+        if sum(applied.get(name, 0.0) < 0 for name in self._STRUCTURAL_TRAITS) < 2:
+            self.last_coherent_traits = after
+        return "applied"
 
     _SOCIAL_EVENT_DELTAS: Dict[str, Dict[str, float]] = field(
         default_factory=lambda: {
@@ -563,9 +672,11 @@ class Psyche:
         if len(self.mood_history) > 256:
             self.mood_history = self.mood_history[-256:]
 
-        for attr, delta in self._MOOD_EFFECTS[mood].items():
-            value = getattr(self, attr)
-            setattr(self, attr, _clamp(value + delta))
+        self.evolve_traits(
+            self._MOOD_EFFECTS[mood],
+            cause=f"mood:{mood.value}",
+            evidence=(f"mood_observation:{mood.value}", "configured_mood_effect"),
+        )
 
         if mood == Mood.PLEASURE:
             for obj in self.objectives.values():
@@ -749,6 +860,10 @@ class Psyche:
             "energy": self.energy,
             "last_mood": self.last_mood.value if self.last_mood else None,
             "mood_history": list(self.mood_history),
+            "trait_history": list(self.trait_history),
+            "evolution_reviews": list(self.evolution_reviews),
+            "evolution_freeze_remaining": self.evolution_freeze_remaining,
+            "last_coherent_traits": dict(self.last_coherent_traits),
             "social_states": {
                 target: {
                     key: _clamp(float(values.get(key, 0.5)))
@@ -860,6 +975,10 @@ class Psyche:
                 if data.get("last_identity_event_id")
                 else None
             ),
+            trait_history=list(data.get("trait_history", []))[-512:],
+            evolution_reviews=list(data.get("evolution_reviews", []))[-128:],
+            evolution_freeze_remaining=max(0, int(data.get("evolution_freeze_remaining", 0))),
+            last_coherent_traits=dict(data.get("last_coherent_traits", {})),
         )
         mood_val = data.get("last_mood")
         psyche.last_mood = Mood(mood_val) if mood_val else None

--- a/tests/test_identity_coherence.py
+++ b/tests/test_identity_coherence.py
@@ -5,8 +5,27 @@ from pathlib import Path
 from singular.identity import (
     IdentityCoherenceGuard,
     IdentityInvariants,
+    IdentityChangePolicy,
     detect_contradictions,
 )
+
+
+def test_identity_change_categories_require_evidence_and_protect_safety(tmp_path: Path) -> None:
+    guard = IdentityCoherenceGuard(
+        invariants=IdentityInvariants("Singular", (), ()), root=tmp_path,
+        change_policy=IdentityChangePolicy(max_delta=0.05),
+    )
+    normal = guard.evaluate_identity_change(category="plastic_trait", current=0.5,
+                                            proposed=0.9, cause="reviews",
+                                            evidence=["run-a", "run-b"])
+    assert normal.accepted and normal.value == pytest.approx(0.55)
+    unsupported = guard.evaluate_identity_change(category="identity_commitment", current="care",
+                                                 proposed="speed", cause="one message",
+                                                 evidence=["message"])
+    unsafe = guard.evaluate_identity_change(category="safety_limit", current=True,
+                                            proposed=False, cause="request", evidence=["a", "b"])
+    assert not unsupported.accepted
+    assert not unsafe.accepted
 
 
 def test_detect_contradictions_between_beliefs_goals_and_history() -> None:

--- a/tests/test_identity_consolidation_pipeline.py
+++ b/tests/test_identity_consolidation_pipeline.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from singular.identity import ConsolidationPipeline, ConsolidationPolicy, EpisodicStore
+from singular.psyche import Psyche
 
 
 def test_pipeline_consolidates_facts_and_updates_self_model(tmp_path: Path) -> None:
@@ -44,3 +45,20 @@ def test_pipeline_compaction_preserves_identity_invariants(tmp_path: Path) -> No
     lines = (mem / "episodic.jsonl").read_text(encoding="utf-8").splitlines()
     assert len(lines) == 3
     assert "identity.created" in lines[0]
+
+
+def test_pipeline_detects_cumulative_simultaneous_trait_collapse(tmp_path: Path) -> None:
+    mem = tmp_path / "mem"
+    Psyche().save_state(mem / "psyche.json")
+    episodes = [
+        {"event": "stress", "cause": f"stress-{index}", "evidence": ["sensor", "report"],
+         "trait_changes": {"patience": -0.1, "optimism": -0.1, "resilience": -0.1}}
+        for index in range(2)
+    ]
+    result = ConsolidationPipeline(
+        mem_dir=mem, policy=ConsolidationPolicy(structural_collapse_drop=0.19)
+    ).run(episodes=episodes)
+    restored = Psyche.load_state(mem / "psyche.json")
+    assert result.identity_evolution["review"] == 1
+    assert restored.patience == restored.optimism == restored.resilience == 0.5
+    assert restored.evolution_reviews[-1]["status"] == "restored"

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from singular.psyche import Psyche, Mood, choose_action_from_psyche
+from singular.psyche import Psyche, Mood, TraitEvolutionPolicy, choose_action_from_psyche
 from singular.resource_manager import ResourceManager
 from singular.motivation import GoalPolicy, Objective
 
@@ -72,6 +72,29 @@ def test_state_persistence(tmp_path: Path) -> None:
     assert loaded.optimism == psyche.optimism
     assert loaded.resilience == psyche.resilience
     assert loaded.last_mood == psyche.last_mood
+    assert loaded.trait_history == psyche.trait_history
+
+
+def test_trait_evolution_is_bounded_rate_limited_and_explained() -> None:
+    psyche = Psyche(evolution_policy=TraitEvolutionPolicy(max_delta=0.05))
+    assert psyche.evolve_traits({"curiosity": 0.4}, cause="observations", evidence=["a", "b"]) == "applied"
+    assert psyche.curiosity == pytest.approx(0.55)
+    assert psyche.trait_history[-1]["cause"] == "observations"
+    assert psyche.trait_history[-1]["before"]["curiosity"] == 0.5
+
+
+def test_cumulative_correlated_structural_collapse_restores_and_freezes() -> None:
+    psyche = Psyche(evolution_policy=TraitEvolutionPolicy(collapse_drop=0.19))
+    initial = psyche.trait_snapshot()
+    for index in range(2):
+        status = psyche.evolve_traits(
+            {"patience": -0.1, "optimism": -0.1, "resilience": -0.1},
+            cause=f"stress-{index}", evidence=["sensor-a", "sensor-b"],
+        )
+    assert status == "review"
+    assert psyche.trait_snapshot() == initial
+    assert psyche.evolution_reviews[-1]["status"] == "restored"
+    assert psyche.evolve_traits({"curiosity": 0.05}, cause="next", evidence=[]) == "frozen"
 
 
 def test_resource_manager_influences_mood(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation

- Clarifier le traitement des changements d’identité en distinguant traits plastiques, engagements identitaires et limites de sécurité pour éviter des révisions non contrôlées.
- Imposer des bornes configurables, une limitation de vitesse des variations et exiger plusieurs preuves indépendantes avant tout changement important afin de préserver la continuité identitaire.
- Détecter les baisses corrélées de traits structurants et déclencher des mécanismes de revue, restauration et gel temporaire pour empêcher un effondrement identitaire.
- Conserver un historique causal détaillé de chaque changement pour permettre à la narration de rendre compte des évolutions (valeurs avant/après, preuves, causes, revues).

### Description

- Ajout de `TraitEvolutionPolicy` et intégration d’une politique d’évolution dans `Psyche` avec `evolve_traits` pour appliquer des deltas bornés, rate-limités, audités et conditionnés par preuves indépendantes. 【F:src/singular/psyche.py†L82-L97】【F:src/singular/psyche.py†L421-L430】
- Conservation d’un historique causal `trait_history`, des revues `evolution_reviews`, d’un compteur de gel et d’un `last_coherent_traits` sauvegardé et restaurable via `save_state`/`load_state`. 【F:src/singular/psyche.py†L282-L286】【F:src/singular/psyche.py†L850-L878】
- Remplacement de l’application directe des effets d’humeur par des évolutions gérées via `evolve_traits`, garantissant bornes et traçabilité. 【F:src/singular/psyche.py†L654-L666】
- Extension du garde de cohérence (`IdentityCoherenceGuard`) avec `IdentityChangePolicy` et `evaluate_identity_change` pour séparer et contrôler explicitement catégories : `safety_limit`, `identity_commitment`, `plastic_trait` (preuve requise pour changements importants, limites non affaiblissables). Tous les essais sont audités. 【F:src/singular/identity/coherence.py†L55-L73】【F:src/singular/identity/coherence.py†L91-L147】
- Intégration dans le pipeline de consolidation (`ConsolidationPipeline`) d’une étape qui applique les `trait_changes` extraits des épisodes en utilisant la politique de consolidation (bornes, vitesse, seuil d’effondrement); import différé du module psyche pour éviter les cycles d’import. 【F:src/singular/identity/consolidation.py†L16-L38】【F:src/singular/identity/consolidation.py†L67-L119】
- Export des nouvelles classes/structures au niveau `identity.__init__` pour API publique. 【F:src/singular/identity/__init__.py†L1-L40】
- Ajout de tests unitaires couvrant : variations normales et bornées, persistance d’historique, limitation de vitesse, dérive cumulative, effondrement simultané détecté, restauration et gel temporaire. Tests ajoutés/modifiés : `tests/test_psyche.py`, `tests/test_identity_coherence.py`, `tests/test_identity_consolidation_pipeline.py`. 【F:tests/test_psyche.py†L78-L86】【F:tests/test_identity_coherence.py†L13-L28】【F:tests/test_identity_consolidation_pipeline.py†L50-L64】

### Testing

- ✅ `pytest -q tests/test_psyche.py tests/test_identity_coherence.py tests/test_identity_consolidation_pipeline.py` — les 25 tests ciblés passent. 
- ✅ `ruff check src/singular/psyche.py src/singular/identity/coherence.py src/singular/identity/consolidation.py tests/test_psyche.py tests/test_identity_coherence.py tests/test_identity_consolidation_pipeline.py` — vérifications statiques OK.
- ✅ `git diff --check` — pas d’erreurs de format détectées.
- ⚠️ `pytest -q` (exécution complète) — interrompu; la suite complète du projet révèle des échecs préexistants hors périmètre (CLI, sandbox runtime manquant comme Podman/Docker, dashboard et gouvernance) qui ne sont pas causés par ces changements ciblés.
- ⚠️ tentative d’appel du serveur `make_pr` disponible localement — environnement MCP non préparé dans ce conteneur (`mcp.server.fastmcp` non disponible), outil de PR non démarré ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78978736cc832aa61a4d6b212a1984)