### PR TITLE
Corrige construction des chemins de configuration quand `os.name` est simulé

### DIFF
--- a/src/singular/root_config.py
+++ b/src/singular/root_config.py
@@ -27,10 +27,10 @@ def _safe_path(raw: str) -> Path:
 def default_registry_root() -> Path:
     """Return the documented fallback registry root."""
 
-    # Go through ``Path`` rather than the cached concrete path class so callers
-    # can override the user home (notably embedders and isolated CLI tests).
+    # Keep the configurable lookup overridable while ensuring its result uses
+    # the concrete path implementation selected on the actual host.
     home = Path.home()
-    return home / _CONFIG_DIRNAME
+    return _HOST_PATH_CLS(home) / _CONFIG_DIRNAME
 
 
 def global_config_path() -> Path:
@@ -42,10 +42,8 @@ def global_config_path() -> Path:
 def project_config_path(cwd: Path | None = None) -> Path:
     """Return the project config file path rooted in cwd."""
 
-    if cwd is not None:
-        base = cwd
-    else:
-        base = Path.cwd()
+    configured_cwd = cwd if cwd is not None else Path.cwd()
+    base = _HOST_PATH_CLS(configured_cwd)
     return base / _CONFIG_DIRNAME / _CONFIG_FILENAME
 
 

--- a/tests/test_root_config.py
+++ b/tests/test_root_config.py
@@ -3,6 +3,27 @@ from pathlib import Path, PosixPath
 import singular.root_config as root_config
 
 
+def test_config_paths_use_native_paths_when_windows_is_simulated(
+    monkeypatch, tmp_path
+) -> None:
+    home = tmp_path / "home"
+    cwd = tmp_path / "workspace"
+    monkeypatch.setattr(root_config.Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(root_config.Path, "cwd", classmethod(lambda cls: cwd))
+    monkeypatch.setattr(root_config.os, "name", "nt")
+
+    registry_root = root_config.default_registry_root()
+    global_path = root_config.global_config_path()
+    project_path = root_config.project_config_path()
+
+    assert registry_root == home / ".singular"
+    assert global_path == home / ".singular" / "config.json"
+    assert project_path == cwd / ".singular" / "config.json"
+    assert isinstance(registry_root, PosixPath)
+    assert isinstance(global_path, PosixPath)
+    assert isinstance(project_path, PosixPath)
+
+
 def test_decode_relative_windows_separators_against_config_directory(
     monkeypatch, tmp_path
 ) -> None:


### PR DESCRIPTION
### Motivation

- Prévenir la construction d'une `Path` concrète inadéquate lorsque `os.name` est simulé (par ex. tests qui patchent `os.name == "nt"`) tout en conservant la possibilité de monkeypatcher les résolutions `home()` et `cwd()`.

### Description

- Convertit explicitement les valeurs retournées par `Path.home()` et `Path.cwd()` avec la classe native mémorisée `_HOST_PATH_CLS` avant de construire les chemins de config dans `default_registry_root()` et `project_config_path()` (fichier `src/singular/root_config.py`).
- Conserve la possibilité d'override via `Path.home` / `Path.cwd` (pour les tests/embeds) puis s'assure que le type final est l'implémentation hôte issue de `_HOST_PATH_CLS`.
- Ajoute un test `test_config_paths_use_native_paths_when_windows_is_simulated` dans `tests/test_root_config.py` qui simule `os.name == "nt"`, monkeypatch `Path.home` / `Path.cwd`, et vérifie que `default_registry_root()`, `global_config_path()` et `project_config_path()` ne lèvent pas et retournent des `PosixPath` valides.

### Testing

- Exécuté `pytest -q tests/test_root_config.py` which returned `6 passed`.
- Exécuté `pytest -q tests/test_root_config.py tests/test_cli_config.py` which returned `23 passed`.
- Tentative d'exécution du suite complète `pytest -q` a été effectuée et a produit `909 passed, 71 failed, 4 skipped` (les échecs sont pour la plupart dépendants de l'environnement, p.ex. sandbox Docker/Podman absent ou dépendances de build manquantes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78f6265d98832a9d7d20a3ad5a9adb)