### PR TITLE
Ajout : méta-apprentissage contextuel et sélection d'opérateurs sensible au risque

### DIFF
--- a/src/singular/beliefs/meta_learning.py
+++ b/src/singular/beliefs/meta_learning.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Iterable
+from datetime import datetime, timezone
+import math
+from typing import Iterable, Mapping
 
-from .store import BeliefStore
+from .store import BeliefStore, _parse_datetime
 
 
 @dataclass(frozen=True)
@@ -29,11 +31,22 @@ class RunFeatures:
     outcome: str
     extracted_features: dict[str, str] = field(default_factory=dict)
     learning_conditions: list[str] = field(default_factory=list)
+    skill_family: str = "unknown"
+    vital_state: str = "stable"
+    objective: str = "unknown"
+    governance_mode: str = "standard"
+    candidate_characteristics: dict[str, str] = field(default_factory=dict)
+    source_run_id: str | None = None
 
     def context_key(self) -> str:
+        candidate = ",".join(
+            f"{key}={value}" for key, value in sorted(self.candidate_characteristics.items())
+        ) or "unknown"
         return (
             f"failure={self.failure_type}|env={self.environment_signal}|"
-            f"mood={self.mood}|outcome={self.outcome}"
+            f"mood={self.mood}|outcome={self.outcome}|family={self.skill_family}|"
+            f"vital={self.vital_state}|objective={self.objective}|"
+            f"governance={self.governance_mode}|candidate={candidate}"
         )
 
     def feature_summary(self) -> dict[str, str]:
@@ -60,6 +73,10 @@ class StrategyRecommendation:
     strategy_reason: str = ""
     supporting_features: dict[str, str] = field(default_factory=dict)
     learning_conditions: list[str] = field(default_factory=list)
+    uncertainty: float = 1.0
+    sample_count: int = 0
+    regression_risk: float = 1.0
+    recency: float = 0.0
 
 
 def extract_run_features(
@@ -70,6 +87,12 @@ def extract_run_features(
     mutated_score: float,
     temperature: float,
     mood: str | None,
+    skill_family: str = "unknown",
+    vital_state: str = "stable",
+    objective: str = "unknown",
+    governance_mode: str = "standard",
+    candidate_characteristics: Mapping[str, str] | None = None,
+    source_run_id: str | None = None,
 ) -> RunFeatures:
     """Extract stable run features for context-conditioned memory."""
 
@@ -118,6 +141,12 @@ def extract_run_features(
         outcome=outcome,
         extracted_features=extracted_features,
         learning_conditions=learning_conditions,
+        skill_family=skill_family,
+        vital_state=vital_state,
+        objective=objective,
+        governance_mode=governance_mode,
+        candidate_characteristics=dict(candidate_characteristics or {}),
+        source_run_id=source_run_id,
     )
 
 
@@ -145,10 +174,10 @@ def register_run_result(
         success=success,
         evidence=evidence,
         reward_delta=reward_delta,
+        source_run_id=features.source_run_id,
     )
-    anticipated_context = (
-        f"failure=anticipated|env={features.environment_signal}|"
-        f"mood={features.mood}|outcome={features.outcome}"
+    anticipated_context = features.context_key().replace(
+        f"failure={features.failure_type}", "failure=anticipated", 1
     )
     store.update_probabilistic_rule(
         context_key=anticipated_context,
@@ -156,6 +185,7 @@ def register_run_result(
         success=success,
         evidence=evidence,
         reward_delta=reward_delta,
+        source_run_id=features.source_run_id,
     )
 
 
@@ -167,26 +197,61 @@ def recommend_strategy(
     mood: str | None,
     outcome_hint: str,
     candidates: Iterable[str],
+    skill_family: str = "unknown",
+    vital_state: str = "stable",
+    objective: str = "unknown",
+    governance_mode: str = "standard",
+    candidate_characteristics: Mapping[str, str] | None = None,
+    minimum_samples: int = 3,
 ) -> StrategyRecommendation | None:
     """Return the highest-confidence strategy for the current context."""
 
     normalized_mood = (mood or "unknown").strip().lower() or "unknown"
     candidate_list = list(candidates)
+    candidate = ",".join(
+        f"{key}={value}" for key, value in sorted((candidate_characteristics or {}).items())
+    ) or "unknown"
     context_key = (
         f"failure={failure_type}|env={environment_signal}|"
-        f"mood={normalized_mood}|outcome={outcome_hint}"
+        f"mood={normalized_mood}|outcome={outcome_hint}|family={skill_family}|"
+        f"vital={vital_state}|objective={objective}|governance={governance_mode}|"
+        f"candidate={candidate}"
     )
     ranked = store.recommend_strategies(
         context_key=context_key, candidates=candidate_list
     )
     if not ranked:
         return None
-    best_operator, confidence = ranked[0]
+    # Rank on conservative confidence, not posterior mean: one lucky success
+    # must never become strong evidence.
+    assessed = []
+    now = datetime.now(timezone.utc)
+    for operator, posterior_mean in ranked:
+        record = store._beliefs[f"strategy:{context_key}->{operator}"]
+        samples = record.runs
+        evidence_weight = samples / (samples + 2.0)
+        confidence = posterior_mean * evidence_weight
+        uncertainty = math.sqrt(
+            (record.alpha * record.beta)
+            / (((record.alpha + record.beta) ** 2) * (record.alpha + record.beta + 1.0))
+        )
+        age_days = max(
+            0.0, (now - _parse_datetime(record.updated_at)).total_seconds() / 86400.0
+        )
+        recency = math.exp(-store.decay_per_day * age_days)
+        regression_risk = record.beta / max(record.alpha + record.beta, 1e-9)
+        assessed.append((confidence, -regression_risk, operator, uncertainty, samples, regression_risk, recency))
+    assessed.sort(reverse=True)
+    confidence, _, best_operator, uncertainty, samples, regression_risk, recency = assessed[0]
     supporting_features = {
         "failure_type": failure_type,
         "environment_signal": environment_signal,
         "mood": normalized_mood,
         "outcome_hint": outcome_hint,
+        "skill_family": skill_family,
+        "vital_state": vital_state,
+        "objective": objective,
+        "governance_mode": governance_mode,
     }
     return StrategyRecommendation(
         operator=best_operator,
@@ -200,5 +265,10 @@ def recommend_strategy(
         learning_conditions=[
             "recommend only strategies with existing probabilistic evidence",
             "rank candidates by decayed Bayesian confidence",
+            f"require at least {minimum_samples} samples for operational preference",
         ],
+        uncertainty=uncertainty,
+        sample_count=samples,
+        regression_risk=regression_risk,
+        recency=recency,
     )

--- a/src/singular/beliefs/store.py
+++ b/src/singular/beliefs/store.py
@@ -40,6 +40,14 @@ class BeliefRecord:
     beta: float = 1.0
     score_ema: float = 0.0
     runs: int = 0
+    source_runs: list[str] = None  # type: ignore[assignment]
+    deprecated_at: str | None = None
+
+    def __post_init__(self) -> None:
+        # A list (rather than only the last evidence string) makes decay
+        # compatible with audit/replay of the observations behind a belief.
+        if self.source_runs is None:
+            self.source_runs = []
 
 
 class BeliefStore:
@@ -84,6 +92,8 @@ class BeliefStore:
                 beta=float(value.get("beta", self.prior_beta)),
                 score_ema=float(value.get("score_ema", 0.0)),
                 runs=int(value.get("runs", 0)),
+                source_runs=[str(item) for item in value.get("source_runs", [])],
+                deprecated_at=value.get("deprecated_at"),
             )
         return beliefs
 
@@ -136,7 +146,11 @@ class BeliefStore:
             record = self._beliefs[key]
             self._apply_decay(record, now)
             if self._is_stale(record, now):
-                self._beliefs.pop(key, None)
+                if record.deprecated_at is not None:
+                    continue
+                # Do not destroy provenance.  Deprecated records remain in the
+                # JSON store but are excluded from recommendations.
+                record.deprecated_at = now.isoformat()
                 removed += 1
             else:
                 record.confidence = record.alpha / max(record.alpha + record.beta, 1e-9)
@@ -153,6 +167,7 @@ class BeliefStore:
         evidence: str,
         reward_delta: float = 0.0,
         when: datetime | None = None,
+        source_run_id: str | None = None,
     ) -> BeliefRecord:
         now = when or _utcnow()
         record = self._beliefs.get(hypothesis) or BeliefRecord(
@@ -171,6 +186,9 @@ class BeliefStore:
         else:
             record.beta += 1.0
         record.runs += 1
+        record.deprecated_at = None
+        if source_run_id and source_run_id not in record.source_runs:
+            record.source_runs.append(source_run_id)
         record.score_ema = (record.score_ema * 0.8) + (float(reward_delta) * 0.2)
         record.confidence = record.alpha / max(record.alpha + record.beta, 1e-9)
         record.updated_at = now.isoformat()
@@ -216,6 +234,7 @@ class BeliefStore:
         evidence: str,
         reward_delta: float = 0.0,
         when: datetime | None = None,
+        source_run_id: str | None = None,
     ) -> BeliefRecord:
         rule_hypothesis = f"strategy:{context_key}->{strategy}"
         return self.update_after_run(
@@ -224,6 +243,7 @@ class BeliefStore:
             evidence=evidence,
             reward_delta=reward_delta,
             when=when,
+            source_run_id=source_run_id,
         )
 
     def recommend_strategies(
@@ -239,11 +259,12 @@ class BeliefStore:
             record = self._beliefs.get(hypothesis)
             if record is None:
                 continue
+            if record.deprecated_at is not None:
+                continue
             self._apply_decay(record, now)
             record.confidence = record.alpha / max(record.alpha + record.beta, 1e-9)
-            record.updated_at = now.isoformat()
             if self._is_stale(record, now):
-                self._beliefs.pop(hypothesis, None)
+                record.deprecated_at = now.isoformat()
                 continue
             ranked.append((name, record.confidence))
         if ranked:

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -1482,6 +1482,18 @@ def run(
                 if temp <= 5.0
                 else "stable"
             )
+            contextual_vital_state = (
+                "terminal" if baseline_failure_risk >= 0.7 else "fragile"
+                if baseline_failure_risk >= 0.35 else "stable"
+            )
+            contextual_objective_weights = asdict(goal_weights)
+            contextual_objective = max(
+                contextual_objective_weights, key=contextual_objective_weights.get
+            )
+            contextual_candidate = {"skill": selected_skill_key}
+            contextual_governance = (
+                "enabled" if governance_policy.mutations_enabled() else "locked"
+            )
             meta_recommendation = None
             if policy != "analyze":
                 meta_recommendation = recommend_strategy(
@@ -1491,6 +1503,11 @@ def run(
                     mood=mood_label,
                     outcome_hint="success",
                     candidates=eligible_operators.keys(),
+                    skill_family=skill_path.suffix.lstrip(".") or "unknown",
+                    vital_state=contextual_vital_state,
+                    objective=contextual_objective,
+                    governance_mode=contextual_governance,
+                    candidate_characteristics=contextual_candidate,
                 )
             if policy == "analyze":
                 op_name = select_operator(
@@ -1504,9 +1521,20 @@ def run(
                 reflection.action is None
                 and meta_recommendation is not None
                 and meta_recommendation.confidence >= 0.55
+                and meta_recommendation.sample_count >= 3
+                and meta_recommendation.regression_risk
+                    <= max(0.05, 1.0 - baseline_failure_risk)
                 and meta_recommendation.operator in eligible_operators
             ):
-                op_name = meta_recommendation.operator
+                op_name = select_operator(
+                    eligible_operators,
+                    stats,
+                    policy,
+                    rng,
+                    objective_bias=combined_bias,
+                    contextual_recommendation=meta_recommendation,
+                    vital_risk=baseline_failure_risk,
+                )
             else:
                 reflected_action = (
                     reflection.action if reflection.action in eligible_operators else None
@@ -2007,6 +2035,12 @@ def run(
                 mutated_score=mutated_score,
                 temperature=temp,
                 mood=mood_value,
+                skill_family=skill_path.suffix.lstrip(".") or "unknown",
+                vital_state=contextual_vital_state,
+                objective=contextual_objective,
+                governance_mode=contextual_governance,
+                candidate_characteristics=contextual_candidate,
+                source_run_id=f"{logger.run_id}:{state.iteration}",
             )
             register_run_result(
                 belief_store,

--- a/src/singular/life/mutation_flow.py
+++ b/src/singular/life/mutation_flow.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import ast
 import importlib
 import random
-from typing import Callable, Dict, Mapping
+from typing import Callable, Dict, Mapping, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from singular.beliefs.meta_learning import StrategyRecommendation
 
 from . import sandbox
 
@@ -75,6 +78,9 @@ def select_operator(
     policy: str,
     rng: random.Random,
     objective_bias: Mapping[str, float] | None = None,
+    contextual_recommendation: "StrategyRecommendation | None" = None,
+    vital_risk: float = 0.0,
+    minimum_evidence: int = 3,
 ) -> str:
     """Reflect on operator history and choose the next mutation strategy."""
 
@@ -83,7 +89,18 @@ def select_operator(
     if policy == "analyze":
         return min(names, key=lambda n: stats[n]["count"])
 
+    # Exploration disappears as extinction risk approaches one.
     epsilon = {"exploit": 0.0, "explore": 1.0}.get(policy, 0.1)
+    epsilon *= max(0.0, 1.0 - min(1.0, vital_risk))
+
+    if (
+        contextual_recommendation is not None
+        and contextual_recommendation.operator in operators
+        and contextual_recommendation.sample_count >= minimum_evidence
+        and contextual_recommendation.regression_risk <= max(0.05, 1.0 - vital_risk)
+        and rng.random() >= epsilon
+    ):
+        return contextual_recommendation.operator
 
     if rng.random() < epsilon or all(stats[n]["count"] == 0 for n in names):
         return rng.choice(names)

--- a/tests/test_life_loop_targeted.py
+++ b/tests/test_life_loop_targeted.py
@@ -296,3 +296,27 @@ def test_cycle_complet_creation_tick_mutation_learning_reproduction_and_stop(tem
         max_iterations=0,
     )
     assert stopped.iteration == state.iteration
+
+
+def test_contextual_operator_is_preferred_for_stable_life_but_refused_terminal() -> None:
+    from singular.beliefs.meta_learning import StrategyRecommendation
+
+    operators = {"proven": _dec_operator, "fallback": _inc_operator}
+    stats = {
+        "proven": {"count": 5, "reward": 0.0},
+        "fallback": {"count": 5, "reward": 5.0},
+    }
+    evidence = StrategyRecommendation(
+        operator="proven", confidence=0.75, context_key="stable",
+        sample_count=8, regression_risk=0.2, uncertainty=0.1, recency=1.0,
+    )
+    stable = select_operator(
+        operators, stats, "exploit", random.Random(0),
+        contextual_recommendation=evidence, vital_risk=0.1,
+    )
+    terminal = select_operator(
+        operators, stats, "exploit", random.Random(0),
+        contextual_recommendation=evidence, vital_risk=0.95,
+    )
+    assert stable == "proven"
+    assert terminal == "fallback"

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -155,3 +155,66 @@ def test_meta_learning_documents_features_and_strategy_conditions(
         "rank candidates by decayed Bayesian confidence"
         in recommendation.learning_conditions
     )
+
+
+def test_contextual_evidence_is_stable_but_not_transferable_to_terminal_life(
+    tmp_path: Path,
+) -> None:
+    store = BeliefStore(path=tmp_path / "beliefs.json")
+    for index in range(6):
+        register_run_result(
+            store,
+            extract_run_features(
+                operator="const_tune",
+                accepted=True,
+                base_score=2.0,
+                mutated_score=1.0,
+                temperature=20.0,
+                mood="calm",
+                skill_family="python",
+                vital_state="stable",
+                objective="robustesse",
+                governance_mode="enabled",
+                candidate_characteristics={"complexity": "low"},
+                source_run_id=f"run-{index}",
+            ),
+            reward_delta=1.0,
+        )
+
+    stable = recommend_strategy(
+        store, failure_type="anticipated", environment_signal="stable",
+        mood="calm", outcome_hint="success", candidates=["const_tune"],
+        skill_family="python", vital_state="stable", objective="robustesse",
+        governance_mode="enabled", candidate_characteristics={"complexity": "low"},
+    )
+    terminal = recommend_strategy(
+        store, failure_type="anticipated", environment_signal="stable",
+        mood="calm", outcome_hint="success", candidates=["const_tune"],
+        skill_family="python", vital_state="terminal", objective="robustesse",
+        governance_mode="enabled", candidate_characteristics={"complexity": "low"},
+    )
+
+    assert stable is not None
+    assert stable.operator == "const_tune"
+    assert stable.sample_count == 6
+    assert stable.confidence > 0.6
+    assert stable.uncertainty < 0.2
+    assert stable.regression_risk < 0.2
+    assert terminal is None
+    assert store.list_beliefs()[0].source_runs == [f"run-{i}" for i in range(6)]
+
+
+def test_one_success_does_not_create_high_confidence(tmp_path: Path) -> None:
+    store = BeliefStore(path=tmp_path / "beliefs.json")
+    features = extract_run_features(
+        operator="lucky", accepted=True, base_score=1.0, mutated_score=0.5,
+        temperature=20.0, mood="calm",
+    )
+    register_run_result(store, features, reward_delta=0.5)
+    recommendation = recommend_strategy(
+        store, failure_type="anticipated", environment_signal="stable",
+        mood="calm", outcome_hint="success", candidates=["lucky"],
+    )
+    assert recommendation is not None
+    assert recommendation.sample_count == 1
+    assert recommendation.confidence < 0.5


### PR DESCRIPTION
### Motivation

- Rendre la mémoire de mutation contextuelle (méta-apprentissage) suffisamment riche pour distinguer opérateur, famille de compétence, état vital, objectif, mode de gouvernance et caractéristiques du candidat afin d'orienter des décisions d'exploration/exploitation sûres.
- Empêcher qu'un seul succès isolé produise une confiance opérationnelle élevée et préserver la traçabilité des runs pour audit et reproductibilité.

### Description

- Étend `RunFeatures` et les clés de contexte dans `src/singular/beliefs/meta_learning.py` pour inclure `skill_family`, `vital_state`, `objective`, `governance_mode`, `candidate_characteristics` et `source_run_id` et compose des context_keys plus granulaires.
- Calcule des métriques de recommandation conservatrices dans `recommend_strategy`: confiance pondérée par nombre d'échantillons, incertitude bayésienne, `sample_count`, `regression_risk` et `recency`, et impose une exigence minimale d'échantillons pour usage opérationnel.
- Modifie l'enregistrement des preuves dans `register_run_result` pour propager `source_run_id` vers le `BeliefStore` et déprécier les règles obsolètes au lieu de les supprimer, en conservant `source_runs` et `deprecated_at` dans `BeliefRecord` (fichier `src/singular/beliefs/store.py`).
- Intègre le contexte réel de la boucle de vie dans la consultation des recommandations (`src/singular/life/loop.py`) et ajuste la sélection d'opérateur (`src/singular/life/mutation_flow.py`) pour : plafonner l'exploration selon le `vital_risk`, préférer une recommandation contextuelle seulement si elle a suffisamment d'échantillons et un risque de régression acceptable, et renvoyer à la sélection normale sinon.
- Ajoute des tests unitaires : cas où un opérateur est recommandé pour une vie stable mais refusé pour une vie terminale, et test assurant qu'un seul succès ne produit pas une haute confiance (`tests/test_meta_learning.py` et `tests/test_life_loop_targeted.py`).

### Testing

- Exécuté `python -m pytest tests/test_meta_learning.py tests/test_beliefs_store.py -q` et les tests ciblés relatifs aux changements ont réussi (tests ciblés passés).
- Exécuté `python -m pytest tests/test_meta_learning.py tests/test_life_loop_targeted.py::test_contextual_operator_is_preferred_for_stable_life_but_refused_terminal -q` et les tests ciblés de sélection contextuelle ont réussi.
- Exécution complète de la suite `pytest -q` a montré des échecs non liés aux changements (état partagé / fichiers mem résiduels); les tests ajoutés/modifiés relatifs au méta-apprentissage et à la sélection contextuelle passent dans l'environnement isolé utilisé pour les validations automatiques.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a789a7fea4c832a939eef4f729fae2e)