### PR TITLE
Repair pytest regressions and CI lint failures

### DIFF
--- a/docs/cli-reference.en.md
+++ b/docs/cli-reference.en.md
@@ -1504,3 +1504,91 @@ Paths below are relative to the root or `SINGULAR_HOME`. Always back up before d
 **Advanced example :** `singular config providers setup ollama --non-interactive --pull --model llama3.2`
 
 **Common errors :** `service_stopped`, `command_missing`, `model_missing`, `download_incomplete`, `timeout`, or `invalid_generation`; every failure includes remediation.
+
+<!-- cli-command: governance -->
+## `governance`
+Governance diagnosis and recovery commands.
+
+
+**Syntax :** `singular governance [-h]`
+
+**Arguments and defaults :** See `--help`; no undocumented implicit argument.
+
+**Prerequisites :** Accessible registry and operator authorization for recovery.
+
+**Target root and life :** Selected registry root; no implicit life.
+
+**Files read or written :** Reads and may update governance state.
+
+**Side effects :** Diagnosis is read-only; recovery is audited.
+
+**Minimal example :** `singular governance`
+
+**Advanced example :** `singular --root /srv/singular governance`
+
+**Common errors :** Missing root, justification, or authorization.
+<!-- cli-command: governance diagnose -->
+## `governance diagnose`
+Displays the auditable state of governance circuit breakers.
+
+
+**Syntax :** `singular governance diagnose [-h]`
+
+**Arguments and defaults :** See `--help`; no undocumented implicit argument.
+
+**Prerequisites :** Accessible registry and operator authorization for recovery.
+
+**Target root and life :** Selected registry root; no implicit life.
+
+**Files read or written :** Reads and may update governance state.
+
+**Side effects :** Diagnosis is read-only; recovery is audited.
+
+**Minimal example :** `singular governance diagnose`
+
+**Advanced example :** `singular --root /srv/singular governance diagnose`
+
+**Common errors :** Missing root, justification, or authorization.
+<!-- cli-command: governance recover -->
+## `governance recover`
+Recovers governance with an explicit operator justification.
+
+
+**Syntax :** `singular governance recover [-h]`
+
+**Arguments and defaults :** See `--help`; no undocumented implicit argument.
+
+**Prerequisites :** Accessible registry and operator authorization for recovery.
+
+**Target root and life :** Selected registry root; no implicit life.
+
+**Files read or written :** Reads and may update governance state.
+
+**Side effects :** Diagnosis is read-only; recovery is audited.
+
+**Minimal example :** `singular governance recover`
+
+**Advanced example :** `singular --root /srv/singular governance recover`
+
+**Common errors :** Missing root, justification, or authorization.
+<!-- cli-command: diagnose governance -->
+## `diagnose governance`
+Diagnostic alias available under the general `diagnose` command.
+
+**Syntax :** `singular diagnose governance [-h]`
+
+**Arguments and defaults :** See `--help`; no undocumented implicit argument.
+
+**Prerequisites :** Accessible registry and operator authorization for recovery.
+
+**Target root and life :** Selected registry root; no implicit life.
+
+**Files read or written :** Reads and may update governance state.
+
+**Side effects :** Diagnosis is read-only; recovery is audited.
+
+**Minimal example :** `singular diagnose governance`
+
+**Advanced example :** `singular --root /srv/singular diagnose governance`
+
+**Common errors :** Missing root, justification, or authorization.

--- a/docs/cli-reference.fr.md
+++ b/docs/cli-reference.fr.md
@@ -1504,3 +1504,91 @@ Les chemins ci-dessous sont relatifs au root ou à `SINGULAR_HOME`. Toujours sau
 ## Alias et aide
 
 `veille` est un alias exact de `watch`; `talk --live` est un alias déprécié de `talk --life`; `birth` peut être désactivé avec `SINGULAR_ENABLE_BIRTH_ALIAS=0`. `singular <commande> --help` reste la source exécutable pour le détail des metavars.
+
+<!-- cli-command: governance -->
+## `governance`
+Commandes de diagnostic et de récupération de la gouvernance.
+
+
+**Syntaxe :** `singular governance [-h]`
+
+**Arguments et défauts :** Voir `--help`; aucun argument implicite non documenté.
+
+**Prérequis :** Registre accessible et autorisation opérateur pour la récupération.
+
+**Root et vie ciblés :** Root du registre sélectionné; aucune vie implicite.
+
+**Fichiers lus ou écrits :** Lit et peut mettre à jour l'état de gouvernance.
+
+**Effets de bord :** Le diagnostic est en lecture seule; la récupération est auditée.
+
+**Exemple minimal :** `singular governance`
+
+**Exemple avancé :** `singular --root /srv/singular governance`
+
+**Erreurs usuelles :** Root absent, justification ou autorisation manquante.
+<!-- cli-command: governance diagnose -->
+## `governance diagnose`
+Affiche l'état auditable des coupe-circuits de gouvernance.
+
+
+**Syntaxe :** `singular governance diagnose [-h]`
+
+**Arguments et défauts :** Voir `--help`; aucun argument implicite non documenté.
+
+**Prérequis :** Registre accessible et autorisation opérateur pour la récupération.
+
+**Root et vie ciblés :** Root du registre sélectionné; aucune vie implicite.
+
+**Fichiers lus ou écrits :** Lit et peut mettre à jour l'état de gouvernance.
+
+**Effets de bord :** Le diagnostic est en lecture seule; la récupération est auditée.
+
+**Exemple minimal :** `singular governance diagnose`
+
+**Exemple avancé :** `singular --root /srv/singular governance diagnose`
+
+**Erreurs usuelles :** Root absent, justification ou autorisation manquante.
+<!-- cli-command: governance recover -->
+## `governance recover`
+Récupère la gouvernance avec une justification opérateur explicite.
+
+
+**Syntaxe :** `singular governance recover [-h]`
+
+**Arguments et défauts :** Voir `--help`; aucun argument implicite non documenté.
+
+**Prérequis :** Registre accessible et autorisation opérateur pour la récupération.
+
+**Root et vie ciblés :** Root du registre sélectionné; aucune vie implicite.
+
+**Fichiers lus ou écrits :** Lit et peut mettre à jour l'état de gouvernance.
+
+**Effets de bord :** Le diagnostic est en lecture seule; la récupération est auditée.
+
+**Exemple minimal :** `singular governance recover`
+
+**Exemple avancé :** `singular --root /srv/singular governance recover`
+
+**Erreurs usuelles :** Root absent, justification ou autorisation manquante.
+<!-- cli-command: diagnose governance -->
+## `diagnose governance`
+Alias de diagnostic disponible sous la commande générale `diagnose`.
+
+**Syntaxe :** `singular diagnose governance [-h]`
+
+**Arguments et défauts :** Voir `--help`; aucun argument implicite non documenté.
+
+**Prérequis :** Registre accessible et autorisation opérateur pour la récupération.
+
+**Root et vie ciblés :** Root du registre sélectionné; aucune vie implicite.
+
+**Fichiers lus ou écrits :** Lit et peut mettre à jour l'état de gouvernance.
+
+**Effets de bord :** Le diagnostic est en lecture seule; la récupération est auditée.
+
+**Exemple minimal :** `singular diagnose governance`
+
+**Exemple avancé :** `singular --root /srv/singular diagnose governance`
+
+**Erreurs usuelles :** Root absent, justification ou autorisation manquante.

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -11,7 +11,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from singular.benchmarks import BenchmarkRegressionError, run_benchmarks
+from singular.benchmarks import BenchmarkRegressionError, run_benchmarks  # noqa: E402
 
 
 def main() -> int:

--- a/scripts/run_offline_multi_life_eval.py
+++ b/scripts/run_offline_multi_life_eval.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
-from singular.evaluation import run_multi_life_evaluation
+from singular.evaluation import run_multi_life_evaluation  # noqa: E402
 
 
 def main() -> int:

--- a/src/singular/beliefs/store.py
+++ b/src/singular/beliefs/store.py
@@ -9,7 +9,7 @@ import math
 import os
 from pathlib import Path
 import tempfile
-from typing import Any, Iterable
+from typing import Iterable
 
 
 def _utcnow() -> datetime:

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -1514,12 +1514,6 @@ def create_app(
         cockpit = _summarize_cockpit(
             current_life_only=current_life_only, selected_life_id=selected_life_id
         )
-        comparison, _ = _aggregate_lives(current_life_only=current_life_only)
-        rows = (
-            comparison.get("table", [])
-            if isinstance(comparison.get("table"), list)
-            else []
-        )
         selected_life = selected_life_id or "Aucune"
         incidents_count = 0
         critical_alerts = cockpit.get("critical_alerts")

--- a/src/singular/identity/__init__.py
+++ b/src/singular/identity/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
     "CoherenceDecision",
     "ConsolidationPipeline",
     "ConsolidationPolicy",
+    "ConsolidationCoordinator",
     "IdentityCoherenceGuard",
     "IdentityChangeDecision",
     "IdentityChangePolicy",

--- a/src/singular/learning/developmental.py
+++ b/src/singular/learning/developmental.py
@@ -7,7 +7,7 @@ but can never grant an action rejected by governance or human approval policy.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 import json
 from pathlib import Path

--- a/src/singular/learning/orchestrator.py
+++ b/src/singular/learning/orchestrator.py
@@ -19,7 +19,6 @@ import uuid
 from singular.beliefs.store import BeliefStore
 from singular.io_utils import atomic_write_text, file_lock
 
-
 FEEDBACK_SOURCES = frozenset({"run", "conversation", "action", "perception", "social"})
 UPDATE_KINDS = frozenset({"strategy", "belief", "skill"})
 
@@ -116,13 +115,17 @@ class LearningOrchestrator:
             return default
 
     def _write(self, path: Path, value: Any) -> None:
-        atomic_write_text(path, json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True))
+        atomic_write_text(
+            path, json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
+        )
 
     def _recover(self) -> None:
         """Finish an interrupted commit; the journal contains the complete next state."""
         with file_lock(self.state_path):
             transaction = self._read(self.journal_path, None)
-            if isinstance(transaction, dict) and isinstance(transaction.get("state"), dict):
+            if isinstance(transaction, dict) and isinstance(
+                transaction.get("state"), dict
+            ):
                 self._write(self.state_path, transaction["state"])
                 self.journal_path.unlink(missing_ok=True)
 
@@ -133,7 +136,9 @@ class LearningOrchestrator:
         self.journal_path.unlink(missing_ok=True)
 
     @staticmethod
-    def normalize(source: str, raw: Mapping[str, Any], *, life_id: str = "default") -> FeedbackEvent:
+    def normalize(
+        source: str, raw: Mapping[str, Any], *, life_id: str = "default"
+    ) -> FeedbackEvent:
         """Normalize an event emitted by any supported runtime surface."""
         reward = raw.get("reward", raw.get("reward_delta", raw.get("score", 0.0)))
         subject = raw.get("subject", raw.get("target", raw.get("hypothesis", "")))
@@ -163,24 +168,43 @@ class LearningOrchestrator:
             cycle = state.setdefault("cycle", {})
             today = datetime.now(timezone.utc).date().isoformat()
             if cycle.get("id") != today:
-                cycle.clear(); cycle.update({"id": today, "events": 0, "candidates": []})
+                cycle.clear()
+                cycle.update({"id": today, "events": 0, "candidates": []})
                 self._apply_decay(state)
             if cycle["events"] >= self.policy.max_events_per_cycle:
                 raise RuntimeError("learning event budget exhausted")
-            if candidate_id not in state["candidates"] and len(cycle["candidates"]) >= self.policy.max_candidates_per_cycle:
+            if (
+                candidate_id not in state["candidates"]
+                and len(cycle["candidates"]) >= self.policy.max_candidates_per_cycle
+            ):
                 raise RuntimeError("candidate budget exhausted")
             previous = state["active"].get(key)
-            candidate = state["candidates"].setdefault(candidate_id, {
-                "id": candidate_id, "key": key, "kind": kind, "subject": event.subject,
-                "proposed_value": proposed_value, "previous_version": previous,
-                "evidence": [], "reward_sum": 0.0, "status": "candidate", "created_at": _now(),
-            })
+            candidate = state["candidates"].setdefault(
+                candidate_id,
+                {
+                    "id": candidate_id,
+                    "key": key,
+                    "kind": kind,
+                    "subject": event.subject,
+                    "proposed_value": proposed_value,
+                    "previous_version": previous,
+                    "evidence": [],
+                    "reward_sum": 0.0,
+                    "status": "candidate",
+                    "created_at": _now(),
+                },
+            )
             # Contradictory proposals never silently overwrite an accumulated candidate.
             if candidate["proposed_value"] != proposed_value:
-                candidate["contradictions"] = int(candidate.get("contradictions", 0)) + 1
+                candidate["contradictions"] = (
+                    int(candidate.get("contradictions", 0)) + 1
+                )
             candidate["evidence"].append(asdict(event))
             candidate["reward_sum"] += float(event.reward)
-            state["events"][event.event_id] = {"candidate_id": candidate_id, "at": _now()}
+            state["events"][event.event_id] = {
+                "candidate_id": candidate_id,
+                "at": _now(),
+            }
             cycle["events"] += 1
             if candidate_id not in cycle["candidates"]:
                 cycle["candidates"].append(candidate_id)
@@ -191,11 +215,17 @@ class LearningOrchestrator:
         for candidate in state.get("candidates", {}).values():
             candidate["reward_sum"] *= min(1.0, max(0.0, self.policy.decay))
 
-    def add_regression_case(self, case_id: str, context: Mapping[str, Any], expected: Any) -> None:
+    def add_regression_case(
+        self, case_id: str, context: Mapping[str, Any], expected: Any
+    ) -> None:
         """Persist a protected capability example used by every promotion."""
         with file_lock(self.regression_path):
             suite = self._read(self.regression_path, {})
-            suite[case_id] = {"context": dict(context), "expected": expected, "updated_at": _now()}
+            suite[case_id] = {
+                "context": dict(context),
+                "expected": expected,
+                "updated_at": _now(),
+            }
             self._write(self.regression_path, suite)
 
     def evaluate_and_promote(self, candidate_id: str) -> PromotionDecision:
@@ -210,27 +240,56 @@ class LearningOrchestrator:
             rewards = [float(item["reward"]) for item in evidence]
             drift = (max(rewards) - min(rewards)) if rewards else 0.0
             reasons = []
-            if len(evidence) < self.policy.minimum_evidence: reasons.append("insufficient_evidence")
-            if len(sources) < self.policy.minimum_distinct_sources: reasons.append("insufficient_source_diversity")
-            if mean < self.policy.promotion_reward: reasons.append("reward_below_threshold")
-            if drift > self.policy.drift_threshold: reasons.append("drift_detected")
-            if candidate.get("contradictions", 0): reasons.append("contradictory_feedback")
+            if len(evidence) < self.policy.minimum_evidence:
+                reasons.append("insufficient_evidence")
+            if len(sources) < self.policy.minimum_distinct_sources:
+                reasons.append("insufficient_source_diversity")
+            if mean < self.policy.promotion_reward:
+                reasons.append("reward_below_threshold")
+            if drift > self.policy.drift_threshold:
+                reasons.append("drift_detected")
+            if candidate.get("contradictions", 0):
+                reasons.append("contradictory_feedback")
             suite = list(self._read(self.regression_path, {}).values())
-            if len(suite) < self.policy.minimum_regression_cases: reasons.append("regression_suite_missing")
-            evaluation = dict(self.evaluator(candidate["kind"], candidate["subject"], candidate["proposed_value"], suite))
+            if len(suite) < self.policy.minimum_regression_cases:
+                reasons.append("regression_suite_missing")
+            evaluation = dict(
+                self.evaluator(
+                    candidate["kind"],
+                    candidate["subject"],
+                    candidate["proposed_value"],
+                    suite,
+                )
+            )
             regression = float(evaluation.get("regression", 0.0))
             retention = float(evaluation.get("retention", 1.0))
             gain = float(evaluation.get("gain", mean))
-            if regression > self.policy.max_regression: reasons.append("regression_limit")
-            if retention < self.policy.minimum_retention: reasons.append("catastrophic_forgetting_risk")
+            if regression > self.policy.max_regression:
+                reasons.append("regression_limit")
+            if retention < self.policy.minimum_retention:
+                reasons.append("catastrophic_forgetting_risk")
             activated = not reasons
             rollback_path = None
             if activated:
                 version = int(state.get("version", 1)) + 1
-                rollback_path = str(self.directory / "rollback" / f"{version}-{candidate_id}.json")
-                self._write(Path(rollback_path), {"key": candidate["key"], "previous": candidate["previous_version"]})
-                active = {"value": candidate["proposed_value"], "version": version, "activated_at": _now(),
-                          "candidate_id": candidate_id, "evaluation": evaluation, "rollback_path": rollback_path}
+                rollback_path = str(
+                    self.directory / "rollback" / f"{version}-{candidate_id}.json"
+                )
+                self._write(
+                    Path(rollback_path),
+                    {
+                        "key": candidate["key"],
+                        "previous": candidate["previous_version"],
+                    },
+                )
+                active = {
+                    "value": candidate["proposed_value"],
+                    "version": version,
+                    "activated_at": _now(),
+                    "candidate_id": candidate_id,
+                    "evaluation": evaluation,
+                    "rollback_path": rollback_path,
+                }
                 state["active"][candidate["key"]] = active
                 state["version"] = version
                 candidate["status"] = "active"
@@ -238,22 +297,44 @@ class LearningOrchestrator:
             else:
                 candidate["status"] = "rejected"
             candidate["evaluation"] = evaluation
-            candidate["activation_decision"] = {"activated": activated, "reasons": reasons, "at": _now()}
+            candidate["activation_decision"] = {
+                "activated": activated,
+                "reasons": reasons,
+                "at": _now(),
+            }
             candidate["rollback_path"] = rollback_path
             self._commit(state)
             self._record_metrics(gain, retention, regression)
-            return PromotionDecision(candidate_id, activated, ",".join(reasons) or "promoted", evaluation, rollback_path)
+            return PromotionDecision(
+                candidate_id,
+                activated,
+                ",".join(reasons) or "promoted",
+                evaluation,
+                rollback_path,
+            )
 
     @staticmethod
-    def _default_evaluator(kind: str, subject: str, value: Any, suite: list[dict[str, Any]]) -> Mapping[str, float]:
+    def _default_evaluator(
+        kind: str, subject: str, value: Any, suite: list[dict[str, Any]]
+    ) -> Mapping[str, float]:
         # With no domain evaluator, preserve the suite rather than claiming improvement.
-        return {"gain": 0.0, "retention": 1.0, "regression": 0.0, "samples": float(len(suite))}
+        return {
+            "gain": 0.0,
+            "retention": 1.0,
+            "regression": 0.0,
+            "samples": float(len(suite)),
+        }
 
     def _publish(self, candidate: Mapping[str, Any], active: Mapping[str, Any]) -> None:
         """Connect validated state to beliefs, skill metadata, and planner choices."""
         kind, subject = candidate["kind"], candidate["subject"]
         if kind == "belief":
-            self.belief_store.update_after_run(subject, success=True, evidence=f"learning:{candidate['id']}", reward_delta=float(candidate["reward_sum"]))
+            self.belief_store.update_after_run(
+                subject,
+                success=True,
+                evidence=f"learning:{candidate['id']}",
+                reward_delta=float(candidate["reward_sum"]),
+            )
         filename = "skill_catalog.json" if kind == "skill" else "planning_learning.json"
         if kind in {"skill", "strategy"}:
             path = self.root / "mem" / self.life_id / filename
@@ -271,24 +352,42 @@ class LearningOrchestrator:
         with file_lock(self.state_path):
             state = self._read(self.state_path, self._empty_state())
             active = state["active"].get(key)
-            if not active: return False
+            if not active:
+                return False
             snapshot = self._read(Path(active["rollback_path"]), {})
             previous = snapshot.get("previous")
-            if previous is None: state["active"].pop(key, None)
-            else: state["active"][key] = previous
+            if previous is None:
+                state["active"].pop(key, None)
+            else:
+                state["active"][key] = previous
             self._commit(state)
             return True
 
     def _record_metrics(self, gain: float, retention: float, regression: float) -> None:
         metrics = self._read(self.metrics_path, {"samples": []})
-        metrics["samples"].append({"at": _now(), "post_feedback_gain_pct": gain * 100,
-                                   "retention_30d_pct": retention * 100,
-                                   "monthly_regression_pct": regression * 100})
+        metrics["samples"].append(
+            {
+                "at": _now(),
+                "post_feedback_gain_pct": gain * 100,
+                "retention_30d_pct": retention * 100,
+                "monthly_regression_pct": regression * 100,
+            }
+        )
         self._write(self.metrics_path, metrics)
 
     def metrics(self) -> Mapping[str, float]:
         samples = self._read(self.metrics_path, {"samples": []})["samples"]
         if not samples:
-            return {"post_feedback_gain_pct": 0.0, "retention_30d_pct": 100.0, "monthly_regression_pct": 0.0}
-        return {key: sum(float(x[key]) for x in samples) / len(samples) for key in
-                ("post_feedback_gain_pct", "retention_30d_pct", "monthly_regression_pct")}
+            return {
+                "post_feedback_gain_pct": 0.0,
+                "retention_30d_pct": 100.0,
+                "monthly_regression_pct": 0.0,
+            }
+        return {
+            key: sum(float(x[key]) for x in samples) / len(samples)
+            for key in (
+                "post_feedback_gain_pct",
+                "retention_30d_pct",
+                "monthly_regression_pct",
+            )
+        }

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -898,9 +898,6 @@ def compute_life_status(
     first_seen = _first_timestamp(period_dates)
     current_time = now or datetime.now(UTC)
     age_days = (current_time - first_seen).days if first_seen else 0
-    narrative_has_content = bool(
-        narrative.get("current_heading") or _list_count(narrative.get("life_periods"))
-    )
     narrative_continuity_signal = _extract_narrative_continuity_signal(
         narrative_with_registry_identity,
         cfg.thresholds.minimum_narrative_trajectory_days,

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -76,7 +76,12 @@ from singular.governance.values import load_value_weights
 from singular.morals import MoralAction, MoralContextBuilder, MoralDecision, MoralDecisionEngine
 from singular.identity.core import IdentityCoreService
 
-from .checkpointing import CHECKPOINT_VERSION, Checkpoint, load_checkpoint, save_checkpoint
+from .checkpointing import (
+    CHECKPOINT_VERSION as CHECKPOINT_VERSION,
+    Checkpoint,
+    load_checkpoint,
+    save_checkpoint,
+)
 from .sandbox_scoring import (
     SandboxScore,
     classify_source_sandbox_path,

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -638,6 +638,7 @@ class OrchestratorService:
             candidates,
             context=context,
             recent_successes=successes,
+            recent_failures=failures,
             max_active=max(0, int(self.config.max_active_generated_quests)),
             restrict_costly=terminal or degraded or circuit_open,
         )

--- a/src/singular/quests.py
+++ b/src/singular/quests.py
@@ -243,6 +243,7 @@ class QuestRuntime:
         *,
         context: str,
         recent_successes: int,
+        recent_failures: int,
         max_active: int,
         restrict_costly: bool = False,
     ) -> dict[str, list[str]]:

--- a/src/singular/root_config.py
+++ b/src/singular/root_config.py
@@ -27,7 +27,9 @@ def _safe_path(raw: str) -> Path:
 def default_registry_root() -> Path:
     """Return the documented fallback registry root."""
 
-    home = _HOST_PATH_CLS.home()
+    # Go through ``Path`` rather than the cached concrete path class so callers
+    # can override the user home (notably embedders and isolated CLI tests).
+    home = Path.home()
     return home / _CONFIG_DIRNAME
 
 
@@ -43,7 +45,7 @@ def project_config_path(cwd: Path | None = None) -> Path:
     if cwd is not None:
         base = cwd
     else:
-        base = _HOST_PATH_CLS.cwd()
+        base = Path.cwd()
     return base / _CONFIG_DIRNAME / _CONFIG_FILENAME
 
 

--- a/tests/test_cli_retention.py
+++ b/tests/test_cli_retention.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 from singular.cli import main
 

--- a/tests/test_targeted_lifecycle_narrative_trajectory.py
+++ b/tests/test_targeted_lifecycle_narrative_trajectory.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import random
 from pathlib import Path
 
 from fastapi_stub import TestClient


### PR DESCRIPTION
### Motivation
- Restore correct behaviour for registry-root resolution, quest reconciliation and checkpoint export to stop multiple pytest regressions and ruff findings discovered during a full test audit.
- Make small defensive and style fixes (Ruff) and add CLI doc entries so documentation tests remain consistent with the parser surface.

### Description
- Resolve registry root resolution to use `Path.home()` / `Path.cwd()` so test harnesses and embedders that override `Path` behave correctly (edited `src/singular/root_config.py`).
- Pass recent failure evidence through generated-quest reconciliation by adding `recent_failures` to `QuestRuntime.reconcile_generated` and wiring it from the orchestrator (edited `src/singular/quests.py` and `src/singular/orchestrator/service.py`).
- Re-expose the checkpoint version symbol required by consumers/tests by importing `CHECKPOINT_VERSION` from `.checkpointing` in the life loop module (edited `src/singular/life/loop.py`).
- Apply a series of Ruff-driven fixes (unused imports, multi-statement line splits, formatting) and small defensive refactors across several modules to clear linter complaints and reduce noise (multiple source and script files updated).
- Add missing CLI documentation entries for the `governance` commands in both French and English reference files (edited `docs/cli-reference.fr.md` and `docs/cli-reference.en.md`).
- Minor script fixes to silence intentional deferred imports for Ruff (edited `scripts/run_benchmarks.py` and `scripts/run_offline_multi_life_eval.py`).

### Testing
- Ran `ruff check .` after the changes and resolved reported issues; `ruff` now reports no remaining blocking findings for the touched files.
- Ran targeted pytest suites: `tests/test_cli_reference.py` (2 passed), and the combined set `tests/test_cli_config.py`, `tests/test_quests_runtime.py`, `tests/test_orchestrator_service.py` and related targeted checks (40 tests) which passed after the fixes.
- Performed a full non-integration pytest audit; result: 894 passed, 82 failed, 4 skipped, 2 deselected — remaining failures are primarily due to sandbox (Docker/Podman) unavailability, historical behaviour-contract differences and pre-existing typing/behavior regressions that need separate follow-ups.
- Ran `mypy src` and observed pre-existing typing debt (299 errors) that remains to be addressed in follow-up work.
- Note: `python -m pip install -e '.[test]'` failed in this environment due to an outbound network/proxy 403 when resolving build dependencies (setuptools), which prevented installing `pytest-cov` and running coverage-based CI checks locally; these CI steps should be validated in the CI runner where network access and packaging are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78ec440af8832a84369b9f845a7cc8)