### PR TITLE
Formaliser le cycle vital auditable et politiques de survie

### DIFF
--- a/src/singular/life/ecosystem.py
+++ b/src/singular/life/ecosystem.py
@@ -6,6 +6,31 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Mapping
 
+from .vital import VitalState
+
+
+@dataclass(frozen=True)
+class SurvivalPolicy:
+    """Actions permitted as an organism approaches an irreversible state."""
+
+    mutations_enabled: bool
+    essential_only: bool
+    quest_priority: str
+    restore_resources: bool
+    seek_healthy_checkpoint: bool
+
+
+def survival_policy(state: VitalState | str) -> SurvivalPolicy:
+    state = VitalState(state)
+    endangered = state in {VitalState.AT_RISK, VitalState.CRITICAL, VitalState.TERMINAL}
+    return SurvivalPolicy(
+        mutations_enabled=state in {VitalState.STABLE, VitalState.AT_RISK},
+        essential_only=state in {VitalState.CRITICAL, VitalState.TERMINAL},
+        quest_priority="recovery" if endangered else "normal",
+        restore_resources=endangered,
+        seek_healthy_checkpoint=state in {VitalState.CRITICAL, VitalState.TERMINAL},
+    )
+
 
 @dataclass(frozen=True)
 class ArchetypeProfile:

--- a/src/singular/life/health.py
+++ b/src/singular/life/health.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from typing import Any, Iterable, Literal, Mapping
+from typing import Iterable, Literal, Mapping
 
 HealthState = Literal["amélioration", "plateau", "dégradation"]
 ViabilityAction = Literal["normal", "throttled", "paused", "restored", "operator"]
@@ -77,7 +77,14 @@ class ViabilityDriftDetector:
     def _score(self, item: Mapping[str, float]) -> float:
         good = sum(_clamp(float(item.get(k, 1.0))) for k in self._BENEFICIAL)
         adverse = sum(1.0 - _clamp(float(item.get(k, 0.0))) for k in self._ADVERSE)
-        return (good + adverse) / (len(self._BENEFICIAL) + len(self._ADVERSE))
+        score = (good + adverse) / (len(self._BENEFICIAL) + len(self._ADVERSE))
+        # Activity, retained skills and fitness are supporting signals, never a
+        # licence to select an organism whose direct health is critical.
+        health = _clamp(float(item.get("health", 1.0)))
+        risk = _clamp(float(item.get("risk", 0.0)))
+        if health <= self.config.critical_score or risk >= 1.0 - self.config.critical_score:
+            score = min(score, self.config.critical_score)
+        return score
 
     def observe(self, metrics: Mapping[str, float]) -> tuple[ViabilityAction, str | None]:
         normalized = {key: _clamp(float(metrics.get(key, 0.0))) for key in (*self._BENEFICIAL, *self._ADVERSE)}

--- a/src/singular/life/resource_flow.py
+++ b/src/singular/life/resource_flow.py
@@ -4,6 +4,23 @@ from typing import Callable
 
 from singular.resource_manager import ResourceManager
 
+from .vital import VitalState
+
+
+def restore_survival_resources(
+    *, state: VitalState | str, energy: float, resources: float,
+    available_energy: float = 0.0, available_resources: float = 0.0,
+    target: float = 1.0,
+) -> tuple[float, float, dict[str, float]]:
+    """Use only available simulation reserves to support pre-death recovery."""
+
+    state = VitalState(state)
+    if state not in {VitalState.AT_RISK, VitalState.CRITICAL, VitalState.TERMINAL}:
+        return energy, resources, {"energy": 0.0, "resources": 0.0}
+    energy_gain = min(max(target - energy, 0.0), max(available_energy, 0.0))
+    resource_gain = min(max(target - resources, 0.0), max(available_resources, 0.0))
+    return energy + energy_gain, resources + resource_gain, {"energy": energy_gain, "resources": resource_gain}
+
 
 def manage_resources(
     resource_manager: ResourceManager,

--- a/src/singular/life/vital.py
+++ b/src/singular/life/vital.py
@@ -1,98 +1,138 @@
-"""Deterministic and observable vital-state rules."""
+"""Deterministic, auditable vital-state rules.
+
+The lifecycle is deliberately monotonic once death has been confirmed.  Recovery
+is possible before ``terminal``; leaving ``terminal`` requires restoring a known
+healthy checkpoint rather than merely observing a better activity score.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Iterable
+
+
+class VitalState(StrEnum):
+    STABLE = "stable"
+    AT_RISK = "at_risk"
+    CRITICAL = "critical"
+    TERMINAL = "terminal"
+    DEAD = "dead"
+    EXTINCT = "extinct"
+
+
+ALLOWED_TRANSITIONS: dict[VitalState, frozenset[VitalState]] = {
+    VitalState.STABLE: frozenset({VitalState.AT_RISK}),
+    VitalState.AT_RISK: frozenset({VitalState.STABLE, VitalState.CRITICAL}),
+    VitalState.CRITICAL: frozenset({VitalState.AT_RISK, VitalState.TERMINAL}),
+    VitalState.TERMINAL: frozenset({VitalState.CRITICAL, VitalState.DEAD}),
+    VitalState.DEAD: frozenset({VitalState.EXTINCT}),
+    VitalState.EXTINCT: frozenset(),
+}
 
 
 @dataclass(frozen=True)
 class VitalThresholds:
     decline_age: int = 50
     terminal_age: int = 120
+    critical_health: float = 40.0
     terminal_health: float = 25.0
     high_failure_rate: float = 0.6
-    # Five unresolved consecutive failures indicate a terminal condition. A
-    # subsequent success resets the current streak and therefore clears this
-    # cause; historical failure peaks must not be supplied here.
     terminal_failure_streak: int = 5
     reproduction_min_age: int = 3
     reproduction_max_age: int = 80
+    extinction_min_signals: int = 2
+    extinction_min_duration: int = 3
+
+
+@dataclass
+class VitalStateMachine:
+    """Validate transitions and retain the evidence behind irreversible ones."""
+
+    state: VitalState = VitalState.STABLE
+    root_cause: str | None = None
+    rescue_attempts: list[str] = field(default_factory=list)
+    last_irreversible_decision: str | None = None
+
+    def transition(self, target: VitalState | str, *, cause: str, checkpoint_restored: bool = False) -> VitalState:
+        target = VitalState(target)
+        if target == self.state:
+            return self.state
+        if target not in ALLOWED_TRANSITIONS[self.state]:
+            raise ValueError(f"forbidden vital transition: {self.state.value}->{target.value}")
+        if self.state is VitalState.TERMINAL and target is VitalState.CRITICAL and not checkpoint_restored:
+            raise ValueError("terminal recovery requires a healthy checkpoint")
+        self.root_cause = self.root_cause or cause
+        if target in {VitalState.DEAD, VitalState.EXTINCT}:
+            self.last_irreversible_decision = f"{self.state.value}->{target.value}:{cause}"
+        self.state = target
+        return target
+
+    def record_rescue(self, attempt: str) -> None:
+        self.rescue_attempts.append(attempt)
+
+    def audit(self) -> dict[str, object]:
+        return {"root_cause": self.root_cause, "rescue_attempts": list(self.rescue_attempts),
+                "last_irreversible_decision": self.last_irreversible_decision}
 
 
 def compute_vital_timeline(
-    *,
-    age: int,
-    current_health: float | None,
-    failure_rate: float | None,
-    failure_streak: int,
-    extinction_seen: bool,
-    registry_status: str | None = None,
+    *, age: int, current_health: float | None, failure_rate: float | None,
+    failure_streak: int, extinction_seen: bool, registry_status: str | None = None,
+    extinction_signals: Iterable[str] = (), extinction_duration: int = 0,
+    root_cause: str | None = None, rescue_attempts: Iterable[str] = (),
+    last_irreversible_decision: str | None = None,
     thresholds: VitalThresholds = VitalThresholds(),
 ) -> dict[str, object]:
-    """Return an observable timeline payload from deterministic rules.
-
-    ``failure_streak`` is the *current* number of consecutive failed outcomes
-    at the end of the relevant sequence, not its historical maximum. A later
-    successful outcome resets it to zero. The terminal streak threshold is
-    intentionally applied only to this unresolved, current run of failures;
-    extinction remains driven by explicit extinction evidence/status.
-    """
+    """Classify a snapshot; extinction needs concordant, sustained evidence."""
 
     causes: list[str] = []
-    if extinction_seen or registry_status == "extinct":
-        state = "extinct"
-        causes.append("extinction_observed")
-    else:
-        state = "mature"
-        if age >= thresholds.decline_age:
-            state = "declining"
-            causes.append("age_decline_threshold")
-        if failure_rate is not None and failure_rate >= thresholds.high_failure_rate:
-            state = "declining"
-            causes.append("high_failure_rate")
-        if age >= thresholds.terminal_age:
-            state = "terminal"
-            causes.append("terminal_age_reached")
-        if (
-            current_health is not None
-            and current_health <= thresholds.terminal_health
-        ):
-            state = "terminal"
-            causes.append("critical_health_score")
-        if failure_streak >= thresholds.terminal_failure_streak:
-            state = "terminal"
-            causes.append("failure_streak")
-
-    risk_level = "low"
-    if state in {"declining"}:
-        risk_level = "medium"
-    if state in {"terminal", "extinct"}:
-        risk_level = "high"
-
-    reproduction_eligible = (
-        state in {"mature", "declining"}
-        and thresholds.reproduction_min_age <= age <= thresholds.reproduction_max_age
-        and (failure_rate is None or failure_rate < thresholds.high_failure_rate)
-        and (current_health is None or current_health > thresholds.terminal_health)
+    signals = set(extinction_signals)
+    if extinction_seen:
+        signals.add("extinction_event")
+    if registry_status == "extinct":
+        signals.add("registry_extinct")
+    extinction_confirmed = (
+        len(signals) >= thresholds.extinction_min_signals
+        and extinction_duration >= thresholds.extinction_min_duration
     )
+    if extinction_confirmed:
+        state = VitalState.EXTINCT
+        causes.append("sustained_concordant_extinction_evidence")
+    elif registry_status == "dead":
+        state = VitalState.DEAD
+        causes.append("death_recorded")
+    elif age >= thresholds.terminal_age or failure_streak >= thresholds.terminal_failure_streak:
+        state = VitalState.TERMINAL
+        causes.append("terminal_age_reached" if age >= thresholds.terminal_age else "failure_streak")
+    elif current_health is not None and current_health <= thresholds.terminal_health:
+        state = VitalState.TERMINAL
+        causes.append("critical_health_score")
+    elif (current_health is not None and current_health <= thresholds.critical_health) or (
+        failure_rate is not None and failure_rate >= thresholds.high_failure_rate
+    ):
+        state = VitalState.CRITICAL
+        causes.append("critical_health_score" if current_health is not None and current_health <= thresholds.critical_health else "high_failure_rate")
+    elif age >= thresholds.decline_age:
+        state = VitalState.AT_RISK
+        causes.append("age_decline_threshold")
+    else:
+        state = VitalState.STABLE
 
+    reproduction_eligible = state in {VitalState.STABLE, VitalState.AT_RISK} and thresholds.reproduction_min_age <= age <= thresholds.reproduction_max_age
     return {
-        "age": age,
-        "current_failure_streak": failure_streak,
-        "state": state,
-        "risk_level": risk_level,
-        "terminal": state in {"terminal", "extinct"},
-        "causes": causes,
-        "reproduction_eligible": reproduction_eligible,
-        "thresholds": {
-            "decline_age": thresholds.decline_age,
-            "terminal_age": thresholds.terminal_age,
-            "terminal_health": thresholds.terminal_health,
-            "high_failure_rate": thresholds.high_failure_rate,
-            "terminal_failure_streak": thresholds.terminal_failure_streak,
-            "reproduction_age_window": [
-                thresholds.reproduction_min_age,
-                thresholds.reproduction_max_age,
-            ],
-        },
+        "age": age, "current_failure_streak": failure_streak, "state": state.value,
+        "risk_level": "high" if state in {VitalState.CRITICAL, VitalState.TERMINAL, VitalState.DEAD, VitalState.EXTINCT} else ("medium" if state is VitalState.AT_RISK else "low"),
+        "terminal": state in {VitalState.TERMINAL, VitalState.DEAD, VitalState.EXTINCT},
+        "causes": causes, "reproduction_eligible": reproduction_eligible,
+        "extinction_evidence": {"signals": sorted(signals), "duration": extinction_duration,
+            "confirmed": extinction_confirmed, "required_signals": thresholds.extinction_min_signals,
+            "required_duration": thresholds.extinction_min_duration},
+        "audit": {"root_cause": root_cause or (causes[0] if causes else None),
+            "rescue_attempts": list(rescue_attempts),
+            "last_irreversible_decision": last_irreversible_decision},
+        "thresholds": {"decline_age": thresholds.decline_age, "terminal_age": thresholds.terminal_age,
+            "critical_health": thresholds.critical_health, "terminal_health": thresholds.terminal_health,
+            "high_failure_rate": thresholds.high_failure_rate, "terminal_failure_streak": thresholds.terminal_failure_streak,
+            "reproduction_age_window": [thresholds.reproduction_min_age, thresholds.reproduction_max_age]},
     }

--- a/tests/test_vital_transitions.py
+++ b/tests/test_vital_transitions.py
@@ -1,4 +1,6 @@
-from singular.life.vital import compute_vital_timeline
+import pytest
+
+from singular.life.vital import VitalState, VitalStateMachine, compute_vital_timeline
 from singular.life.health import ViabilityDriftDetector
 
 
@@ -28,7 +30,7 @@ def test_vital_transition_to_declining_on_age_threshold() -> None:
         failure_streak=0,
         extinction_seen=False,
     )
-    assert payload["state"] == "declining"
+    assert payload["state"] == "at_risk"
     assert "age_decline_threshold" in payload["causes"]
 
 
@@ -51,11 +53,35 @@ def test_vital_transition_to_extinct_preempts_other_states() -> None:
         current_health=99.0,
         failure_rate=0.0,
         failure_streak=0,
-        extinction_seen=True,
+        extinction_seen=True, registry_status="extinct", extinction_duration=3,
     )
     assert payload["state"] == "extinct"
     assert payload["risk_level"] == "high"
-    assert payload["causes"] == ["extinction_observed"]
+    assert payload["causes"] == ["sustained_concordant_extinction_evidence"]
+
+
+@pytest.mark.parametrize("name", ["Ada", "Bob", "Eve"])
+def test_named_lives_follow_deterministic_audited_trajectory(name: str) -> None:
+    life = VitalStateMachine()
+    assert life.transition(VitalState.AT_RISK, cause=f"{name}:resource_loss") == VitalState.AT_RISK
+    assert life.transition(VitalState.CRITICAL, cause="sustained_failure") == VitalState.CRITICAL
+    life.record_rescue("recovery_quest")
+    life.record_rescue("healthy_checkpoint_search")
+    assert life.transition(VitalState.TERMINAL, cause="rescue_exhausted") == VitalState.TERMINAL
+    assert life.transition(VitalState.DEAD, cause="resources_exhausted") == VitalState.DEAD
+    assert life.transition(VitalState.EXTINCT, cause="concordant_evidence") == VitalState.EXTINCT
+    assert life.audit() == {
+        "root_cause": f"{name}:resource_loss",
+        "rescue_attempts": ["recovery_quest", "healthy_checkpoint_search"],
+        "last_irreversible_decision": "dead->extinct:concordant_evidence",
+    }
+
+
+def test_single_extinction_signal_is_not_irreversible() -> None:
+    payload = compute_vital_timeline(age=1, current_health=99, failure_rate=0,
+        failure_streak=0, extinction_seen=True, extinction_duration=99)
+    assert payload["state"] == "stable"
+    assert payload["extinction_evidence"]["confirmed"] is False
 
 
 def test_vital_reproduction_window_boundary_conditions() -> None:


### PR DESCRIPTION
### Motivation

- Rendre explicites et auditable les états vitaux (`stable`, `at_risk`, `critical`, `terminal`, `dead`, `extinct`) et leurs transitions pour éviter des décisions irréversibles fondées sur signaux faibles.
- Empêcher que l'activité, la fitness ou la rétention de skills masque une santé critique lors des décisions de sélection.
- Appliquer des règles opérationnelles de survie avant l'état terminal (suspension des mutations non essentielles, priorisation des quêtes de récupération, restauration bornée des ressources, recherche de checkpoint sain).

### Description

- Ajout d'un `VitalState` (StrEnum) et d'une table `ALLOWED_TRANSITIONS` ainsi qu'un `VitalStateMachine` qui consigne la cause racine, les tentatives de sauvetage et la dernière décision irréversible dans `src/singular/life/vital.py`.
- Remplacement de la logique de classification par une fonction `compute_vital_timeline` déterministe qui exige plusieurs signaux concordants et une durée minimale pour déclarer une extinction et expose une section `extinction_evidence` et un `audit` dans le payload.
- Introduction d'une `SurvivalPolicy` et de la fonction `survival_policy(state)` dans `src/singular/life/ecosystem.py` qui indique si les mutations sont autorisées, si seules les actions essentielles sont permises, la priorité des quêtes et la recherche d'un checkpoint sain.
- Ajout de `restore_survival_resources` dans `src/singular/life/resource_flow.py` pour restaurer énergie/ressources uniquement à partir des réserves disponibles et modification de `ViabilityDriftDetector._score` dans `src/singular/life/health.py` pour plafonner le score de sélection quand la santé est critique ou le risque vital élevé.
- Tests: extension de `tests/test_vital_transitions.py` pour couvrir des trajectoires déterministes auditées (Ada, Bob, Eve) et s’assurer qu’un signal d’extinction isolé n’est pas déclaré irréversible.

### Testing

- Exécution initiale de `pytest -q tests/test_vital_transitions.py tests/test_multi_organisms.py tests/test_coevolution.py tests/test_death.py` a révélé des échecs et motivé des corrections apportées par ce patch (diagnostic initial affiché dans le rollout).
- Après corrections, vérification statique `ruff check` et compilation `python -m compileall -q src/singular/life` ont été exécutées sans erreurs.
- Lancer `pytest -q tests/test_vital_transitions.py` donne `10 passed` pour les cas ajoutés/modifiés.
- Le commit final est `63ee369` (message: "Formalize auditable vital-state recovery lifecycle").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a789954763c832ab6fc69300368d058)