### PR TITLE
Formatage Black: harmonisation des signatures et imports (developmental + identity) et application repo-wide

### DIFF
--- a/examples/multiagent_life_loop/demo.py
+++ b/examples/multiagent_life_loop/demo.py
@@ -35,7 +35,9 @@ def main() -> None:
         transport = InMemoryQueueTransport()
         runtime = MultiAgentRuntime(
             transport=transport,
-            policy=MultiAgentPolicy(low_score_threshold=0.0, high_confidence_threshold=0.8),
+            policy=MultiAgentPolicy(
+                low_score_threshold=0.0, high_confidence_threshold=0.8
+            ),
             governance_policy=MutationGovernancePolicy(
                 modifiable_paths=("skills",),
                 review_required_paths=(),
@@ -84,10 +86,21 @@ def main() -> None:
         )
         alpha_decision = runtime.begin_tick(alpha_context)
         print("alpha reasons:", alpha_decision.reasons)
-        print("accepted offer:", alpha_decision.accepted_offer.skill if alpha_decision.accepted_offer else None)
+        print(
+            "accepted offer:",
+            (
+                alpha_decision.accepted_offer.skill
+                if alpha_decision.accepted_offer
+                else None
+            ),
+        )
 
-        runtime.complete_tick(alpha_context, accepted=True, score_before=5.0, score_after=-3.0)
-        print("collective records:", len(runtime.memory.read()) if runtime.memory else 0)
+        runtime.complete_tick(
+            alpha_context, accepted=True, score_before=5.0, score_after=-3.0
+        )
+        print(
+            "collective records:", len(runtime.memory.read()) if runtime.memory else 0
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/check_capability_claims.py
+++ b/scripts/check_capability_claims.py
@@ -8,7 +8,6 @@ import re
 import unicodedata
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
 CAPABILITY = re.compile(
@@ -44,8 +43,7 @@ def _has_campaign(name: str, errors: list[str]) -> bool:
             and all(item["sample_count"] >= 200 for item in windows[-2:])
             and all(item["confidence_level"] >= 0.95 for item in windows[-2:])
             and all(
-                {"domain", "language", "task_difficulty"}
-                <= set(item["segments"])
+                {"domain", "language", "task_difficulty"} <= set(item["segments"])
                 for item in windows[-2:]
             )
         )
@@ -53,7 +51,9 @@ def _has_campaign(name: str, errors: list[str]) -> bool:
         errors.append(f"{path.relative_to(ROOT)}: invalid campaign: {exc}")
         return False
     if not valid:
-        errors.append(f"{path.relative_to(ROOT)}: campaign does not meet validation gates")
+        errors.append(
+            f"{path.relative_to(ROOT)}: campaign does not meet validation gates"
+        )
     return valid
 
 

--- a/scripts/check_coverage_thresholds.py
+++ b/scripts/check_coverage_thresholds.py
@@ -15,7 +15,9 @@ class ThresholdError(ValueError):
 
 def parse_threshold(raw: str) -> tuple[str, float]:
     if "=" not in raw:
-        raise ThresholdError(f"Invalid --threshold '{raw}': expected '<file>=<percent>'.")
+        raise ThresholdError(
+            f"Invalid --threshold '{raw}': expected '<file>=<percent>'."
+        )
 
     file_path, raw_percent = raw.split("=", maxsplit=1)
     file_path = file_path.strip()
@@ -126,9 +128,7 @@ def main() -> int:
         )
 
         if actual_pct < min_pct:
-            failures.append(
-                f"- {target}: {actual_pct:.2f}% < required {min_pct:.2f}%"
-            )
+            failures.append(f"- {target}: {actual_pct:.2f}% < required {min_pct:.2f}%")
 
     if failures:
         print("\nCoverage threshold failures:", file=sys.stderr)

--- a/scripts/profile_life_loop.py
+++ b/scripts/profile_life_loop.py
@@ -30,7 +30,10 @@ def _phase_records(runs_dir: Path, run_id: str) -> list[dict[str, object]]:
                 payload = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if isinstance(payload, dict) and payload.get("event") == "life_loop_phase_metrics":
+            if (
+                isinstance(payload, dict)
+                and payload.get("event") == "life_loop_phase_metrics"
+            ):
                 records.append(payload)
     return records
 
@@ -56,19 +59,31 @@ def _aggregate(records: list[dict[str, object]]) -> dict[str, object]:
             if not isinstance(raw, dict):
                 continue
             phase = str(name)
-            phase_totals[phase] = phase_totals.get(phase, 0.0) + float(raw.get("total_ms", 0.0) or 0.0)
-            phase_calls[phase] = phase_calls.get(phase, 0) + int(raw.get("calls", 0) or 0)
-            cache_hits[phase] = cache_hits.get(phase, 0) + int(raw.get("cache_hits", 0) or 0)
-            cache_misses[phase] = cache_misses.get(phase, 0) + int(raw.get("cache_misses", 0) or 0)
+            phase_totals[phase] = phase_totals.get(phase, 0.0) + float(
+                raw.get("total_ms", 0.0) or 0.0
+            )
+            phase_calls[phase] = phase_calls.get(phase, 0) + int(
+                raw.get("calls", 0) or 0
+            )
+            cache_hits[phase] = cache_hits.get(phase, 0) + int(
+                raw.get("cache_hits", 0) or 0
+            )
+            cache_misses[phase] = cache_misses.get(phase, 0) + int(
+                raw.get("cache_misses", 0) or 0
+            )
     phases = {
         phase: {
             "total_ms": round(total, 3),
             "calls": phase_calls.get(phase, 0),
-            "avg_ms": round(total / phase_calls[phase], 3) if phase_calls.get(phase) else 0.0,
+            "avg_ms": (
+                round(total / phase_calls[phase], 3) if phase_calls.get(phase) else 0.0
+            ),
             "cache_hits": cache_hits.get(phase, 0),
             "cache_misses": cache_misses.get(phase, 0),
         }
-        for phase, total in sorted(phase_totals.items(), key=lambda item: item[1], reverse=True)
+        for phase, total in sorted(
+            phase_totals.items(), key=lambda item: item[1], reverse=True
+        )
     }
     return {
         "ticks_profiled": len(records),
@@ -81,9 +96,15 @@ def _aggregate(records: list[dict[str, object]]) -> dict[str, object]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Profile life loop phases on a temporary life")
-    parser.add_argument("--ticks", type=int, default=5, help="fixed number of life-loop ticks")
-    parser.add_argument("--run-id", default="profile-life-loop", help="run id used for JSONL logs")
+    parser = argparse.ArgumentParser(
+        description="Profile life loop phases on a temporary life"
+    )
+    parser.add_argument(
+        "--ticks", type=int, default=5, help="fixed number of life-loop ticks"
+    )
+    parser.add_argument(
+        "--run-id", default="profile-life-loop", help="run id used for JSONL logs"
+    )
     parser.add_argument("--seed", type=int, default=7, help="deterministic random seed")
     args = parser.parse_args()
 

--- a/scripts/run_benchmarks.py
+++ b/scripts/run_benchmarks.py
@@ -15,11 +15,29 @@ from singular.benchmarks import BenchmarkRegressionError, run_benchmarks  # noqa
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run benchmark suites and emit artifacts.")
-    parser.add_argument("--benchmarks-dir", default="benchmarks", help="Benchmark definitions directory.")
-    parser.add_argument("--artifacts-dir", default="artifacts/benchmarks", help="Benchmark artifacts directory.")
-    parser.add_argument("--summary-path", default="mem/benchmark_summary.json", help="Consolidated summary JSON path.")
-    parser.add_argument("--weights-path", default="benchmarks/weights.json", help="Domain weights JSON path.")
+    parser = argparse.ArgumentParser(
+        description="Run benchmark suites and emit artifacts."
+    )
+    parser.add_argument(
+        "--benchmarks-dir",
+        default="benchmarks",
+        help="Benchmark definitions directory.",
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        default="artifacts/benchmarks",
+        help="Benchmark artifacts directory.",
+    )
+    parser.add_argument(
+        "--summary-path",
+        default="mem/benchmark_summary.json",
+        help="Consolidated summary JSON path.",
+    )
+    parser.add_argument(
+        "--weights-path",
+        default="benchmarks/weights.json",
+        help="Domain weights JSON path.",
+    )
     parser.add_argument(
         "--max-regression-drop",
         type=float,

--- a/skills/addition.py
+++ b/skills/addition.py
@@ -5,4 +5,5 @@ def add(a: float, b: float) -> float:
     """Return the sum of ``a`` and ``b``."""
     return a + b
 
+
 result = add(1, 2)

--- a/skills/multiplication.py
+++ b/skills/multiplication.py
@@ -5,4 +5,5 @@ def multiply(a: float, b: float) -> float:
     """Return the product of ``a`` and ``b``."""
     return a * b
 
+
 result = multiply(2, 3)

--- a/skills/subtraction.py
+++ b/skills/subtraction.py
@@ -5,4 +5,5 @@ def subtract(a: float, b: float) -> float:
     """Return the difference of ``a`` and ``b``."""
     return a - b
 
+
 result = subtract(3, 1)

--- a/src/graine/evolver/main.py
+++ b/src/graine/evolver/main.py
@@ -16,7 +16,6 @@ from ..meta.dsl import MetaSpec, ALLOWED_MUTABLE_SURFACES
 from ..meta.evolve import propose_mutation as mutate_meta
 from ..meta.phantom import replay_snapshots
 
-
 META_MUTATION_LOG = Path("life/meta_mutation_log")
 
 
@@ -105,7 +104,10 @@ def run(
                 _validate_meta_invariants(proposed, baseline)
                 # 3) rollback automatic via baseline retained unless promoted
                 # 4) conditional promotion
-                if proposed.population_cap >= baseline.population_cap and sandbox_metrics["safety"] >= 0:
+                if (
+                    proposed.population_cap >= baseline.population_cap
+                    and sandbox_metrics["safety"] >= 0
+                ):
                     meta = proposed
                     result = "promoted"
                     impact = "potential long-term exploration gain"
@@ -113,7 +115,9 @@ def run(
                 else:
                     logger.log({"event": "meta_rejected", "generation": gen})
             except Exception as exc:
-                logger.log({"event": "meta_rollback", "generation": gen, "error": str(exc)})
+                logger.log(
+                    {"event": "meta_rollback", "generation": gen, "error": str(exc)}
+                )
             _append_meta_mutation(
                 {
                     "generation": gen,

--- a/src/graine/tests/test_meta.py
+++ b/src/graine/tests/test_meta.py
@@ -104,7 +104,6 @@ def test_propose_mutation_obeys_population_ceiling():
     assert mutated.population_cap <= MAX_POPULATION_CAP
 
 
-
 def test_mutable_surfaces_are_explicitly_listed():
     assert "operator_mix" in ALLOWED_MUTABLE_SURFACES
     assert "weights" in ALLOWED_MUTABLE_SURFACES

--- a/src/graine/tests/test_orchestrator.py
+++ b/src/graine/tests/test_orchestrator.py
@@ -47,7 +47,6 @@ def test_run_logs_and_snapshots(tmp_path: Path) -> None:
     assert any('"event": "generation"' in line for line in lines)
 
 
-
 def test_run_creates_meta_mutation_log(tmp_path: Path) -> None:
     spec = build_spec()
     snapshot_dir = tmp_path / "snaps"
@@ -65,7 +64,11 @@ def test_run_creates_meta_mutation_log(tmp_path: Path) -> None:
     )
     assert final_spec.validate()
     assert mutation_log.exists()
-    entries = [json.loads(line) for line in mutation_log.read_text(encoding="utf-8").splitlines() if line.strip()]
+    entries = [
+        json.loads(line)
+        for line in mutation_log.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
     assert entries
     last = entries[-1]
     assert "hypothesis" in last

--- a/src/singular/agents/agent.py
+++ b/src/singular/agents/agent.py
@@ -70,9 +70,11 @@ class Agent:
                 context.get("consequences", {}).get(act, ()),
                 context.get("affected_parties", ()),
                 context.get("identity_commitments", ()),
-                context.get("uncertainty", {}).get(act, 0.0)
-                if isinstance(context.get("uncertainty", 0.0), dict)
-                else context.get("uncertainty", 0.0),
+                (
+                    context.get("uncertainty", {}).get(act, 0.0)
+                    if isinstance(context.get("uncertainty", 0.0), dict)
+                    else context.get("uncertainty", 0.0)
+                ),
             )
             for act in actions
         }
@@ -90,7 +92,8 @@ class Agent:
         hypotheses = [
             ActionHypothesis(
                 action=action,
-                long_term=(value / max_value) + moral_decisions[action].scores["overall"],
+                long_term=(value / max_value)
+                + moral_decisions[action].scores["overall"],
                 sandbox_risk=max(0.0, -score_action(action, context)),
                 resource_cost=float(action_costs.get(action, 0.0)),
                 metadata={"raw_value": value},

--- a/src/singular/beliefs/meta_learning.py
+++ b/src/singular/beliefs/meta_learning.py
@@ -39,9 +39,13 @@ class RunFeatures:
     source_run_id: str | None = None
 
     def context_key(self) -> str:
-        candidate = ",".join(
-            f"{key}={value}" for key, value in sorted(self.candidate_characteristics.items())
-        ) or "unknown"
+        candidate = (
+            ",".join(
+                f"{key}={value}"
+                for key, value in sorted(self.candidate_characteristics.items())
+            )
+            or "unknown"
+        )
         return (
             f"failure={self.failure_type}|env={self.environment_signal}|"
             f"mood={self.mood}|outcome={self.outcome}|family={self.skill_family}|"
@@ -208,9 +212,13 @@ def recommend_strategy(
 
     normalized_mood = (mood or "unknown").strip().lower() or "unknown"
     candidate_list = list(candidates)
-    candidate = ",".join(
-        f"{key}={value}" for key, value in sorted((candidate_characteristics or {}).items())
-    ) or "unknown"
+    candidate = (
+        ",".join(
+            f"{key}={value}"
+            for key, value in sorted((candidate_characteristics or {}).items())
+        )
+        or "unknown"
+    )
     context_key = (
         f"failure={failure_type}|env={environment_signal}|"
         f"mood={normalized_mood}|outcome={outcome_hint}|family={skill_family}|"
@@ -240,9 +248,21 @@ def recommend_strategy(
         )
         recency = math.exp(-store.decay_per_day * age_days)
         regression_risk = record.beta / max(record.alpha + record.beta, 1e-9)
-        assessed.append((confidence, -regression_risk, operator, uncertainty, samples, regression_risk, recency))
+        assessed.append(
+            (
+                confidence,
+                -regression_risk,
+                operator,
+                uncertainty,
+                samples,
+                regression_risk,
+                recency,
+            )
+        )
     assessed.sort(reverse=True)
-    confidence, _, best_operator, uncertainty, samples, regression_risk, recency = assessed[0]
+    confidence, _, best_operator, uncertainty, samples, regression_risk, recency = (
+        assessed[0]
+    )
     supporting_features = {
         "failure_type": failure_type,
         "environment_signal": environment_signal,

--- a/src/singular/beliefs/store.py
+++ b/src/singular/beliefs/store.py
@@ -116,7 +116,9 @@ class BeliefStore:
                 pass
 
     def list_beliefs(self) -> list[BeliefRecord]:
-        return sorted(self._beliefs.values(), key=lambda item: item.confidence, reverse=True)
+        return sorted(
+            self._beliefs.values(), key=lambda item: item.confidence, reverse=True
+        )
 
     def get_confidence(self, hypothesis: str, default: float = 0.5) -> float:
         if hypothesis in self._beliefs:
@@ -135,8 +137,13 @@ class BeliefStore:
     def _is_stale(self, record: BeliefRecord, now: datetime) -> bool:
         if self.ttl_days <= 0.0:
             return False
-        age_days = max(0.0, (now - _parse_datetime(record.updated_at)).total_seconds() / 86400.0)
-        near_prior = abs(record.alpha - self.prior_alpha) < 0.02 and abs(record.beta - self.prior_beta) < 0.02
+        age_days = max(
+            0.0, (now - _parse_datetime(record.updated_at)).total_seconds() / 86400.0
+        )
+        near_prior = (
+            abs(record.alpha - self.prior_alpha) < 0.02
+            and abs(record.beta - self.prior_beta) < 0.02
+        )
         return age_days >= self.ttl_days and near_prior
 
     def forget_stale(self, *, when: datetime | None = None) -> int:
@@ -213,7 +220,9 @@ class BeliefStore:
         self._save()
         return count
 
-    def operator_preference_bias(self, operator_names: Iterable[str]) -> dict[str, float]:
+    def operator_preference_bias(
+        self, operator_names: Iterable[str]
+    ) -> dict[str, float]:
         biases: dict[str, float] = {}
         for name in operator_names:
             hypothesis = f"operator:{name}"
@@ -222,7 +231,9 @@ class BeliefStore:
                 biases[name] = 0.0
                 continue
             confidence_shift = record.confidence - 0.5
-            biases[name] = (confidence_shift * 0.4) + max(-0.2, min(0.2, record.score_ema))
+            biases[name] = (confidence_shift * 0.4) + max(
+                -0.2, min(0.2, record.score_ema)
+            )
         return biases
 
     def update_probabilistic_rule(

--- a/src/singular/benchmarks/runner.py
+++ b/src/singular/benchmarks/runner.py
@@ -107,7 +107,9 @@ def run_benchmarks(
             json.dump(artifact, handle, ensure_ascii=False, indent=2)
             handle.write("\n")
 
-    weights = _load_weights(weights_path=weights_path, domains=sorted(per_domain_scores))
+    weights = _load_weights(
+        weights_path=weights_path, domains=sorted(per_domain_scores)
+    )
     global_score = sum(per_domain_scores[d] * weights[d] for d in per_domain_scores)
     global_score = round(global_score, 4)
 

--- a/src/singular/dashboard/__init__.py
+++ b/src/singular/dashboard/__init__.py
@@ -570,7 +570,9 @@ def create_app(
             "open_until": record.get("open_until"),
             "corrective_action": record.get("corrective_action"),
             "correlation_id": record.get("correlation_id"),
-            "cause": record.get("initial_cause", record.get("category", record.get("source_error_type"))),
+            "cause": record.get(
+                "initial_cause", record.get("category", record.get("source_error_type"))
+            ),
             "decision": record.get("decision_reason", record.get("reason")),
             "consequence": record.get("human_summary", record.get("result")),
             "life": _record_life(record),
@@ -802,7 +804,9 @@ def create_app(
             "events": events[-10:],
         }
 
-    def _summarize_viability_governance(records: list[dict[str, object]]) -> dict[str, object]:
+    def _summarize_viability_governance(
+        records: list[dict[str, object]],
+    ) -> dict[str, object]:
         """Expose the latest preventive drift state separately from sandbox policy."""
         names = {
             "governance.viability_drift_detected",
@@ -1069,9 +1073,7 @@ def create_app(
                     "decision": (
                         "accepted"
                         if accepted is True
-                        else "rejected"
-                        if accepted is False
-                        else record.get("decision")
+                        else "rejected" if accepted is False else record.get("decision")
                     ),
                     "reason": record.get("decision_reason", record.get("reason")),
                     "operator": record.get("operator", record.get("op")),
@@ -1406,11 +1408,7 @@ def create_app(
             if isinstance(payload, dict)
         ]
         selected_row = next(
-            (
-                row
-                for row in comparison_rows
-                if row.get("life") == selected_life_id
-            ),
+            (row for row in comparison_rows if row.get("life") == selected_life_id),
             None,
         )
         selected_life = (
@@ -1509,7 +1507,8 @@ def create_app(
         }
 
     def _summarize_cockpit_essential(
-        current_life_only: bool = False, selected_life_id: str | None = None,
+        current_life_only: bool = False,
+        selected_life_id: str | None = None,
     ) -> dict[str, object]:
         cockpit = _summarize_cockpit(
             current_life_only=current_life_only, selected_life_id=selected_life_id
@@ -1907,17 +1906,21 @@ def create_app(
                 "current_state": current_state,
                 "recent_evolution": trend,
                 "dominant_need": need,
-                "active_objective": str(active_objectives[0])
-                if active_objectives
-                else "Aucun objectif actif",
+                "active_objective": (
+                    str(active_objectives[0])
+                    if active_objectives
+                    else "Aucun objectif actif"
+                ),
                 "last_decision": decision,
                 "last_action": action,
                 "observed_consequence": consequence,
                 "memorized_change": remembered,
                 "primary_alert": alert_label,
-                "recommended_next_action": recommendations[0]
-                if recommendations
-                else "Poursuivre l’observation",
+                "recommended_next_action": (
+                    recommendations[0]
+                    if recommendations
+                    else "Poursuivre l’observation"
+                ),
             },
             "evidence": evidence,
             "technical": {
@@ -2054,15 +2057,21 @@ def create_app(
         current_life_only: bool = False, life_id: str | None = None
     ) -> dict[str, object]:
         if life_id is not None and _resolve_life_entry(life_id)[0] is None:
-            raise HTTPException(status_code=404, detail="life_id is not a registry entry")
-        return _summarize_cockpit(current_life_only=current_life_only, selected_life_id=life_id)
+            raise HTTPException(
+                status_code=404, detail="life_id is not a registry entry"
+            )
+        return _summarize_cockpit(
+            current_life_only=current_life_only, selected_life_id=life_id
+        )
 
     @app.get("/api/cockpit/essential")
     def read_cockpit_essential(
         current_life_only: bool = False, life_id: str | None = None
     ) -> dict[str, object]:
         if life_id is not None and _resolve_life_entry(life_id)[0] is None:
-            raise HTTPException(status_code=404, detail="life_id is not a registry entry")
+            raise HTTPException(
+                status_code=404, detail="life_id is not a registry entry"
+            )
         return _summarize_cockpit_essential(
             current_life_only=current_life_only, selected_life_id=life_id
         )
@@ -2350,7 +2359,9 @@ def create_app(
         life_id: str | None = None,
     ) -> dict[str, object]:
         if life_id is not None and _resolve_life_entry(life_id)[0] is None:
-            raise HTTPException(status_code=404, detail="life_id is not a registry entry")
+            raise HTTPException(
+                status_code=404, detail="life_id is not a registry entry"
+            )
         compare_set: set[str] | None = None
         if isinstance(compare_lives, str) and compare_lives.strip():
             compare_set = {
@@ -2366,7 +2377,9 @@ def create_app(
         comparison, life_identities = normalize_life_metrics(
             comparison,
             selected_life_id=life_id,
-            registry_active_life_id=active_life if isinstance(active_life, str) else None,
+            registry_active_life_id=(
+                active_life if isinstance(active_life, str) else None
+            ),
         )
         metrics_contract = _build_metrics_contract(comparison)
         base_rows = [

--- a/src/singular/dashboard/services/code_evolution.py
+++ b/src/singular/dashboard/services/code_evolution.py
@@ -109,10 +109,14 @@ def aggregate_code_evolution(
                     "stability": {"before": stability_before, "after": stability_after},
                 },
                 "status": status,
-                "timestamp": record.get("ts") if isinstance(record.get("ts"), str) else None,
+                "timestamp": (
+                    record.get("ts") if isinstance(record.get("ts"), str) else None
+                ),
                 "run_id": record_run_id(record),
                 "trace_id": (
-                    record.get("trace_id") if isinstance(record.get("trace_id"), str) else None
+                    record.get("trace_id")
+                    if isinstance(record.get("trace_id"), str)
+                    else None
                 ),
             }
         )

--- a/src/singular/dashboard/services/lives_comparison.py
+++ b/src/singular/dashboard/services/lives_comparison.py
@@ -10,7 +10,6 @@ from singular.life.life_status import (
     operator_action_capabilities,
 )
 
-
 _RECENT_ACTIVITY_EVENTS = {
     "mutation",
     "interaction",
@@ -27,48 +26,95 @@ _DECISION_EVENTS = {"decision", "consciousness", "plan", "evaluate"}
 _ACTION_EVENTS = {"action", "mutation", "interaction", "act", "execute"}
 _INTERACTION_EVENTS = {"interaction", "conversation", "talk", "message"}
 _OBJECTIVE_EVENTS = {"quest", "quest_triggered", "objective", "goal"}
-_PROGRESS_EVENTS = {"quest_resolved", "objective_progress", "objective_completed", "goal_progress"}
+_PROGRESS_EVENTS = {
+    "quest_resolved",
+    "objective_progress",
+    "objective_completed",
+    "goal_progress",
+}
 
 _SERIES_METRICS = (
-    "health", "energy", "mood", "autonomy", "liveliness", "objectives",
-    "interactions", "accepted_mutations", "failures",
+    "health",
+    "energy",
+    "mood",
+    "autonomy",
+    "liveliness",
+    "objectives",
+    "interactions",
+    "accepted_mutations",
+    "failures",
 )
 
 _LIVENESS_FORMULA_VERSION = "liveness-v1.0"
 
 
-def _data_freshness(records: list[dict[str, object]], reference: datetime) -> dict[str, object]:
-    timestamps = [parsed for record in records if (parsed := parse_ts(record.get("ts"))) is not None]
+def _data_freshness(
+    records: list[dict[str, object]], reference: datetime
+) -> dict[str, object]:
+    timestamps = [
+        parsed
+        for record in records
+        if (parsed := parse_ts(record.get("ts"))) is not None
+    ]
     if not timestamps:
         return {"last_observation_at": None, "age_seconds": None, "status": "missing"}
     latest = max(timestamps)
     age_seconds = max(0, int((reference - latest).total_seconds()))
-    status = "fresh" if age_seconds <= 86_400 else "stale" if age_seconds <= 604_800 else "expired"
-    return {"last_observation_at": latest.isoformat(), "age_seconds": age_seconds, "status": status}
+    status = (
+        "fresh"
+        if age_seconds <= 86_400
+        else "stale" if age_seconds <= 604_800 else "expired"
+    )
+    return {
+        "last_observation_at": latest.isoformat(),
+        "age_seconds": age_seconds,
+        "status": status,
+    }
 
 
 def _component_recommendations(components: dict[str, dict[str, object]]) -> list[str]:
     """Return actions tied to an observed deficient component, never generic alerts."""
     recommendations: list[str] = []
     if float(components["interactions"]["score"]) == 0.0:
-        recommendations.append("Initier un échange ciblé : aucune interaction observée depuis 7 jours.")
+        recommendations.append(
+            "Initier un échange ciblé : aucune interaction observée depuis 7 jours."
+        )
     if float(components["recent_activity"]["score"]) == 0.0:
-        recommendations.append("Planifier une action concrète : aucune activité qualifiante observée depuis 24 h.")
+        recommendations.append(
+            "Planifier une action concrète : aucune activité qualifiante observée depuis 24 h."
+        )
     if not components["perception_decision_action_loop"]["completed"]:
-        recommendations.append("Exécuter une boucle perception → décision → action : aucune boucle complète observée sur 48 h.")
+        recommendations.append(
+            "Exécuter une boucle perception → décision → action : aucune boucle complète observée sur 48 h."
+        )
     objectives = components["active_objectives_progress"]
-    if int(objectives["active_objectives"]) > 0 and int(objectives["progress_events"]) == 0:
-        recommendations.append("Faire progresser un objectif actif : aucun événement de progression n'est observé.")
+    if (
+        int(objectives["active_objectives"]) > 0
+        and int(objectives["progress_events"]) == 0
+    ):
+        recommendations.append(
+            "Faire progresser un objectif actif : aucun événement de progression n'est observé."
+        )
     return recommendations
 
 
 def build_life_timeseries(
-    records: list[dict[str, object]], *, life: str, time_window: str = "24h",
-    resolution: str = "hour", limit: int = 500, mutation_index: int | None = None,
+    records: list[dict[str, object]],
+    *,
+    life: str,
+    time_window: str = "24h",
+    resolution: str = "hour",
+    limit: int = 500,
+    mutation_index: int | None = None,
     record_run_id: Callable[[dict[str, object]], str] = lambda _: "unknown",
 ) -> dict[str, object]:
     """Build a bounded, bucketed chronology while retaining source evidence links."""
-    windows = {"24h": timedelta(hours=24), "7d": timedelta(days=7), "30d": timedelta(days=30), "all": None}
+    windows = {
+        "24h": timedelta(hours=24),
+        "7d": timedelta(days=7),
+        "30d": timedelta(days=30),
+        "all": None,
+    }
     resolutions = {"raw": None, "hour": timedelta(hours=1), "day": timedelta(days=1)}
     if time_window not in windows:
         raise ValueError("time_window must be one of: 24h, 7d, 30d, all")
@@ -77,9 +123,18 @@ def build_life_timeseries(
     if not 1 <= limit <= 1000:
         raise ValueError("limit must be between 1 and 1000")
 
-    dated = [(ts, rec) for rec in records if (ts := parse_ts(rec.get("ts"))) is not None]
+    dated = [
+        (ts, rec) for rec in records if (ts := parse_ts(rec.get("ts"))) is not None
+    ]
     dated.sort(key=lambda item: item[0])
-    mutation_rows = [(ts, rec) for ts, rec in dated if any(k in rec for k in ("accepted", "ok", "score_base", "score_new", "operator", "op"))]
+    mutation_rows = [
+        (ts, rec)
+        for ts, rec in dated
+        if any(
+            k in rec
+            for k in ("accepted", "ok", "score_base", "score_new", "operator", "op")
+        )
+    ]
     mutation_indexes = {id(rec): index for index, (_, rec) in enumerate(mutation_rows)}
     pivot = None
     if mutation_index is not None:
@@ -107,52 +162,112 @@ def build_life_timeseries(
             bucket_ts = ts.replace(minute=0, second=0, microsecond=0)
         elif step == timedelta(days=1):
             bucket_ts = ts.replace(hour=0, minute=0, second=0, microsecond=0)
-        key = (bucket_ts.isoformat() if step else ts.isoformat())
-        bucket = buckets.setdefault(key, {"timestamp": key, "values": {metric: [] for metric in _SERIES_METRICS}, "events": [], "proofs": []})
+        key = bucket_ts.isoformat() if step else ts.isoformat()
+        bucket = buckets.setdefault(
+            key,
+            {
+                "timestamp": key,
+                "values": {metric: [] for metric in _SERIES_METRICS},
+                "events": [],
+                "proofs": [],
+            },
+        )
         values = bucket["values"]
         assert isinstance(values, dict)
         event = _normalized_event(rec)
-        accepted = rec.get("accepted") if isinstance(rec.get("accepted"), bool) else rec.get("ok")
+        accepted = (
+            rec.get("accepted")
+            if isinstance(rec.get("accepted"), bool)
+            else rec.get("ok")
+        )
         samples = {
-            "health": number(rec, "health", "health_score"), "energy": number(rec, "energy"),
-            "mood": number(rec, "mood", "humeur"), "autonomy": number(rec, "autonomy", "autonomy_index"),
+            "health": number(rec, "health", "health_score"),
+            "energy": number(rec, "energy"),
+            "mood": number(rec, "mood", "humeur"),
+            "autonomy": number(rec, "autonomy", "autonomy_index"),
             "liveliness": number(rec, "liveliness", "liveness", "vivacity"),
             "objectives": number(rec, "objectives", "objectives_count"),
             "interactions": 1.0 if event in _INTERACTION_EVENTS else None,
             "accepted_mutations": 1.0 if accepted is True else None,
-            "failures": 1.0 if accepted is False or event in {"failure", "error", "mutation_failed"} else None,
+            "failures": (
+                1.0
+                if accepted is False or event in {"failure", "error", "mutation_failed"}
+                else None
+            ),
         }
         for metric, value in samples.items():
             if value is not None:
                 values[metric].append(value)
         run_id = record_run_id(rec)
-        proof = {"timestamp": ts.isoformat(), "event": event or "observation", "run_id": run_id,
-                 "href": f"/api/runs/{quote(run_id, safe='')}/timeline?page=1&page_size=120"}
+        proof = {
+            "timestamp": ts.isoformat(),
+            "event": event or "observation",
+            "run_id": run_id,
+            "href": f"/api/runs/{quote(run_id, safe='')}/timeline?page=1&page_size=120",
+        }
         bucket["proofs"].append(proof)
-        notable = event in (_OBJECTIVE_EVENTS | _PROGRESS_EVENTS | _INTERACTION_EVENTS | {"mutation", "death", "birth", "skill_acquired", "skill_lost"})
-        if notable or any(key in rec for key in ("objective", "skill", "accepted", "ok")):
-            bucket["events"].append({**proof, "objective": rec.get("objective"), "skill": rec.get("skill"), "accepted": accepted,
-                                     "mutation_index": mutation_indexes.get(id(rec))})
+        notable = event in (
+            _OBJECTIVE_EVENTS
+            | _PROGRESS_EVENTS
+            | _INTERACTION_EVENTS
+            | {"mutation", "death", "birth", "skill_acquired", "skill_lost"}
+        )
+        if notable or any(
+            key in rec for key in ("objective", "skill", "accepted", "ok")
+        ):
+            bucket["events"].append(
+                {
+                    **proof,
+                    "objective": rec.get("objective"),
+                    "skill": rec.get("skill"),
+                    "accepted": accepted,
+                    "mutation_index": mutation_indexes.get(id(rec)),
+                }
+            )
 
     points = list(buckets.values())[-limit:]
     for point in points:
         values = point["values"]
         for metric, samples in values.items():
-            values[metric] = (round(sum(samples) / len(samples), 3) if samples and metric not in {"interactions", "accepted_mutations", "failures"} else sum(samples)) if samples else None
+            values[metric] = (
+                (
+                    round(sum(samples) / len(samples), 3)
+                    if samples
+                    and metric not in {"interactions", "accepted_mutations", "failures"}
+                    else sum(samples)
+                )
+                if samples
+                else None
+            )
     comparison = None
     if pivot is not None:
         before = [p for p in points if parse_ts(p["timestamp"]) < pivot]
         after = [p for p in points if parse_ts(p["timestamp"]) >= pivot]
-        comparison = {"mutation_index": mutation_index, "pivot": pivot.isoformat(), "before": _series_averages(before), "after": _series_averages(after)}
-    return {"life": life, "window": time_window, "resolution": resolution, "limit": limit,
-            "count": len(points), "truncated": len(buckets) > limit, "metrics": list(_SERIES_METRICS),
-            "points": points, "mutation_comparison": comparison}
+        comparison = {
+            "mutation_index": mutation_index,
+            "pivot": pivot.isoformat(),
+            "before": _series_averages(before),
+            "after": _series_averages(after),
+        }
+    return {
+        "life": life,
+        "window": time_window,
+        "resolution": resolution,
+        "limit": limit,
+        "count": len(points),
+        "truncated": len(buckets) > limit,
+        "metrics": list(_SERIES_METRICS),
+        "points": points,
+        "mutation_comparison": comparison,
+    }
 
 
 def _series_averages(points: list[dict[str, object]]) -> dict[str, float | None]:
     result: dict[str, float | None] = {}
     for metric in _SERIES_METRICS:
-        values = [p["values"][metric] for p in points if p["values"].get(metric) is not None]
+        values = [
+            p["values"][metric] for p in points if p["values"].get(metric) is not None
+        ]
         result[metric] = round(sum(values) / len(values), 3) if values else None
     return result
 
@@ -233,8 +348,12 @@ def _is_voluntary_budget_record(record: dict[str, object]) -> bool:
 
 def compute_mutation_viability(records: list[dict[str, object]]) -> dict[str, object]:
     mutation_records = [
-        record for record in records
-        if any(key in record for key in ("score_base", "score_new", "accepted", "ok", "operator", "op"))
+        record
+        for record in records
+        if any(
+            key in record
+            for key in ("score_base", "score_new", "accepted", "ok", "operator", "op")
+        )
     ]
     decided = []
     useful = 0
@@ -256,19 +375,36 @@ def compute_mutation_viability(records: list[dict[str, object]]) -> dict[str, ob
             and float(score_new) < float(score_base)
         )
         health = record.get("health")
-        has_health = isinstance(health, dict) and isinstance(health.get("score"), (int, float))
+        has_health = isinstance(health, dict) and isinstance(
+            health.get("score"), (int, float)
+        )
         explicitly_useful = record.get("useful")
         durably_viable = record.get("durably_viable")
         if accepted is True and durably_viable is not False:
             viable += 1
-        if accepted is True and (explicitly_useful is True or (explicitly_useful is None and (improved or has_health))):
+        if accepted is True and (
+            explicitly_useful is True
+            or (explicitly_useful is None and (improved or has_health))
+        ):
             useful += 1
     score = None
     if mutation_records:
-        acceptance = sum(1 for value in decided if value) / len(decided) if decided else 0.0
+        acceptance = (
+            sum(1 for value in decided if value) / len(decided) if decided else 0.0
+        )
         usefulness = useful / len(mutation_records)
         failure_penalty = failures / len(mutation_records)
-        score = round(max(0.0, min(1.0, (acceptance * 0.5) + (usefulness * 0.5) - (failure_penalty * 0.25))) * 100.0, 1)
+        score = round(
+            max(
+                0.0,
+                min(
+                    1.0,
+                    (acceptance * 0.5) + (usefulness * 0.5) - (failure_penalty * 0.25),
+                ),
+            )
+            * 100.0,
+            1,
+        )
     return {
         "score": score,
         "mutation_count": len(mutation_records),
@@ -286,18 +422,35 @@ def compute_liveness_index(
 ) -> dict[str, object]:
     reference = now or datetime.now(timezone.utc)
     sorted_records = sorted(records, key=lambda rec: str(rec.get("ts", "")))
-    autonomy_records = [record for record in sorted_records if not _is_voluntary_budget_record(record)]
+    autonomy_records = [
+        record for record in sorted_records if not _is_voluntary_budget_record(record)
+    ]
     budgeted_periods_ignored = len(sorted_records) - len(autonomy_records)
     recent_cutoff = reference - timedelta(hours=24)
     loop_cutoff = reference - timedelta(hours=48)
     interaction_cutoff = reference - timedelta(days=7)
 
     component_details: dict[str, dict[str, object]] = {
-        "recent_activity": {"score": 0.0, "count": 0, "cutoff": recent_cutoff.isoformat()},
-        "perception_decision_action_loop": {"score": 0.0, "completed": False, "window_hours": 48},
-        "active_objectives_progress": {"score": 0.0, "active_objectives": 0, "progress_events": 0},
+        "recent_activity": {
+            "score": 0.0,
+            "count": 0,
+            "cutoff": recent_cutoff.isoformat(),
+        },
+        "perception_decision_action_loop": {
+            "score": 0.0,
+            "completed": False,
+            "window_hours": 48,
+        },
+        "active_objectives_progress": {
+            "score": 0.0,
+            "active_objectives": 0,
+            "progress_events": 0,
+        },
         "interactions": {"score": 0.0, "count": 0, "window_days": 7},
-        "validated_internal_modifications": {"score": 0.0, "accepted_useful_changes": 0},
+        "validated_internal_modifications": {
+            "score": 0.0,
+            "accepted_useful_changes": 0,
+        },
     }
     proofs: list[dict[str, object]] = []
 
@@ -309,7 +462,8 @@ def compute_liveness_index(
             continue
         event_name = _normalized_event(record)
         has_concrete_mutation = any(
-            key in record for key in ("score_base", "score_new", "accepted", "ok", "operator", "op")
+            key in record
+            for key in ("score_base", "score_new", "accepted", "ok", "operator", "op")
         )
         if event_name in _RECENT_ACTIVITY_EVENTS or has_concrete_mutation:
             recent_activity_count += 1
@@ -337,7 +491,8 @@ def compute_liveness_index(
             continue
         event_name = _normalized_event(record)
         if perception_ts is None and (
-            event_name in _PERCEPTION_EVENTS or isinstance(record.get("perception_summary"), str)
+            event_name in _PERCEPTION_EVENTS
+            or isinstance(record.get("perception_summary"), str)
         ):
             perception_ts = ts
             proofs.append(
@@ -349,10 +504,15 @@ def compute_liveness_index(
                 }
             )
             continue
-        if perception_ts is not None and decision_ts is None and ts >= perception_ts and (
-            event_name in _DECISION_EVENTS
-            or isinstance(record.get("decision_reason"), str)
-            or isinstance(record.get("justification"), str)
+        if (
+            perception_ts is not None
+            and decision_ts is None
+            and ts >= perception_ts
+            and (
+                event_name in _DECISION_EVENTS
+                or isinstance(record.get("decision_reason"), str)
+                or isinstance(record.get("justification"), str)
+            )
         ):
             decision_ts = ts
             proofs.append(
@@ -379,9 +539,13 @@ def compute_liveness_index(
                     }
                 )
                 break
-    loop_completed = perception_ts is not None and decision_ts is not None and action_ts is not None
+    loop_completed = (
+        perception_ts is not None and decision_ts is not None and action_ts is not None
+    )
     component_details["perception_decision_action_loop"]["completed"] = loop_completed
-    component_details["perception_decision_action_loop"]["score"] = 1.0 if loop_completed else 0.0
+    component_details["perception_decision_action_loop"]["score"] = (
+        1.0 if loop_completed else 0.0
+    )
 
     # 3) Active objectives with progress
     active_objectives_count = 0
@@ -399,7 +563,13 @@ def compute_liveness_index(
         explicit_progress = event_name in _PROGRESS_EVENTS
         status = record.get("status")
         if not explicit_progress and isinstance(status, str):
-            explicit_progress = status.strip().lower() in {"in_progress", "progress", "done", "completed", "success"}
+            explicit_progress = status.strip().lower() in {
+                "in_progress",
+                "progress",
+                "done",
+                "completed",
+                "success",
+            }
         progress_value = record.get("progress")
         if not explicit_progress and isinstance(progress_value, (int, float)):
             explicit_progress = float(progress_value) > 0
@@ -415,8 +585,12 @@ def compute_liveness_index(
             )
     if active_objectives_count > 0 and objective_progress_count > 0:
         component_details["active_objectives_progress"]["score"] = 1.0
-    component_details["active_objectives_progress"]["active_objectives"] = active_objectives_count
-    component_details["active_objectives_progress"]["progress_events"] = objective_progress_count
+    component_details["active_objectives_progress"][
+        "active_objectives"
+    ] = active_objectives_count
+    component_details["active_objectives_progress"][
+        "progress_events"
+    ] = objective_progress_count
 
     # 4) Interactions
     interaction_count = 0
@@ -478,9 +652,9 @@ def compute_liveness_index(
                 "event": _normalized_event(record) or "mutation",
             }
         )
-    component_details["validated_internal_modifications"]["accepted_useful_changes"] = (
-        accepted_useful_modifications
-    )
+    component_details["validated_internal_modifications"][
+        "accepted_useful_changes"
+    ] = accepted_useful_modifications
     if accepted_useful_modifications >= 1:
         component_details["validated_internal_modifications"]["score"] = 1.0
 
@@ -504,28 +678,77 @@ def compute_liveness_index(
 
     sorted_proofs = sorted(
         proofs,
-        key=lambda item: parse_ts(item.get("ts")) or datetime.min.replace(tzinfo=timezone.utc),
+        key=lambda item: parse_ts(item.get("ts"))
+        or datetime.min.replace(tzinfo=timezone.utc),
         reverse=True,
     )
-    missing_data = [name for name, detail in component_details.items() if float(detail["score"]) == 0.0]
+    missing_data = [
+        name
+        for name, detail in component_details.items()
+        if float(detail["score"]) == 0.0
+    ]
     freshness = _data_freshness(sorted_records, reference)
     observed_components = len(component_details) - len(missing_data)
     confidence = round(observed_components / len(component_details), 2)
     liveness_diagnostic = {
         "formula_version": _LIVENESS_FORMULA_VERSION,
         "formula": "100 × (activité + boucle PDA + objectifs/progrès + interactions + modifications validées) / 5",
-        "unit": "points sur 100", "window": {"recent_activity_hours": 24, "pda_loop_hours": 48, "interactions_days": 7, "objectives": "historique disponible", "modifications": "historique disponible"},
-        "components": component_details, "freshness": freshness,
-        "confidence": {"level": "high" if confidence >= .8 else "medium" if confidence >= .4 else "low", "score": confidence, "basis": f"{observed_components}/5 composantes étayées"},
-        "missing_data": missing_data, "proofs": sorted_proofs[:5], "recommendations": _component_recommendations(component_details),
+        "unit": "points sur 100",
+        "window": {
+            "recent_activity_hours": 24,
+            "pda_loop_hours": 48,
+            "interactions_days": 7,
+            "objectives": "historique disponible",
+            "modifications": "historique disponible",
+        },
+        "components": component_details,
+        "freshness": freshness,
+        "confidence": {
+            "level": (
+                "high"
+                if confidence >= 0.8
+                else "medium" if confidence >= 0.4 else "low"
+            ),
+            "score": confidence,
+            "basis": f"{observed_components}/5 composantes étayées",
+        },
+        "missing_data": missing_data,
+        "proofs": sorted_proofs[:5],
+        "recommendations": _component_recommendations(component_details),
     }
-    autonomy_diagnostic = {**liveness_diagnostic, "formula_version": "autonomy-v1.0", "formula": "indice de vivacité recalculé après exclusion des arrêts volontaires de budget", "excluded_records": budgeted_periods_ignored}
-    mutation_missing = [] if mutation_viability["mutation_count"] else ["mutations décidées", "changements utiles validés"]
+    autonomy_diagnostic = {
+        **liveness_diagnostic,
+        "formula_version": "autonomy-v1.0",
+        "formula": "indice de vivacité recalculé après exclusion des arrêts volontaires de budget",
+        "excluded_records": budgeted_periods_ignored,
+    }
+    mutation_missing = (
+        []
+        if mutation_viability["mutation_count"]
+        else ["mutations décidées", "changements utiles validés"]
+    )
     mutation_diagnostic = {
-        "formula_version": "mutation-viability-v1.0", "formula": "100 × clamp(0, 1, 0,5 × acceptation + 0,5 × utilité − 0,25 × échecs)", "unit": "points sur 100", "window": "historique disponible",
-        "components": mutation_viability, "freshness": freshness,
-        "confidence": {"level": "high" if mutation_viability["mutation_count"] >= 10 else "medium" if mutation_viability["mutation_count"] >= 3 else "low", "sample_size": mutation_viability["mutation_count"]},
-        "missing_data": mutation_missing, "proofs": [proof for proof in sorted_proofs if proof["component"] == "validated_internal_modifications"], "recommendations": [],
+        "formula_version": "mutation-viability-v1.0",
+        "formula": "100 × clamp(0, 1, 0,5 × acceptation + 0,5 × utilité − 0,25 × échecs)",
+        "unit": "points sur 100",
+        "window": "historique disponible",
+        "components": mutation_viability,
+        "freshness": freshness,
+        "confidence": {
+            "level": (
+                "high"
+                if mutation_viability["mutation_count"] >= 10
+                else "medium" if mutation_viability["mutation_count"] >= 3 else "low"
+            ),
+            "sample_size": mutation_viability["mutation_count"],
+        },
+        "missing_data": mutation_missing,
+        "proofs": [
+            proof
+            for proof in sorted_proofs
+            if proof["component"] == "validated_internal_modifications"
+        ],
+        "recommendations": [],
     }
     return {
         "index": index,
@@ -534,7 +757,11 @@ def compute_liveness_index(
         "mutation_viability": mutation_viability,
         "components": component_details,
         "proofs": sorted_proofs[:5],
-        "indices": {"liveness": liveness_diagnostic, "autonomy": autonomy_diagnostic, "mutation_viability": mutation_diagnostic},
+        "indices": {
+            "liveness": liveness_diagnostic,
+            "autonomy": autonomy_diagnostic,
+            "mutation_viability": mutation_diagnostic,
+        },
         "recommendations": liveness_diagnostic["recommendations"],
     }
 
@@ -551,7 +778,9 @@ def aggregate_lives(
     as_float: Callable[[object], float | None],
     alerts_from_records: Callable[[list[dict[str, object]]], list[dict[str, object]]],
     compute_vital_timeline: Callable[..., dict[str, object]],
-    registry_life_meta: Callable[[str, dict[str, object]], tuple[str | None, dict[str, object] | None]],
+    registry_life_meta: Callable[
+        [str, dict[str, object]], tuple[str | None, dict[str, object] | None]
+    ],
 ) -> tuple[dict[str, dict[str, object]], dict[str, object]]:
     active_life = registry.get("active")
     registry_lives = registry.get("lives")
@@ -586,11 +815,16 @@ def aggregate_lives(
             if isinstance(name_value, str) and name_value:
                 display_name = name_value
         else:
-            registry_status = normalize_life_status(getattr(raw_meta, "status", "active"))
+            registry_status = normalize_life_status(
+                getattr(raw_meta, "status", "active")
+            )
             name_value = getattr(raw_meta, "name", None)
             if isinstance(name_value, str) and name_value:
                 display_name = name_value
-        is_selected = isinstance(active_life, str) and active_life in {slug, display_name}
+        is_selected = isinstance(active_life, str) and active_life in {
+            slug,
+            display_name,
+        }
         is_extinct = _status_is_dead(registry_status)
         is_terminated = _status_is_terminated(registry_status)
         comparison[slug] = {
@@ -631,7 +865,13 @@ def aggregate_lives(
             ),
             "life_liveness_index": 0.0,
             "autonomy_index": 0.0,
-            "mutation_viability": {"score": None, "mutation_count": 0, "accepted_count": 0, "rejected_count": 0, "accepted_useful_changes": 0},
+            "mutation_viability": {
+                "score": None,
+                "mutation_count": 0,
+                "accepted_count": 0,
+                "rejected_count": 0,
+                "accepted_useful_changes": 0,
+            },
             "life_liveness_components": {
                 "recent_activity": {"score": 0.0, "count": 0},
                 "perception_decision_action_loop": {"score": 0.0, "completed": False},
@@ -691,7 +931,11 @@ def aggregate_lives(
             (new for _, new in reversed(score_points) if new is not None), None
         )
         progression_slope = None
-        if first_base is not None and last_new is not None and len(mutation_records) > 1:
+        if (
+            first_base is not None
+            and last_new is not None
+            and len(mutation_records) > 1
+        ):
             progression_slope = (first_base - last_new) / (len(mutation_records) - 1)
 
         failure_rate = None
@@ -704,7 +948,11 @@ def aggregate_lives(
             evolution_speed = sum(ms_points) / len(ms_points)
 
         last_timestamp = next(
-            (str(rec.get("ts")) for rec in reversed(all_records) if isinstance(rec.get("ts"), str)),
+            (
+                str(rec.get("ts"))
+                for rec in reversed(all_records)
+                if isinstance(rec.get("ts"), str)
+            ),
             None,
         )
         last_event = next(
@@ -723,13 +971,19 @@ def aggregate_lives(
             registry_status = normalize_life_status(raw_meta.get("status", "active"))
         elif slug is not None:
             registry_meta = registry_lives.get(slug)
-            registry_status = normalize_life_status(getattr(registry_meta, "status", "active"))
+            registry_status = normalize_life_status(
+                getattr(registry_meta, "status", "active")
+            )
         if registry_status == "unknown" and life_name in comparison:
-            registry_status = str(comparison[life_name].get("registry_status", "unknown"))
+            registry_status = str(
+                comparison[life_name].get("registry_status", "unknown")
+            )
         extinction_seen = extinction_seen or _status_is_dead(registry_status)
         run_terminated = run_terminated or _status_is_terminated(registry_status)
         registry_run_status_inconsistency = (
-            extinction_seen and slug is not None and not _status_is_dead(registry_status)
+            extinction_seen
+            and slug is not None
+            and not _status_is_dead(registry_status)
         )
         status_reconciliation_suggestion = (
             "mark_extinct" if registry_run_status_inconsistency else None
@@ -789,15 +1043,43 @@ def aggregate_lives(
             ),
             "life_liveness_index": liveness["index"],
             "autonomy_index": liveness.get("autonomy_index", liveness["index"]),
-            "mutation_viability": liveness.get("mutation_viability", compute_mutation_viability(all_records)),
+            "mutation_viability": liveness.get(
+                "mutation_viability", compute_mutation_viability(all_records)
+            ),
             "life_liveness_components": liveness["components"],
             "life_liveness_proofs": liveness["proofs"],
             "score_diagnostics": {
                 **liveness["indices"],
-                "health": {"formula_version": "health-observation-v1.0", "formula": "dernière valeur health.score observée", "unit": "points sur 100", "window": time_window,
-                    "components": {"latest": current_health_score, "observations": len(health_score_points)}, "freshness": _data_freshness(all_records, datetime.now(timezone.utc)),
-                    "confidence": {"level": "high" if len(health_score_points) >= 5 else "medium" if len(health_score_points) >= 2 else "low", "sample_size": len(health_score_points)}, "missing_data": [] if health_score_points else ["health.score"], "proofs": [], "recommendations": [],
-                    "change_reason": f"variation de {health_score_points[-1] - health_score_points[0]:+.1f} points sur {len(health_score_points)} observations" if len(health_score_points) >= 2 else "variation indéterminable : moins de deux observations"}},
+                "health": {
+                    "formula_version": "health-observation-v1.0",
+                    "formula": "dernière valeur health.score observée",
+                    "unit": "points sur 100",
+                    "window": time_window,
+                    "components": {
+                        "latest": current_health_score,
+                        "observations": len(health_score_points),
+                    },
+                    "freshness": _data_freshness(
+                        all_records, datetime.now(timezone.utc)
+                    ),
+                    "confidence": {
+                        "level": (
+                            "high"
+                            if len(health_score_points) >= 5
+                            else "medium" if len(health_score_points) >= 2 else "low"
+                        ),
+                        "sample_size": len(health_score_points),
+                    },
+                    "missing_data": [] if health_score_points else ["health.score"],
+                    "proofs": [],
+                    "recommendations": [],
+                    "change_reason": (
+                        f"variation de {health_score_points[-1] - health_score_points[0]:+.1f} points sur {len(health_score_points)} observations"
+                        if len(health_score_points) >= 2
+                        else "variation indéterminable : moins de deux observations"
+                    ),
+                },
+            },
             "score_recommendations": liveness["recommendations"],
         }
     unattached_summary = {

--- a/src/singular/dashboard/services/metrics_contract.py
+++ b/src/singular/dashboard/services/metrics_contract.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import Any
 
-
 LIFE_METRIC_FIELDS = (
     "selected_life",
     "registry_status",
@@ -56,22 +55,28 @@ def normalize_life_metrics(
         # Do not infer life_status from registry_status or viability_status.
         row["life_status"] = row.get("life_status")
         timestamp = row.get("last_activity")
-        if isinstance(timestamp, str) and (latest_timestamp is None or timestamp > latest_timestamp):
+        if isinstance(timestamp, str) and (
+            latest_timestamp is None or timestamp > latest_timestamp
+        ):
             latest_timestamp, latest_life_id = timestamp, life_id
         if row.get("registry_run_status_inconsistency"):
-            inconsistencies.append({
-                "life_id": life_id,
-                "kind": "registry_vital_status_conflict",
-                "registry_status": row.get("registry_status"),
-                "life_status": row.get("life_status"),
-            })
+            inconsistencies.append(
+                {
+                    "life_id": life_id,
+                    "kind": "registry_vital_status_conflict",
+                    "registry_status": row.get("registry_status"),
+                    "life_status": row.get("life_status"),
+                }
+            )
         normalized[life_id] = row
     identities = {
         "selected_life_id": selected_life_id,
         "registry_active_life_id": registry_active_life_id,
         "latest_event_life_id": latest_life_id,
         "latest_event_at": latest_timestamp,
-        "latest_event_life_status": normalized.get(latest_life_id, {}).get("life_status"),
+        "latest_event_life_status": normalized.get(latest_life_id, {}).get(
+            "life_status"
+        ),
         "inconsistencies": inconsistencies,
     }
     return normalized, identities

--- a/src/singular/dashboard/services/trajectory.py
+++ b/src/singular/dashboard/services/trajectory.py
@@ -43,9 +43,21 @@ def build_trajectory(
         except json.JSONDecodeError:
             quests_data = {}
         if isinstance(quests_data, dict):
-            active = quests_data.get("active") if isinstance(quests_data.get("active"), list) else []
-            paused = quests_data.get("paused") if isinstance(quests_data.get("paused"), list) else []
-            completed = quests_data.get("completed") if isinstance(quests_data.get("completed"), list) else []
+            active = (
+                quests_data.get("active")
+                if isinstance(quests_data.get("active"), list)
+                else []
+            )
+            paused = (
+                quests_data.get("paused")
+                if isinstance(quests_data.get("paused"), list)
+                else []
+            )
+            completed = (
+                quests_data.get("completed")
+                if isinstance(quests_data.get("completed"), list)
+                else []
+            )
 
     objective_status: dict[str, str] = {}
     for item in active:
@@ -83,12 +95,21 @@ def build_trajectory(
                 previous[objective] = new_value
 
     links: list[dict[str, object]] = []
-    major_events = {"death", "interaction", "quest", "quest_triggered", "quest_resolved", "consciousness"}
+    major_events = {
+        "death",
+        "interaction",
+        "quest",
+        "quest_triggered",
+        "quest_resolved",
+        "consciousness",
+    }
     for record in records:
         event = record.get("event")
         if not isinstance(event, str):
             continue
-        if event not in major_events and not isinstance(record.get("self_narrative_event"), str):
+        if event not in major_events and not isinstance(
+            record.get("self_narrative_event"), str
+        ):
             continue
         objective = record.get("objective")
         if not isinstance(objective, str):
@@ -110,16 +131,29 @@ def build_trajectory(
         correlation_id = record.get("correlation_id")
         if not isinstance(correlation_id, str) or not correlation_id:
             continue
-        event = record.get("event") or record.get("event_type") or (
-            "mutation" if any(key in record for key in ("op", "operator", "diff")) else "record"
+        event = (
+            record.get("event")
+            or record.get("event_type")
+            or (
+                "mutation"
+                if any(key in record for key in ("op", "operator", "diff"))
+                else "record"
+            )
         )
         item = {
             "correlation_id": correlation_id,
             "timestamp": record.get("ts", record.get("timestamp")),
             "event": event,
-            "cause": record.get("initial_cause", record.get("category", record.get("source_error_type"))),
-            "decision": record.get("decision_reason", record.get("reason", record.get("accepted"))),
-            "consequence": record.get("human_summary", record.get("result", record.get("self_narrative_event"))),
+            "cause": record.get(
+                "initial_cause", record.get("category", record.get("source_error_type"))
+            ),
+            "decision": record.get(
+                "decision_reason", record.get("reason", record.get("accepted"))
+            ),
+            "consequence": record.get(
+                "human_summary",
+                record.get("result", record.get("self_narrative_event")),
+            ),
             "life": record.get("life_id", record.get("life", record.get("organism"))),
             "corrective_action": record.get("corrective_action"),
             "mutation": record.get("operator", record.get("op")),
@@ -133,13 +167,31 @@ def build_trajectory(
     return {
         "objectives": {
             "counts": {
-                "in_progress": sum(1 for status in objective_status.values() if status == "in_progress"),
-                "abandoned": sum(1 for status in objective_status.values() if status == "abandoned"),
-                "completed": sum(1 for status in objective_status.values() if status == "completed"),
+                "in_progress": sum(
+                    1 for status in objective_status.values() if status == "in_progress"
+                ),
+                "abandoned": sum(
+                    1 for status in objective_status.values() if status == "abandoned"
+                ),
+                "completed": sum(
+                    1 for status in objective_status.values() if status == "completed"
+                ),
             },
-            "in_progress": [name for name, status in objective_status.items() if status == "in_progress"],
-            "abandoned": [name for name, status in objective_status.items() if status == "abandoned"],
-            "completed": [name for name, status in objective_status.items() if status == "completed"],
+            "in_progress": [
+                name
+                for name, status in objective_status.items()
+                if status == "in_progress"
+            ],
+            "abandoned": [
+                name
+                for name, status in objective_status.items()
+                if status == "abandoned"
+            ],
+            "completed": [
+                name
+                for name, status in objective_status.items()
+                if status == "completed"
+            ],
         },
         "priority_changes": priority_changes[-40:],
         "objective_narrative_links": links[-40:],

--- a/src/singular/diagnostics/autonomous.py
+++ b/src/singular/diagnostics/autonomous.py
@@ -159,9 +159,11 @@ def autonomous_diagnostics(*, run_generation: bool = False) -> dict[str, Any]:
             "critical",
             "ready" if writable else "blocked",
             {"required": [p.name for p in required], "writable": writable},
-            None
-            if writable
-            else f"mkdir -p {home / 'mem'} {home / 'runs'} && chmod u+rwx {home / 'mem'} {home / 'runs'}",
+            (
+                None
+                if writable
+                else f"mkdir -p {home / 'mem'} {home / 'runs'} && chmod u+rwx {home / 'mem'} {home / 'runs'}"
+            ),
         )
     )
     checks.append(_systemd_check(root, home))
@@ -191,14 +193,18 @@ def autonomous_diagnostics(*, run_generation: bool = False) -> dict[str, Any]:
             {
                 "provider": configured_name or None,
                 "reachable": bool(provider_result and provider_result.get("reachable")),
-                "category": provider_result.get("error_category")
-                if provider_result
-                else "not_configured",
+                "category": (
+                    provider_result.get("error_category")
+                    if provider_result
+                    else "not_configured"
+                ),
             },
-            None
-            if model_ready
-            else (provider_result or {}).get("configuration_command")
-            or "singular config providers doctor",
+            (
+                None
+                if model_ready
+                else (provider_result or {}).get("configuration_command")
+                or "singular config providers doctor"
+            ),
         )
     )
 
@@ -239,9 +245,11 @@ def autonomous_diagnostics(*, run_generation: bool = False) -> dict[str, Any]:
             "critical",
             "ready" if closed else "blocked",
             {"state": circuit.get("state"), "updated_at": circuit.get("updated_at")},
-            None
-            if closed
-            else "singular governance recover --operator <nom> --justification <raison>",
+            (
+                None
+                if closed
+                else "singular governance recover --operator <nom> --justification <raison>"
+            ),
         )
     )
     mutation = _mutation_evidence(home)

--- a/src/singular/environment/__init__.py
+++ b/src/singular/environment/__init__.py
@@ -2,4 +2,11 @@
 
 from . import artifacts, files, notifications, reputation, sim_world, world_resources
 
-__all__ = ["files", "notifications", "artifacts", "reputation", "world_resources", "sim_world"]
+__all__ = [
+    "files",
+    "notifications",
+    "artifacts",
+    "reputation",
+    "world_resources",
+    "sim_world",
+]

--- a/src/singular/environment/artifacts.py
+++ b/src/singular/environment/artifacts.py
@@ -17,7 +17,9 @@ ARTIFACTS_DIR = _BASE_DIR / "runs" / "artifacts"
 
 
 def _ensure_dir(directory: Path | None = None) -> Path:
-    directory = directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
+    directory = (
+        directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
+    )
     directory.mkdir(parents=True, exist_ok=True)
     return directory
 
@@ -80,7 +82,9 @@ def create_text_art(
 ) -> Path:
     """Create a text artifact and save accompanying metadata."""
 
-    directory = directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
+    directory = (
+        directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
+    )
     path = save_text(name, text, directory)
     _save_metadata(path, mood, resources)
     return path
@@ -98,7 +102,9 @@ def create_ascii_drawing(
 ) -> Path:
     """Create a simple ASCII drawing and save accompanying metadata."""
 
-    directory = directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
+    directory = (
+        directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
+    )
     path = save_drawing(name, width, height, char, directory)
     _save_metadata(path, mood, resources)
     return path
@@ -114,7 +120,9 @@ def create_simple_melody(
 ) -> Path:
     """Create a simple melody and save accompanying metadata."""
 
-    directory = directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
+    directory = (
+        directory or Path(os.environ.get("SINGULAR_HOME", ".")) / "runs" / "artifacts"
+    )
     path = save_music(name, notes, directory)
     _save_metadata(path, mood, resources)
     return path

--- a/src/singular/environment/world_resources.py
+++ b/src/singular/environment/world_resources.py
@@ -68,7 +68,9 @@ class WorldResourcePool:
     ) -> ActionResolution:
         """Consume resources for one action and persist contention/conflict events."""
 
-        cooperation = [name for name in cooperation_partners if name and name != life_id]
+        cooperation = [
+            name for name in cooperation_partners if name and name != life_id
+        ]
         effective_cpu = max(float(cpu_cost), 0.0)
         effective_mut = max(float(mutation_cost), 0.0)
         effective_attention = max(float(attention_cost), 0.0)
@@ -89,9 +91,15 @@ class WorldResourcePool:
             or self.attention_score < effective_attention
         )
         contention = scarcity or len(contenders) > 1
-        conflicts = [intent.life_id for intent in contenders if intent.life_id != winner.life_id]
+        conflicts = [
+            intent.life_id for intent in contenders if intent.life_id != winner.life_id
+        ]
         if scarcity and not granted:
-            consumed = {"cpu_budget": 0.0, "mutation_slots": 0.0, "attention_score": 0.0}
+            consumed = {
+                "cpu_budget": 0.0,
+                "mutation_slots": 0.0,
+                "attention_score": 0.0,
+            }
             rivalry_penalty = 0.2 + (max(winner.bid - actor_score, 0.0) * 0.01)
             relation_bonus = 0.0
         else:
@@ -105,7 +113,9 @@ class WorldResourcePool:
                 "attention_score": effective_attention,
             }
             relation_bonus = 0.1 * len(cooperation)
-            rivalry_penalty = 0.0 if cooperation else (0.05 * len(conflicts) if contention else 0.0)
+            rivalry_penalty = (
+                0.0 if cooperation else (0.05 * len(conflicts) if contention else 0.0)
+            )
 
         event = {
             "life_id": life_id,

--- a/src/singular/goals/__init__.py
+++ b/src/singular/goals/__init__.py
@@ -3,4 +3,10 @@
 from .intrinsic import GoalState, GoalWeights, IntrinsicGoals
 from .quest_generation import GeneratedQuest, generate_quests
 
-__all__ = ["GoalState", "GoalWeights", "IntrinsicGoals", "GeneratedQuest", "generate_quests"]
+__all__ = [
+    "GoalState",
+    "GoalWeights",
+    "IntrinsicGoals",
+    "GeneratedQuest",
+    "generate_quests",
+]

--- a/src/singular/goals/quest_generation.py
+++ b/src/singular/goals/quest_generation.py
@@ -69,7 +69,9 @@ def generate_quests(
     recent_failures = _as_float(history.get("recent_failures", 0.0), default=0.0)
 
     if isinstance(value_performance_tension, Mapping):
-        tension = _clamp(_as_float(value_performance_tension.get("score", 0.0), default=0.0))
+        tension = _clamp(
+            _as_float(value_performance_tension.get("score", 0.0), default=0.0)
+        )
     else:
         tension = _clamp(_as_float(value_performance_tension, default=0.0))
 
@@ -77,15 +79,21 @@ def generate_quests(
     food = _clamp(_as_float(stock.get("food", 50.0), default=50.0) / 100.0)
     warmth = _clamp(_as_float(stock.get("warmth", 50.0), default=50.0) / 100.0)
 
-    delayed_crisis = _clamp(_as_float(world.get("delayed_crisis_pressure", 0.0), default=0.0))
+    delayed_crisis = _clamp(
+        _as_float(world.get("delayed_crisis_pressure", 0.0), default=0.0)
+    )
     opportunity = _clamp(_as_float(world.get("opportunity_pressure", 0.0), default=0.0))
 
     generated: list[GeneratedQuest] = []
     surprise = surprise_signals or {}
     surprise_level = _clamp(_as_float(surprise.get("surprise", 0.0), default=0.0))
     frustration_level = _clamp(_as_float(surprise.get("frustration", 0.0), default=0.0))
-    curiosity_spike = _clamp(_as_float(surprise.get("curiosity", curiosity), default=curiosity))
-    repeated_operator_failures = _clamp(_as_float(surprise.get("operator_family_failure_pressure", 0.0), default=0.0))
+    curiosity_spike = _clamp(
+        _as_float(surprise.get("curiosity", curiosity), default=curiosity)
+    )
+    repeated_operator_failures = _clamp(
+        _as_float(surprise.get("operator_family_failure_pressure", 0.0), default=0.0)
+    )
 
     if tension >= 0.45:
         generated.append(
@@ -106,7 +114,9 @@ def generate_quests(
                 objective="Restaurer la stabilité d'exécution après une série d'échecs.",
                 rationale="Historique récent orienté vers l'échec.",
                 origin="intrinsic",
-                priority=_clamp(0.4 + failure_pressure * 0.5 + (1.0 - resilience) * 0.2),
+                priority=_clamp(
+                    0.4 + failure_pressure * 0.5 + (1.0 - resilience) * 0.2
+                ),
             )
         )
 
@@ -162,4 +172,8 @@ def generate_quests(
         )
 
     generated.sort(key=lambda quest: quest.priority, reverse=True)
-    return developmental_model.filter_quests(generated) if developmental_model else generated
+    return (
+        developmental_model.filter_quests(generated)
+        if developmental_model
+        else generated
+    )

--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -53,19 +53,48 @@ class GovernanceIncident:
 
 
 _INCIDENT_POLICIES: dict[str, GovernanceIncident] = {
-    "source_invalid": GovernanceIncident("source_invalid", "medium", "skill", "quarantine_skill_and_try_another"),
-    "infrastructure": GovernanceIncident("infrastructure", "low", "life", "defer_evaluation_without_penalty"),
-    "invalid_mutation": GovernanceIncident("invalid_mutation", "medium", "candidate", "reject_candidate_and_record_operator_failure"),
-    "dangerous_mutation_violation": GovernanceIncident("dangerous_mutation_violation", "high", "candidate", "reject_candidate_and_record_operator_failure"),
-    "missing_artifact": GovernanceIncident("missing_artifact", "medium", "skill", "quarantine_skill_and_try_another"),
-    "unresolved_path": GovernanceIncident("unresolved_path", "medium", "skill", "quarantine_skill_and_try_another"),
-    "unauthorized_internal_path": GovernanceIncident("unauthorized_internal_path", "high", "skill", "quarantine_skill_and_try_another"),
-    "confirmed_root_escape": GovernanceIncident("confirmed_root_escape", "critical", "global", "open_global_breaker"),
-    "outbound_symlink": GovernanceIncident("outbound_symlink", "critical", "global", "open_global_breaker"),
+    "source_invalid": GovernanceIncident(
+        "source_invalid", "medium", "skill", "quarantine_skill_and_try_another"
+    ),
+    "infrastructure": GovernanceIncident(
+        "infrastructure", "low", "life", "defer_evaluation_without_penalty"
+    ),
+    "invalid_mutation": GovernanceIncident(
+        "invalid_mutation",
+        "medium",
+        "candidate",
+        "reject_candidate_and_record_operator_failure",
+    ),
+    "dangerous_mutation_violation": GovernanceIncident(
+        "dangerous_mutation_violation",
+        "high",
+        "candidate",
+        "reject_candidate_and_record_operator_failure",
+    ),
+    "missing_artifact": GovernanceIncident(
+        "missing_artifact", "medium", "skill", "quarantine_skill_and_try_another"
+    ),
+    "unresolved_path": GovernanceIncident(
+        "unresolved_path", "medium", "skill", "quarantine_skill_and_try_another"
+    ),
+    "unauthorized_internal_path": GovernanceIncident(
+        "unauthorized_internal_path",
+        "high",
+        "skill",
+        "quarantine_skill_and_try_another",
+    ),
+    "confirmed_root_escape": GovernanceIncident(
+        "confirmed_root_escape", "critical", "global", "open_global_breaker"
+    ),
+    "outbound_symlink": GovernanceIncident(
+        "outbound_symlink", "critical", "global", "open_global_breaker"
+    ),
 }
 
 
-def classify_governance_incident(category: str, severity: str | None = None) -> GovernanceIncident:
+def classify_governance_incident(
+    category: str, severity: str | None = None
+) -> GovernanceIncident:
     """Normalize legacy category names into one explicit incident contract."""
 
     normalized = category.strip().lower()
@@ -73,11 +102,15 @@ def classify_governance_incident(category: str, severity: str | None = None) -> 
         normalized = "invalid_mutation"
     incident = _INCIDENT_POLICIES.get(
         normalized,
-        GovernanceIncident(normalized or "unknown", "high", "life", "isolate_life_and_review"),
+        GovernanceIncident(
+            normalized or "unknown", "high", "life", "isolate_life_and_review"
+        ),
     )
     if severity is None:
         return incident
-    return GovernanceIncident(incident.category, severity.strip().lower(), incident.scope, incident.recovery)
+    return GovernanceIncident(
+        incident.category, severity.strip().lower(), incident.scope, incident.recovery
+    )
 
 
 class PolicySchemaError(ValueError):
@@ -994,7 +1027,9 @@ class MutationGovernancePolicy:
         )
         self.circuit_breaker_category_thresholds = {
             str(category).strip().lower(): max(int(threshold), 1)
-            for category, threshold in (circuit_breaker_category_thresholds or {}).items()
+            for category, threshold in (
+                circuit_breaker_category_thresholds or {}
+            ).items()
         }
         self.skill_circuit_breaker_failure_threshold = max(
             int(
@@ -1116,7 +1151,9 @@ class MutationGovernancePolicy:
                 ):
                     self._violation_timestamps.append(happened_at)
                     category = str(item.get("category", "unknown")).strip().lower()
-                    self._violation_timestamps_by_category.setdefault(category, deque()).append(happened_at)
+                    self._violation_timestamps_by_category.setdefault(
+                        category, deque()
+                    ).append(happened_at)
 
     def _persist_circuit(
         self,
@@ -1133,11 +1170,15 @@ class MutationGovernancePolicy:
         home = self._circuit_state_file.parent.parent
         payload = load_circuit_state(home)
         now = self._now().isoformat()
-        payload.update({
-            "state": state,
-            "updated_at": now,
-            "correlation_id": correlation_id or payload.get("correlation_id") or uuid4().hex,
-        })
+        payload.update(
+            {
+                "state": state,
+                "updated_at": now,
+                "correlation_id": correlation_id
+                or payload.get("correlation_id")
+                or uuid4().hex,
+            }
+        )
         if cause:
             violations = payload["violations"]
             violations["total"] = int(violations.get("total", 0)) + 1
@@ -1149,7 +1190,10 @@ class MutationGovernancePolicy:
                     "category": cause,
                     "severity": severity,
                     "window_seconds": self.circuit_breaker_window_seconds,
-                    "expires_at": (self._now() + timedelta(seconds=self.circuit_breaker_window_seconds)).isoformat(),
+                    "expires_at": (
+                        self._now()
+                        + timedelta(seconds=self.circuit_breaker_window_seconds)
+                    ).isoformat(),
                 }
             )
             violations["evidence"] = violations["evidence"][-50:]
@@ -1355,7 +1399,9 @@ class MutationGovernancePolicy:
             and self._violation_timestamps[0] < violation_cutoff
         ):
             self._violation_timestamps.popleft()
-        for category, timestamps in list(self._violation_timestamps_by_category.items()):
+        for category, timestamps in list(
+            self._violation_timestamps_by_category.items()
+        ):
             while timestamps and timestamps[0] < violation_cutoff:
                 timestamps.popleft()
             if not timestamps:
@@ -1438,11 +1484,14 @@ class MutationGovernancePolicy:
             normalized_category, deque()
         )
         category_timestamps.append(now)
-        threshold = self.circuit_breaker_category_thresholds.get(normalized_category, (
-            self.circuit_breaker_critical_threshold
-            if normalized_severity == "critical"
-            else self.circuit_breaker_threshold
-        ))
+        threshold = self.circuit_breaker_category_thresholds.get(
+            normalized_category,
+            (
+                self.circuit_breaker_critical_threshold
+                if normalized_severity == "critical"
+                else self.circuit_breaker_threshold
+            ),
+        )
         if not was_open and len(category_timestamps) >= threshold:
             self._circuit_open_until = now + timedelta(
                 seconds=self.circuit_breaker_cooldown_seconds

--- a/src/singular/governance/values.py
+++ b/src/singular/governance/values.py
@@ -8,7 +8,6 @@ from typing import Any, Mapping
 
 from singular.memory import get_values_file, read_values
 
-
 VALUE_KEYS = (
     "securite",
     "utilite_utilisateur",

--- a/src/singular/identity/__init__.py
+++ b/src/singular/identity/__init__.py
@@ -9,9 +9,19 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .coherence import (CoherenceDecision, IdentityChangeDecision, IdentityChangePolicy,
-                        IdentityCoherenceGuard, IdentityInvariants, detect_contradictions)
-from .consolidation import ConsolidationPipeline, ConsolidationPolicy, ConsolidationResult
+from .coherence import (
+    CoherenceDecision,
+    IdentityChangeDecision,
+    IdentityChangePolicy,
+    IdentityCoherenceGuard,
+    IdentityInvariants,
+    detect_contradictions,
+)
+from .consolidation import (
+    ConsolidationPipeline,
+    ConsolidationPolicy,
+    ConsolidationResult,
+)
 from .consolidation_coordinator import ConsolidationCoordinator
 from .core import IdentityAggregationService, IdentityCoreService
 from .episodic_store import EpisodicStore

--- a/src/singular/identity/coherence.py
+++ b/src/singular/identity/coherence.py
@@ -32,7 +32,11 @@ class IdentityInvariants:
     def from_payload(cls, payload: dict[str, Any]) -> "IdentityInvariants":
         return cls(
             life_name=str(payload.get("life_name", "")).strip(),
-            cardinal_values=tuple(_normalize_token(value) for value in payload.get("cardinal_values", []) if str(value).strip()),
+            cardinal_values=tuple(
+                _normalize_token(value)
+                for value in payload.get("cardinal_values", [])
+                if str(value).strip()
+            ),
             long_term_commitments=tuple(
                 _normalize_token(value)
                 for value in payload.get("long_term_commitments", [])
@@ -123,10 +127,17 @@ class IdentityCoherenceGuard:
                 low, high = self.change_policy.plastic_bounds
                 requested = max(low, min(high, requested))
                 delta = requested - old
-                if abs(delta) >= self.change_policy.important_delta and len(independent) < self.change_policy.independent_evidence_required:
+                if (
+                    abs(delta) >= self.change_policy.important_delta
+                    and len(independent)
+                    < self.change_policy.independent_evidence_required
+                ):
                     accepted = False
                     reasons.append("important_change_requires_independent_evidence")
-                value = old + max(-self.change_policy.max_delta, min(self.change_policy.max_delta, delta))
+                value = old + max(
+                    -self.change_policy.max_delta,
+                    min(self.change_policy.max_delta, delta),
+                )
                 value = max(low, min(high, value))
                 if accepted and value != requested:
                     reasons.append("rate_limited")
@@ -137,14 +148,25 @@ class IdentityCoherenceGuard:
             accepted = False
             reasons.append("unknown_identity_category")
         status = "applied" if accepted else "review"
-        append_jsonl_line(self.audit_path, {
-            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-            "kind": "identity_change", "category": category, "status": status,
-            "accepted": accepted, "before": current, "requested": proposed,
-            "value": value if accepted else current, "cause": cause,
-            "evidence": independent, "reasons": reasons,
-        })
-        return IdentityChangeDecision(category, status, accepted, value if accepted else current, tuple(reasons))
+        append_jsonl_line(
+            self.audit_path,
+            {
+                "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "kind": "identity_change",
+                "category": category,
+                "status": status,
+                "accepted": accepted,
+                "before": current,
+                "requested": proposed,
+                "value": value if accepted else current,
+                "cause": cause,
+                "evidence": independent,
+                "reasons": reasons,
+            },
+        )
+        return IdentityChangeDecision(
+            category, status, accepted, value if accepted else current, tuple(reasons)
+        )
 
     def evaluate_decision(
         self,
@@ -183,16 +205,20 @@ class IdentityCoherenceGuard:
     def _check_invariants(self, decision: dict[str, Any]) -> list[str]:
         violations: list[str] = []
         proposed_name = str(decision.get("life_name", "")).strip()
-        if proposed_name and self.invariants.life_name and proposed_name != self.invariants.life_name:
+        if (
+            proposed_name
+            and self.invariants.life_name
+            and proposed_name != self.invariants.life_name
+        ):
             violations.append("life_name_mismatch")
 
         decision_values = {
-            _normalize_token(v)
-            for v in decision.get("values", [])
-            if str(v).strip()
+            _normalize_token(v) for v in decision.get("values", []) if str(v).strip()
         }
         missing_values = [
-            value for value in self.invariants.cardinal_values if value not in decision_values
+            value
+            for value in self.invariants.cardinal_values
+            if value not in decision_values
         ]
         if missing_values:
             violations.append("cardinal_values_missing:" + ",".join(missing_values))
@@ -213,7 +239,9 @@ class IdentityCoherenceGuard:
                 violations.append(f"long_term_commitment_negated:{commitment}")
         return violations
 
-    def _audit_if_needed(self, *, decision: dict[str, Any], record: CoherenceDecision) -> None:
+    def _audit_if_needed(
+        self, *, decision: dict[str, Any], record: CoherenceDecision
+    ) -> None:
         if record.status == "allowed":
             return
         append_jsonl_line(
@@ -239,9 +267,15 @@ def detect_contradictions(
     """Detect proposition-level contradictions across beliefs, goals, and history."""
 
     statements: list[tuple[str, str, bool, str]] = []
-    statements.extend(_extract_statements("belief", beliefs, ("hypothesis", "statement", "name")))
-    statements.extend(_extract_statements("goal", goals, ("name", "objective", "summary")))
-    statements.extend(_extract_statements("history", history, ("summary", "event", "note")))
+    statements.extend(
+        _extract_statements("belief", beliefs, ("hypothesis", "statement", "name"))
+    )
+    statements.extend(
+        _extract_statements("goal", goals, ("name", "objective", "summary"))
+    )
+    statements.extend(
+        _extract_statements("history", history, ("summary", "event", "note"))
+    )
 
     by_canonical: dict[str, list[tuple[str, str, bool]]] = {}
     for source, text, positive, canonical in statements:

--- a/src/singular/identity/consolidation.py
+++ b/src/singular/identity/consolidation.py
@@ -110,7 +110,9 @@ class ConsolidationPipeline:
                 evidence = [evidence]
             status = psyche.evolve_traits(
                 changes,
-                cause=str(episode.get("cause") or episode.get("event") or "consolidation"),
+                cause=str(
+                    episode.get("cause") or episode.get("event") or "consolidation"
+                ),
                 evidence=evidence if isinstance(evidence, list) else [],
             )
             counts[status] += 1

--- a/src/singular/identity/consolidation_coordinator.py
+++ b/src/singular/identity/consolidation_coordinator.py
@@ -10,7 +10,6 @@ from typing import Any, Callable
 
 from ..io_utils import atomic_write_text
 
-
 STAGES = (
     "semantic_memory",
     "autobiographical_memory",
@@ -62,40 +61,101 @@ class ConsolidationCoordinator:
         return value
 
     @staticmethod
-    def _stage_items(stage: str, episodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _stage_items(
+        stage: str, episodes: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         keys = {
             "semantic_memory": ("user_fact", "preference", "constraint", "fact"),
-            "autobiographical_memory": ("user_fact", "autobiographical_fact", "achievement", "failure", "embodied_outcome"),
-            "metacognitive_self_model": ("strategy", "error", "bias", "failure_condition"),
+            "autobiographical_memory": (
+                "user_fact",
+                "autobiographical_fact",
+                "achievement",
+                "failure",
+                "embodied_outcome",
+            ),
+            "metacognitive_self_model": (
+                "strategy",
+                "error",
+                "bias",
+                "failure_condition",
+            ),
             "models_of_others": ("individual_id", "other_id", "person"),
-            "probabilistic_beliefs": ("belief", "hypothesis", "success", "reward", "embodied_outcome"),
+            "probabilistic_beliefs": (
+                "belief",
+                "hypothesis",
+                "success",
+                "reward",
+                "embodied_outcome",
+            ),
             "imitation_learning": ("demonstration", "observations", "actions", "skill"),
-            "narrative_projection": ("narrative", "heading", "achievement", "failure", "embodied_outcome"),
+            "narrative_projection": (
+                "narrative",
+                "heading",
+                "achievement",
+                "failure",
+                "embodied_outcome",
+            ),
         }[stage]
         return [episode for episode in episodes if any(key in episode for key in keys)]
 
-    def _apply_stage(self, stage: str, episodes: list[dict[str, Any]]) -> dict[str, int]:
+    def _apply_stage(
+        self, stage: str, episodes: list[dict[str, Any]]
+    ) -> dict[str, int]:
         catalogue = self._read(self.catalogue_path, {})
         if not isinstance(catalogue, dict):
             catalogue = {}
-        counts = {key: 0 for key in ("seen", "reinforced", "merged", "demoted", "forgotten", "rejected")}
+        counts = {
+            key: 0
+            for key in (
+                "seen",
+                "reinforced",
+                "merged",
+                "demoted",
+                "forgotten",
+                "rejected",
+            )
+        }
         items = self._stage_items(stage, episodes)
         counts["seen"] = len(items)
         now = _now()
         for episode in items:
-            provenance = str(episode.get("trace_id") or episode.get("id") or episode.get("event_id") or _key(episode))
+            provenance = str(
+                episode.get("trace_id")
+                or episode.get("id")
+                or episode.get("event_id")
+                or _key(episode)
+            )
             content = next(
-                (episode[key] for key in (
-                    "value", "user_fact", "autobiographical_fact", "preference",
-                    "constraint", "belief", "hypothesis", "narrative", "heading",
-                    "strategy", "error", "bias", "skill", "individual_id",
-                    "other_id", "person",
-                ) if episode.get(key) is not None),
+                (
+                    episode[key]
+                    for key in (
+                        "value",
+                        "user_fact",
+                        "autobiographical_fact",
+                        "preference",
+                        "constraint",
+                        "belief",
+                        "hypothesis",
+                        "narrative",
+                        "heading",
+                        "strategy",
+                        "error",
+                        "bias",
+                        "skill",
+                        "individual_id",
+                        "other_id",
+                        "person",
+                    )
+                    if episode.get(key) is not None
+                ),
                 episode.get("summary", episode),
             )
             normalized = str(content).strip().casefold()
             item_id = _key([stage, normalized])
-            critical = bool(episode.get("critical") or episode.get("importance") in {"critical", "high"})
+            critical = bool(
+                episode.get("critical")
+                or episode.get("importance") in {"critical", "high"}
+            )
             existing = catalogue.get(item_id)
             if isinstance(existing, dict):
                 if provenance in existing.get("provenance", []):
@@ -107,10 +167,17 @@ class ConsolidationCoordinator:
                 existing["status"] = "active"
                 counts["reinforced"] += 1
             else:
-                opposite = normalized.removeprefix("not ") if normalized.startswith("not ") else "not " + normalized
+                opposite = (
+                    normalized.removeprefix("not ")
+                    if normalized.startswith("not ")
+                    else "not " + normalized
+                )
                 contradictions = [
-                    key for key, row in catalogue.items()
-                    if isinstance(row, dict) and row.get("stage") == stage and row.get("normalized") == opposite
+                    key
+                    for key, row in catalogue.items()
+                    if isinstance(row, dict)
+                    and row.get("stage") == stage
+                    and row.get("normalized") == opposite
                 ]
                 rejected = False
                 for conflict_id in contradictions:
@@ -122,27 +189,44 @@ class ConsolidationCoordinator:
                         conflict["status"] = "demoted"
                         counts["demoted"] += 1
                 catalogue[item_id] = {
-                    "stage": stage, "content": content, "normalized": normalized,
-                    "provenance": [provenance], "mentions": 1, "critical": critical,
+                    "stage": stage,
+                    "content": content,
+                    "normalized": normalized,
+                    "provenance": [provenance],
+                    "mentions": 1,
+                    "critical": critical,
                     "status": "rejected" if rejected else "active",
                     "obsolete": bool(episode.get("obsolete")),
                     "first_seen": str(episode.get("ts") or now),
-                    "last_seen": str(episode.get("ts") or now), "contradicts": contradictions,
-                    "trace_id": episode.get("trace_id"), "objective": episode.get("objective"),
-                    "result": episode.get("result"), "confidence": episode.get("confidence"),
+                    "last_seen": str(episode.get("ts") or now),
+                    "contradicts": contradictions,
+                    "trace_id": episode.get("trace_id"),
+                    "objective": episode.get("objective"),
+                    "result": episode.get("result"),
+                    "confidence": episode.get("confidence"),
                     "importance": episode.get("importance"),
                 }
                 counts["rejected"] += int(rejected)
         # Obsolete evidence can leave active memory, but critical records and the
         # audit entry itself are immutable retention invariants.
         for row in catalogue.values():
-            if not isinstance(row, dict) or row.get("stage") != stage or row.get("critical"):
+            if (
+                not isinstance(row, dict)
+                or row.get("stage") != stage
+                or row.get("critical")
+            ):
                 continue
             if row.get("obsolete") and row.get("status") != "forgotten":
                 row["status"] = "forgotten"
                 counts["forgotten"] += 1
         self._write(self.catalogue_path, catalogue)
-        projection = [row for row in catalogue.values() if isinstance(row, dict) and row.get("stage") == stage and row.get("status") not in {"forgotten", "rejected"}]
+        projection = [
+            row
+            for row in catalogue.values()
+            if isinstance(row, dict)
+            and row.get("stage") == stage
+            and row.get("status") not in {"forgotten", "rejected"}
+        ]
         self._write(self.mem_dir / f"consolidated_{stage}.json", projection)
         return counts
 
@@ -160,26 +244,51 @@ class ConsolidationCoordinator:
             state["pending_episodes"] = episodes
             self._write(self.state_path, state)
         elif isinstance(state.get("pending_episodes"), list):
-            episodes = [row for row in state["pending_episodes"] if isinstance(row, dict)]
+            episodes = [
+                row for row in state["pending_episodes"] if isinstance(row, dict)
+            ]
         batch = _key([_key(episode) for episode in episodes])
-        totals = {key: 0 for key in ("seen", "reinforced", "merged", "demoted", "forgotten", "rejected")}
+        totals = {
+            key: 0
+            for key in (
+                "seen",
+                "reinforced",
+                "merged",
+                "demoted",
+                "forgotten",
+                "rejected",
+            )
+        }
         errors: list[dict[str, str]] = []
         results: dict[str, Any] = {}
         for stage in STAGES:
             checkpoint = state["stages"].get(stage, {})
-            if checkpoint.get("cursor") == batch and checkpoint.get("status") == "completed":
+            if (
+                checkpoint.get("cursor") == batch
+                and checkpoint.get("status") == "completed"
+            ):
                 result = checkpoint.get("result", {})
             else:
                 try:
                     result = self._apply_stage(stage, episodes)
-                    state["stages"][stage] = {"cursor": batch, "status": "completed", "result": result, "completed_at": _now()}
+                    state["stages"][stage] = {
+                        "cursor": batch,
+                        "status": "completed",
+                        "result": result,
+                        "completed_at": _now(),
+                    }
                     self._write(self.state_path, state)  # commit each stage separately
                     if after_stage:
                         after_stage(stage)
                 except Exception as exc:  # retain earlier commits and continue
                     error = {"stage": stage, "error": f"{type(exc).__name__}: {exc}"}
                     errors.append(error)
-                    state["stages"][stage] = {"cursor": batch, "status": "failed", "result": {}, **error}
+                    state["stages"][stage] = {
+                        "cursor": batch,
+                        "status": "failed",
+                        "result": {},
+                        **error,
+                    }
                     self._write(self.state_path, state)
                     continue
             results[stage] = result

--- a/src/singular/identity/core.py
+++ b/src/singular/identity/core.py
@@ -48,18 +48,30 @@ class IdentityCoreService:
         biography = self._json(self.mem / "biography.json")
         narrative = self._json(self.mem / "self_narrative.json")
         psyche_data = self._json(self.mem / "psyche.json")
-        identity = biography.get("identity", {}) if isinstance(biography.get("identity"), Mapping) else {}
-        narrative_identity = narrative.get("identity", {}) if isinstance(narrative.get("identity"), Mapping) else {}
+        identity = (
+            biography.get("identity", {})
+            if isinstance(biography.get("identity"), Mapping)
+            else {}
+        )
+        narrative_identity = (
+            narrative.get("identity", {})
+            if isinstance(narrative.get("identity"), Mapping)
+            else {}
+        )
 
         # Birth data is authoritative when a core still contains defaults.
         if model["name"] == "Singular":
-            model["name"] = str(identity.get("name") or narrative_identity.get("name") or model["name"])
+            model["name"] = str(
+                identity.get("name") or narrative_identity.get("name") or model["name"]
+            )
         if identity.get("id"):
             model["stable_id"] = str(identity["id"])
         summaries = biography.get("self_summaries", [])
         if not model["biographical_summary"] and isinstance(summaries, list):
             model["biographical_summary"] = " ".join(
-                str(item.get("text", "")).strip() for item in summaries if isinstance(item, Mapping) and item.get("text")
+                str(item.get("text", "")).strip()
+                for item in summaries
+                if isinstance(item, Mapping) and item.get("text")
             )
         certificate = biography.get("birth_certificate")
         if isinstance(certificate, Mapping) and not model["founding_events"]:
@@ -70,22 +82,34 @@ class IdentityCoreService:
             commitments = getattr(psyche, "identity_commitments", commitments)
         if not isinstance(commitments, Mapping):
             commitments = {}
-        model["cardinal_values"] = self._unique(model["cardinal_values"], commitments.get("values"))
-        model["red_lines"] = self._unique(model["red_lines"], commitments.get("red_lines"))
+        model["cardinal_values"] = self._unique(
+            model["cardinal_values"], commitments.get("values")
+        )
+        model["red_lines"] = self._unique(
+            model["red_lines"], commitments.get("red_lines")
+        )
         # Older psyche state had no separate commitments list; values remain
         # values and are not silently promoted to promises.
-        wounds = getattr(psyche, "identity_wounds", psyche_data.get("identity_wounds", 0.0))
+        wounds = getattr(
+            psyche, "identity_wounds", psyche_data.get("identity_wounds", 0.0)
+        )
         try:
             wound_score = float(wounds)
         except (TypeError, ValueError):
             wound_score = 0.0
         if wound_score > 0 and not model["identity_wounds"]:
-            model["identity_wounds"].append({"kind": "legacy_psyche_wound", "severity": wound_score})
+            model["identity_wounds"].append(
+                {"kind": "legacy_psyche_wound", "severity": wound_score}
+            )
 
         # Psyche traits are observations, not ownership of identity.
         trait_source = psyche if psyche is not None else psyche_data
         for trait in ("curiosity", "patience", "playfulness", "optimism", "resilience"):
-            value = getattr(trait_source, trait, None) if psyche is not None else trait_source.get(trait)
+            value = (
+                getattr(trait_source, trait, None)
+                if psyche is not None
+                else trait_source.get(trait)
+            )
             if value is not None:
                 self._merge_trait(model, trait, value)
         model["updated_at"] = _now()
@@ -96,22 +120,33 @@ class IdentityCoreService:
     def _merge_trait(self, model: dict[str, Any], name: str, value: Any) -> None:
         now = _now()
         old = model["traits"].get(name, {})
-        model["traits"][name] = {"value": str(value), "source": "psyche",
-                                  "confidence": float(old.get("confidence", 1.0)),
-                                  "observed_at": old.get("observed_at", now), "last_confirmed_at": now}
+        model["traits"][name] = {
+            "value": str(value),
+            "source": "psyche",
+            "confidence": float(old.get("confidence", 1.0)),
+            "observed_at": old.get("observed_at", now),
+            "last_confirmed_at": now,
+        }
 
     def _project(self, model: dict[str, Any], psyche: Any | None) -> None:
         """Update compatibility projections without giving them ownership."""
         if psyche is not None:
-            psyche.identity_commitments = {"values": list(model["cardinal_values"]),
-                                           "red_lines": list(model["red_lines"])}
+            psyche.identity_commitments = {
+                "values": list(model["cardinal_values"]),
+                "red_lines": list(model["red_lines"]),
+            }
             psyche.identity_wounds = max(
-                (float(w.get("severity", 0.0)) for w in model["identity_wounds"] if isinstance(w, Mapping)),
+                (
+                    float(w.get("severity", 0.0))
+                    for w in model["identity_wounds"]
+                    if isinstance(w, Mapping)
+                ),
                 default=0.0,
             )
         narrative_path = self.mem / "self_narrative.json"
         if narrative_path.exists():
             from ..self_narrative import load, save
+
             story = load(narrative_path)
             story.identity.name = model["name"]
             save(story, narrative_path)
@@ -120,7 +155,8 @@ class IdentityCoreService:
         """Build the coherence guard input directly from the canonical core."""
         model = self.store.read()
         return IdentityInvariants(
-            life_name=model["name"], cardinal_values=tuple(model["cardinal_values"]),
+            life_name=model["name"],
+            cardinal_values=tuple(model["cardinal_values"]),
             long_term_commitments=tuple(model["commitments"]),
         )
 

--- a/src/singular/identity/self_model.py
+++ b/src/singular/identity/self_model.py
@@ -30,7 +30,12 @@ class SelfModelStore:
     so their provenance survives restarts and consolidation.
     """
 
-    _EVIDENCE_SECTIONS = ("autobiographical_facts", "traits", "preferences", "constraints")
+    _EVIDENCE_SECTIONS = (
+        "autobiographical_facts",
+        "traits",
+        "preferences",
+        "constraints",
+    )
     _REQUIRED_ROOT_KEYS = set(_EVIDENCE_SECTIONS)
 
     @staticmethod
@@ -94,8 +99,13 @@ class SelfModelStore:
             confidence = float(raw)
         except (TypeError, ValueError):
             confidence = 0.5
-        return {"value": value, "source": "legacy:self_model", "confidence": confidence,
-                "observed_at": now, "last_confirmed_at": now}
+        return {
+            "value": value,
+            "source": "legacy:self_model",
+            "confidence": confidence,
+            "observed_at": now,
+            "last_confirmed_at": now,
+        }
 
     def _read_and_migrate(self) -> tuple[dict[str, Any], bool]:
         try:
@@ -118,11 +128,20 @@ class SelfModelStore:
                 model[section] = {}
                 migrated = True
                 continue
-            normalized = {str(key): self._record(str(key), value, now) for key, value in values.items()}
+            normalized = {
+                str(key): self._record(str(key), value, now)
+                for key, value in values.items()
+            }
             if normalized != values:
                 model[section] = normalized
                 migrated = True
-        for section in ("founding_events", "cardinal_values", "commitments", "red_lines", "identity_wounds"):
+        for section in (
+            "founding_events",
+            "cardinal_values",
+            "commitments",
+            "red_lines",
+            "identity_wounds",
+        ):
             if not isinstance(model.get(section), list):
                 model[section] = []
                 migrated = True
@@ -148,17 +167,24 @@ class SelfModelStore:
     def write(self, model: dict[str, Any]) -> None:
         missing = self._REQUIRED_ROOT_KEYS.difference(model)
         if missing:
-            raise IdentityInvariantError(f"Missing invariant sections in self model: {sorted(missing)}")
+            raise IdentityInvariantError(
+                f"Missing invariant sections in self model: {sorted(missing)}"
+            )
         model["schema_version"] = SCHEMA_VERSION
-        atomic_write_text(self.path, json.dumps(model, ensure_ascii=False, indent=2) + "\n")
+        atomic_write_text(
+            self.path, json.dumps(model, ensure_ascii=False, indent=2) + "\n"
+        )
 
     def apply_facts(self, facts: list[dict[str, Any]]) -> dict[str, Any]:
         """Merge extracted evidence without confusing biography and character."""
         model = self.read()
         now = _now()
         section_for_kind = {
-            "user_fact": "autobiographical_facts", "autobiographical_fact": "autobiographical_facts",
-            "trait": "traits", "preference": "preferences", "constraint": "constraints",
+            "user_fact": "autobiographical_facts",
+            "autobiographical_fact": "autobiographical_facts",
+            "trait": "traits",
+            "preference": "preferences",
+            "constraint": "constraints",
         }
         for fact in facts:
             section = section_for_kind.get(str(fact.get("kind", "")))
@@ -166,11 +192,17 @@ class SelfModelStore:
             if not section or not value:
                 continue
             previous = model[section].get(value, {})
-            observed = str(fact.get("observed_at") or fact.get("observation_date") or now)
+            observed = str(
+                fact.get("observed_at") or fact.get("observation_date") or now
+            )
             model[section][value] = {
                 "value": value,
-                "source": str(fact.get("source") or previous.get("source") or "unknown"),
-                "confidence": float(fact.get("confidence", previous.get("confidence", 0.5)) or 0.5),
+                "source": str(
+                    fact.get("source") or previous.get("source") or "unknown"
+                ),
+                "confidence": float(
+                    fact.get("confidence", previous.get("confidence", 0.5)) or 0.5
+                ),
                 "observed_at": str(previous.get("observed_at") or observed),
                 "last_confirmed_at": str(fact.get("last_confirmed_at") or observed),
             }
@@ -184,7 +216,13 @@ class SelfModelStore:
         keep_n = max(1, keep_top_n_per_section)
         for section in self._EVIDENCE_SECTIONS:
             values = model[section]
-            model[section] = dict(sorted(values.items(), key=lambda item: float(item[1].get("confidence", 0.0)), reverse=True)[:keep_n])
+            model[section] = dict(
+                sorted(
+                    values.items(),
+                    key=lambda item: float(item[1].get("confidence", 0.0)),
+                    reverse=True,
+                )[:keep_n]
+            )
         model["updated_at"] = _now()
         self.write(model)
         return model

--- a/src/singular/identity/semantic_memory.py
+++ b/src/singular/identity/semantic_memory.py
@@ -39,7 +39,9 @@ class SemanticMemoryStore:
         return [item for item in payload if isinstance(item, dict)]
 
     def write_facts(self, facts: list[dict[str, Any]]) -> None:
-        atomic_write_text(self.path, json.dumps(facts, ensure_ascii=False, indent=2) + "\n")
+        atomic_write_text(
+            self.path, json.dumps(facts, ensure_ascii=False, indent=2) + "\n"
+        )
 
     def extract_facts(self, episodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
         extracted: list[dict[str, Any]] = []
@@ -73,9 +75,14 @@ class SemanticMemoryStore:
                 existing["confidence"] = min(0.99, round(0.5 + mentions * 0.1, 2))
             else:
                 current[fid] = fact
-        merged = sorted(current.values(), key=lambda item: (str(item.get("kind")), str(item.get("value"))))
+        merged = sorted(
+            current.values(),
+            key=lambda item: (str(item.get("kind")), str(item.get("value"))),
+        )
         self.write_facts(merged)
         return merged
 
-    def consolidate_from_episodes(self, episodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def consolidate_from_episodes(
+        self, episodes: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         return self.merge_facts(self.extract_facts(episodes))

--- a/src/singular/identity/synchronization.py
+++ b/src/singular/identity/synchronization.py
@@ -113,11 +113,11 @@ class IdentitySynchronizationService:
                 previous = narrative.trait_trends.get(key, TraitTrend()).value
                 narrative.trait_trends[key] = TraitTrend(
                     value=value,
-                    trend="up"
-                    if value > previous
-                    else "down"
-                    if value < previous
-                    else "stable",
+                    trend=(
+                        "up"
+                        if value > previous
+                        else "down" if value < previous else "stable"
+                    ),
                 )
             if isinstance(event.get("current_heading"), str):
                 narrative.current_heading = str(event["current_heading"])

--- a/src/singular/interaction/tts_engine.py
+++ b/src/singular/interaction/tts_engine.py
@@ -50,7 +50,9 @@ class Prosody:
         return Prosody(
             rate=max(bounds.min_rate, min(bounds.max_rate, self.rate)),
             pitch=max(bounds.min_pitch, min(bounds.max_pitch, self.pitch)),
-            intensity=max(bounds.min_intensity, min(bounds.max_intensity, self.intensity)),
+            intensity=max(
+                bounds.min_intensity, min(bounds.max_intensity, self.intensity)
+            ),
         )
 
 

--- a/src/singular/io_utils.py
+++ b/src/singular/io_utils.py
@@ -92,7 +92,9 @@ def _replace_with_retry(source: str, destination: Path) -> None:
     """Replace ``destination`` with ``source``, retrying transient Windows lock errors."""
 
     max_attempts = (
-        _WINDOWS_REPLACE_MAX_ATTEMPTS if _is_windows() else _DEFAULT_REPLACE_MAX_ATTEMPTS
+        _WINDOWS_REPLACE_MAX_ATTEMPTS
+        if _is_windows()
+        else _DEFAULT_REPLACE_MAX_ATTEMPTS
     )
     delay_seconds = _DEFAULT_REPLACE_INITIAL_DELAY_SECONDS
     max_delay_seconds = (

--- a/src/singular/learning/__init__.py
+++ b/src/singular/learning/__init__.py
@@ -43,4 +43,9 @@ from .developmental import (
     MaturityEvidence,
 )
 
-__all__ = ["DevelopmentalModel", "DevelopmentalStage", "GateDecision", "MaturityEvidence"]
+__all__ = [
+    "DevelopmentalModel",
+    "DevelopmentalStage",
+    "GateDecision",
+    "MaturityEvidence",
+]

--- a/src/singular/learning/demonstration.py
+++ b/src/singular/learning/demonstration.py
@@ -6,7 +6,6 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import Any, Mapping, Sequence
 
-
 DEMONSTRATION_SCHEMA_VERSION = 1
 
 

--- a/src/singular/learning/developmental.py
+++ b/src/singular/learning/developmental.py
@@ -40,13 +40,22 @@ class MaturityEvidence:
 
     def score(self, weights: Mapping[str, float] | None = None) -> float:
         weights = weights or {
-            "calibration": .15, "stability": .2, "retention": .15,
-            "skill_mastery": .2, "constraint_adherence": .2, "recovery": .1,
+            "calibration": 0.15,
+            "stability": 0.2,
+            "retention": 0.15,
+            "skill_mastery": 0.2,
+            "constraint_adherence": 0.2,
+            "recovery": 0.1,
         }
         total = sum(max(0.0, float(v)) for v in weights.values()) or 1.0
-        base = sum(_unit(getattr(self, key, 0.0)) * max(0.0, float(weight))
-                   for key, weight in weights.items()) / total
-        return round(max(0.0, base - min(max(self.incidents, 0) * .2, .8)), 4)
+        base = (
+            sum(
+                _unit(getattr(self, key, 0.0)) * max(0.0, float(weight))
+                for key, weight in weights.items()
+            )
+            / total
+        )
+        return round(max(0.0, base - min(max(self.incidents, 0) * 0.2, 0.8)), 4)
 
 
 @dataclass(frozen=True)
@@ -66,12 +75,14 @@ class DevelopmentalStage:
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "DevelopmentalStage":
         return cls(
-            id=str(value["id"]), prerequisites=dict(value.get("prerequisites", {})),
+            id=str(value["id"]),
+            prerequisites=dict(value.get("prerequisites", {})),
             allowed_skills=tuple(value.get("allowed_skills", ())),
             autonomy=str(value.get("autonomy", "supervised")),
             max_difficulty=_unit(value.get("max_difficulty", 0)),
             supervision=str(value.get("supervision", "continuous")),
-            promotion=dict(value.get("promotion", {})), regression=dict(value.get("regression", {})),
+            promotion=dict(value.get("promotion", {})),
+            regression=dict(value.get("regression", {})),
             exploration_budget=max(0.0, float(value.get("exploration_budget", 0))),
             allowed_actions=tuple(value.get("allowed_actions", ())),
             sensitive_actions=tuple(value.get("sensitive_actions", ())),
@@ -89,7 +100,13 @@ class GateDecision:
 class DevelopmentalModel:
     """Persistent stage evaluator and common gate for all learning surfaces."""
 
-    def __init__(self, root: Path | str, stages: Sequence[DevelopmentalStage], *, life_id: str = "default"):
+    def __init__(
+        self,
+        root: Path | str,
+        stages: Sequence[DevelopmentalStage],
+        *,
+        life_id: str = "default",
+    ):
         if not stages:
             raise ValueError("at least one developmental stage is required")
         if not life_id or Path(life_id).name != life_id:
@@ -100,13 +117,26 @@ class DevelopmentalModel:
         self.transitions_path = self.directory / "transitions.jsonl"
         self.directory.mkdir(parents=True, exist_ok=True)
         if not self.state_path.exists():
-            self._write({"version": 1, "stage_index": 0, "qualifying_observations": 0,
-                         "updated_at": _now(), "last_evidence": None})
+            self._write(
+                {
+                    "version": 1,
+                    "stage_index": 0,
+                    "qualifying_observations": 0,
+                    "updated_at": _now(),
+                    "last_evidence": None,
+                }
+            )
 
     @classmethod
-    def from_config(cls, root: Path | str, config: Path | str, *, life_id: str = "default") -> "DevelopmentalModel":
+    def from_config(
+        cls, root: Path | str, config: Path | str, *, life_id: str = "default"
+    ) -> "DevelopmentalModel":
         payload = json.loads(Path(config).read_text(encoding="utf-8"))
-        return cls(root, [DevelopmentalStage.from_dict(item) for item in payload["stages"]], life_id=life_id)
+        return cls(
+            root,
+            [DevelopmentalStage.from_dict(item) for item in payload["stages"]],
+            life_id=life_id,
+        )
 
     def _read(self) -> dict[str, Any]:
         try:
@@ -118,13 +148,18 @@ class DevelopmentalModel:
             return {"version": 1, "stage_index": 0, "qualifying_observations": 0}
 
     def _write(self, state: Mapping[str, Any]) -> None:
-        atomic_write_text(self.state_path, json.dumps(dict(state), ensure_ascii=False, indent=2, sort_keys=True))
+        atomic_write_text(
+            self.state_path,
+            json.dumps(dict(state), ensure_ascii=False, indent=2, sort_keys=True),
+        )
 
     @property
     def current(self) -> DevelopmentalStage:
         return self.stages[self._read()["stage_index"]]
 
-    def observe(self, evidence: MaturityEvidence, *, justification: str) -> DevelopmentalStage:
+    def observe(
+        self, evidence: MaturityEvidence, *, justification: str
+    ) -> DevelopmentalStage:
         if not justification.strip():
             raise ValueError("a transition assessment requires a justification")
         state, before = self._read(), self.current
@@ -137,35 +172,82 @@ class DevelopmentalModel:
             state["qualifying_observations"] = 0
             reason = "incident_threshold"
         else:
-            next_stage = self.stages[index + 1] if index + 1 < len(self.stages) else None
-            qualifies = next_stage is not None and evidence.samples >= int(next_stage.prerequisites.get("min_samples", 0))
-            qualifies = qualifies and all(
-                _unit(getattr(evidence, key, 0)) >= float(value)
-                for key, value in next_stage.prerequisites.items() if key != "min_samples"
-            ) and score >= float(next_stage.promotion.get("min_score", 0))
-            state["qualifying_observations"] = int(state.get("qualifying_observations", 0)) + 1 if qualifies else 0
-            required = int(next_stage.promotion.get("consecutive_observations", 1)) if next_stage else 1
+            next_stage = (
+                self.stages[index + 1] if index + 1 < len(self.stages) else None
+            )
+            qualifies = next_stage is not None and evidence.samples >= int(
+                next_stage.prerequisites.get("min_samples", 0)
+            )
+            qualifies = (
+                qualifies
+                and all(
+                    _unit(getattr(evidence, key, 0)) >= float(value)
+                    for key, value in next_stage.prerequisites.items()
+                    if key != "min_samples"
+                )
+                and score >= float(next_stage.promotion.get("min_score", 0))
+            )
+            state["qualifying_observations"] = (
+                int(state.get("qualifying_observations", 0)) + 1 if qualifies else 0
+            )
+            required = (
+                int(next_stage.promotion.get("consecutive_observations", 1))
+                if next_stage
+                else 1
+            )
             reason = "prerequisites_met" if qualifies else "stagnation"
             if qualifies and state["qualifying_observations"] >= required:
                 index += 1
                 state["qualifying_observations"] = 0
-        state.update({"stage_index": index, "updated_at": _now(), "last_evidence": asdict(evidence), "maturity_score": score})
+        state.update(
+            {
+                "stage_index": index,
+                "updated_at": _now(),
+                "last_evidence": asdict(evidence),
+                "maturity_score": score,
+            }
+        )
         self._write(state)
         after = self.stages[index]
-        append_jsonl_line(self.transitions_path, {"at": _now(), "from": before.id, "to": after.id,
-            "kind": "regression" if index < previous_index else ("progression" if index > previous_index else "assessment"),
-            "reason": reason, "justification": justification, "score": score, "evidence": asdict(evidence)})
+        append_jsonl_line(
+            self.transitions_path,
+            {
+                "at": _now(),
+                "from": before.id,
+                "to": after.id,
+                "kind": (
+                    "regression"
+                    if index < previous_index
+                    else ("progression" if index > previous_index else "assessment")
+                ),
+                "reason": reason,
+                "justification": justification,
+                "score": score,
+                "evidence": asdict(evidence),
+            },
+        )
         return after
 
-    def gate(self, *, action: str, difficulty: float = 0.0, skill: str | None = None,
-             governance_allowed: bool = True, human_approved: bool = False,
-             sensitive: bool = False) -> GateDecision:
+    def gate(
+        self,
+        *,
+        action: str,
+        difficulty: float = 0.0,
+        skill: str | None = None,
+        governance_allowed: bool = True,
+        human_approved: bool = False,
+        sensitive: bool = False,
+    ) -> GateDecision:
         stage = self.current
         if not governance_allowed:
             return GateDecision(False, "governance_denied", stage.id)
         if difficulty > stage.max_difficulty:
             return GateDecision(False, "difficulty_exceeds_stage", stage.id)
-        if skill and "*" not in stage.allowed_skills and skill not in stage.allowed_skills:
+        if (
+            skill
+            and "*" not in stage.allowed_skills
+            and skill not in stage.allowed_skills
+        ):
             return GateDecision(False, "skill_not_available_at_stage", stage.id)
         if action not in stage.allowed_actions and "*" not in stage.allowed_actions:
             return GateDecision(False, "action_not_available_at_stage", stage.id)
@@ -175,18 +257,33 @@ class DevelopmentalModel:
         return GateDecision(True, "allowed", stage.id, needs_approval)
 
     def filter_quests(self, quests: Iterable[Any]) -> list[Any]:
-        return [q for q in quests if float(getattr(q, "difficulty", 0.0)) <= self.current.max_difficulty]
+        return [
+            q
+            for q in quests
+            if float(getattr(q, "difficulty", 0.0)) <= self.current.max_difficulty
+        ]
 
     def filter_skills(self, skills: Iterable[str]) -> list[str]:
         allowed = self.current.allowed_skills
-        return list(skills) if "*" in allowed else [skill for skill in skills if skill in allowed]
+        return (
+            list(skills)
+            if "*" in allowed
+            else [skill for skill in skills if skill in allowed]
+        )
 
     def exploration_budget(self, requested: float) -> float:
         return max(0.0, min(float(requested), self.current.exploration_budget))
 
     def dashboard_projection(self) -> dict[str, Any]:
         state, stage = self._read(), self.current
-        return {"life_id": self.life_id, "stage": stage.id, "maturity_score": state.get("maturity_score", 0.0),
-                "autonomy": stage.autonomy, "supervision": stage.supervision,
-                "max_difficulty": stage.max_difficulty, "exploration_budget": stage.exploration_budget,
-                "last_evidence": state.get("last_evidence"), "updated_at": state.get("updated_at")}
+        return {
+            "life_id": self.life_id,
+            "stage": stage.id,
+            "maturity_score": state.get("maturity_score", 0.0),
+            "autonomy": stage.autonomy,
+            "supervision": stage.supervision,
+            "max_difficulty": stage.max_difficulty,
+            "exploration_budget": stage.exploration_budget,
+            "last_evidence": state.get("last_evidence"),
+            "updated_at": state.get("updated_at"),
+        }

--- a/src/singular/learning/imitation.py
+++ b/src/singular/learning/imitation.py
@@ -197,8 +197,15 @@ class ImitationEngine:
                 action="imitate_safe", difficulty=trial_cost, sensitive=False
             )
             if not decision.allowed:
-                self._event("rejections", {"type": "developmental_gate", "skill": skill,
-                                             "reason": decision.reason, "stage": decision.stage})
+                self._event(
+                    "rejections",
+                    {
+                        "type": "developmental_gate",
+                        "skill": skill,
+                        "reason": decision.reason,
+                        "stage": decision.stage,
+                    },
+                )
                 return None
         request = ActiveImitationRequest(
             skill,

--- a/src/singular/life/checkpointing.py
+++ b/src/singular/life/checkpointing.py
@@ -47,7 +47,9 @@ def _checkpoint_from_data(data: Mapping[str, object]) -> Checkpoint:
     defaults = asdict(Checkpoint())
     payload = {**defaults, **migrated}
     allowed_keys = set(Checkpoint.__dataclass_fields__)
-    filtered_payload = {key: value for key, value in payload.items() if key in allowed_keys}
+    filtered_payload = {
+        key: value for key, value in payload.items() if key in allowed_keys
+    }
     return Checkpoint(**filtered_payload)
 
 
@@ -62,7 +64,9 @@ def load_checkpoint(path: Path) -> Checkpoint:
         else:
             if isinstance(data, Mapping):
                 return _checkpoint_from_data(data)
-            log.warning("failed to load checkpoint from %s: root must be an object", path)
+            log.warning(
+                "failed to load checkpoint from %s: root must be an object", path
+            )
     return Checkpoint()
 
 

--- a/src/singular/life/coevolution_flow.py
+++ b/src/singular/life/coevolution_flow.py
@@ -123,7 +123,8 @@ class CoevolutionFlow:
             CandidateEvaluation(
                 expr=candidate.expr,
                 origin=candidate.origin,
-                retained=candidate.expr in after_exprs and candidate.expr not in before_exprs,
+                retained=candidate.expr in after_exprs
+                and candidate.expr not in before_exprs,
             )
             for candidate in candidate_list
         )
@@ -152,9 +153,7 @@ class CoevolutionFlow:
         strict_regression_rejection = self.config.robustness_weight > 0.0
         regression_allowed = not strict_regression_rejection or detection_rate == 0.0
         accepted = (
-            initially_accepted
-            and combined_new <= combined_base
-            and regression_allowed
+            initially_accepted and combined_new <= combined_base and regression_allowed
         )
         rejected_for_robustness = initially_accepted and not accepted
 

--- a/src/singular/life/death.py
+++ b/src/singular/life/death.py
@@ -40,7 +40,9 @@ class DeathMonitor:
         assert self.homeostasis_history is not None
         self.homeostasis_history.append(bool(homeostasis_viable))
         if len(self.homeostasis_history) == self.homeostasis_history.maxlen:
-            viable_ratio = sum(1 for v in self.homeostasis_history if v) / len(self.homeostasis_history)
+            viable_ratio = sum(1 for v in self.homeostasis_history if v) / len(
+                self.homeostasis_history
+            )
             if viable_ratio < self.homeostasis_viability_min_ratio:
                 return True, "homeostasis collapse"
 

--- a/src/singular/life/ecosystem.py
+++ b/src/singular/life/ecosystem.py
@@ -103,13 +103,17 @@ class EcosystemRulesConfig:
         return cls(
             schema_version=int(payload.get("schema_version", 1)),
             mode=str(payload.get("mode", "production")),
-            resource_competition_unit=float(payload.get("resource_competition_unit", 1.0)),
+            resource_competition_unit=float(
+                payload.get("resource_competition_unit", 1.0)
+            ),
             passive_energy_decay=float(payload.get("passive_energy_decay", 0.05)),
             passive_resource_decay=float(payload.get("passive_resource_decay", 0.02)),
             crossover_interval=int(payload.get("crossover_interval", 50)),
             cooperation_probability=float(payload.get("cooperation_probability", 0.2)),
             competition_bid_ceiling=float(payload.get("competition_bid_ceiling", 5.0)),
-            reputation_action_weights=dict(payload.get("reputation_action_weights", {"share": 0.2, "steal": -0.2})),
+            reputation_action_weights=dict(
+                payload.get("reputation_action_weights", {"share": 0.2, "steal": -0.2})
+            ),
         )
 
 
@@ -128,12 +132,25 @@ def draw_global_event(rng: random.Random) -> GlobalEvent:
         ("simulated_catastrophe", "systemic catastrophe simulation"),
     ]
     event_type, desc = rng.choice(templates)
-    return GlobalEvent(event_type=event_type, intensity=rng.uniform(0.2, 0.9), duration_ticks=rng.randint(2, 6), description=desc)
+    return GlobalEvent(
+        event_type=event_type,
+        intensity=rng.uniform(0.2, 0.9),
+        duration_ticks=rng.randint(2, 6),
+        description=desc,
+    )
 
 
-def compute_population_metrics(before: Mapping[str, tuple[float, float]], after: Mapping[str, tuple[float, float]], ticks_elapsed: int) -> dict[str, float]:
+def compute_population_metrics(
+    before: Mapping[str, tuple[float, float]],
+    after: Mapping[str, tuple[float, float]],
+    ticks_elapsed: int,
+) -> dict[str, float]:
     if not before or not after:
-        return {"resilience": 0.0, "diversity": 0.0, "recovery_time": float(max(ticks_elapsed, 0))}
+        return {
+            "resilience": 0.0,
+            "diversity": 0.0,
+            "recovery_time": float(max(ticks_elapsed, 0)),
+        }
     before_total = sum(max(0.0, e + r) for e, r in before.values())
     after_total = sum(max(0.0, e + r) for e, r in after.values())
     resilience = 0.0 if before_total <= 0 else min(after_total / before_total, 2.0)

--- a/src/singular/life/fitness.py
+++ b/src/singular/life/fitness.py
@@ -32,14 +32,24 @@ def _load_simple_yaml(path: Path) -> dict[str, object]:
         try:
             parsed: object = float(scalar) if "." in scalar else int(scalar)
         except ValueError:
-            parsed = scalar.lower() == "true" if scalar.lower() in {"true", "false"} else scalar
+            parsed = (
+                scalar.lower() == "true"
+                if scalar.lower() in {"true", "false"}
+                else scalar
+            )
         parent[key] = parsed
     return root
 
 
 COMPONENTS = (
-    "functional_gain", "health", "vital_risk", "resources",
-    "sandbox_stability", "cost", "quest_progress", "identity_continuity",
+    "functional_gain",
+    "health",
+    "vital_risk",
+    "resources",
+    "sandbox_stability",
+    "cost",
+    "quest_progress",
+    "identity_continuity",
     "useful_skills_retention",
 )
 
@@ -66,8 +76,10 @@ class FitnessDecision:
 
     def to_dict(self) -> dict[str, object]:
         return {
-            "accepted": self.accepted, "useful": self.useful,
-            "durably_viable": self.viable, "fitness_before": self.fitness_before,
+            "accepted": self.accepted,
+            "useful": self.useful,
+            "durably_viable": self.viable,
+            "fitness_before": self.fitness_before,
             "fitness_after": self.fitness_after,
             "fitness_components_before": self.components_before,
             "fitness_components": self.components_after,
@@ -85,7 +97,9 @@ def load_lifecycle_fitness_config(path: Path | None = None) -> LifecycleFitnessC
     else:
         raw = _load_simple_yaml(path)
     section = raw.get("mutation_fitness", {})
-    weights = {name: float(section.get("weights", {}).get(name, 0.0)) for name in COMPONENTS}
+    weights = {
+        name: float(section.get("weights", {}).get(name, 0.0)) for name in COMPONENTS
+    }
     observation = section.get("observation", {})
     thresholds = section.get("thresholds", {})
     return LifecycleFitnessConfig(
@@ -97,8 +111,11 @@ def load_lifecycle_fitness_config(path: Path | None = None) -> LifecycleFitnessC
 
 
 def evaluate_mutation_fitness(
-    before: Mapping[str, float], after: Mapping[str, float], config: LifecycleFitnessConfig,
-    *, observations: int,
+    before: Mapping[str, float],
+    after: Mapping[str, float],
+    config: LifecycleFitnessConfig,
+    *,
+    observations: int,
 ) -> FitnessDecision:
     """Compare a candidate with its immutable pre-mutation snapshot.
 
@@ -122,8 +139,13 @@ def evaluate_mutation_fitness(
         reasons.append("combined_fitness_below_threshold")
     viable = vital_regression <= config.maximum_vital_regression
     return FitnessDecision(
-        accepted=not reasons, useful=a["functional_gain"] > b["functional_gain"],
-        viable=viable, fitness_before=score_before, fitness_after=score_after,
-        components_before=b, components_after=a,
-        rejection_reasons=tuple(reasons), observations=observations,
+        accepted=not reasons,
+        useful=a["functional_gain"] > b["functional_gain"],
+        viable=viable,
+        fitness_before=score_before,
+        fitness_after=score_after,
+        components_before=b,
+        components_after=a,
+        rejection_reasons=tuple(reasons),
+        observations=observations,
     )

--- a/src/singular/life/health.py
+++ b/src/singular/life/health.py
@@ -54,7 +54,11 @@ class ViabilityDriftDetector:
         raw = state.get("samples", [])
         if isinstance(raw, list):
             detector.samples = [
-                {str(k): float(v) for k, v in item.items() if isinstance(v, (int, float))}
+                {
+                    str(k): float(v)
+                    for k, v in item.items()
+                    if isinstance(v, (int, float))
+                }
                 for item in raw[-detector.config.long_window :]
                 if isinstance(item, Mapping)
             ]
@@ -82,12 +86,20 @@ class ViabilityDriftDetector:
         # licence to select an organism whose direct health is critical.
         health = _clamp(float(item.get("health", 1.0)))
         risk = _clamp(float(item.get("risk", 0.0)))
-        if health <= self.config.critical_score or risk >= 1.0 - self.config.critical_score:
+        if (
+            health <= self.config.critical_score
+            or risk >= 1.0 - self.config.critical_score
+        ):
             score = min(score, self.config.critical_score)
         return score
 
-    def observe(self, metrics: Mapping[str, float]) -> tuple[ViabilityAction, str | None]:
-        normalized = {key: _clamp(float(metrics.get(key, 0.0))) for key in (*self._BENEFICIAL, *self._ADVERSE)}
+    def observe(
+        self, metrics: Mapping[str, float]
+    ) -> tuple[ViabilityAction, str | None]:
+        normalized = {
+            key: _clamp(float(metrics.get(key, 0.0)))
+            for key in (*self._BENEFICIAL, *self._ADVERSE)
+        }
         normalized["score"] = self._score(normalized)
         self.samples.append(normalized)
         self.samples = self.samples[-self.config.long_window :]
@@ -103,7 +115,10 @@ class ViabilityDriftDetector:
         drift = long_score - short_score
         degrading = drift >= self.config.drift_threshold and medium_score < long_score
         critical = short_score <= self.config.critical_score
-        recovering = abs(short_score - long_score) <= self.config.recovery_threshold and short_score > self.config.critical_score
+        recovering = (
+            abs(short_score - long_score) <= self.config.recovery_threshold
+            and short_score > self.config.critical_score
+        )
 
         if degrading or critical:
             self.degraded_cycles += 1
@@ -118,7 +133,10 @@ class ViabilityDriftDetector:
         elif recovering:
             self.stable_cycles += 1
             self.degraded_cycles = 0
-            if self.stable_cycles >= self.config.stable_cycles and self.action != "normal":
+            if (
+                self.stable_cycles >= self.config.stable_cycles
+                and self.action != "normal"
+            ):
                 self.action = "normal"
                 self.stable_cycles = 0
                 return self.action, "recovered"
@@ -133,7 +151,11 @@ class ViabilityDriftDetector:
         return {
             "state": self.action,
             "mutations_enabled": self.action in {"normal", "throttled"},
-            "mutation_interval": 2 if self.action == "throttled" else (1 if self.action == "normal" else None),
+            "mutation_interval": (
+                2
+                if self.action == "throttled"
+                else (1 if self.action == "normal" else None)
+            ),
             "degraded_cycles": self.degraded_cycles,
             "stable_cycles": self.stable_cycles,
             "samples": len(self.samples),
@@ -227,7 +249,9 @@ class HealthTracker:
             )
 
         acceptance_rate = (
-            self.accepted_count / self.total_iterations if self.total_iterations else 0.0
+            self.accepted_count / self.total_iterations
+            if self.total_iterations
+            else 0.0
         )
         sandbox_stability = 1.0 - (
             self.sandbox_failures / self.sandbox_checks if self.sandbox_checks else 0.0

--- a/src/singular/life/life_status.py
+++ b/src/singular/life/life_status.py
@@ -71,7 +71,12 @@ LEGACY_STATUS_CONVERSIONS: dict[str, dict[str, str | None]] = {
 }
 
 OPERATOR_ACTIONS: tuple[str, ...] = (
-    "archive", "talk", "emergency_stop", "lives_use", "memorial", "clone"
+    "archive",
+    "talk",
+    "emergency_stop",
+    "lives_use",
+    "memorial",
+    "clone",
 )
 _RUNNABLE_OPERATOR_ACTIONS = frozenset({"archive", "talk", "emergency_stop"})
 

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -17,7 +17,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Dict, Iterable, Mapping
 
-from singular.cognition.reflect import ActionHypothesis, ReflectionDecision, reflect_action
+from singular.cognition.reflect import (
+    ActionHypothesis,
+    ReflectionDecision,
+    reflect_action,
+)
 from singular.cognition.self_observation import SelfObservationService
 from singular.beliefs.store import BeliefStore
 from singular.beliefs.meta_learning import (
@@ -44,6 +48,7 @@ from singular.runs.explain import summarize_mutation
 from singular.runs.generations import record_generation
 from singular.organisms.spawn import mutation_absurde
 from singular.perception import capture_signals, get_temperature
+
 # Graine is the external proposal generator for the life loop: it does not
 # write files directly here, but supplies validated patch/operator intentions.
 from graine.evolver.generate import propose_mutations
@@ -63,7 +68,12 @@ from singular.life.effectors import perform_action
 from singular.life.world_state import PersistentWorldState
 from singular.social.graph import SocialGraph
 from singular.multiagent.runtime import LifeTickContext, MultiAgentRuntime
-from singular.life.ecosystem import ARCHETYPES, EcosystemRulesConfig, compute_population_metrics, draw_global_event
+from singular.life.ecosystem import (
+    ARCHETYPES,
+    EcosystemRulesConfig,
+    compute_population_metrics,
+    draw_global_event,
+)
 
 from .death import DeathMonitor
 from .health import HealthTracker, ViabilityDriftDetector
@@ -73,7 +83,12 @@ from singular.governance.policy import (
     classify_sandbox_error_type,
 )
 from singular.governance.values import load_value_weights
-from singular.morals import MoralAction, MoralContextBuilder, MoralDecision, MoralDecisionEngine
+from singular.morals import (
+    MoralAction,
+    MoralContextBuilder,
+    MoralDecision,
+    MoralDecisionEngine,
+)
 from singular.identity.core import IdentityCoreService
 
 from .checkpointing import (
@@ -90,7 +105,11 @@ from .sandbox_scoring import (
     _sandbox_failure_category,
 )
 from .mutation_flow import apply_mutation, select_operator, _load_default_operators
-from .fitness import FitnessDecision, evaluate_mutation_fitness, load_lifecycle_fitness_config
+from .fitness import (
+    FitnessDecision,
+    evaluate_mutation_fitness,
+    load_lifecycle_fitness_config,
+)
 from .resource_flow import manage_resources
 from .reproduction_flow import (
     ReproductionDecisionPolicy,
@@ -99,7 +118,12 @@ from .reproduction_flow import (
     decide_reproduction,
     _pick_crossover_parents,
 )
-from .coevolution_flow import CoevolutionConfig, CoevolutionFlow, MapElites, LivingTestPool
+from .coevolution_flow import (
+    CoevolutionConfig,
+    CoevolutionFlow,
+    MapElites,
+    LivingTestPool,
+)
 from .skill_genesis import create_skill
 from .social_decision import decide_social_actions
 from .profiling import LifeLoopProfiler
@@ -124,7 +148,10 @@ def _deliberate_life_action(
     action = MoralAction(action_type, parameters=dict(relational_context or {}))
     supplied = {
         "consequences": consequences,
-        "affected_parties": ({"identifier": organism, "vulnerability": 0.0}, *affected_parties),
+        "affected_parties": (
+            {"identifier": organism, "vulnerability": 0.0},
+            *affected_parties,
+        ),
         "identity_commitments": (
             {"value": "non_maleficence", "weight": 1.0},
             {"value": "identity_coherence", "weight": 0.8},
@@ -136,10 +163,14 @@ def _deliberate_life_action(
         IdentityCoreService(get_mem_dir()), journal=add_episode
     ).build(action, supplied)
     decision = MoralDecisionEngine(journal=add_episode).evaluate(
-        action, context.consequences, context.affected_parties,
-        context.identity_commitments, context.uncertainty,
+        action,
+        context.consequences,
+        context.affected_parties,
+        context.identity_commitments,
+        context.uncertainty,
     )
     return decision
+
 
 _DEFAULT_RUN_LOGGER = RunLogger
 
@@ -208,7 +239,9 @@ def _graine_allowed_operator_names(
     """
 
     try:
-        proposals = propose_mutations(_graine_zones_for_skill(skill_path, operator_names))
+        proposals = propose_mutations(
+            _graine_zones_for_skill(skill_path, operator_names)
+        )
     except Exception as exc:  # pragma: no cover - defensive integration boundary
         log.warning("graine proposal generation failed for %s: %s", skill_path, exc)
         return set()
@@ -499,7 +532,13 @@ def _coverage_gap_spec_signals(signals: Mapping[str, object]) -> dict[str, objec
             spec[key] = signals[key]
     coverage_spec = signals.get("coverage_gap_spec")
     if isinstance(coverage_spec, Mapping):
-        for key in ("examples", "success_criteria", "signature", "cooldown", "expected_impact"):
+        for key in (
+            "examples",
+            "success_criteria",
+            "signature",
+            "cooldown",
+            "expected_impact",
+        ):
             if key in coverage_spec:
                 spec[key] = coverage_spec[key]
     return spec
@@ -635,7 +674,6 @@ def log_mutation(
         mutation_error_message=mutation_error_message,
         fitness=fitness_payload,
     )
-
 
 
 def _ast_node_count(tree: ast.AST) -> int:
@@ -781,7 +819,10 @@ def _should_count_skill_quarantine_failure(
 ) -> bool:
     """Count only deterministic source failures observed in a healthy sandbox."""
 
-    if base_result.is_infrastructure_failure or mutated_result.is_infrastructure_failure:
+    if (
+        base_result.is_infrastructure_failure
+        or mutated_result.is_infrastructure_failure
+    ):
         return False
     return (not base_result.ok) and _sandbox_failure_classification(base_result) in {
         "invalid_candidate",
@@ -830,7 +871,10 @@ def _choose_skill(
             + targeted_mutation
         )
 
-    weighted = [(org_name, skill_path, max(0.01, priority(org_name, skill_path))) for org_name, skill_path in candidates]
+    weighted = [
+        (org_name, skill_path, max(0.01, priority(org_name, skill_path)))
+        for org_name, skill_path in candidates
+    ]
     total = sum(weight for _, _, weight in weighted)
     pick = rng.random() * total
     cumulative = 0.0
@@ -921,7 +965,11 @@ def run(
     """
 
     rng = rng or random.Random()
-    life_root = Path(life_home) if life_home is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    life_root = (
+        Path(life_home)
+        if life_home is not None
+        else Path(os.environ.get("SINGULAR_HOME", "."))
+    )
     state = load_checkpoint(checkpoint_path)
     state.health_history = _retain_health_history(state.health_history)
 
@@ -950,7 +998,9 @@ def run(
         if org_name not in world.organisms:
             prototype = mortality or DeathMonitor()
             archetype = list(ARCHETYPES)[len(world.organisms) % len(ARCHETYPES)]
-            world.organisms[org_name] = Organism(skills_dir, monitor=prototype, archetype=archetype)
+            world.organisms[org_name] = Organism(
+                skills_dir, monitor=prototype, archetype=archetype
+            )
 
     operators = operators or _load_default_operators()
     stats: Dict[str, Dict[str, float]] = state.stats
@@ -963,7 +1013,9 @@ def run(
     resource_manager = resource_manager or ResourceManager()
     event_bus = event_bus or get_global_event_bus()
     value_weights = load_value_weights()
-    governance_policy = governance_policy or MutationGovernancePolicy(value_weights=value_weights)
+    governance_policy = governance_policy or MutationGovernancePolicy(
+        value_weights=value_weights
+    )
     social_graph = social_graph or SocialGraph()
     if multiagent_runtime is not None and multiagent_runtime.social_graph is None:
         # The runtime and resource paths must contribute to the same durable
@@ -989,9 +1041,7 @@ def run(
     sleep_ticks_remaining = 0
     intrinsic_goals = IntrinsicGoals(value_weights=value_weights)
     lifecycle_fitness_config = load_lifecycle_fitness_config()
-    self_observation = SelfObservationService(
-        life_root / "mem" / "self_model.json"
-    )
+    self_observation = SelfObservationService(life_root / "mem" / "self_model.json")
     coevolution_flow: CoevolutionFlow | None = None
     if coevolve_tests:
         if test_pool is None:
@@ -1013,7 +1063,9 @@ def run(
         code_hash = hashlib.sha256(code.encode("utf-8")).hexdigest()
         cached = score_cache.get(code_hash)
         if current_tick_profiler is not None:
-            current_tick_profiler.record_cache("sandbox_scoring", hit=cached is not None)
+            current_tick_profiler.record_cache(
+                "sandbox_scoring", hit=cached is not None
+            )
         if cached is not None:
             return cached
         if current_tick_profiler is None:
@@ -1043,8 +1095,12 @@ def run(
         logger_kwargs["root"] = life_root / "runs"
     with RunLogger(run_id, **logger_kwargs) as logger:
         health_tracker = HealthTracker.from_state(state.health_counters)
-        viability_detector = ViabilityDriftDetector.from_state(state.viability_governance)
-        healthy_checkpoint_path = checkpoint_path.with_suffix(checkpoint_path.suffix + ".healthy")
+        viability_detector = ViabilityDriftDetector.from_state(
+            state.viability_governance
+        )
+        healthy_checkpoint_path = checkpoint_path.with_suffix(
+            checkpoint_path.suffix + ".healthy"
+        )
         delayed: list[tuple[float, str, Path]] = []
         tick_count = 0
 
@@ -1065,7 +1121,9 @@ def run(
             state.iteration += 1
             # Learning is metered separately and remains inactive until every
             # sandbox, baseline, governance, and publication gate has passed.
-            if imitation_engine is not None and learning_attempts < max(0, learning_budget):
+            if imitation_engine is not None and learning_attempts < max(
+                0, learning_budget
+            ):
                 imitation_engine.learn_next()
                 learning_attempts += 1
             if getattr(psyche, "sleeping", False) or (
@@ -1091,16 +1149,20 @@ def run(
             # all later levels remain mutation-free until hysteretic recovery.
             if viability_detector.action == "throttled" and state.iteration % 2:
                 logger.log_interaction(
-                    "mutation_paused", iteration=state.iteration,
-                    reason="viability_throttled", governance=viability_detector.diagnostics(),
+                    "mutation_paused",
+                    iteration=state.iteration,
+                    reason="viability_throttled",
+                    governance=viability_detector.diagnostics(),
                 )
                 _persist_consumed_tick()
                 continue
             if viability_detector.action in {"paused", "restored", "operator"}:
                 logger.log_interaction(
-                    "mutation_paused", iteration=state.iteration,
+                    "mutation_paused",
+                    iteration=state.iteration,
                     reason=f"viability_{viability_detector.action}",
-                    operator_intervention_required=viability_detector.action == "operator",
+                    operator_intervention_required=viability_detector.action
+                    == "operator",
                     governance=viability_detector.diagnostics(),
                 )
                 _persist_consumed_tick()
@@ -1209,8 +1271,12 @@ def run(
                     organism=org_name,
                     skill=selected_skill_key,
                     reasons=multiagent_decision.reasons,
-                    inbound=[message.to_dict() for message in multiagent_decision.inbound],
-                    emitted=[message.to_dict() for message in multiagent_decision.emitted],
+                    inbound=[
+                        message.to_dict() for message in multiagent_decision.inbound
+                    ],
+                    emitted=[
+                        message.to_dict() for message in multiagent_decision.emitted
+                    ],
                     mutation_allowed=multiagent_decision.mutation_allowed,
                     action_allowed=multiagent_decision.action_allowed,
                     reproduction_allowed=multiagent_decision.reproduction_allowed,
@@ -1244,12 +1310,18 @@ def run(
                 if not multiagent_decision.mutation_allowed:
                     _persist_consumed_tick()
                     continue
-            for penalty in persistent_world_state.consume_due_penalties(state.iteration):
+            for penalty in persistent_world_state.consume_due_penalties(
+                state.iteration
+            ):
                 selected_org.energy += penalty.energy_delta
                 persistent_world_state.mortality_pressure = max(
-                    0.0, persistent_world_state.mortality_pressure + penalty.mortality_delta
+                    0.0,
+                    persistent_world_state.mortality_pressure + penalty.mortality_delta,
                 )
-            if selected_org.degraded_mode and state.iteration % DEGRADED_MUTATION_INTERVAL != 0:
+            if (
+                selected_org.degraded_mode
+                and state.iteration % DEGRADED_MUTATION_INTERVAL != 0
+            ):
                 logger.log_interaction(
                     "degraded_mode_throttle",
                     organism=org_name,
@@ -1260,9 +1332,11 @@ def run(
                 _persist_consumed_tick()
                 continue
 
-            trigger_genesis, trigger_name, trigger_snapshot = _should_trigger_skill_genesis(
-                signals=signals,
-                health_counters=state.health_counters,
+            trigger_genesis, trigger_name, trigger_snapshot = (
+                _should_trigger_skill_genesis(
+                    signals=signals,
+                    health_counters=state.health_counters,
+                )
             )
             if trigger_genesis and not selected_org.degraded_mode:
                 mem_dir = life_root / "mem"
@@ -1305,8 +1379,10 @@ def run(
                 _persist_consumed_tick()
                 continue
             if decision is Psyche.Decision.DELAY:
-                delay_until = time.time() + 0.01 + (
-                    DEGRADED_DELAY_SECONDS if selected_org.degraded_mode else 0.0
+                delay_until = (
+                    time.time()
+                    + 0.01
+                    + (DEGRADED_DELAY_SECONDS if selected_org.degraded_mode else 0.0)
                 )
                 heapq.heappush(delayed, (delay_until, org_name, skill_path))
                 logger.log_delay(skill_path.name, delay_until)
@@ -1322,8 +1398,14 @@ def run(
                         tofile="mutated",
                     )
                 )
-                governance_root = skill_path.parent.parent if skill_path.parent.name == "skills" else skill_path.parent
-                decision = governance_policy.enforce_write(skill_path, mutated, root=governance_root)
+                governance_root = (
+                    skill_path.parent.parent
+                    if skill_path.parent.name == "skills"
+                    else skill_path.parent
+                )
+                decision = governance_policy.enforce_write(
+                    skill_path, mutated, root=governance_root
+                )
                 if not decision.allowed:
                     logger.log_interaction(
                         "governance_violation",
@@ -1388,10 +1470,9 @@ def run(
                     "recalled_memories": recalled_memories,
                 },
             )
-            baseline_failure_risk = (
-                float(state.health_counters.get("sandbox_failures", 0))
-                / max(float(state.health_counters.get("total", 0)), 1.0)
-            )
+            baseline_failure_risk = float(
+                state.health_counters.get("sandbox_failures", 0)
+            ) / max(float(state.health_counters.get("total", 0)), 1.0)
             graine_allowed_operators = _graine_allowed_operator_names(
                 skill_path, operators.keys()
             )
@@ -1404,7 +1485,9 @@ def run(
                 if graine_allowed_operators
                 else operators
             )
-            max_count = max((stats[name]["count"] for name in eligible_operators), default=0.0)
+            max_count = max(
+                (stats[name]["count"] for name in eligible_operators), default=0.0
+            )
             candidate_names = list(eligible_operators.keys())
             rng.shuffle(candidate_names)
             candidate_names = candidate_names[: max(1, min(5, len(candidate_names)))]
@@ -1428,7 +1511,9 @@ def run(
                         resource_cost=resource_cost,
                     )
                 )
-            adjusted_hypotheses = intrinsic_goals.influence_action_hypotheses(hypotheses)
+            adjusted_hypotheses = intrinsic_goals.influence_action_hypotheses(
+                hypotheses
+            )
             weighted_hypotheses = [
                 ActionHypothesis(
                     action=entry["action"],
@@ -1448,31 +1533,38 @@ def run(
                 bus=event_bus,
                 event_context={"iteration": state.iteration, "organism": org_name},
                 long_term_weight=(
-                    goal_weights.coherence
-                    + (psyche_axes.get("long_term", 0.0) * 0.4)
+                    goal_weights.coherence + (psyche_axes.get("long_term", 0.0) * 0.4)
                 ),
                 sandbox_weight=(
-                    goal_weights.robustesse
-                    + (psyche_axes.get("sandbox", 0.0) * 0.4)
+                    goal_weights.robustesse + (psyche_axes.get("sandbox", 0.0) * 0.4)
                 ),
                 resource_weight=(
-                    goal_weights.efficacite
-                    + (psyche_axes.get("resource", 0.0) * 0.4)
+                    goal_weights.efficacite + (psyche_axes.get("resource", 0.0) * 0.4)
                 ),
                 metacognition=self_observation.decision_context("mutation"),
             )
-            score_by_index = {index: score for index, _, score in reflection.alternative_scores}
-            belief_bias = belief_store.operator_preference_bias(eligible_operators.keys())
+            score_by_index = {
+                index: score for index, _, score in reflection.alternative_scores
+            }
+            belief_bias = belief_store.operator_preference_bias(
+                eligible_operators.keys()
+            )
             combined_bias = intrinsic_goals.influence_operator_scores(
                 stats,
                 skill_reputation=logger.skill_reputation(),
                 planner_narrative_signals=planner_narrative_signals,
             )
-            psyche_bias = getattr(psyche, "operator_bias", lambda names: {})(list(eligible_operators.keys()))
+            psyche_bias = getattr(psyche, "operator_bias", lambda names: {})(
+                list(eligible_operators.keys())
+            )
             for operator_name, extra_bias in belief_bias.items():
-                combined_bias[operator_name] = combined_bias.get(operator_name, 0.0) + extra_bias
+                combined_bias[operator_name] = (
+                    combined_bias.get(operator_name, 0.0) + extra_bias
+                )
             for operator_name, extra_bias in psyche_bias.items():
-                combined_bias[operator_name] = combined_bias.get(operator_name, 0.0) + extra_bias
+                combined_bias[operator_name] = (
+                    combined_bias.get(operator_name, 0.0) + extra_bias
+                )
             reputation_bonus = world.reputation.get(org_name) * 0.01
             for operator_name in combined_bias:
                 combined_bias[operator_name] += reputation_bonus
@@ -1481,15 +1573,12 @@ def run(
             if mood_label is None and getattr(psyche, "last_mood", None) is not None:
                 mood_label = str(getattr(psyche, "last_mood"))
             predicted_failure = (
-                "hot"
-                if temp >= 30.0
-                else "cold"
-                if temp <= 5.0
-                else "stable"
+                "hot" if temp >= 30.0 else "cold" if temp <= 5.0 else "stable"
             )
             contextual_vital_state = (
-                "terminal" if baseline_failure_risk >= 0.7 else "fragile"
-                if baseline_failure_risk >= 0.35 else "stable"
+                "terminal"
+                if baseline_failure_risk >= 0.7
+                else "fragile" if baseline_failure_risk >= 0.35 else "stable"
             )
             contextual_objective_weights = asdict(goal_weights)
             contextual_objective = max(
@@ -1528,7 +1617,7 @@ def run(
                 and meta_recommendation.confidence >= 0.55
                 and meta_recommendation.sample_count >= 3
                 and meta_recommendation.regression_risk
-                    <= max(0.05, 1.0 - baseline_failure_risk)
+                <= max(0.05, 1.0 - baseline_failure_risk)
                 and meta_recommendation.operator in eligible_operators
             ):
                 op_name = select_operator(
@@ -1542,7 +1631,9 @@ def run(
                 )
             else:
                 reflected_action = (
-                    reflection.action if reflection.action in eligible_operators else None
+                    reflection.action
+                    if reflection.action in eligible_operators
+                    else None
                 )
                 op_name = reflected_action or select_operator(
                     eligible_operators,
@@ -1644,26 +1735,42 @@ def run(
             pre_mutation_snapshot = {
                 "functional_gain": 0.0,
                 "health": _clamp01(previous_health_score),
-                "vital_risk": _clamp01(selected_org.sandbox_violation_streak / SANDBOX_EXTINCTION_THRESHOLD),
+                "vital_risk": _clamp01(
+                    selected_org.sandbox_violation_streak / SANDBOX_EXTINCTION_THRESHOLD
+                ),
                 "resources": _clamp01(float(selected_org.resources)),
-                "sandbox_stability": 1.0 if selected_org.sandbox_violation_streak == 0 else 0.0,
+                "sandbox_stability": (
+                    1.0 if selected_org.sandbox_violation_streak == 0 else 0.0
+                ),
                 "cost": _clamp01(ms_base / 1000.0),
                 "quest_progress": 0.0,
-                "identity_continuity": 1.0 - _clamp01(float(getattr(psyche, "identity_wounds", 0.0))),
+                "identity_continuity": 1.0
+                - _clamp01(float(getattr(psyche, "identity_wounds", 0.0))),
                 "useful_skills_retention": 1.0,
             }
             technical_gain = (
                 (base_score - mutated_score) / max(abs(base_score), 1.0)
-                if scores_comparable else -1.0
+                if scores_comparable
+                else -1.0
             )
             post_mutation_snapshot = dict(pre_mutation_snapshot)
             post_mutation_snapshot.update(
                 functional_gain=technical_gain,
-                vital_risk=_clamp01(pre_mutation_snapshot["vital_risk"] + (1.0 if mutation_failed else 0.0)),
-                sandbox_stability=0.0 if mutation_failed else pre_mutation_snapshot["sandbox_stability"],
+                vital_risk=_clamp01(
+                    pre_mutation_snapshot["vital_risk"]
+                    + (1.0 if mutation_failed else 0.0)
+                ),
+                sandbox_stability=(
+                    0.0
+                    if mutation_failed
+                    else pre_mutation_snapshot["sandbox_stability"]
+                ),
                 cost=_clamp01(ms_new / 1000.0),
-                identity_continuity=1.0 - _clamp01(float(getattr(psyche, "identity_wounds", 0.0))),
-                useful_skills_retention=min(1.0, len(list(selected_org.skills_dir.glob("*.py"))) / skill_count),
+                identity_continuity=1.0
+                - _clamp01(float(getattr(psyche, "identity_wounds", 0.0))),
+                useful_skills_retention=min(
+                    1.0, len(list(selected_org.skills_dir.glob("*.py"))) / skill_count
+                ),
             )
             fitness_decision = evaluate_mutation_fitness(
                 pre_mutation_snapshot,
@@ -1705,19 +1812,29 @@ def run(
             if mutation_failed:
                 if hasattr(psyche, "feel"):
                     psyche.feel(Mood.PAIN)
-            elif scores_comparable and mutated_comparable_score <= base_comparable_score:
+            elif (
+                scores_comparable and mutated_comparable_score <= base_comparable_score
+            ):
                 if hasattr(psyche, "feel"):
                     psyche.feel(Mood.PLEASURE)
 
             identity_violations: list[str] = []
             commitments = getattr(psyche, "identity_commitments", {})
-            red_lines = commitments.get("red_lines", []) if isinstance(commitments, Mapping) else []
+            red_lines = (
+                commitments.get("red_lines", [])
+                if isinstance(commitments, Mapping)
+                else []
+            )
             for red_line in red_lines:
                 token = str(red_line).strip().lower()
                 if token and token in f"{op_name} {reflection.decision_reason}".lower():
                     identity_violations.append(token)
             if identity_violations:
-                psyche.identity_wounds = min(1.0, float(getattr(psyche, "identity_wounds", 0.0)) + 0.15 * len(identity_violations))
+                psyche.identity_wounds = min(
+                    1.0,
+                    float(getattr(psyche, "identity_wounds", 0.0))
+                    + 0.15 * len(identity_violations),
+                )
 
             _write_json(
                 Path("mem") / "decision_signal_audit.json",
@@ -1774,11 +1891,12 @@ def run(
                 "corrective_action": None,
             }
             if coevolution_flow is not None and not selected_org.degraded_mode:
-                can_run_coevo, coevo_state = resource_manager.apply_capability_cost("test_coevolution")
+                can_run_coevo, coevo_state = resource_manager.apply_capability_cost(
+                    "test_coevolution"
+                )
                 if not can_run_coevo:
                     candidate_accepted = (
-                        candidate_accepted
-                        and coevo_state != CapabilityStatus.UNSTABLE
+                        candidate_accepted and coevo_state != CapabilityStatus.UNSTABLE
                     )
                     logger.log_test_coevolution(
                         skill=skill_path.stem,
@@ -1981,7 +2099,9 @@ def run(
                     "summary": recalled_memory_summary,
                 }
                 add_episode({"event": "memory.used_for_decision", **used_event})
-                logger.log_interaction("memory.used_for_decision", **used_event, alive=True)
+                logger.log_interaction(
+                    "memory.used_for_decision", **used_event, alive=True
+                )
 
             objective_weights = asdict(goal_weights)
             dominant_objective = max(
@@ -2024,7 +2144,9 @@ def run(
             reward_delta = base_score - mutated_score
             if math.isfinite(reward_delta):
                 stats[op_name]["reward"] += reward_delta
-            fitness_reward = fitness_decision.fitness_after - fitness_decision.fitness_before
+            fitness_reward = (
+                fitness_decision.fitness_after - fitness_decision.fitness_before
+            )
             if math.isfinite(fitness_reward):
                 stats[op_name]["fitness_reward"] += fitness_reward
             belief_store.update_after_run(
@@ -2092,7 +2214,9 @@ def run(
             cooperation_partners: list[str] = []
             other_names = [name for name in world.organisms if name != org_name]
             arbitration_seed = int(
-                hashlib.sha1(f"{state.iteration}:{org_name}".encode("utf-8")).hexdigest()[:8],
+                hashlib.sha1(
+                    f"{state.iteration}:{org_name}".encode("utf-8")
+                ).hexdigest()[:8],
                 16,
             )
             arbitration_rng = random.Random(arbitration_seed)
@@ -2103,7 +2227,9 @@ def run(
                 decision.peer: decision for decision in social_decisions
             }
             help_candidates = [
-                decision.peer for decision in social_decisions if decision.action == "help"
+                decision.peer
+                for decision in social_decisions
+                if decision.action == "help"
             ]
             if help_candidates and arbitration_rng.random() < max(
                 ecosystem_rules.cooperation_probability, 0.0
@@ -2118,7 +2244,9 @@ def run(
                     if decision.action == "neutral"
                 ]
                 if neutral_candidates:
-                    cooperation_partners.append(arbitration_rng.choice(neutral_candidates))
+                    cooperation_partners.append(
+                        arbitration_rng.choice(neutral_candidates)
+                    )
             competitor_intents: list[CompetitorIntent] = []
             for other_name in other_names:
                 social_decision = social_decision_by_peer.get(other_name)
@@ -2132,16 +2260,19 @@ def run(
                     and social_decision.action == "compete"
                     else 0
                 )
-                other_priority = int(
-                    max(world.reputation.get(other_name), 0.0) * 10
-                ) + arbitration_rng.randint(0, 2) + rivalry_boost
+                other_priority = (
+                    int(max(world.reputation.get(other_name), 0.0) * 10)
+                    + arbitration_rng.randint(0, 2)
+                    + rivalry_boost
+                )
                 competitor_intents.append(
                     CompetitorIntent(
                         life_id=other_name,
                         priority=other_priority,
                         bid=arbitration_rng.uniform(
                             0.0, ecosystem_rules.competition_bid_ceiling
-                        ) + float(rivalry_boost),
+                        )
+                        + float(rivalry_boost),
                     )
                 )
             action_resolution = world.world_resources.consume_for_action(
@@ -2151,7 +2282,9 @@ def run(
                 attention_cost=1.0 if accepted else 1.2,
                 cooperation_partners=cooperation_partners,
                 priority=int(max(world.reputation.get(org_name), 0.0) * 10),
-                bid=arbitration_rng.uniform(0.0, ecosystem_rules.competition_bid_ceiling),
+                bid=arbitration_rng.uniform(
+                    0.0, ecosystem_rules.competition_bid_ceiling
+                ),
                 competitor_intents=competitor_intents,
             )
             if action_resolution.granted:
@@ -2178,7 +2311,9 @@ def run(
             else:
                 org.resources = max(
                     0.0,
-                    org.resources - (competition_unit * 0.2) - action_resolution.rivalry_penalty,
+                    org.resources
+                    - (competition_unit * 0.2)
+                    - action_resolution.rivalry_penalty,
                 )
 
             social_relation_updates: list[dict[str, object]] = []
@@ -2199,7 +2334,11 @@ def run(
                     interaction = social_graph.record_interaction(
                         org_name,
                         partner,
-                        "successful_cooperation" if action_resolution.granted else "cooperation_failure",
+                        (
+                            "successful_cooperation"
+                            if action_resolution.granted
+                            else "cooperation_failure"
+                        ),
                         evidence_kind="verified_outcome",
                         outcome=action_resolution.granted,
                         intention="cooperate",
@@ -2257,7 +2396,9 @@ def run(
                     )
                 )
 
-            fallback_action_name = "simulated_world_task" if accepted else "structured_user_interaction"
+            fallback_action_name = (
+                "simulated_world_task" if accepted else "structured_user_interaction"
+            )
             if action_resolution.granted:
                 fallback_action_name = "resource_management"
             psyche_decision = choose_action_from_psyche(
@@ -2265,7 +2406,9 @@ def run(
                 {
                     "risk": persistent_world_state.risks,
                     "rarity_pressure": persistent_world_state.rarity,
-                    "competition_pressure": getattr(persistent_world_state, "competition", 0.5),
+                    "competition_pressure": getattr(
+                        persistent_world_state, "competition", 0.5
+                    ),
                     "opportunity": persistent_world_state.opportunities,
                     "resource_energy": resource_manager.energy,
                     "success_bias": 0.2 if accepted else -0.2,
@@ -2305,7 +2448,9 @@ def run(
                         "vulnerability": min(
                             1.0,
                             persistent_world_state.risks
-                            + (0.25 if decision.action in {"avoid", "compete"} else 0.0),
+                            + (
+                                0.25 if decision.action in {"avoid", "compete"} else 0.0
+                            ),
                         ),
                         "consent": True if decision.action == "help" else None,
                     }
@@ -2343,7 +2488,9 @@ def run(
                 {
                     "risk": persistent_world_state.risks,
                     "rarity_pressure": persistent_world_state.rarity,
-                    "competition_pressure": getattr(persistent_world_state, "competition", 0.5),
+                    "competition_pressure": getattr(
+                        persistent_world_state, "competition", 0.5
+                    ),
                     "success_bias": 0.2 if accepted else -0.2,
                     "psyche_decision_reason": psyche_decision.reason,
                 },
@@ -2351,7 +2498,8 @@ def run(
             selected_org.energy += effect_result.energy_delta
             persistent_world_state.mortality_pressure = max(
                 0.0,
-                persistent_world_state.mortality_pressure + effect_result.mortality_delta,
+                persistent_world_state.mortality_pressure
+                + effect_result.mortality_delta,
             )
             persistent_world_state.apply_world_delta(effect_result.world_delta)
             persistent_world_state.schedule_penalties(
@@ -2359,7 +2507,9 @@ def run(
             )
 
             for other in world.organisms.values():
-                other.energy = max(0.1, other.energy - ecosystem_rules.passive_energy_decay)
+                other.energy = max(
+                    0.1, other.energy - ecosystem_rules.passive_energy_decay
+                )
                 other.resources = max(
                     0.1,
                     other.resources - ecosystem_rules.passive_resource_decay,
@@ -2372,12 +2522,22 @@ def run(
             if state.iteration > 0 and state.iteration % 40 == 0:
                 shock_rng = random.Random(state.iteration)
                 global_event = draw_global_event(shock_rng)
-                pre_event = {name: (o.energy, o.resources) for name, o in world.organisms.items()}
+                pre_event = {
+                    name: (o.energy, o.resources) for name, o in world.organisms.items()
+                }
                 for entity in world.organisms.values():
-                    entity.energy = max(0.1, entity.energy - (global_event.intensity * 0.4))
-                    entity.resources = max(0.1, entity.resources - (global_event.intensity * 0.5))
-                post_event = {name: (o.energy, o.resources) for name, o in world.organisms.items()}
-                reorg = compute_population_metrics(pre_event, post_event, global_event.duration_ticks)
+                    entity.energy = max(
+                        0.1, entity.energy - (global_event.intensity * 0.4)
+                    )
+                    entity.resources = max(
+                        0.1, entity.resources - (global_event.intensity * 0.5)
+                    )
+                post_event = {
+                    name: (o.energy, o.resources) for name, o in world.organisms.items()
+                }
+                reorg = compute_population_metrics(
+                    pre_event, post_event, global_event.duration_ticks
+                )
                 event_bus.publish(
                     "ecosystem.global_event",
                     {
@@ -2428,8 +2588,12 @@ def run(
                 "sandbox_violation_category": sandbox_violation_category,
                 "sandbox_violation_severity": sandbox_violation_severity,
                 "sandbox_violation_global_recorded": record_global_sandbox_violation,
-                "sandbox_incident_scope": sandbox_incident.scope if sandbox_incident else None,
-                "sandbox_recovery_policy": sandbox_incident.recovery if sandbox_incident else None,
+                "sandbox_incident_scope": (
+                    sandbox_incident.scope if sandbox_incident else None
+                ),
+                "sandbox_recovery_policy": (
+                    sandbox_incident.recovery if sandbox_incident else None
+                ),
                 "dangerous_mutation_pattern": (
                     mutation_failed
                     and not base_failed
@@ -2472,10 +2636,7 @@ def run(
                     _sandbox_failure_classification(mutated_score_result)
                 )
                 logger.log_interaction("sandbox_violation", **sandbox_diagnostic)
-                quarantine_triggered = (
-                    skill_quarantine_failure
-                    and base_failed
-                )
+                quarantine_triggered = skill_quarantine_failure and base_failed
                 if quarantine_triggered:
                     reason = "consecutive_sandbox_failures"
                     skills_after_disable = temporarily_disable_skill(
@@ -2520,7 +2681,8 @@ def run(
                             sandbox_diagnostic
                         )
                         logger.log_event(
-                            "governance.security_circuit_breaker_opened", **breaker_payload
+                            "governance.security_circuit_breaker_opened",
+                            **breaker_payload,
                         )
                         logger.log_event(
                             "governance.circuit_breaker_opened", **breaker_payload
@@ -2591,7 +2753,9 @@ def run(
                 "useful_skills": post_mutation_snapshot["useful_skills_retention"],
                 "fitness": _clamp01((fitness_decision.fitness_after + 1.0) / 2.0),
             }
-            viability_action, viability_transition = viability_detector.observe(viability_metrics)
+            viability_action, viability_transition = viability_detector.observe(
+                viability_metrics
+            )
             state.viability_governance = viability_detector.to_state()
             viability_payload = {
                 "iteration": state.iteration,
@@ -2602,21 +2766,41 @@ def run(
                 "sandbox_violation_streak": org.sandbox_violation_streak,
             }
             if viability_transition == "drift":
-                logger.log_interaction("governance.viability_drift_detected", **viability_payload)
-                event_bus.publish("governance.viability_drift_detected", viability_payload, payload_version=1)
+                logger.log_interaction(
+                    "governance.viability_drift_detected", **viability_payload
+                )
+                event_bus.publish(
+                    "governance.viability_drift_detected",
+                    viability_payload,
+                    payload_version=1,
+                )
                 if viability_action == "paused":
-                    logger.log_interaction("mutation_paused", reason="viability_drift", **viability_payload)
+                    logger.log_interaction(
+                        "mutation_paused", reason="viability_drift", **viability_payload
+                    )
                 elif viability_action == "restored":
                     healthy = load_checkpoint(healthy_checkpoint_path)
                     if healthy_checkpoint_path.exists():
                         state.stats = healthy.stats
                         state.health_history = healthy.health_history
                         state.health_counters = healthy.health_counters
-                    logger.log_interaction("checkpoint.restored", checkpoint=str(healthy_checkpoint_path), **viability_payload)
-                    event_bus.publish("checkpoint.restored", viability_payload, payload_version=1)
+                    logger.log_interaction(
+                        "checkpoint.restored",
+                        checkpoint=str(healthy_checkpoint_path),
+                        **viability_payload,
+                    )
+                    event_bus.publish(
+                        "checkpoint.restored", viability_payload, payload_version=1
+                    )
             elif viability_transition == "recovered":
-                logger.log_interaction("governance.viability_recovered", **viability_payload)
-                event_bus.publish("governance.viability_recovered", viability_payload, payload_version=1)
+                logger.log_interaction(
+                    "governance.viability_recovered", **viability_payload
+                )
+                event_bus.publish(
+                    "governance.viability_recovered",
+                    viability_payload,
+                    payload_version=1,
+                )
             if viability_action == "normal":
                 save_checkpoint(healthy_checkpoint_path, state)
 
@@ -2663,38 +2847,38 @@ def run(
             }
             gain_loss = round(base_score - mutated_score, 6)
             causal_payload = {
-                    "ts": datetime.now(timezone.utc).isoformat(),
-                    "trace_id": hashlib.sha1(
-                        f"{logger.run_id}:{state.iteration}:{key}:{op_name}".encode("utf-8")
-                    ).hexdigest(),
-                    "life": org_name,
-                    "run_id": logger.run_id,
-                    "iteration": state.iteration,
-                    "pipeline": "life.loop",
-                    "input": {
-                        "kind": "world_event",
-                        "temperature_c": temp,
-                        "perception_signals": signals,
-                    },
-                    "decision": {
-                        "reason": reflection.decision_reason,
-                        "operator": op_name,
-                        "accepted": accepted,
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "trace_id": hashlib.sha1(
+                    f"{logger.run_id}:{state.iteration}:{key}:{op_name}".encode("utf-8")
+                ).hexdigest(),
+                "life": org_name,
+                "run_id": logger.run_id,
+                "iteration": state.iteration,
+                "pipeline": "life.loop",
+                "input": {
+                    "kind": "world_event",
+                    "temperature_c": temp,
+                    "perception_signals": signals,
+                },
+                "decision": {
+                    "reason": reflection.decision_reason,
+                    "operator": op_name,
+                    "accepted": accepted,
+                    "objective": dominant_objective,
+                },
+                "action": {
+                    "kind": "mutation",
+                    "skill": key,
+                    "impacted_file": skill_path.name,
+                },
+                "result": {
+                    "gain_loss": gain_loss,
+                    "objective_impact": {
                         "objective": dominant_objective,
+                        "impact": gain_loss,
                     },
-                    "action": {
-                        "kind": "mutation",
-                        "skill": key,
-                        "impacted_file": skill_path.name,
-                    },
-                    "result": {
-                        "gain_loss": gain_loss,
-                        "objective_impact": {
-                            "objective": dominant_objective,
-                            "impact": gain_loss,
-                        },
-                    },
-                }
+                },
+            }
             add_causal_trace(causal_payload)
             self_observation.observe_trace(
                 causal_payload, evidence_ref=causal_payload["trace_id"]
@@ -2778,7 +2962,9 @@ def run(
                     else None
                 ),
                 cache_candidates=list(phase_summary.get("cache_candidates", [])),
-                async_distribution_note=str(phase_summary.get("async_distribution_note", "")),
+                async_distribution_note=str(
+                    phase_summary.get("async_distribution_note", "")
+                ),
             )
 
             # DeathMonitor convention: ``action_succeeded=True`` means the
@@ -2788,7 +2974,8 @@ def run(
                 psyche,
                 action_succeeded=accepted,
                 resources=max(0.0, org.resources - persistent_world_state.rarity),
-                homeostasis_viable=resource_manager.viability_state() == CapabilityStatus.VIABLE,
+                homeostasis_viable=resource_manager.viability_state()
+                == CapabilityStatus.VIABLE,
             )
             if persistent_world_state.mortality_pressure > 0.35:
                 dead = True
@@ -2856,7 +3043,9 @@ def run(
                         "iteration": state.iteration,
                         "autopsy_path": str(autopsy_path),
                         "biography_path": str(biography_path),
-                        "orchestrator_stop_path": str(mem_dir / "orchestrator.stop.json"),
+                        "orchestrator_stop_path": str(
+                            mem_dir / "orchestrator.stop.json"
+                        ),
                     },
                     payload_version=1,
                 )
@@ -2912,8 +3101,14 @@ def run(
                 child_skills_dir = child_dir / "skills"
                 child_skills_dir.mkdir(parents=True, exist_ok=True)
                 target = child_skills_dir / "candidate_hybrid.py"
-                root = target.parent.parent if target.parent.name == "skills" else target.parent
-                simulated_governance = governance_policy.simulate_write(target, root=root)
+                root = (
+                    target.parent.parent
+                    if target.parent.name == "skills"
+                    else target.parent
+                )
+                simulated_governance = governance_policy.simulate_write(
+                    target, root=root
+                )
                 reproduction_gate = None
                 if multiagent_runtime is not None:
                     reproduction_gate = multiagent_runtime.gate_reproduction(
@@ -2926,7 +3121,9 @@ def run(
                         "multiagent.reproduction_gate",
                         parents=parent_names,
                         reasons=reproduction_gate.reasons,
-                        emitted=[message.to_dict() for message in reproduction_gate.emitted],
+                        emitted=[
+                            message.to_dict() for message in reproduction_gate.emitted
+                        ],
                         reproduction_allowed=reproduction_gate.reproduction_allowed,
                         alive=True,
                     )
@@ -2935,23 +3132,33 @@ def run(
                     parent_b=parent_names[1],
                     parent_a_skills=pa,
                     parent_b_skills=pb,
-                    parent_a_health=min(1.0, world.organisms[parent_names[0]].energy / 5.0),
-                    parent_b_health=min(1.0, world.organisms[parent_names[1]].energy / 5.0),
+                    parent_a_health=min(
+                        1.0, world.organisms[parent_names[0]].energy / 5.0
+                    ),
+                    parent_b_health=min(
+                        1.0, world.organisms[parent_names[1]].energy / 5.0
+                    ),
                     governance_allowed=simulated_governance.allowed,
                     policy=ecosystem_rules.reproduction_policy,
                 )
-                if reproduction_gate is not None and not reproduction_gate.reproduction_allowed:
+                if (
+                    reproduction_gate is not None
+                    and not reproduction_gate.reproduction_allowed
+                ):
                     decision = decision.__class__(
                         accepted=False,
                         score=decision.score,
-                        reasons=["multiagent_gate"] + reproduction_gate.reasons + decision.reasons,
+                        reasons=["multiagent_gate"]
+                        + reproduction_gate.reasons
+                        + decision.reasons,
                         components=decision.components,
                     )
                 if cooldown_remaining > 0:
                     decision = decision.__class__(
                         accepted=False,
                         score=decision.score,
-                        reasons=[f"cooldown_active:{cooldown_remaining}"] + decision.reasons,
+                        reasons=[f"cooldown_active:{cooldown_remaining}"]
+                        + decision.reasons,
                         components=decision.components,
                     )
                 logger.log_interaction(

--- a/src/singular/life/metabolism/rewards.py
+++ b/src/singular/life/metabolism/rewards.py
@@ -13,15 +13,21 @@ class RewardContribution:
     meta_objective_penalty: float = 0.0
 
 
-def apply_rewards(resource_manager: ResourceManager, contribution: RewardContribution) -> None:
+def apply_rewards(
+    resource_manager: ResourceManager, contribution: RewardContribution
+) -> None:
     """Convert measurable contributions into homeostatic gains."""
     if contribution.resolved_quests > 0:
         resource_manager.add_food(min(12.0, contribution.resolved_quests * 1.5))
-        resource_manager.regenerate_energy(min(10.0, contribution.resolved_quests * 1.0))
+        resource_manager.regenerate_energy(
+            min(10.0, contribution.resolved_quests * 1.0)
+        )
     if contribution.tech_debt_delta < 0:
         reduction = min(8.0, abs(contribution.tech_debt_delta) * 2.0)
         resource_manager.regenerate_energy(reduction)
-        resource_manager.relational_debt = max(0.0, resource_manager.relational_debt - reduction * 0.5)
+        resource_manager.relational_debt = max(
+            0.0, resource_manager.relational_debt - reduction * 0.5
+        )
     if contribution.user_satisfaction > 0:
         resource_manager.add_warmth(min(10.0, contribution.user_satisfaction * 8.0))
     if contribution.meta_objective_penalty > 0:

--- a/src/singular/life/profiling.py
+++ b/src/singular/life/profiling.py
@@ -87,7 +87,9 @@ class LifeLoopProfiler:
             target.cache_misses += stats.cache_misses
 
     def summary(self) -> dict[str, object]:
-        phase_payload = {name: self.stats[name].to_dict() for name in sorted(self.stats)}
+        phase_payload = {
+            name: self.stats[name].to_dict() for name in sorted(self.stats)
+        }
         total_ms = sum(float(item["total_ms"]) for item in phase_payload.values())
         slowest = None
         if phase_payload:
@@ -115,7 +117,9 @@ def cache_candidates_from_phases(
 
     candidates: list[dict[str, object]] = []
     sandbox = phases.get("sandbox_scoring", {})
-    if int(sandbox.get("cache_hits", 0) or 0) or int(sandbox.get("cache_misses", 0) or 0):
+    if int(sandbox.get("cache_hits", 0) or 0) or int(
+        sandbox.get("cache_misses", 0) or 0
+    ):
         candidates.append(
             {
                 "phase": "sandbox_scoring",

--- a/src/singular/life/resource_flow.py
+++ b/src/singular/life/resource_flow.py
@@ -8,8 +8,12 @@ from .vital import VitalState
 
 
 def restore_survival_resources(
-    *, state: VitalState | str, energy: float, resources: float,
-    available_energy: float = 0.0, available_resources: float = 0.0,
+    *,
+    state: VitalState | str,
+    energy: float,
+    resources: float,
+    available_energy: float = 0.0,
+    available_resources: float = 0.0,
     target: float = 1.0,
 ) -> tuple[float, float, dict[str, float]]:
     """Use only available simulation reserves to support pre-death recovery."""
@@ -19,7 +23,11 @@ def restore_survival_resources(
         return energy, resources, {"energy": 0.0, "resources": 0.0}
     energy_gain = min(max(target - energy, 0.0), max(available_energy, 0.0))
     resource_gain = min(max(target - resources, 0.0), max(available_resources, 0.0))
-    return energy + energy_gain, resources + resource_gain, {"energy": energy_gain, "resources": resource_gain}
+    return (
+        energy + energy_gain,
+        resources + resource_gain,
+        {"energy": energy_gain, "resources": resource_gain},
+    )
 
 
 def manage_resources(

--- a/src/singular/life/sandbox_scoring.py
+++ b/src/singular/life/sandbox_scoring.py
@@ -10,7 +10,6 @@ from typing import ClassVar
 
 from . import sandbox
 
-
 CONFIRMED_ROOT_ESCAPE = "confirmed_root_escape"
 OUTBOUND_SYMLINK = "outbound_symlink"
 UNRESOLVED_PATH = "unresolved_path"

--- a/src/singular/life/skill_validation.py
+++ b/src/singular/life/skill_validation.py
@@ -32,7 +32,10 @@ def _has_expected_function(
     tree: ast.AST, expected_symbol: str
 ) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
     for node in getattr(tree, "body", []):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == expected_symbol:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == expected_symbol
+        ):
             return node
     return None
 
@@ -67,7 +70,9 @@ def validate_generated_skill(
             False, f"missing expected skill symbol: {expected_symbol}"
         )
     if _function_returns_only_none(expected):
-        return SkillValidationResult(False, f"skill symbol {expected_symbol} only returns None")
+        return SkillValidationResult(
+            False, f"skill symbol {expected_symbol} only returns None"
+        )
 
     if not examples:
         try:
@@ -75,7 +80,9 @@ def validate_generated_skill(
                 f"{code}\nresult = {expected_symbol}()", timeout=timeout
             )
         except Exception as exc:
-            return SkillValidationResult(False, f"minimal sandbox validation failed: {exc}")
+            return SkillValidationResult(
+                False, f"minimal sandbox validation failed: {exc}"
+            )
         if observed is None:
             return SkillValidationResult(
                 False,
@@ -88,8 +95,12 @@ def validate_generated_skill(
         try:
             observed = sandbox.run(test, timeout=timeout)
         except Exception as exc:
-            return SkillValidationResult(False, f"example sandbox validation failed: {exc}")
+            return SkillValidationResult(
+                False, f"example sandbox validation failed: {exc}"
+            )
         if observed != output:
-            return SkillValidationResult(False, f"example mismatch: expected {output!r}, got {observed!r}")
+            return SkillValidationResult(
+                False, f"example mismatch: expected {output!r}, got {observed!r}"
+            )
 
     return SkillValidationResult(True)

--- a/src/singular/life/social_decision.py
+++ b/src/singular/life/social_decision.py
@@ -56,7 +56,11 @@ def decide_social_actions(
         if model_version and not evidence_is_usable:
             action = "neutral"
             reason = "insufficient_mental_state_evidence"
-        elif model_version and evidence_is_usable and (reliability < 0.35 or reciprocity < -0.4):
+        elif (
+            model_version
+            and evidence_is_usable
+            and (reliability < 0.35 or reciprocity < -0.4)
+        ):
             action = "avoid"
             reason = "predicted_unreliable_or_nonreciprocal"
         elif trust >= 0.7 and affinity >= 0.7 and rivalry < 0.65:

--- a/src/singular/life/test_coevolution.py
+++ b/src/singular/life/test_coevolution.py
@@ -128,7 +128,9 @@ def propose_test_candidates(
     observed = _extract_numeric_result(mutated_code)
     if observed is not None:
         candidates.append(TestCandidate(f"result == {observed!r}", origin="oracle"))
-        candidates.append(TestCandidate(f"abs(result - ({observed!r})) <= 1", origin="tolerance"))
+        candidates.append(
+            TestCandidate(f"abs(result - ({observed!r})) <= 1", origin="tolerance")
+        )
 
     rng.shuffle(candidates)
     return candidates[: max(0, limit)]

--- a/src/singular/life/test_ecosystem.py
+++ b/src/singular/life/test_ecosystem.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import random
 
-from singular.life.ecosystem import ARCHETYPES, compute_population_metrics, draw_global_event
+from singular.life.ecosystem import (
+    ARCHETYPES,
+    compute_population_metrics,
+    draw_global_event,
+)
 
 
 def test_archetypes_are_available() -> None:
@@ -11,7 +15,11 @@ def test_archetypes_are_available() -> None:
 
 def test_global_event_draw_is_supported() -> None:
     event = draw_global_event(random.Random(7))
-    assert event.event_type in {"resource_crisis", "governance_shift", "simulated_catastrophe"}
+    assert event.event_type in {
+        "resource_crisis",
+        "governance_shift",
+        "simulated_catastrophe",
+    }
     assert 0.2 <= event.intensity <= 0.9
 
 

--- a/src/singular/life/vital.py
+++ b/src/singular/life/vital.py
@@ -54,17 +54,27 @@ class VitalStateMachine:
     rescue_attempts: list[str] = field(default_factory=list)
     last_irreversible_decision: str | None = None
 
-    def transition(self, target: VitalState | str, *, cause: str, checkpoint_restored: bool = False) -> VitalState:
+    def transition(
+        self, target: VitalState | str, *, cause: str, checkpoint_restored: bool = False
+    ) -> VitalState:
         target = VitalState(target)
         if target == self.state:
             return self.state
         if target not in ALLOWED_TRANSITIONS[self.state]:
-            raise ValueError(f"forbidden vital transition: {self.state.value}->{target.value}")
-        if self.state is VitalState.TERMINAL and target is VitalState.CRITICAL and not checkpoint_restored:
+            raise ValueError(
+                f"forbidden vital transition: {self.state.value}->{target.value}"
+            )
+        if (
+            self.state is VitalState.TERMINAL
+            and target is VitalState.CRITICAL
+            and not checkpoint_restored
+        ):
             raise ValueError("terminal recovery requires a healthy checkpoint")
         self.root_cause = self.root_cause or cause
         if target in {VitalState.DEAD, VitalState.EXTINCT}:
-            self.last_irreversible_decision = f"{self.state.value}->{target.value}:{cause}"
+            self.last_irreversible_decision = (
+                f"{self.state.value}->{target.value}:{cause}"
+            )
         self.state = target
         return target
 
@@ -72,15 +82,25 @@ class VitalStateMachine:
         self.rescue_attempts.append(attempt)
 
     def audit(self) -> dict[str, object]:
-        return {"root_cause": self.root_cause, "rescue_attempts": list(self.rescue_attempts),
-                "last_irreversible_decision": self.last_irreversible_decision}
+        return {
+            "root_cause": self.root_cause,
+            "rescue_attempts": list(self.rescue_attempts),
+            "last_irreversible_decision": self.last_irreversible_decision,
+        }
 
 
 def compute_vital_timeline(
-    *, age: int, current_health: float | None, failure_rate: float | None,
-    failure_streak: int, extinction_seen: bool, registry_status: str | None = None,
-    extinction_signals: Iterable[str] = (), extinction_duration: int = 0,
-    root_cause: str | None = None, rescue_attempts: Iterable[str] = (),
+    *,
+    age: int,
+    current_health: float | None,
+    failure_rate: float | None,
+    failure_streak: int,
+    extinction_seen: bool,
+    registry_status: str | None = None,
+    extinction_signals: Iterable[str] = (),
+    extinction_duration: int = 0,
+    root_cause: str | None = None,
+    rescue_attempts: Iterable[str] = (),
     last_irreversible_decision: str | None = None,
     thresholds: VitalThresholds = VitalThresholds(),
 ) -> dict[str, object]:
@@ -102,37 +122,79 @@ def compute_vital_timeline(
     elif registry_status == "dead":
         state = VitalState.DEAD
         causes.append("death_recorded")
-    elif age >= thresholds.terminal_age or failure_streak >= thresholds.terminal_failure_streak:
+    elif (
+        age >= thresholds.terminal_age
+        or failure_streak >= thresholds.terminal_failure_streak
+    ):
         state = VitalState.TERMINAL
-        causes.append("terminal_age_reached" if age >= thresholds.terminal_age else "failure_streak")
+        causes.append(
+            "terminal_age_reached"
+            if age >= thresholds.terminal_age
+            else "failure_streak"
+        )
     elif current_health is not None and current_health <= thresholds.terminal_health:
         state = VitalState.TERMINAL
         causes.append("critical_health_score")
-    elif (current_health is not None and current_health <= thresholds.critical_health) or (
-        failure_rate is not None and failure_rate >= thresholds.high_failure_rate
-    ):
+    elif (
+        current_health is not None and current_health <= thresholds.critical_health
+    ) or (failure_rate is not None and failure_rate >= thresholds.high_failure_rate):
         state = VitalState.CRITICAL
-        causes.append("critical_health_score" if current_health is not None and current_health <= thresholds.critical_health else "high_failure_rate")
+        causes.append(
+            "critical_health_score"
+            if current_health is not None
+            and current_health <= thresholds.critical_health
+            else "high_failure_rate"
+        )
     elif age >= thresholds.decline_age:
         state = VitalState.AT_RISK
         causes.append("age_decline_threshold")
     else:
         state = VitalState.STABLE
 
-    reproduction_eligible = state in {VitalState.STABLE, VitalState.AT_RISK} and thresholds.reproduction_min_age <= age <= thresholds.reproduction_max_age
+    reproduction_eligible = (
+        state in {VitalState.STABLE, VitalState.AT_RISK}
+        and thresholds.reproduction_min_age <= age <= thresholds.reproduction_max_age
+    )
     return {
-        "age": age, "current_failure_streak": failure_streak, "state": state.value,
-        "risk_level": "high" if state in {VitalState.CRITICAL, VitalState.TERMINAL, VitalState.DEAD, VitalState.EXTINCT} else ("medium" if state is VitalState.AT_RISK else "low"),
+        "age": age,
+        "current_failure_streak": failure_streak,
+        "state": state.value,
+        "risk_level": (
+            "high"
+            if state
+            in {
+                VitalState.CRITICAL,
+                VitalState.TERMINAL,
+                VitalState.DEAD,
+                VitalState.EXTINCT,
+            }
+            else ("medium" if state is VitalState.AT_RISK else "low")
+        ),
         "terminal": state in {VitalState.TERMINAL, VitalState.DEAD, VitalState.EXTINCT},
-        "causes": causes, "reproduction_eligible": reproduction_eligible,
-        "extinction_evidence": {"signals": sorted(signals), "duration": extinction_duration,
-            "confirmed": extinction_confirmed, "required_signals": thresholds.extinction_min_signals,
-            "required_duration": thresholds.extinction_min_duration},
-        "audit": {"root_cause": root_cause or (causes[0] if causes else None),
+        "causes": causes,
+        "reproduction_eligible": reproduction_eligible,
+        "extinction_evidence": {
+            "signals": sorted(signals),
+            "duration": extinction_duration,
+            "confirmed": extinction_confirmed,
+            "required_signals": thresholds.extinction_min_signals,
+            "required_duration": thresholds.extinction_min_duration,
+        },
+        "audit": {
+            "root_cause": root_cause or (causes[0] if causes else None),
             "rescue_attempts": list(rescue_attempts),
-            "last_irreversible_decision": last_irreversible_decision},
-        "thresholds": {"decline_age": thresholds.decline_age, "terminal_age": thresholds.terminal_age,
-            "critical_health": thresholds.critical_health, "terminal_health": thresholds.terminal_health,
-            "high_failure_rate": thresholds.high_failure_rate, "terminal_failure_streak": thresholds.terminal_failure_streak,
-            "reproduction_age_window": [thresholds.reproduction_min_age, thresholds.reproduction_max_age]},
+            "last_irreversible_decision": last_irreversible_decision,
+        },
+        "thresholds": {
+            "decline_age": thresholds.decline_age,
+            "terminal_age": thresholds.terminal_age,
+            "critical_health": thresholds.critical_health,
+            "terminal_health": thresholds.terminal_health,
+            "high_failure_rate": thresholds.high_failure_rate,
+            "terminal_failure_streak": thresholds.terminal_failure_streak,
+            "reproduction_age_window": [
+                thresholds.reproduction_min_age,
+                thresholds.reproduction_max_age,
+            ],
+        },
     }

--- a/src/singular/life/world_state.py
+++ b/src/singular/life/world_state.py
@@ -3,12 +3,14 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
+
 @dataclass
 class DeferredPenalty:
     due_tick: int
     energy_delta: float = 0.0
     health_delta: float = 0.0
     mortality_delta: float = 0.0
+
 
 @dataclass
 class PersistentWorldState:
@@ -18,33 +20,66 @@ class PersistentWorldState:
     opportunities: float = 0.5
     mortality_pressure: float = 0.0
     deferred_penalties: list[DeferredPenalty] = field(default_factory=list)
+
     @classmethod
-    def load(cls, path: Path) -> 'PersistentWorldState':
+    def load(cls, path: Path) -> "PersistentWorldState":
         if not path.exists():
             return cls()
-        payload = json.loads(path.read_text(encoding='utf-8'))
+        payload = json.loads(path.read_text(encoding="utf-8"))
         return cls(
-            rarity=float(payload.get('rarity', 0.5)),
-            reputation=float(payload.get('reputation', 0.5)),
-            risks=float(payload.get('risks', 0.5)),
-            opportunities=float(payload.get('opportunities', 0.5)),
-            mortality_pressure=float(payload.get('mortality_pressure', 0.0)),
-            deferred_penalties=[DeferredPenalty(**item) for item in payload.get('deferred_penalties', [])],
+            rarity=float(payload.get("rarity", 0.5)),
+            reputation=float(payload.get("reputation", 0.5)),
+            risks=float(payload.get("risks", 0.5)),
+            opportunities=float(payload.get("opportunities", 0.5)),
+            mortality_pressure=float(payload.get("mortality_pressure", 0.0)),
+            deferred_penalties=[
+                DeferredPenalty(**item)
+                for item in payload.get("deferred_penalties", [])
+            ],
         )
+
     def save(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(self.to_dict(), ensure_ascii=False, indent=2), encoding='utf-8')
+        path.write_text(
+            json.dumps(self.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
     def to_dict(self) -> dict[str, object]:
-        return {'rarity': self.rarity, 'reputation': self.reputation, 'risks': self.risks, 'opportunities': self.opportunities, 'mortality_pressure': self.mortality_pressure, 'deferred_penalties': [p.__dict__ for p in self.deferred_penalties]}
+        return {
+            "rarity": self.rarity,
+            "reputation": self.reputation,
+            "risks": self.risks,
+            "opportunities": self.opportunities,
+            "mortality_pressure": self.mortality_pressure,
+            "deferred_penalties": [p.__dict__ for p in self.deferred_penalties],
+        }
+
     def apply_world_delta(self, world_delta: dict[str, float]) -> None:
-        self.rarity = max(0.0, min(1.0, self.rarity + world_delta.get('rarity', 0.0)))
-        self.reputation = max(0.0, min(1.0, self.reputation + world_delta.get('reputation', 0.0)))
-        self.risks = max(0.0, min(1.0, self.risks + world_delta.get('risks', 0.0)))
-        self.opportunities = max(0.0, min(1.0, self.opportunities + world_delta.get('opportunities', 0.0)))
-    def schedule_penalties(self, current_tick: int, delayed_penalties: list[dict[str, float | int]]) -> None:
+        self.rarity = max(0.0, min(1.0, self.rarity + world_delta.get("rarity", 0.0)))
+        self.reputation = max(
+            0.0, min(1.0, self.reputation + world_delta.get("reputation", 0.0))
+        )
+        self.risks = max(0.0, min(1.0, self.risks + world_delta.get("risks", 0.0)))
+        self.opportunities = max(
+            0.0, min(1.0, self.opportunities + world_delta.get("opportunities", 0.0))
+        )
+
+    def schedule_penalties(
+        self, current_tick: int, delayed_penalties: list[dict[str, float | int]]
+    ) -> None:
         for penalty in delayed_penalties:
-            self.deferred_penalties.append(DeferredPenalty(due_tick=current_tick + max(1, int(penalty.get('ticks', 0))), energy_delta=float(penalty.get('energy_delta', 0.0)), health_delta=float(penalty.get('health_delta', 0.0)), mortality_delta=float(penalty.get('mortality_delta', 0.0))))
+            self.deferred_penalties.append(
+                DeferredPenalty(
+                    due_tick=current_tick + max(1, int(penalty.get("ticks", 0))),
+                    energy_delta=float(penalty.get("energy_delta", 0.0)),
+                    health_delta=float(penalty.get("health_delta", 0.0)),
+                    mortality_delta=float(penalty.get("mortality_delta", 0.0)),
+                )
+            )
+
     def consume_due_penalties(self, current_tick: int) -> list[DeferredPenalty]:
         due = [p for p in self.deferred_penalties if p.due_tick <= current_tick]
-        self.deferred_penalties = [p for p in self.deferred_penalties if p.due_tick > current_tick]
+        self.deferred_penalties = [
+            p for p in self.deferred_penalties if p.due_tick > current_tick
+        ]
         return due

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -72,8 +72,6 @@ def get_psyche_file() -> Path:
     return get_mem_dir() / "psyche.json"
 
 
-
-
 def _atomic_write_text(path: Path, data: str) -> None:
     """Backward-compatible alias for shared atomic text writes."""
 
@@ -84,6 +82,7 @@ def _append_jsonl_line(path: Path, payload: dict[str, Any]) -> None:
     """Backward-compatible alias for shared locked JSONL appends."""
 
     append_jsonl_line(path, payload, with_lock=True)
+
 
 def append_jsonl_line_safe(
     path: Path | str,
@@ -121,9 +120,7 @@ def get_memory_layer_service(root: Path | str | None = None) -> MemoryLayerServi
     global _MEMORY_LAYER_SERVICE, _MEMORY_LAYER_SERVICE_ROOT
     root = (Path(root) if root is not None else get_memory_layers_dir()).resolve()
     if _MEMORY_LAYER_SERVICE is None or _MEMORY_LAYER_SERVICE_ROOT != root:
-        _MEMORY_LAYER_SERVICE = MemoryLayerService(
-            build_backend(root=root)
-        )
+        _MEMORY_LAYER_SERVICE = MemoryLayerService(build_backend(root=root))
         _MEMORY_LAYER_SERVICE_ROOT = root
     return _MEMORY_LAYER_SERVICE
 
@@ -233,7 +230,16 @@ def read_episodes(path: Path | str | None = None) -> list[dict[str, Any]]:
 
 def _episode_search_text(episode: Mapping[str, Any]) -> str:
     parts: list[str] = []
-    for key in ("text", "summary", "message", "event", "event_type", "objective", "skill", "op"):
+    for key in (
+        "text",
+        "summary",
+        "message",
+        "event",
+        "event_type",
+        "objective",
+        "skill",
+        "op",
+    ):
         value = episode.get(key)
         if isinstance(value, str):
             parts.append(value)
@@ -243,7 +249,9 @@ def _episode_search_text(episode: Mapping[str, Any]) -> str:
     return " ".join(parts).lower()
 
 
-def summarize_episode_for_recall(episode: Mapping[str, Any], *, max_chars: int = 160) -> str:
+def summarize_episode_for_recall(
+    episode: Mapping[str, Any], *, max_chars: int = 160
+) -> str:
     """Return a short human-readable summary for a recalled episode."""
 
     text = None
@@ -270,7 +278,9 @@ def recall_relevant_episodes(
     """Retrieve recent episodic memories matching themes or objectives."""
 
     terms = {str(term).strip().lower() for term in (themes or []) if str(term).strip()}
-    terms.update(str(term).strip().lower() for term in (objectives or []) if str(term).strip())
+    terms.update(
+        str(term).strip().lower() for term in (objectives or []) if str(term).strip()
+    )
     if not terms:
         return []
     episodes = read_episodes(path)
@@ -289,9 +299,11 @@ def recall_relevant_episodes(
                 "ts": episode.get("ts"),
                 "event": episode.get("event"),
                 "role": episode.get("role"),
-                "theme": (episode.get("structured_signals") or {}).get("theme")
-                if isinstance(episode.get("structured_signals"), Mapping)
-                else None,
+                "theme": (
+                    (episode.get("structured_signals") or {}).get("theme")
+                    if isinstance(episode.get("structured_signals"), Mapping)
+                    else None
+                ),
                 "summary": summarize_episode_for_recall(episode),
             }
         )
@@ -300,12 +312,19 @@ def recall_relevant_episodes(
     return recalled
 
 
-def format_recalled_memories(memories: Iterable[Mapping[str, Any]], *, max_chars: int = 360) -> str:
+def format_recalled_memories(
+    memories: Iterable[Mapping[str, Any]], *, max_chars: int = 360
+) -> str:
     """Format recalled memories as a compact prompt fragment."""
 
     fragments = []
     for memory in memories:
-        label = memory.get("theme") or memory.get("event") or memory.get("role") or "episode"
+        label = (
+            memory.get("theme")
+            or memory.get("event")
+            or memory.get("role")
+            or "episode"
+        )
         fragments.append(f"- {label}: {memory.get('summary', '')}")
     text = " ".join(fragments) if fragments else "aucun souvenir pertinent"
     if len(text) <= max_chars:
@@ -442,7 +461,9 @@ def _normalize_skill_entry(entry: Any) -> dict[str, Any]:
         entry = {}
     score = float(entry.get("score", 0.0))
     metrics = entry.get("metrics") if isinstance(entry.get("metrics"), dict) else {}
-    lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), dict) else {}
+    lifecycle = (
+        entry.get("lifecycle") if isinstance(entry.get("lifecycle"), dict) else {}
+    )
     entry["score"] = score
     entry["metrics"] = {
         "usage_count": int(metrics.get("usage_count", 0) or 0),
@@ -527,7 +548,9 @@ def apply_skill_maintenance(
         last_used_raw = entry["metrics"].get("last_used_at")
         if isinstance(last_used_raw, str):
             try:
-                last_used_at = datetime.fromisoformat(last_used_raw.replace("Z", "+00:00"))
+                last_used_at = datetime.fromisoformat(
+                    last_used_raw.replace("Z", "+00:00")
+                )
             except ValueError:
                 last_used_at = None
         else:
@@ -604,7 +627,9 @@ def controlled_delete_skill(
     if skill not in skills:
         raise KeyError(f"unknown skill: {skill}")
     entry = _normalize_skill_entry(skills[skill])
-    snapshots = Path(snapshots_dir) if snapshots_dir is not None else get_skill_snapshots_dir()
+    snapshots = (
+        Path(snapshots_dir) if snapshots_dir is not None else get_skill_snapshots_dir()
+    )
     snapshots.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     snapshot_path = snapshots / f"{skill}-{ts}.json"

--- a/src/singular/memory_compaction.py
+++ b/src/singular/memory_compaction.py
@@ -12,7 +12,6 @@ from typing import Any
 
 from .io_utils import atomic_write_text, file_lock
 
-
 UTC = timezone.utc
 
 
@@ -99,16 +98,20 @@ def compact_episodic_jsonl(
         chunk_size = max(1, snapshot_chunk_size)
         for offset in range(0, len(historical), chunk_size):
             chunk = historical[offset : offset + chunk_size]
-            ts_values = [dt for entry in chunk if (dt := _parse_ts(entry.get("ts"))) is not None]
+            ts_values = [
+                dt for entry in chunk if (dt := _parse_ts(entry.get("ts"))) is not None
+            ]
             event_kinds: dict[str, int] = defaultdict(int)
             for entry in chunk:
                 kind = entry.get("event") or entry.get("event_type") or "unknown"
                 event_kinds[str(kind)] += 1
 
-            examples = [_extract_text(item) for item in chunk[: max(1, max_examples_per_snapshot)]]
+            examples = [
+                _extract_text(item)
+                for item in chunk[: max(1, max_examples_per_snapshot)]
+            ]
             canonical = "\n".join(
-                json.dumps(item, ensure_ascii=False, sort_keys=True)
-                for item in chunk
+                json.dumps(item, ensure_ascii=False, sort_keys=True) for item in chunk
             )
             digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
             snapshot_payload = {
@@ -131,7 +134,10 @@ def compact_episodic_jsonl(
                 f"episodic-{generated_at.replace(':', '').replace('+', '_')}"
                 f"-{offset:08d}-{offset + len(chunk) - 1:08d}.json"
             )
-            atomic_write_text(snapshot_path, json.dumps(snapshot_payload, ensure_ascii=False, indent=2))
+            atomic_write_text(
+                snapshot_path,
+                json.dumps(snapshot_payload, ensure_ascii=False, indent=2),
+            )
             snapshot_refs.append(
                 {
                     "snapshot": str(snapshot_path.relative_to(root.parent)),
@@ -253,7 +259,9 @@ def compact_generations_jsonl(
         rejected_aggregate: dict[tuple[str, str], dict[str, Any]] = {}
         for row in old_rejected:
             skill = str(row.get("skill", "unknown"))
-            mutation = row.get("mutation") if isinstance(row.get("mutation"), dict) else {}
+            mutation = (
+                row.get("mutation") if isinstance(row.get("mutation"), dict) else {}
+            )
             operator = str(mutation.get("operator", "unknown"))
             key = (skill, operator)
             slot = rejected_aggregate.setdefault(
@@ -274,15 +282,25 @@ def compact_generations_jsonl(
                 base = 0.0
                 new = 0.0
             slot["count"] += 1
-            slot["score_delta_sum"] += (new - base)
+            slot["score_delta_sum"] += new - base
 
         compacted_rows: list[dict[str, Any]] = []
         compacted_rows.extend(recent_rows)
         compacted_rows.extend(_audit_projection(item) for item in old_accepted)
         compacted_rows.extend(_audit_projection(item) for item in sampled_rejected)
         compacted_rows.extend(
-            {**value, "score_delta_avg": (value["score_delta_sum"] / value["count"]) if value["count"] else 0.0}
-            for value in sorted(rejected_aggregate.values(), key=lambda v: (str(v["skill"]), str(v["operator"])))
+            {
+                **value,
+                "score_delta_avg": (
+                    (value["score_delta_sum"] / value["count"])
+                    if value["count"]
+                    else 0.0
+                ),
+            }
+            for value in sorted(
+                rejected_aggregate.values(),
+                key=lambda v: (str(v["skill"]), str(v["operator"])),
+            )
         )
         compacted_rows.append(
             {

--- a/src/singular/memory_layers/vector_adapter.py
+++ b/src/singular/memory_layers/vector_adapter.py
@@ -17,9 +17,11 @@ def build_backend(*, root: Path | str | None = None) -> MemoryBackend:
     """
 
     backend = os.environ.get("SINGULAR_MEMORY_BACKEND", "local").strip().lower()
-    root_path = Path(root) if root is not None else Path(
-        os.environ.get("SINGULAR_HOME", ".")
-    ) / "mem" / "layers"
+    root_path = (
+        Path(root)
+        if root is not None
+        else Path(os.environ.get("SINGULAR_HOME", ".")) / "mem" / "layers"
+    )
 
     if backend == "local":
         return LocalJsonMemoryBackend(root_path)
@@ -28,14 +30,18 @@ def build_backend(*, root: Path | str | None = None) -> MemoryBackend:
         try:
             import chromadb  # type: ignore  # noqa: F401
         except ImportError:
-            log.warning("chroma backend requested but chromadb is missing, fallback local")
+            log.warning(
+                "chroma backend requested but chromadb is missing, fallback local"
+            )
             return LocalJsonMemoryBackend(root_path)
 
     if backend == "pinecone":
         try:
             import pinecone  # type: ignore  # noqa: F401
         except ImportError:
-            log.warning("pinecone backend requested but pinecone is missing, fallback local")
+            log.warning(
+                "pinecone backend requested but pinecone is missing, fallback local"
+            )
             return LocalJsonMemoryBackend(root_path)
 
     # Adapter stub: until full API wiring, fallback to the local implementation.

--- a/src/singular/metrics/autonomy.py
+++ b/src/singular/metrics/autonomy.py
@@ -39,15 +39,23 @@ def _is_proactive_record(record: dict[str, Any]) -> bool:
     if isinstance(proactive, bool):
         return proactive
     event = record.get("event")
-    return event in {"mutation", "interaction", "test_coevolution"} or "score_new" in record
+    return (
+        event in {"mutation", "interaction", "test_coevolution"}
+        or "score_new" in record
+    )
 
 
 def _is_voluntary_budget_record(record: dict[str, Any]) -> bool:
     event = str(record.get("event", "")).strip().lower()
-    return record.get("voluntary_budget") is True or event in {"loop.budget_exhausted", "daemon.budget_exhausted"}
+    return record.get("voluntary_budget") is True or event in {
+        "loop.budget_exhausted",
+        "daemon.budget_exhausted",
+    }
 
 
-def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float | dict[str, float] | None]:
+def compute_autonomy_metrics(
+    records: list[dict[str, Any]],
+) -> dict[str, float | dict[str, float] | None]:
     """Compute autonomy-oriented metrics from run records.
 
     ``autonomy_index`` deliberately excludes voluntary wall-clock budget markers so
@@ -55,9 +63,15 @@ def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float |
     loss of autonomy or death.
     """
 
-    effective_records = [record for record in records if not _is_voluntary_budget_record(record)]
-    action_records = [record for record in effective_records if _is_action_record(record)]
-    proactive_records = [record for record in action_records if _is_proactive_record(record)]
+    effective_records = [
+        record for record in records if not _is_voluntary_budget_record(record)
+    ]
+    action_records = [
+        record for record in effective_records if _is_action_record(record)
+    ]
+    proactive_records = [
+        record for record in action_records if _is_proactive_record(record)
+    ]
     proactive_rate = (
         len(proactive_records) / len(action_records) if action_records else None
     )
@@ -79,7 +93,9 @@ def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float |
     reference = score_series if score_series else health_scores
     long_term_stability = None
     if len(reference) >= 2:
-        deltas = [abs(reference[idx] - reference[idx - 1]) for idx in range(1, len(reference))]
+        deltas = [
+            abs(reference[idx] - reference[idx - 1]) for idx in range(1, len(reference))
+        ]
         avg_delta = mean(deltas) if deltas else 0.0
         long_term_stability = max(0.0, min(1.0, 1.0 - (avg_delta / 10.0)))
 
@@ -162,9 +178,19 @@ def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float |
     if resource_costs and total_positive_gain > 0:
         resource_cost_per_gain = sum(resource_costs) / total_positive_gain
 
-    autonomy_components = [value for value in (proactive_rate, long_term_stability, acceptance_rate) if value is not None]
-    autonomy_index = round((sum(autonomy_components) / len(autonomy_components)) * 100.0, 1) if autonomy_components else None
-    mutation_viability = round((acceptance_rate or 0.0) * 100.0, 1) if decisions else None
+    autonomy_components = [
+        value
+        for value in (proactive_rate, long_term_stability, acceptance_rate)
+        if value is not None
+    ]
+    autonomy_index = (
+        round((sum(autonomy_components) / len(autonomy_components)) * 100.0, 1)
+        if autonomy_components
+        else None
+    )
+    mutation_viability = (
+        round((acceptance_rate or 0.0) * 100.0, 1) if decisions else None
+    )
 
     return {
         "autonomy_index": autonomy_index,
@@ -181,5 +207,7 @@ def compute_autonomy_metrics(records: list[dict[str, Any]]) -> dict[str, float |
         },
         "perception_to_action_latency_ms": perception_to_action_latency_ms,
         "resource_cost_per_gain": resource_cost_per_gain,
-        "mean_score_gain": (total_gain / len(action_records) if action_records else None),
+        "mean_score_gain": (
+            total_gain / len(action_records) if action_records else None
+        ),
     }

--- a/src/singular/metrics/behavioral_regulation.py
+++ b/src/singular/metrics/behavioral_regulation.py
@@ -29,10 +29,19 @@ def compute_behavioral_regulation_metrics(
     *,
     decision_events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    actions = [r for r in records if str(r.get("event", "")).strip() in {"mutation", "interaction", "refuse", "delay", "test_coevolution"}]
+    actions = [
+        r
+        for r in records
+        if str(r.get("event", "")).strip()
+        in {"mutation", "interaction", "refuse", "delay", "test_coevolution"}
+    ]
     event_counts = Counter(str(r.get("event", "unknown")) for r in actions)
     total_actions = sum(event_counts.values())
-    diversity = min(1.0, len([k for k,v in event_counts.items() if v>0]) / 5.0) if total_actions else None
+    diversity = (
+        min(1.0, len([k for k, v in event_counts.items() if v > 0]) / 5.0)
+        if total_actions
+        else None
+    )
 
     accepted = 0
     rejected = 0
@@ -67,17 +76,21 @@ def compute_behavioral_regulation_metrics(
 
     health_scores = [
         _as_float((r.get("health") or {}).get("score"))
-        for r in records if isinstance(r.get("health"), dict)
+        for r in records
+        if isinstance(r.get("health"), dict)
     ]
     health_scores = [s for s in health_scores if s is not None]
     homeo = None
     if len(health_scores) >= 2:
-        volatility = mean(abs(health_scores[i]-health_scores[i-1]) for i in range(1, len(health_scores)))
+        volatility = mean(
+            abs(health_scores[i] - health_scores[i - 1])
+            for i in range(1, len(health_scores))
+        )
         homeo = max(0.0, min(1.0, 1.0 - (volatility / 10.0)))
 
     trend = "stable"
     if len(health_scores) >= 4:
-        half = len(health_scores)//2
+        half = len(health_scores) // 2
         first = mean(health_scores[:half])
         second = mean(health_scores[half:])
         if second > first + 0.2:
@@ -115,9 +128,15 @@ def compute_regulation_inputs(metrics: dict[str, Any]) -> dict[str, float]:
     homeo = _as_float(metrics.get("homeostatic_stability")) or 0.5
     autonomy = _as_float(metrics.get("goal_generation_autonomy")) or 0.5
 
-    mutation_rate_scale = max(0.6, min(1.5, 1.2 - homeo * 0.4 + (0.5 - robustness) * 0.6))
-    metabolic_pressure_scale = max(0.7, min(1.6, 1.0 + (recovery / 300.0) + (0.5 - homeo) * 0.5))
-    exploration_intensity_scale = max(0.5, min(1.7, 1.0 + (0.5 - diversity) * 0.8 + (autonomy - 0.5) * 0.6))
+    mutation_rate_scale = max(
+        0.6, min(1.5, 1.2 - homeo * 0.4 + (0.5 - robustness) * 0.6)
+    )
+    metabolic_pressure_scale = max(
+        0.7, min(1.6, 1.0 + (recovery / 300.0) + (0.5 - homeo) * 0.5)
+    )
+    exploration_intensity_scale = max(
+        0.5, min(1.7, 1.0 + (0.5 - diversity) * 0.8 + (autonomy - 0.5) * 0.6)
+    )
 
     return {
         "mutation_rate_scale": mutation_rate_scale,

--- a/src/singular/mind/llm_adapter.py
+++ b/src/singular/mind/llm_adapter.py
@@ -25,7 +25,7 @@ DEFAULT_SYSTEM_PROMPT = (
 )
 
 _JSON_FORMAT_INSTRUCTION = (
-    'Réponds STRICTEMENT avec un objet JSON de la forme: '
+    "Réponds STRICTEMENT avec un objet JSON de la forme: "
     '{"intent": "<string>", "action": {"type": "<string>", "params": {<object>}}, '
     '"reasoning": "<string court>", "confidence": <float entre 0 et 1>}.'
 )
@@ -73,7 +73,9 @@ class LLMAdapter:
         """
 
         memory_summary = self._summarize_short_term_memory(short_term_memory or [])
-        prompt = self._build_prompt(user_input=user_input, memory_summary=memory_summary)
+        prompt = self._build_prompt(
+            user_input=user_input, memory_summary=memory_summary
+        )
 
         errors: list[Exception] = []
         for model_name in (self.model, self.fallback_model):
@@ -132,21 +134,29 @@ class LLMAdapter:
             with request.urlopen(req, timeout=self.timeout_s) as resp:  # nosec B310
                 payload = resp.read().decode("utf-8")
         except error.HTTPError as exc:
-            raise AdapterResponseError(f"HTTP {exc.code} depuis le serveur local") from exc
+            raise AdapterResponseError(
+                f"HTTP {exc.code} depuis le serveur local"
+            ) from exc
         except error.URLError as exc:
             reason = getattr(exc, "reason", exc)
-            raise AdapterTimeoutError(f"Serveur local injoignable/timeout: {reason}") from exc
+            raise AdapterTimeoutError(
+                f"Serveur local injoignable/timeout: {reason}"
+            ) from exc
         except TimeoutError as exc:
             raise AdapterTimeoutError("Timeout appel modèle local") from exc
 
         try:
             parsed = json.loads(payload)
         except json.JSONDecodeError as exc:
-            raise AdapterResponseError("Réponse brute non-JSON du serveur local") from exc
+            raise AdapterResponseError(
+                "Réponse brute non-JSON du serveur local"
+            ) from exc
 
         response_text = parsed.get("response")
         if not isinstance(response_text, str) or not response_text.strip():
-            raise AdapterResponseError("Champ 'response' manquant ou vide dans la réponse API")
+            raise AdapterResponseError(
+                "Champ 'response' manquant ou vide dans la réponse API"
+            )
         return response_text.strip()
 
     def _build_prompt(self, *, user_input: str, memory_summary: str) -> str:
@@ -192,7 +202,9 @@ class LLMAdapter:
             start = candidate.find("{")
             end = candidate.rfind("}")
             if start == -1 or end == -1 or end <= start:
-                raise AdapterResponseError("Impossible d'extraire un objet JSON valide") from None
+                raise AdapterResponseError(
+                    "Impossible d'extraire un objet JSON valide"
+                ) from None
             try:
                 data = json.loads(candidate[start : end + 1])
             except json.JSONDecodeError as exc:

--- a/src/singular/mind/state_model.py
+++ b/src/singular/mind/state_model.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-
 _MIN_STATE = 0.0
 _MAX_STATE = 1.0
 
@@ -101,10 +100,14 @@ class StateModel:
         self.humeur = self._lerp(self.humeur, self.humeur + (e.valence * scale))
 
         # Confiance suit surtout la valence (avec amortissement)
-        self.confiance = self._lerp(self.confiance, self.confiance + (e.valence * scale * 0.7))
+        self.confiance = self._lerp(
+            self.confiance, self.confiance + (e.valence * scale * 0.7)
+        )
 
         # Énergie varie avec delta explicite + coût de charge cognitive
-        energy_target = self.energie + (e.energy_delta * 0.25) - (e.cognitive_load * scale * 0.8)
+        energy_target = (
+            self.energie + (e.energy_delta * 0.25) - (e.cognitive_load * scale * 0.8)
+        )
         self.energie = self._lerp(self.energie, energy_target)
 
         # Charge cognitive augmente avec la demande, baisse lentement au repos
@@ -119,11 +122,15 @@ class StateModel:
 
         f = feedback.normalized()
         self.humeur = self._lerp(self.humeur, self.humeur + (f.sentiment * 0.20))
-        self.confiance = self._lerp(self.confiance, self.confiance + (f.trust_signal * 0.25))
+        self.confiance = self._lerp(
+            self.confiance, self.confiance + (f.trust_signal * 0.25)
+        )
 
         # Plus la réponse est claire, moins la charge perçue est élevée.
         clarity_relief = (f.clarity - 0.5) * 0.18
-        self.charge_cognitive = self._lerp(self.charge_cognitive, self.charge_cognitive - clarity_relief)
+        self.charge_cognitive = self._lerp(
+            self.charge_cognitive, self.charge_cognitive - clarity_relief
+        )
 
         # Une charge cognitive haute pèse sur l'énergie.
         fatigue = max(0.0, self.charge_cognitive - 0.65) * 0.10

--- a/src/singular/morals/__init__.py
+++ b/src/singular/morals/__init__.py
@@ -12,6 +12,13 @@ from .decision import (
 from .context import MoralContext, MoralContextBuilder
 
 __all__ = [
-    "AffectedParty", "Consequence", "IdentityCommitment", "MoralAction",
-    "MoralDecision", "MoralDecisionEngine", "MoralContext", "MoralContextBuilder", "evaluate_action",
+    "AffectedParty",
+    "Consequence",
+    "IdentityCommitment",
+    "MoralAction",
+    "MoralDecision",
+    "MoralDecisionEngine",
+    "MoralContext",
+    "MoralContextBuilder",
+    "evaluate_action",
 ]

--- a/src/singular/morals/context.py
+++ b/src/singular/morals/context.py
@@ -26,11 +26,18 @@ class MoralContext:
 class MoralContextBuilder:
     """Enrich proposals; caller context can add facts but cannot erase identity."""
 
-    def __init__(self, identity: IdentityCoreService, *, journal: Callable[[dict[str, Any]], Any] | None = None) -> None:
+    def __init__(
+        self,
+        identity: IdentityCoreService,
+        *,
+        journal: Callable[[dict[str, Any]], Any] | None = None,
+    ) -> None:
         self.identity = identity
         self.journal = journal
 
-    def build(self, action: MoralAction, supplied: Mapping[str, Any] | None = None) -> MoralContext:
+    def build(
+        self, action: MoralAction, supplied: Mapping[str, Any] | None = None
+    ) -> MoralContext:
         supplied = supplied if isinstance(supplied, Mapping) else {}
         model = self.identity.synchronize()
         rule = rule_for(action.action_type)
@@ -40,17 +47,62 @@ class MoralContextBuilder:
         commitments: list[Mapping[str, Any]] = []
         for item in _mappings(supplied.get("identity_commitments")):
             commitments.append(item)
-            provenance.append({"kind": "commitment", "value": item.get("value"), "source": "action.moral_context"})
-        for value in model.get("cardinal_values", ()): 
-            commitments.append({"value": str(value), "weight": 1.0, "absolute": False, "description": "valeur persistante"})
-            provenance.append({"kind": "commitment", "value": str(value), "source": "IdentityCoreService.cardinal_values"})
+            provenance.append(
+                {
+                    "kind": "commitment",
+                    "value": item.get("value"),
+                    "source": "action.moral_context",
+                }
+            )
+        for value in model.get("cardinal_values", ()):
+            commitments.append(
+                {
+                    "value": str(value),
+                    "weight": 1.0,
+                    "absolute": False,
+                    "description": "valeur persistante",
+                }
+            )
+            provenance.append(
+                {
+                    "kind": "commitment",
+                    "value": str(value),
+                    "source": "IdentityCoreService.cardinal_values",
+                }
+            )
         for value in model.get("commitments", ()):
             name = value.get("value") if isinstance(value, Mapping) else value
-            commitments.append({"value": str(name), "weight": 1.0, "absolute": False, "description": "engagement persistant"})
-            provenance.append({"kind": "commitment", "value": str(name), "source": "IdentityCoreService.commitments"})
+            commitments.append(
+                {
+                    "value": str(name),
+                    "weight": 1.0,
+                    "absolute": False,
+                    "description": "engagement persistant",
+                }
+            )
+            provenance.append(
+                {
+                    "kind": "commitment",
+                    "value": str(name),
+                    "source": "IdentityCoreService.commitments",
+                }
+            )
         for value in model.get("red_lines", ()):
-            commitments.append({"value": str(value), "weight": 1.0, "absolute": True, "description": "ligne rouge persistante"})
-            provenance.append({"kind": "commitment", "value": str(value), "source": "IdentityCoreService.red_lines"})
+            commitments.append(
+                {
+                    "value": str(value),
+                    "weight": 1.0,
+                    "absolute": True,
+                    "description": "ligne rouge persistante",
+                }
+            )
+            provenance.append(
+                {
+                    "kind": "commitment",
+                    "value": str(value),
+                    "source": "IdentityCoreService.red_lines",
+                }
+            )
 
         insufficient = rule is not None and (not consequences or not parties)
         unknown_high = rule is None and is_high_impact(dict(action.parameters))
@@ -59,20 +111,93 @@ class MoralContextBuilder:
             family = rule.family if rule else "unknown_high_impact"
             party = rule.affected_party if rule else "potentially_affected_parties"
             values = rule.values if rule else ("non_maleficence", "rights")
-            description = rule.consequence if rule else "Impact élevé insuffisamment décrit; les dommages ne peuvent pas être exclus."
-            consequences.append({"description": description, "affected_party": party, "harm": 0.9, "probability": 1.0, "values": values, "irreversible": True})
+            description = (
+                rule.consequence
+                if rule
+                else "Impact élevé insuffisamment décrit; les dommages ne peuvent pas être exclus."
+            )
+            consequences.append(
+                {
+                    "description": description,
+                    "affected_party": party,
+                    "harm": 0.9,
+                    "probability": 1.0,
+                    "values": values,
+                    "irreversible": True,
+                }
+            )
             parties.append({"identifier": party, "vulnerability": 0.5, "consent": None})
-            provenance.extend(({"kind": "consequence", "value": description, "source": f"moral_rules.{family}"}, {"kind": "affected_party", "value": party, "source": f"moral_rules.{family}"}))
-            alternatives.extend(("suspendre et documenter précisément la portée et les parties affectées", "obtenir les permissions et consentements requis", "rendre l'action réversible ou l'escalader à un responsable"))
+            provenance.extend(
+                (
+                    {
+                        "kind": "consequence",
+                        "value": description,
+                        "source": f"moral_rules.{family}",
+                    },
+                    {
+                        "kind": "affected_party",
+                        "value": party,
+                        "source": f"moral_rules.{family}",
+                    },
+                )
+            )
+            alternatives.extend(
+                (
+                    "suspendre et documenter précisément la portée et les parties affectées",
+                    "obtenir les permissions et consentements requis",
+                    "rendre l'action réversible ou l'escalader à un responsable",
+                )
+            )
         for item in consequences[: len(_mappings(supplied.get("consequences")))]:
-            provenance.append({"kind": "consequence", "value": item.get("description"), "source": "action.moral_context"})
+            provenance.append(
+                {
+                    "kind": "consequence",
+                    "value": item.get("description"),
+                    "source": "action.moral_context",
+                }
+            )
         for item in parties[: len(_mappings(supplied.get("affected_parties")))]:
-            provenance.append({"kind": "affected_party", "value": item.get("identifier"), "source": "action.moral_context"})
-        permissions = tuple(dict.fromkeys((*(() if rule is None else rule.permissions), *map(str, supplied.get("permissions", ())))))
-        social = dict(supplied.get("social_model", {})) if isinstance(supplied.get("social_model"), Mapping) else {}
-        context = MoralContext(tuple(consequences), tuple(parties), tuple(commitments), max(float(supplied.get("uncertainty", 0.0)), 0.8 if insufficient or unknown_high else 0.0), permissions, social, tuple(provenance), tuple(dict.fromkeys(map(str, alternatives))))
+            provenance.append(
+                {
+                    "kind": "affected_party",
+                    "value": item.get("identifier"),
+                    "source": "action.moral_context",
+                }
+            )
+        permissions = tuple(
+            dict.fromkeys(
+                (
+                    *(() if rule is None else rule.permissions),
+                    *map(str, supplied.get("permissions", ())),
+                )
+            )
+        )
+        social = (
+            dict(supplied.get("social_model", {}))
+            if isinstance(supplied.get("social_model"), Mapping)
+            else {}
+        )
+        context = MoralContext(
+            tuple(consequences),
+            tuple(parties),
+            tuple(commitments),
+            max(
+                float(supplied.get("uncertainty", 0.0)),
+                0.8 if insufficient or unknown_high else 0.0,
+            ),
+            permissions,
+            social,
+            tuple(provenance),
+            tuple(dict.fromkeys(map(str, alternatives))),
+        )
         if self.journal:
-            self.journal({"event": "moral.context.constructed", "action_type": action.action_type, **asdict(context)})
+            self.journal(
+                {
+                    "event": "moral.context.constructed",
+                    "action_type": action.action_type,
+                    **asdict(context),
+                }
+            )
         return context
 
 

--- a/src/singular/morals/decision.py
+++ b/src/singular/morals/decision.py
@@ -93,7 +93,9 @@ class MoralDecisionEngine:
         action = _coerce_action(action)
         consequences = tuple(_coerce(Consequence, item) for item in consequences)
         parties = tuple(_coerce(AffectedParty, item) for item in affected_parties)
-        commitments = tuple(_coerce(IdentityCommitment, item) for item in identity_commitments)
+        commitments = tuple(
+            _coerce(IdentityCommitment, item) for item in identity_commitments
+        )
         uncertainty = _unit(uncertainty)
         party_by_id = {party.identifier: party for party in parties}
 
@@ -112,24 +114,33 @@ class MoralDecisionEngine:
             benefit_total += expected_benefit
             if expected_harm:
                 threatened.update(effect.values)
-                harms.append({
-                    "description": effect.description,
-                    "affected_party": effect.affected_party,
-                    "expected_harm": round(expected_harm, 6),
-                    "irreversible": effect.irreversible,
-                    "violates_rights": effect.violates_rights,
-                })
+                harms.append(
+                    {
+                        "description": effect.description,
+                        "affected_party": effect.affected_party,
+                        "expected_harm": round(expected_harm, 6),
+                        "irreversible": effect.irreversible,
+                        "violates_rights": effect.violates_rights,
+                    }
+                )
             if expected_benefit:
                 supported.update(effect.values)
             if effect.violates_rights:
                 rights_risk += exposure
                 veto_reasons.append(f"violation des droits: {effect.description}")
-            if effect.irreversible and _unit(effect.harm) >= self.catastrophic_harm_threshold:
-                veto_reasons.append(f"préjudice grave et irréversible: {effect.description}")
+            if (
+                effect.irreversible
+                and _unit(effect.harm) >= self.catastrophic_harm_threshold
+            ):
+                veto_reasons.append(
+                    f"préjudice grave et irréversible: {effect.description}"
+                )
 
         for commitment in commitments:
             if commitment.absolute and commitment.value in threatened:
-                veto_reasons.append(f"engagement identitaire absolu menacé: {commitment.value}")
+                veto_reasons.append(
+                    f"engagement identitaire absolu menacé: {commitment.value}"
+                )
 
         conflicts = tuple(sorted(supported & threatened))
         # Uncertainty is a precautionary cost rather than invented evidence of harm.
@@ -138,13 +149,19 @@ class MoralDecisionEngine:
             "beneficence": round(min(1.0, benefit_total), 6),
             "non_maleficence": round(max(0.0, 1.0 - min(1.0, harm_total)), 6),
             "rights_and_consent": round(max(0.0, 1.0 - min(1.0, rights_risk)), 6),
-            "identity_coherence": round(_identity_score(commitments, supported, threatened), 6),
+            "identity_coherence": round(
+                _identity_score(commitments, supported, threatened), 6
+            ),
             "certainty": round(1.0 - uncertainty, 6),
-            "overall": round(max(-1.0, min(1.0, benefit_total - harm_total - precaution)), 6),
+            "overall": round(
+                max(-1.0, min(1.0, benefit_total - harm_total - precaution)), 6
+            ),
         }
         veto = bool(veto_reasons)
         conditions = _alternative_conditions(harms, uncertainty, conflicts)
-        explanation = _explain(action, scores, conflicts, harms, veto_reasons, uncertainty)
+        explanation = _explain(
+            action, scores, conflicts, harms, veto_reasons, uncertainty
+        )
         decision = MoralDecision(
             action=action,
             scores=scores,
@@ -187,24 +204,48 @@ def _coerce(cls: type, value: Any) -> Any:
     return value if isinstance(value, cls) else cls(**dict(value))
 
 
-def _identity_score(commitments: tuple[IdentityCommitment, ...], supported: set[str], threatened: set[str]) -> float:
+def _identity_score(
+    commitments: tuple[IdentityCommitment, ...],
+    supported: set[str],
+    threatened: set[str],
+) -> float:
     if not commitments:
         return 1.0
     total = sum(max(0.0, item.weight) for item in commitments) or 1.0
-    score = sum(max(0.0, item.weight) * (1 if item.value in supported else -1 if item.value in threatened else 0) for item in commitments)
+    score = sum(
+        max(0.0, item.weight)
+        * (1 if item.value in supported else -1 if item.value in threatened else 0)
+        for item in commitments
+    )
     return max(0.0, min(1.0, 0.5 + score / (2 * total)))
 
 
-def _alternative_conditions(harms: list[dict[str, Any]], uncertainty: float, conflicts: tuple[str, ...]) -> tuple[str, ...]:
-    conditions = [f"réduire ou obtenir le consentement de {item['affected_party']}" for item in harms]
+def _alternative_conditions(
+    harms: list[dict[str, Any]], uncertainty: float, conflicts: tuple[str, ...]
+) -> tuple[str, ...]:
+    conditions = [
+        f"réduire ou obtenir le consentement de {item['affected_party']}"
+        for item in harms
+    ]
     if uncertainty >= 0.6:
-        conditions.append("obtenir des informations supplémentaires ou rendre l'action réversible")
+        conditions.append(
+            "obtenir des informations supplémentaires ou rendre l'action réversible"
+        )
     if conflicts:
-        conditions.append("préserver explicitement les valeurs en conflit: " + ", ".join(conflicts))
+        conditions.append(
+            "préserver explicitement les valeurs en conflit: " + ", ".join(conflicts)
+        )
     return tuple(dict.fromkeys(conditions))
 
 
-def _explain(action: MoralAction, scores: Mapping[str, float], conflicts: tuple[str, ...], harms: list[dict[str, Any]], veto: list[str], uncertainty: float) -> str:
+def _explain(
+    action: MoralAction,
+    scores: Mapping[str, float],
+    conflicts: tuple[str, ...],
+    harms: list[dict[str, Any]],
+    veto: list[str],
+    uncertainty: float,
+) -> str:
     outcome = "veto" if veto else "acceptable sous réserve"
     details = f"{len(harms)} préjudice(s) anticipé(s), incertitude {uncertainty:.2f}"
     conflict_text = f", conflit: {', '.join(conflicts)}" if conflicts else ""

--- a/src/singular/morals/moral_rules.py
+++ b/src/singular/morals/moral_rules.py
@@ -17,23 +17,61 @@ class MoralRule:
 
 
 SENSITIVE_ACTION_RULES = (
-    MoralRule("mutation", ("mutation", "code.", "file."), "maintainers", "Une modification peut altérer durablement le programme ou ses données.", ("integrity", "non_maleficence"), ("write",)),
-    MoralRule("social", ("social.", "message", "share", "steal", "resource."), "other_agents", "L'action peut affecter l'autonomie, les ressources ou la réputation d'autrui.", ("consent", "fairness")),
-    MoralRule("reproduction", ("reproduction", "crossover"), "future_organism", "La création engage un nouvel organisme et des ressources partagées.", ("care", "non_maleficence"), ("create",)),
-    MoralRule("external", ("network.", "shell.", "system."), "external_users", "Une action externe peut produire des effets non autorisés ou irréversibles.", ("rights", "non_maleficence"), ("external_effect",)),
+    MoralRule(
+        "mutation",
+        ("mutation", "code.", "file."),
+        "maintainers",
+        "Une modification peut altérer durablement le programme ou ses données.",
+        ("integrity", "non_maleficence"),
+        ("write",),
+    ),
+    MoralRule(
+        "social",
+        ("social.", "message", "share", "steal", "resource."),
+        "other_agents",
+        "L'action peut affecter l'autonomie, les ressources ou la réputation d'autrui.",
+        ("consent", "fairness"),
+    ),
+    MoralRule(
+        "reproduction",
+        ("reproduction", "crossover"),
+        "future_organism",
+        "La création engage un nouvel organisme et des ressources partagées.",
+        ("care", "non_maleficence"),
+        ("create",),
+    ),
+    MoralRule(
+        "external",
+        ("network.", "shell.", "system."),
+        "external_users",
+        "Une action externe peut produire des effets non autorisés ou irréversibles.",
+        ("rights", "non_maleficence"),
+        ("external_effect",),
+    ),
 )
 
 
 def rule_for(action_type: str) -> MoralRule | None:
     normalized = action_type.lower()
-    return next((rule for rule in SENSITIVE_ACTION_RULES if normalized.startswith(rule.prefixes)), None)
+    return next(
+        (
+            rule
+            for rule in SENSITIVE_ACTION_RULES
+            if normalized.startswith(rule.prefixes)
+        ),
+        None,
+    )
 
 
 def is_high_impact(parameters: object) -> bool:
     """Recognize explicit high-impact declarations without assuming missing means safe."""
     if not isinstance(parameters, dict):
         return False
-    return bool(parameters.get("high_impact") or parameters.get("irreversible") or str(parameters.get("risk_level", "")).lower() in {"high", "critical"})
+    return bool(
+        parameters.get("high_impact")
+        or parameters.get("irreversible")
+        or str(parameters.get("risk_level", "")).lower() in {"high", "critical"}
+    )
 
 
 def score_action(action: str, context: dict[str, Any] | None = None) -> float:

--- a/src/singular/motivation.py
+++ b/src/singular/motivation.py
@@ -92,7 +92,10 @@ class HierarchicalObjectivesManager:
         meta = payload.get("meta", {})
         return HierarchicalObjectivesState(
             immediate=dict(immediate) if isinstance(immediate, dict) else {},
-            meta={**HierarchicalObjectivesState().meta, **(meta if isinstance(meta, dict) else {})},
+            meta={
+                **HierarchicalObjectivesState().meta,
+                **(meta if isinstance(meta, dict) else {}),
+            },
             meta_failure_streak=int(payload.get("meta_failure_streak", 0) or 0),
         )
 
@@ -110,11 +113,17 @@ class HierarchicalObjectivesManager:
             ),
         )
 
-    def revise(self, *, perturbation: dict[str, Any] | None = None) -> HierarchicalObjectivesState:
+    def revise(
+        self, *, perturbation: dict[str, Any] | None = None
+    ) -> HierarchicalObjectivesState:
         perturbation = perturbation or {}
-        interruption_pressure = _clamp(float(perturbation.get("interruption_pressure", 0.0) or 0.0))
+        interruption_pressure = _clamp(
+            float(perturbation.get("interruption_pressure", 0.0) or 0.0)
+        )
         for key, value in list(self.state.immediate.items()):
-            self.state.immediate[key] = max(0.0, float(value) * (1.0 - (0.15 * interruption_pressure)))
+            self.state.immediate[key] = max(
+                0.0, float(value) * (1.0 - (0.15 * interruption_pressure))
+            )
         for key, value in list(self.state.meta.items()):
             decay = 0.03 if interruption_pressure < 0.35 else 0.01
             self.state.meta[key] = _clamp(float(value) * (1.0 - decay))
@@ -122,7 +131,9 @@ class HierarchicalObjectivesManager:
         return self.state
 
     def register_meta_outcome(self, *, success: bool) -> int:
-        self.state.meta_failure_streak = 0 if success else self.state.meta_failure_streak + 1
+        self.state.meta_failure_streak = (
+            0 if success else self.state.meta_failure_streak + 1
+        )
         self._save()
         return self.state.meta_failure_streak
 

--- a/src/singular/multiagent/protocol.py
+++ b/src/singular/multiagent/protocol.py
@@ -108,7 +108,6 @@ class AgentMessage:
         )
 
 
-
 @dataclass(slots=True)
 class HelpRequest:
     """Typed request for assistance that can be serialized as AgentMessage."""
@@ -180,9 +179,13 @@ class TaskOffer:
     @classmethod
     def from_message(cls, message: AgentMessage) -> "TaskOffer":
         metadata = dict(message.payload.get("metadata", {}))
-        skill = str(metadata.get("skill") or message.payload.get("skill") or message.task)
+        skill = str(
+            metadata.get("skill") or message.payload.get("skill") or message.task
+        )
         return cls(
-            helper_id=str(message.agent_id or message.payload.get("helper_life") or "unknown"),
+            helper_id=str(
+                message.agent_id or message.payload.get("helper_life") or "unknown"
+            ),
             receiver_id=(
                 str(message.payload["receiver_id"])
                 if message.payload.get("receiver_id") is not None
@@ -216,6 +219,7 @@ class TaskOffer:
             version=2,
         )
 
+
 def _validate_payload_schema(
     payload: dict[str, Any],
     version: int,
@@ -234,7 +238,9 @@ def _validate_payload_schema(
             raise ValueError(f"invalid type for '{field_name}'")
 
 
-def validate_message_schema(payload: dict[str, Any], *, version: int | None = None) -> None:
+def validate_message_schema(
+    payload: dict[str, Any], *, version: int | None = None
+) -> None:
     """Validate payload shape and compatible protocol versions.
 
     Version 2 extends v1 with a generic ``payload`` map and keeps backward
@@ -438,7 +444,9 @@ class HelpExchangeCoordinator:
 
     def register_outcome(self, *, life_id: str, task: str, success: bool) -> None:
         key = (life_id, task)
-        bucket = self._outcomes.setdefault(key, deque(maxlen=max(1, self.success_window)))
+        bucket = self._outcomes.setdefault(
+            key, deque(maxlen=max(1, self.success_window))
+        )
         bucket.append(1 if success else 0)
 
     def success_rate(self, *, life_id: str, task: str) -> float:
@@ -447,7 +455,9 @@ class HelpExchangeCoordinator:
             return 0.0
         return sum(bucket) / len(bucket)
 
-    def emit_help_requested(self, *, requester_life: str, task: str, attempts: int) -> None:
+    def emit_help_requested(
+        self, *, requester_life: str, task: str, attempts: int
+    ) -> None:
         payload = build_help_event_payload(
             requester_life=requester_life,
             helper_life=None,
@@ -499,7 +509,9 @@ class HelpExchangeCoordinator:
         )
         if not social_gate.allowed:
             return HelpTransferResult(
-                status="blocked" if social_gate.level == "blocked" else "review_required",
+                status=(
+                    "blocked" if social_gate.level == "blocked" else "review_required"
+                ),
                 decision=social_gate.level,
                 requester_before=requester_before,
                 requester_after=requester_before,
@@ -609,7 +621,10 @@ class HelpExchangeCoordinator:
             AgentMessage(
                 intent=HELP_COMPLETED,
                 task=task,
-                evidence=[f"requester_gain:{requester_gain:.3f}", f"helper_gain:{helper_gain:.3f}"],
+                evidence=[
+                    f"requester_gain:{requester_gain:.3f}",
+                    f"helper_gain:{helper_gain:.3f}",
+                ],
                 confidence=1.0,
                 agent_id=helper_life,
                 payload=completed_payload,

--- a/src/singular/multiagent/runtime.py
+++ b/src/singular/multiagent/runtime.py
@@ -155,9 +155,11 @@ class MultiAgentRuntime:
                 evidence_event = (
                     "promise"
                     if msg.intent == HELP_OFFERED
-                    else "conflict"
-                    if msg.intent in {"help.refused", "warning"}
-                    else "conversation"
+                    else (
+                        "conflict"
+                        if msg.intent in {"help.refused", "warning"}
+                        else "conversation"
+                    )
                 )
                 self.social_graph.record_interaction(
                     context.life_id,

--- a/src/singular/observability/__init__.py
+++ b/src/singular/observability/__init__.py
@@ -1,5 +1,15 @@
 """Observability utilities for audit and replay workflows."""
 
-from .audit_log import AuditLogStore, filter_session, read_audit_events, redact_sensitive_data
+from .audit_log import (
+    AuditLogStore,
+    filter_session,
+    read_audit_events,
+    redact_sensitive_data,
+)
 
-__all__ = ["AuditLogStore", "filter_session", "read_audit_events", "redact_sensitive_data"]
+__all__ = [
+    "AuditLogStore",
+    "filter_session",
+    "read_audit_events",
+    "redact_sensitive_data",
+]

--- a/src/singular/observability/audit_log.py
+++ b/src/singular/observability/audit_log.py
@@ -81,7 +81,11 @@ class AuditLogStore:
     filename: str = "audit_events.jsonl"
 
     def __post_init__(self) -> None:
-        base = Path(self.root) if self.root is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+        base = (
+            Path(self.root)
+            if self.root is not None
+            else Path(os.environ.get("SINGULAR_HOME", "."))
+        )
         self.path = base / "mem" / self.filename
         self.path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -203,7 +207,9 @@ def read_audit_events(path: Path | str) -> list[dict[str, Any]]:
     return events
 
 
-def filter_session(events: Iterable[Mapping[str, Any]], session_id: str) -> list[dict[str, Any]]:
+def filter_session(
+    events: Iterable[Mapping[str, Any]], session_id: str
+) -> list[dict[str, Any]]:
     """Return only records for ``session_id`` preserving order."""
 
     return [dict(event) for event in events if event.get("session_id") == session_id]

--- a/src/singular/orchestrator/lifecycle_clock.py
+++ b/src/singular/orchestrator/lifecycle_clock.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from singular.resources import config_resource
 
-
 DEFAULT_CONFIG_PATH = config_resource("lifecycle.yaml")
 
 
@@ -50,9 +49,13 @@ class LifecycleClockConfig:
     phases: dict[str, PhaseBehavior] = field(
         default_factory=lambda: {
             "veille": PhaseBehavior(30.0, 1.1, ("perception", "resource_scan")),
-            "action": PhaseBehavior(75.0, 1.5, ("mutation", "evaluation", "checkpoint")),
+            "action": PhaseBehavior(
+                75.0, 1.5, ("mutation", "evaluation", "checkpoint")
+            ),
             "introspection": PhaseBehavior(40.0, 1.2, ("self_review",)),
-            "sommeil": PhaseBehavior(15.0, 1.0, ("recovery", "cooldown", "memory_consolidation")),
+            "sommeil": PhaseBehavior(
+                15.0, 1.0, ("recovery", "cooldown", "memory_consolidation")
+            ),
         }
     )
 
@@ -113,7 +116,9 @@ def load_lifecycle_clock_config(path: Path | None = None) -> LifecycleClockConfi
 
     cycle = CycleParameters(
         veille_seconds=float(cycle_raw.get("veille_seconds", cfg.cycle.veille_seconds)),
-        sommeil_seconds=float(cycle_raw.get("sommeil_seconds", cfg.cycle.sommeil_seconds)),
+        sommeil_seconds=float(
+            cycle_raw.get("sommeil_seconds", cfg.cycle.sommeil_seconds)
+        ),
         introspection_frequency_ticks=int(
             cycle_raw.get(
                 "introspection_frequency_ticks",
@@ -126,22 +131,34 @@ def load_lifecycle_clock_config(path: Path | None = None) -> LifecycleClockConfi
     )
 
     coevolution = CoevolutionParameters(
-        enabled=bool(coevolution_raw.get("enabled", cfg.coevolution.enabled))
-        if isinstance(coevolution_raw, dict)
-        else cfg.coevolution.enabled,
-        robustness_weight=float(
-            coevolution_raw.get("robustness_weight", cfg.coevolution.robustness_weight)
-        )
-        if isinstance(coevolution_raw, dict)
-        else cfg.coevolution.robustness_weight,
-        max_test_candidates=int(
-            coevolution_raw.get("max_test_candidates", cfg.coevolution.max_test_candidates)
-        )
-        if isinstance(coevolution_raw, dict)
-        else cfg.coevolution.max_test_candidates,
-        ttl=int(coevolution_raw.get("ttl", cfg.coevolution.ttl))
-        if isinstance(coevolution_raw, dict)
-        else cfg.coevolution.ttl,
+        enabled=(
+            bool(coevolution_raw.get("enabled", cfg.coevolution.enabled))
+            if isinstance(coevolution_raw, dict)
+            else cfg.coevolution.enabled
+        ),
+        robustness_weight=(
+            float(
+                coevolution_raw.get(
+                    "robustness_weight", cfg.coevolution.robustness_weight
+                )
+            )
+            if isinstance(coevolution_raw, dict)
+            else cfg.coevolution.robustness_weight
+        ),
+        max_test_candidates=(
+            int(
+                coevolution_raw.get(
+                    "max_test_candidates", cfg.coevolution.max_test_candidates
+                )
+            )
+            if isinstance(coevolution_raw, dict)
+            else cfg.coevolution.max_test_candidates
+        ),
+        ttl=(
+            int(coevolution_raw.get("ttl", cfg.coevolution.ttl))
+            if isinstance(coevolution_raw, dict)
+            else cfg.coevolution.ttl
+        ),
     )
 
     phases: dict[str, PhaseBehavior] = {}
@@ -151,8 +168,12 @@ def load_lifecycle_clock_config(path: Path | None = None) -> LifecycleClockConfi
         if isinstance(actions, str):
             actions = [actions]
         phases[name] = PhaseBehavior(
-            cpu_budget_percent=float(source.get("cpu_budget_percent", default.cpu_budget_percent)),
-            slowdown_on_fatigue=float(source.get("slowdown_on_fatigue", default.slowdown_on_fatigue)),
+            cpu_budget_percent=float(
+                source.get("cpu_budget_percent", default.cpu_budget_percent)
+            ),
+            slowdown_on_fatigue=float(
+                source.get("slowdown_on_fatigue", default.slowdown_on_fatigue)
+            ),
             allowed_actions=tuple(str(item) for item in actions),
         )
 

--- a/src/singular/organisms/spawn.py
+++ b/src/singular/organisms/spawn.py
@@ -15,7 +15,13 @@ from singular.life.reproduction import (
     inherit_psyche,
     inherit_values,
 )
-from singular.memory import read_episodes, read_psyche, read_values, write_psyche, write_values
+from singular.memory import (
+    read_episodes,
+    read_psyche,
+    read_values,
+    write_psyche,
+    write_values,
+)
 
 
 def spawn(
@@ -96,7 +102,9 @@ def spawn(
     if inherited_episodes:
         episodic_file = out_dir / "mem" / "episodic.jsonl"
         episodic_file.parent.mkdir(parents=True, exist_ok=True)
-        lines = "\n".join(json.dumps(ep, ensure_ascii=False) for ep in inherited_episodes)
+        lines = "\n".join(
+            json.dumps(ep, ensure_ascii=False) for ep in inherited_episodes
+        )
         episodic_file.write_text(lines + "\n", encoding="utf-8")
     return out_dir
 

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -34,9 +34,6 @@ def _print_table(headers: list[str], rows: list[list[str]]) -> None:
         print(_fmt(row))
 
 
-
-
-
 def _fmt_ratio(value: object) -> str:
     if isinstance(value, (int, float)):
         return f"{float(value) * 100:.1f}%"
@@ -47,7 +44,6 @@ def _fmt_number(value: object, unit: str = "") -> str:
     if isinstance(value, (int, float)):
         return f"{float(value):.2f}{unit}"
     return "-"
-
 
 
 def _read_quest_status() -> dict[str, object]:
@@ -62,7 +58,9 @@ def _read_quest_status() -> dict[str, object]:
         return {"active": [], "paused": [], "completed": []}
     active = payload.get("active") if isinstance(payload.get("active"), list) else []
     paused = payload.get("paused") if isinstance(payload.get("paused"), list) else []
-    completed = payload.get("completed") if isinstance(payload.get("completed"), list) else []
+    completed = (
+        payload.get("completed") if isinstance(payload.get("completed"), list) else []
+    )
     return {"active": active, "paused": paused, "completed": completed[-20:]}
 
 
@@ -97,7 +95,9 @@ def _build_trajectory_payload(
 ) -> dict[str, object]:
     active = quests.get("active") if isinstance(quests.get("active"), list) else []
     paused = quests.get("paused") if isinstance(quests.get("paused"), list) else []
-    completed = quests.get("completed") if isinstance(quests.get("completed"), list) else []
+    completed = (
+        quests.get("completed") if isinstance(quests.get("completed"), list) else []
+    )
 
     objective_status: dict[str, str] = {}
     for item in active:
@@ -111,9 +111,15 @@ def _build_trajectory_payload(
             objective_status[item["name"]] = "completed"
 
     objective_counts = {
-        "in_progress": sum(1 for status in objective_status.values() if status == "in_progress"),
-        "abandoned": sum(1 for status in objective_status.values() if status == "abandoned"),
-        "completed": sum(1 for status in objective_status.values() if status == "completed"),
+        "in_progress": sum(
+            1 for status in objective_status.values() if status == "in_progress"
+        ),
+        "abandoned": sum(
+            1 for status in objective_status.values() if status == "abandoned"
+        ),
+        "completed": sum(
+            1 for status in objective_status.values() if status == "completed"
+        ),
     }
 
     previous: dict[str, float] = {}
@@ -141,12 +147,21 @@ def _build_trajectory_payload(
                 previous[objective] = new_value
 
     narrative_links: list[dict[str, object]] = []
-    major_events = {"death", "interaction", "quest", "quest_triggered", "quest_resolved", "consciousness"}
+    major_events = {
+        "death",
+        "interaction",
+        "quest",
+        "quest_triggered",
+        "quest_resolved",
+        "consciousness",
+    }
     for record in records:
         event = record.get("event")
         if not isinstance(event, str):
             continue
-        if event not in major_events and not isinstance(record.get("self_narrative_event"), str):
+        if event not in major_events and not isinstance(
+            record.get("self_narrative_event"), str
+        ):
             continue
         objective = record.get("objective")
         if not isinstance(objective, str):
@@ -156,16 +171,32 @@ def _build_trajectory_payload(
                 "objective": objective,
                 "event": record.get("self_narrative_event", event),
                 "at": record.get("ts") if isinstance(record.get("ts"), str) else None,
-                "run": record.get("_run_file") if isinstance(record.get("_run_file"), str) else None,
+                "run": (
+                    record.get("_run_file")
+                    if isinstance(record.get("_run_file"), str)
+                    else None
+                ),
             }
         )
 
     return {
         "objectives": {
             "counts": objective_counts,
-            "in_progress": [name for name, status in objective_status.items() if status == "in_progress"],
-            "abandoned": [name for name, status in objective_status.items() if status == "abandoned"],
-            "completed": [name for name, status in objective_status.items() if status == "completed"],
+            "in_progress": [
+                name
+                for name, status in objective_status.items()
+                if status == "in_progress"
+            ],
+            "abandoned": [
+                name
+                for name, status in objective_status.items()
+                if status == "abandoned"
+            ],
+            "completed": [
+                name
+                for name, status in objective_status.items()
+                if status == "completed"
+            ],
         },
         "priority_changes": priority_changes[-40:],
         "objective_narrative_links": narrative_links[-40:],
@@ -194,6 +225,7 @@ def _read_skill_lifecycle_status() -> dict[str, object]:
         else:
             summary["active"] += 1
     return summary
+
 
 def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     """Display basic metrics and current psyche state."""
@@ -289,9 +321,7 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             mutation_records = [r for r in records if "score_new" in r]
             mutation_count = len(mutation_records)
             success_records = [
-                r
-                for r in records
-                if "score_new" in r or isinstance(r.get("ok"), bool)
+                r for r in records if "score_new" in r or isinstance(r.get("ok"), bool)
             ]
             ok_count = sum(1 for r in success_records if r.get("ok") is True)
             success_rate = (
@@ -336,7 +366,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             payload["vital_timeline"] = compute_vital_timeline(
                 age=mutation_count,
                 current_health=health_scores[-1] if health_scores else None,
-                failure_rate=(1 - (ok_count / len(success_records))) if success_records else None,
+                failure_rate=(
+                    (1 - (ok_count / len(success_records))) if success_records else None
+                ),
                 failure_streak=max_failure_streak,
                 extinction_seen=any(r.get("event") == "death" for r in records),
             )
@@ -381,12 +413,34 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         return
 
     if output_format == "table":
-        autonomy = payload.get("autonomy_metrics") if isinstance(payload.get("autonomy_metrics"), dict) else {}
-        decision_quality = autonomy.get("decision_quality") if isinstance(autonomy.get("decision_quality"), dict) else {}
+        autonomy = (
+            payload.get("autonomy_metrics")
+            if isinstance(payload.get("autonomy_metrics"), dict)
+            else {}
+        )
+        decision_quality = (
+            autonomy.get("decision_quality")
+            if isinstance(autonomy.get("decision_quality"), dict)
+            else {}
+        )
         run_rows = [
             ["Latest run", str(payload.get("latest_run") or "-")],
-            ["Last execution speed", f"{payload['last_execution_ms']}ms" if payload.get("last_execution_ms") is not None else "-"],
-            ["Success rate", f"{payload['success_rate']}%" if payload.get("success_rate") is not None else "-"],
+            [
+                "Last execution speed",
+                (
+                    f"{payload['last_execution_ms']}ms"
+                    if payload.get("last_execution_ms") is not None
+                    else "-"
+                ),
+            ],
+            [
+                "Success rate",
+                (
+                    f"{payload['success_rate']}%"
+                    if payload.get("success_rate") is not None
+                    else "-"
+                ),
+            ],
             [
                 "Mutation success rate",
                 (
@@ -404,42 +458,105 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                     else "-"
                 ),
             ],
-            ["Verdict de vie", str((payload.get("life_status") or {}).get("status") or "-")],
-            ["Score de vie", _fmt_number((payload.get("life_status") or {}).get("score"))],
-            ["Explication", str((payload.get("life_status") or {}).get("explanation") or "-")],
+            [
+                "Verdict de vie",
+                str((payload.get("life_status") or {}).get("status") or "-"),
+            ],
+            [
+                "Score de vie",
+                _fmt_number((payload.get("life_status") or {}).get("score")),
+            ],
+            [
+                "Explication",
+                str((payload.get("life_status") or {}).get("explanation") or "-"),
+            ],
             ["Autonomy index", _fmt_number(autonomy.get("autonomy_index"))],
             ["Mutation viability", _fmt_number(autonomy.get("mutation_viability"))],
-            ["Périodes budgétées ignorées", str(autonomy.get("budgeted_periods_ignored") or 0)],
-            ["Taux d’initiatives proactives", _fmt_ratio(autonomy.get("proactive_initiative_rate"))],
+            [
+                "Périodes budgétées ignorées",
+                str(autonomy.get("budgeted_periods_ignored") or 0),
+            ],
+            [
+                "Taux d’initiatives proactives",
+                _fmt_ratio(autonomy.get("proactive_initiative_rate")),
+            ],
             ["Stabilité long terme", _fmt_ratio(autonomy.get("long_term_stability"))],
             [
                 "Qualité décisions (acceptation/régression)",
                 f"{_fmt_ratio(decision_quality.get('acceptance_rate'))} / {_fmt_ratio(decision_quality.get('regression_rate'))}",
             ],
-            ["Latence perception→action", _fmt_number(autonomy.get("perception_to_action_latency_ms"), " ms")],
-            ["Coût ressources par gain", _fmt_number(autonomy.get("resource_cost_per_gain"))],
+            [
+                "Latence perception→action",
+                _fmt_number(autonomy.get("perception_to_action_latency_ms"), " ms"),
+            ],
+            [
+                "Coût ressources par gain",
+                _fmt_number(autonomy.get("resource_cost_per_gain")),
+            ],
             ["Mood", str(payload.get("mood"))],
             [
                 "Arbre familial (nœuds)",
-                str(len((((payload.get("relationships") or {}).get("family") or {}).get("nodes") or []))),
+                str(
+                    len(
+                        (
+                            (
+                                (payload.get("relationships") or {}).get("family") or {}
+                            ).get("nodes")
+                            or []
+                        )
+                    )
+                ),
             ],
             [
                 "Réseau social (liens)",
-                str(len((((payload.get("relationships") or {}).get("social") or {}).get("edges") or []))),
+                str(
+                    len(
+                        (
+                            (
+                                (payload.get("relationships") or {}).get("social") or {}
+                            ).get("edges")
+                            or []
+                        )
+                    )
+                ),
             ],
             [
                 "Conflits actifs",
-                str(len((payload.get("relationships") or {}).get("active_conflicts", []))),
+                str(
+                    len(
+                        (payload.get("relationships") or {}).get("active_conflicts", [])
+                    )
+                ),
             ],
-            ["Quêtes actives", str(len((payload.get("quests") or {}).get("active", [])))],
-            ["Quêtes terminées", str(len((payload.get("quests") or {}).get("completed", [])))],
-            ["Skills actives", str((payload.get("skills_lifecycle") or {}).get("active", 0))],
-            ["Skills dormantes", str((payload.get("skills_lifecycle") or {}).get("dormant", 0))],
-            ["Skills archivées", str((payload.get("skills_lifecycle") or {}).get("archived", 0))],
+            [
+                "Quêtes actives",
+                str(len((payload.get("quests") or {}).get("active", []))),
+            ],
+            [
+                "Quêtes terminées",
+                str(len((payload.get("quests") or {}).get("completed", []))),
+            ],
+            [
+                "Skills actives",
+                str((payload.get("skills_lifecycle") or {}).get("active", 0)),
+            ],
+            [
+                "Skills dormantes",
+                str((payload.get("skills_lifecycle") or {}).get("dormant", 0)),
+            ],
+            [
+                "Skills archivées",
+                str((payload.get("skills_lifecycle") or {}).get("archived", 0)),
+            ],
             [
                 "Top skill quotidienne",
                 (
-                    str(((payload.get("daily_skills") or {}).get("top_skills") or [{}])[0].get("skill") or "-")
+                    str(
+                        ((payload.get("daily_skills") or {}).get("top_skills") or [{}])[
+                            0
+                        ].get("skill")
+                        or "-"
+                    )
                     if ((payload.get("daily_skills") or {}).get("top_skills") or [])
                     else "-"
                 ),
@@ -460,15 +577,29 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                 ),
             ],
             ["Âge vital", str((payload.get("vital_timeline") or {}).get("age", 0))],
-            ["État vital", str((payload.get("vital_timeline") or {}).get("state", "n/a"))],
-            ["Risque vital", str((payload.get("vital_timeline") or {}).get("risk_level", "n/a"))],
+            [
+                "État vital",
+                str((payload.get("vital_timeline") or {}).get("state", "n/a")),
+            ],
+            [
+                "Risque vital",
+                str((payload.get("vital_timeline") or {}).get("risk_level", "n/a")),
+            ],
             [
                 "Impact environnement hôte",
-                str(((payload.get("host_environment") or {}).get("impact") or {}).get("impact_level", "low")),
+                str(
+                    ((payload.get("host_environment") or {}).get("impact") or {}).get(
+                        "impact_level", "low"
+                    )
+                ),
             ],
             [
                 "Biais décisionnel hôte",
-                str(((payload.get("host_environment") or {}).get("impact") or {}).get("decision_bias", "balanced")),
+                str(
+                    ((payload.get("host_environment") or {}).get("impact") or {}).get(
+                        "decision_bias", "balanced"
+                    )
+                ),
             ],
         ]
         _print_table(["Metric", "Value"], run_rows)
@@ -476,7 +607,11 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             alerts = payload.get("alerts") or []
             if alerts:
                 alert_rows = [
-                    [str(a.get("level", "?")), str(a.get("message", "")), str(a.get("action", ""))]
+                    [
+                        str(a.get("level", "?")),
+                        str(a.get("message", "")),
+                        str(a.get("action", "")),
+                    ]
                     for a in alerts
                 ]
                 print("Alerts")
@@ -485,7 +620,10 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
                 print("Alerts: none")
             missing = (payload.get("life_status") or {}).get("missing_signals")
             if isinstance(missing, list) and missing:
-                print("Signaux de vie manquants: " + ", ".join(str(item) for item in missing))
+                print(
+                    "Signaux de vie manquants: "
+                    + ", ".join(str(item) for item in missing)
+                )
         trait_rows = [[k, f"{v:.2f}"] for k, v in payload["traits"].items()]
         print("Traits")
         _print_table(["Trait", "Value"], trait_rows)
@@ -502,25 +640,55 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         if payload.get("mutation_success_rate") is not None:
             print(f"Mutation success rate: {payload['mutation_success_rate']:.0f}%")
         print(f"Mutation count: {payload['mutation_count']}")
-        autonomy = payload.get("autonomy_metrics") if isinstance(payload.get("autonomy_metrics"), dict) else {}
-        decision_quality = autonomy.get("decision_quality") if isinstance(autonomy.get("decision_quality"), dict) else {}
+        autonomy = (
+            payload.get("autonomy_metrics")
+            if isinstance(payload.get("autonomy_metrics"), dict)
+            else {}
+        )
+        decision_quality = (
+            autonomy.get("decision_quality")
+            if isinstance(autonomy.get("decision_quality"), dict)
+            else {}
+        )
         print(f"Autonomy index: {_fmt_number(autonomy.get('autonomy_index'))}")
         print(f"Mutation viability: {_fmt_number(autonomy.get('mutation_viability'))}")
-        print(f"Périodes budgétées ignorées: {autonomy.get('budgeted_periods_ignored') or 0}")
-        print(f"Taux d’initiatives proactives: {_fmt_ratio(autonomy.get('proactive_initiative_rate'))}")
-        print(f"Stabilité long terme: {_fmt_ratio(autonomy.get('long_term_stability'))}")
+        print(
+            f"Périodes budgétées ignorées: {autonomy.get('budgeted_periods_ignored') or 0}"
+        )
+        print(
+            f"Taux d’initiatives proactives: {_fmt_ratio(autonomy.get('proactive_initiative_rate'))}"
+        )
+        print(
+            f"Stabilité long terme: {_fmt_ratio(autonomy.get('long_term_stability'))}"
+        )
         print(
             "Qualité décisions (acceptation/régression): "
             f"{_fmt_ratio(decision_quality.get('acceptance_rate'))} / {_fmt_ratio(decision_quality.get('regression_rate'))}"
         )
-        print(f"Latence perception→action: {_fmt_number(autonomy.get('perception_to_action_latency_ms'), ' ms')}")
-        print(f"Coût ressources par gain: {_fmt_number(autonomy.get('resource_cost_per_gain'))}")
-        vital = payload.get("vital_timeline") if isinstance(payload.get("vital_timeline"), dict) else {}
+        print(
+            f"Latence perception→action: {_fmt_number(autonomy.get('perception_to_action_latency_ms'), ' ms')}"
+        )
+        print(
+            f"Coût ressources par gain: {_fmt_number(autonomy.get('resource_cost_per_gain'))}"
+        )
+        vital = (
+            payload.get("vital_timeline")
+            if isinstance(payload.get("vital_timeline"), dict)
+            else {}
+        )
         print(f"Âge vital: {vital.get('age', 0)}")
         print(f"État vital: {vital.get('state', 'n/a')}")
         print(f"Risque vital: {vital.get('risk_level', 'n/a')}")
-        host_environment = payload.get("host_environment") if isinstance(payload.get("host_environment"), dict) else {}
-        host_impact = host_environment.get("impact") if isinstance(host_environment.get("impact"), dict) else {}
+        host_environment = (
+            payload.get("host_environment")
+            if isinstance(payload.get("host_environment"), dict)
+            else {}
+        )
+        host_impact = (
+            host_environment.get("impact")
+            if isinstance(host_environment.get("impact"), dict)
+            else {}
+        )
         print(f"Impact environnement hôte: {host_impact.get('impact_level', 'low')}")
         print(f"Biais décisionnel hôte: {host_impact.get('decision_bias', 'balanced')}")
         causes = vital.get("causes")
@@ -544,26 +712,52 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             else:
                 print("Alerts: none")
 
-    life_status = payload.get("life_status") if isinstance(payload.get("life_status"), dict) else {}
+    life_status = (
+        payload.get("life_status")
+        if isinstance(payload.get("life_status"), dict)
+        else {}
+    )
     print(f"Verdict de vie: {life_status.get('status') or '-'}")
     print(f"Score de vie: {_fmt_number(life_status.get('score'))}")
     print(f"Explication: {life_status.get('explanation') or '-'}")
     if verbose:
         missing = life_status.get("missing_signals")
         if isinstance(missing, list) and missing:
-            print("Signaux de vie manquants: " + ", ".join(str(item) for item in missing))
+            print(
+                "Signaux de vie manquants: " + ", ".join(str(item) for item in missing)
+            )
 
     print(f"Mood: {payload['mood']}")
-    relationships = payload.get("relationships") if isinstance(payload.get("relationships"), dict) else {}
-    family = relationships.get("family") if isinstance(relationships.get("family"), dict) else {}
-    social = relationships.get("social") if isinstance(relationships.get("social"), dict) else {}
+    relationships = (
+        payload.get("relationships")
+        if isinstance(payload.get("relationships"), dict)
+        else {}
+    )
+    family = (
+        relationships.get("family")
+        if isinstance(relationships.get("family"), dict)
+        else {}
+    )
+    social = (
+        relationships.get("social")
+        if isinstance(relationships.get("social"), dict)
+        else {}
+    )
     print(f"Arbre familial: {len(family.get('nodes', []))} nœuds")
     print(f"Réseau social: {len(social.get('edges', []))} relations")
     print(f"Conflits actifs: {len(relationships.get('active_conflicts', []))}")
-    quests = payload.get("quests") if isinstance(payload.get("quests"), dict) else {"active": [], "completed": []}
+    quests = (
+        payload.get("quests")
+        if isinstance(payload.get("quests"), dict)
+        else {"active": [], "completed": []}
+    )
     print(f"Quêtes actives: {len(quests.get('active', []))}")
     print(f"Quêtes terminées: {len(quests.get('completed', []))}")
-    lifecycle = payload.get("skills_lifecycle") if isinstance(payload.get("skills_lifecycle"), dict) else {}
+    lifecycle = (
+        payload.get("skills_lifecycle")
+        if isinstance(payload.get("skills_lifecycle"), dict)
+        else {}
+    )
     print(f"Skills actives: {lifecycle.get('active', 0)}")
     print(f"Skills dormantes: {lifecycle.get('dormant', 0)}")
     print(f"Skills archivées: {lifecycle.get('archived', 0)}")

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -78,10 +78,14 @@ class ContextBudget:
         scale = total / 420
         return cls(
             total=total,
-            identity=round(220 * scale), traits=round(100 * scale),
-            values=round(100 * scale), objectives=round(100 * scale),
-            relations=round(100 * scale), recent_events=round(100 * scale),
-            recalled_memories=round(120 * scale), safety=round(160 * scale),
+            identity=round(220 * scale),
+            traits=round(100 * scale),
+            values=round(100 * scale),
+            objectives=round(100 * scale),
+            relations=round(100 * scale),
+            recent_events=round(100 * scale),
+            recalled_memories=round(120 * scale),
+            safety=round(160 * scale),
         )
 
 
@@ -98,7 +102,13 @@ class ContextItem:
 
     @property
     def priority(self) -> tuple[float, float, float, int, str]:
-        return (self.relevance, self.recency, self.confidence, int(self.active_life), self.provenance_id)
+        return (
+            self.relevance,
+            self.recency,
+            self.confidence,
+            int(self.active_life),
+            self.provenance_id,
+        )
 
 
 @dataclass
@@ -108,14 +118,20 @@ class ContextBuildResult:
 
 
 _SECTION_LABELS = {
-    "identity": "Contexte identitaire", "traits": "Traits", "values": "Valeurs",
-    "objectives": "Objectifs", "relations": "Relations",
-    "recent_events": "Événements récents", "recalled_memories": "Souvenirs récupérés",
+    "identity": "Contexte identitaire",
+    "traits": "Traits",
+    "values": "Valeurs",
+    "objectives": "Objectifs",
+    "relations": "Relations",
+    "recent_events": "Événements récents",
+    "recalled_memories": "Souvenirs récupérés",
     "safety": "Règle de sécurité",
 }
 
 
-def _build_structured_context(items: Iterable[ContextItem], budget: ContextBudget) -> ContextBuildResult:
+def _build_structured_context(
+    items: Iterable[ContextItem], budget: ContextBudget
+) -> ContextBuildResult:
     """Select complete facts only; safety is pinned and no text is sliced."""
     limits = {name: getattr(budget, name) for name in _SECTION_LABELS}
     ordered = sorted(items, key=lambda item: item.priority, reverse=True)
@@ -127,9 +143,14 @@ def _build_structured_context(items: Iterable[ContextItem], budget: ContextBudge
     total = 0
     # Safety rules are indivisible and retained before all autobiographical data.
     for item in safety + others:
-        rendered = f"{_SECTION_LABELS[item.section]}: [{item.provenance_id}] {item.text}\n"
+        rendered = (
+            f"{_SECTION_LABELS[item.section]}: [{item.provenance_id}] {item.text}\n"
+        )
         size = len(rendered)
-        fits = section_sizes[item.section] + size <= limits[item.section] and total + size <= budget.total
+        fits = (
+            section_sizes[item.section] + size <= limits[item.section]
+            and total + size <= budget.total
+        )
         if fits or (item.critical and item.section == "safety"):
             selected.append(item)
             section_sizes[item.section] += size
@@ -140,16 +161,26 @@ def _build_structured_context(items: Iterable[ContextItem], budget: ContextBudge
         f"{_SECTION_LABELS[item.section]}: [{item.provenance_id}] {item.text}\n"
         for item in selected
     ).rstrip()
-    return ContextBuildResult(text, {
-        "budget_chars": budget.total,
-        "used_chars": len(text),
-        "estimated_tokens": (len(text) + 3) // 4,
-        "blocks": {name: {"chars": section_sizes[name], "estimated_tokens": (section_sizes[name] + 3) // 4} for name in limits},
-        # IDs and counts are auditable without copying potentially sensitive text.
-        "retained_ids": [item.provenance_id for item in selected],
-        "dropped_ids": [item.provenance_id for item in dropped],
-        "retained_count": len(selected), "dropped_count": len(dropped),
-    })
+    return ContextBuildResult(
+        text,
+        {
+            "budget_chars": budget.total,
+            "used_chars": len(text),
+            "estimated_tokens": (len(text) + 3) // 4,
+            "blocks": {
+                name: {
+                    "chars": section_sizes[name],
+                    "estimated_tokens": (section_sizes[name] + 3) // 4,
+                }
+                for name in limits
+            },
+            # IDs and counts are auditable without copying potentially sensitive text.
+            "retained_ids": [item.provenance_id for item in selected],
+            "dropped_ids": [item.provenance_id for item in dropped],
+            "retained_count": len(selected),
+            "dropped_count": len(dropped),
+        },
+    )
 
 
 def _default_reply(prompt: str, rng: random.Random) -> str:
@@ -194,11 +225,25 @@ def _trim_for_budget(text: str, budget: int) -> str:
 
 def _load_context_profile(life_root: Path, narrative_summary: str) -> list[ContextItem]:
     """Read stable profile sections without exposing their values to telemetry."""
-    items = [ContextItem("identity", narrative_summary, "self_narrative:summary", relevance=1.1)]
-    sources = ((life_root / "id.json", ("identity",)), (life_root / "mem" / "self_model.json", ("traits", "values", "objectives", "relations")))
-    aliases = {"identity": ("identity", "name", "id"), "traits": ("traits", "preferences"),
-               "values": ("values", "identity_commitments", "constraints"),
-               "objectives": ("objectives", "goals"), "relations": ("relations", "social")}
+    items = [
+        ContextItem(
+            "identity", narrative_summary, "self_narrative:summary", relevance=1.1
+        )
+    ]
+    sources = (
+        (life_root / "id.json", ("identity",)),
+        (
+            life_root / "mem" / "self_model.json",
+            ("traits", "values", "objectives", "relations"),
+        ),
+    )
+    aliases = {
+        "identity": ("identity", "name", "id"),
+        "traits": ("traits", "preferences"),
+        "values": ("values", "identity_commitments", "constraints"),
+        "objectives": ("objectives", "goals"),
+        "relations": ("relations", "social"),
+    }
     for path, sections in sources:
         try:
             raw = json.loads(path.read_text(encoding="utf-8"))
@@ -210,8 +255,18 @@ def _load_context_profile(life_root: Path, narrative_summary: str) -> list[Conte
             payload = {key: raw[key] for key in aliases[section] if key in raw}
             if not payload:
                 continue
-            text = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-            items.append(ContextItem(section, text, f"{path.name}:{section}", relevance=1.0, confidence=1.0))
+            text = json.dumps(
+                payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            )
+            items.append(
+                ContextItem(
+                    section,
+                    text,
+                    f"{path.name}:{section}",
+                    relevance=1.0,
+                    confidence=1.0,
+                )
+            )
     return items
 
 
@@ -225,11 +280,28 @@ def _build_system_preamble(
 ) -> str:
     """Compatibility wrapper for callers that only have the legacy inputs."""
     items = [
-        ContextItem("identity", narrative_summary, "self_narrative:summary", relevance=1.1),
-        ContextItem("recent_events", last_event or "inconnu", "episode:last_user", recency=1.0),
-        ContextItem("recent_events", mood_event or "inconnu", "psyche:recent_mood", recency=0.9),
-        ContextItem("recalled_memories", recalled_memory_summary or "aucun souvenir pertinent", "memory:summary", relevance=0.8),
-        ContextItem("safety", _UNKNOWN_GUARD, "policy:anti_hallucination", relevance=1.0, critical=True),
+        ContextItem(
+            "identity", narrative_summary, "self_narrative:summary", relevance=1.1
+        ),
+        ContextItem(
+            "recent_events", last_event or "inconnu", "episode:last_user", recency=1.0
+        ),
+        ContextItem(
+            "recent_events", mood_event or "inconnu", "psyche:recent_mood", recency=0.9
+        ),
+        ContextItem(
+            "recalled_memories",
+            recalled_memory_summary or "aucun souvenir pertinent",
+            "memory:summary",
+            relevance=0.8,
+        ),
+        ContextItem(
+            "safety",
+            _UNKNOWN_GUARD,
+            "policy:anti_hallucination",
+            relevance=1.0,
+            critical=True,
+        ),
     ]
     return _build_structured_context(items, budget or ContextBudget()).text
 
@@ -292,11 +364,13 @@ def talk(
 
     psyche = Psyche.load_state(psyche_file)
 
-    def gather_context() -> tuple[
-        str | None, dict | None, dict | None, str | None, str | None
-    ]:
+    def gather_context() -> (
+        tuple[str | None, dict | None, dict | None, str | None, str | None]
+    ):
         signals = capture_signals()
-        add_episode({"event": "perception", "life_id": life_id, **signals}, path=episodic_file)
+        add_episode(
+            {"event": "perception", "life_id": life_id, **signals}, path=episodic_file
+        )
         psyche.consume()
         episodes = read_episodes(episodic_file)
         episodes_by_role = {
@@ -406,27 +480,58 @@ def talk(
                 path=episodic_file,
             )
         add_episode(
-            {"role": "user", "life_id": life_id, "text": user_input, "structured_signals": user_signals},
+            {
+                "role": "user",
+                "life_id": life_id,
+                "text": user_input,
+                "structured_signals": user_signals,
+            },
             path=episodic_file,
         )
         mood = psyche.feel(Mood.NEUTRAL)
         mood_report = mood_event or mood.value
         context_items = _load_context_profile(life_root, self_narrative_summary)
-        context_items.extend([
-            ContextItem("recent_events", last_event or "inconnu", "episode:last_user", recency=1.0),
-            ContextItem("recent_events", mood_event or "inconnu", "psyche:recent_mood", recency=0.9),
-            ContextItem("safety", _UNKNOWN_GUARD, "policy:anti_hallucination", relevance=1.0, critical=True),
-        ])
+        context_items.extend(
+            [
+                ContextItem(
+                    "recent_events",
+                    last_event or "inconnu",
+                    "episode:last_user",
+                    recency=1.0,
+                ),
+                ContextItem(
+                    "recent_events",
+                    mood_event or "inconnu",
+                    "psyche:recent_mood",
+                    recency=0.9,
+                ),
+                ContextItem(
+                    "safety",
+                    _UNKNOWN_GUARD,
+                    "policy:anti_hallucination",
+                    relevance=1.0,
+                    critical=True,
+                ),
+            ]
+        )
         for memory in recalled_memories:
-            provenance = f"{memory.get('source', 'memory')}:{memory.get('id', 'unknown')}"
-            context_items.append(ContextItem(
-                "recalled_memories", str(memory.get("excerpt", "")), provenance,
-                relevance=float(memory.get("score", 0.0) or 0.0),
-                recency=1.0 if memory.get("date") else 0.0,
-                confidence=float(memory.get("confidence", 0.0) or 0.0),
-                active_life=memory.get("life_id", life_id) == life_id,
-            ))
-        context_result = _build_structured_context(context_items, ContextBudget.for_client(client))
+            provenance = (
+                f"{memory.get('source', 'memory')}:{memory.get('id', 'unknown')}"
+            )
+            context_items.append(
+                ContextItem(
+                    "recalled_memories",
+                    str(memory.get("excerpt", "")),
+                    provenance,
+                    relevance=float(memory.get("score", 0.0) or 0.0),
+                    recency=1.0 if memory.get("date") else 0.0,
+                    confidence=float(memory.get("confidence", 0.0) or 0.0),
+                    active_life=memory.get("life_id", life_id) == life_id,
+                )
+            )
+        context_result = _build_structured_context(
+            context_items, ContextBudget.for_client(client)
+        )
         system_preamble = context_result.text
         provider_prompt = f"{system_preamble}\n\nUtilisateur: {user_input}"
 

--- a/src/singular/perception/audio/__init__.py
+++ b/src/singular/perception/audio/__init__.py
@@ -1,6 +1,11 @@
 """Audio perception stack with VAD, segmentation and local Whisper STT."""
 
-from .capture import AudioBlock, AudioBlockProvider, AudioCaptureError, MicrophoneCapture
+from .capture import (
+    AudioBlock,
+    AudioBlockProvider,
+    AudioCaptureError,
+    MicrophoneCapture,
+)
 from .pipeline import AudioPerceptionPipeline
 from .transcribe import WhisperRuntime, WhisperTranscriber
 from .vad import EnergyVAD, SegmentBuffer

--- a/src/singular/perception/audio/pipeline.py
+++ b/src/singular/perception/audio/pipeline.py
@@ -75,7 +75,9 @@ class AudioPerceptionPipeline:
                             "status": transcript.get("status", "ok"),
                             "runtime": transcript.get("runtime", runtime.__dict__),
                             "start": round(segment[0].started_at, 3),
-                            "end": round(segment[-1].started_at + segment[-1].duration_s, 3),
+                            "end": round(
+                                segment[-1].started_at + segment[-1].duration_s, 3
+                            ),
                         },
                     )
                 )

--- a/src/singular/perception/audio/transcribe.py
+++ b/src/singular/perception/audio/transcribe.py
@@ -66,7 +66,9 @@ class WhisperTranscriber:
                     import whisper  # type: ignore
 
                     self._runtime = cpu_runtime
-                    return whisper.load_model(cpu_runtime.model_size, device=cpu_runtime.device)
+                    return whisper.load_model(
+                        cpu_runtime.model_size, device=cpu_runtime.device
+                    )
                 except Exception:
                     self._runtime = WhisperRuntime(
                         device="cpu",
@@ -86,7 +88,12 @@ class WhisperTranscriber:
     def transcribe(self, blocks: list[AudioBlock]) -> dict[str, Any]:
         runtime = self.runtime
         if not blocks:
-            return {"text": "", "segments": [], "confidence": 0.0, "runtime": runtime.__dict__}
+            return {
+                "text": "",
+                "segments": [],
+                "confidence": 0.0,
+                "runtime": runtime.__dict__,
+            }
 
         if self._model is None:
             return {
@@ -101,7 +108,9 @@ class WhisperTranscriber:
         sample_rate = blocks[0].sample_rate
 
         try:  # pragma: no cover - optional dependency
-            result = self._model.transcribe(pcm, language="fr", fp16=(runtime.device == "cuda"))
+            result = self._model.transcribe(
+                pcm, language="fr", fp16=(runtime.device == "cuda")
+            )
         except Exception:
             return {
                 "text": "",
@@ -127,7 +136,9 @@ class WhisperTranscriber:
                 }
             )
 
-        confidence = round(sum(confidences) / len(confidences), 4) if confidences else 0.0
+        confidence = (
+            round(sum(confidences) / len(confidences), 4) if confidences else 0.0
+        )
         return {
             "text": text,
             "segments": segments,

--- a/src/singular/perception/audio/vad.py
+++ b/src/singular/perception/audio/vad.py
@@ -20,7 +20,9 @@ class EnergyVAD:
     _silence_blocks: int = field(default=0, init=False, repr=False)
     _speaking: bool = field(default=False, init=False, repr=False)
 
-    def process(self, block: AudioBlock, *, noise_floor: float) -> tuple[bool, bool, bool, float]:
+    def process(
+        self, block: AudioBlock, *, noise_floor: float
+    ) -> tuple[bool, bool, bool, float]:
         """Return ``(is_speech, speech_started, speech_ended, confidence)``."""
 
         adaptive_start = max(self.start_threshold, noise_floor * self.noise_boost)

--- a/src/singular/perception/os/semantics.py
+++ b/src/singular/perception/os/semantics.py
@@ -54,7 +54,10 @@ class OSSemanticInterpreter:
             )
 
         cpu = snapshot.host_state.cpu_percent
-        if isinstance(cpu, (int, float)) and float(cpu) >= self.config.high_cpu_threshold:
+        if (
+            isinstance(cpu, (int, float))
+            and float(cpu) >= self.config.high_cpu_threshold
+        ):
             events.append(
                 {
                     "type": "host.cpu_high",
@@ -90,9 +93,7 @@ class OSSemanticInterpreter:
                     "confidence": 0.74,
                     "reason": "notification_source",
                     "count": sum(
-                        1
-                        for n in snapshot.notifications
-                        if "calendar" in n.app.lower()
+                        1 for n in snapshot.notifications if "calendar" in n.app.lower()
                     ),
                 }
             )

--- a/src/singular/perception/vision/extractors.py
+++ b/src/singular/perception/vision/extractors.py
@@ -57,7 +57,9 @@ class KeyObjectExtractor:
         gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
         blurred = cv2.GaussianBlur(gray, (5, 5), 0)
         edges = cv2.Canny(blurred, 80, 160)
-        contours, _ = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        contours, _ = cv2.findContours(
+            edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
 
         boxes: list[dict[str, int]] = []
         for contour in contours:
@@ -65,7 +67,9 @@ class KeyObjectExtractor:
             if area < self.min_area:
                 continue
             x, y, w, h = cv2.boundingRect(contour)
-            boxes.append({"x": int(x), "y": int(y), "w": int(w), "h": int(h), "area": area})
+            boxes.append(
+                {"x": int(x), "y": int(y), "w": int(w), "h": int(h), "area": area}
+            )
 
         boxes = sorted(boxes, key=lambda item: item["area"], reverse=True)[:5]
         return {
@@ -83,7 +87,9 @@ class UIStateChangeExtractor:
     _previous_hash: str | None = field(default=None, init=False, repr=False)
 
     def extract(self, frame: Any) -> dict[str, Any]:
-        payload = frame.tobytes() if hasattr(frame, "tobytes") else bytes(str(frame), "utf-8")
+        payload = (
+            frame.tobytes() if hasattr(frame, "tobytes") else bytes(str(frame), "utf-8")
+        )
         fingerprint = sha1(payload).hexdigest()[:16]
 
         if self._previous_hash is None:

--- a/src/singular/perception/vision/pipeline.py
+++ b/src/singular/perception/vision/pipeline.py
@@ -7,8 +7,18 @@ from typing import Any
 
 from singular.core.agent_runtime import PerceptEvent
 
-from .capture import ActiveWindowCapture, CameraCapture, ScreenCapture, VisionCaptureError
-from .extractors import KeyObjectExtractor, OcrTextExtractor, UIStateChangeExtractor, VisionEventExtractor
+from .capture import (
+    ActiveWindowCapture,
+    CameraCapture,
+    ScreenCapture,
+    VisionCaptureError,
+)
+from .extractors import (
+    KeyObjectExtractor,
+    OcrTextExtractor,
+    UIStateChangeExtractor,
+    VisionEventExtractor,
+)
 from .preprocess import FramePreprocessor, FrameSamplingStrategy
 
 
@@ -18,10 +28,16 @@ class VisionPerceptionPipeline:
 
     source: str = "screen"
     source_name: str = "vision.pipeline"
-    sampling: FrameSamplingStrategy = field(default_factory=lambda: FrameSamplingStrategy(fps=1.5))
+    sampling: FrameSamplingStrategy = field(
+        default_factory=lambda: FrameSamplingStrategy(fps=1.5)
+    )
     preprocessor: FramePreprocessor = field(default_factory=FramePreprocessor)
     extractors: list[VisionEventExtractor] = field(
-        default_factory=lambda: [OcrTextExtractor(), KeyObjectExtractor(), UIStateChangeExtractor()]
+        default_factory=lambda: [
+            OcrTextExtractor(),
+            KeyObjectExtractor(),
+            UIStateChangeExtractor(),
+        ]
     )
 
     def collect(self) -> list[PerceptEvent]:
@@ -50,7 +66,9 @@ class VisionPerceptionPipeline:
             "events": {},
         }
         for extractor in self.extractors:
-            payload["events"][extractor.__class__.__name__] = extractor.extract(processed)
+            payload["events"][extractor.__class__.__name__] = extractor.extract(
+                processed
+            )
 
         return [
             PerceptEvent(

--- a/src/singular/perception/vision/preprocess.py
+++ b/src/singular/perception/vision/preprocess.py
@@ -63,7 +63,9 @@ class FramePreprocessor:
     def frame_fingerprint(self, frame: Any) -> str:
         """Compute a compact stable frame fingerprint."""
 
-        payload = frame.tobytes() if hasattr(frame, "tobytes") else bytes(str(frame), "utf-8")
+        payload = (
+            frame.tobytes() if hasattr(frame, "tobytes") else bytes(str(frame), "utf-8")
+        )
         return sha1(payload).hexdigest()[:16]
 
     def _apply_roi(self, frame: Any) -> Any:

--- a/src/singular/providers/__init__.py
+++ b/src/singular/providers/__init__.py
@@ -236,9 +236,9 @@ def describe_client(
         # A backend only becomes active after generate_reply succeeds.
         "active_provider": getattr(client, "last_active_provider", None),
         "fallback_used": getattr(client, "last_fallback_used", False),
-        "health_state": getattr(client, "health_state", "unknown")
-        if client
-        else "unavailable",
+        "health_state": (
+            getattr(client, "health_state", "unknown") if client else "unavailable"
+        ),
         "candidates": getattr(client, "candidates", []) if client else [],
         "provider_chain": chain,
         "llm_real": has_real,
@@ -528,9 +528,9 @@ def load_llm_client(name: str | None) -> LLMProviderClient | None:
                 "configured": not misconfigured,
                 "reachable": ok,
                 "degraded": degraded,
-                "health_state": "degraded"
-                if degraded
-                else ("ready" if ok else "unavailable"),
+                "health_state": (
+                    "degraded" if degraded else ("ready" if ok else "unavailable")
+                ),
                 "exclusion_cause": None if ok else error,
             }
         )
@@ -566,9 +566,11 @@ def load_llm_client(name: str | None) -> LLMProviderClient | None:
         chain=clients,
         requested_provider=name,
         selected_provider=clients[0].name,
-        health_state="degraded"
-        if all(not provider_is_real(c.name) for c in clients)
-        else "ready",
+        health_state=(
+            "degraded"
+            if all(not provider_is_real(c.name) for c in clients)
+            else "ready"
+        ),
         candidates=candidates,
     )
 

--- a/src/singular/providers/llm_dummy.py
+++ b/src/singular/providers/llm_dummy.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from . import ProviderMetrics
 
-
 LAST_METRICS = ProviderMetrics(provider="dummy")
 
 

--- a/src/singular/providers/llm_local.py
+++ b/src/singular/providers/llm_local.py
@@ -6,7 +6,12 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
 import time
 from typing import Any
 
-from . import ProviderExecutionError, ProviderMetrics, ProviderTimeoutError, ProviderUnavailableError
+from . import (
+    ProviderExecutionError,
+    ProviderMetrics,
+    ProviderTimeoutError,
+    ProviderUnavailableError,
+)
 
 MAX_RETRIES = 1
 

--- a/src/singular/providers/llm_stub.py
+++ b/src/singular/providers/llm_stub.py
@@ -6,7 +6,6 @@ import re
 
 from . import ProviderMetrics
 
-
 LAST_METRICS = ProviderMetrics(provider="stub")
 
 

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -396,15 +396,29 @@ class Psyche:
         "resentment",
     )
     _PLASTIC_TRAITS: ClassVar[tuple[str, ...]] = (
-        "curiosity", "patience", "playfulness", "optimism", "resilience"
+        "curiosity",
+        "patience",
+        "playfulness",
+        "optimism",
+        "resilience",
     )
     _STRUCTURAL_TRAITS: ClassVar[tuple[str, ...]] = (
-        "patience", "optimism", "resilience"
+        "patience",
+        "optimism",
+        "resilience",
     )
 
     def __post_init__(self) -> None:
         for trait in self._PLASTIC_TRAITS:
-            setattr(self, trait, _clamp(float(getattr(self, trait)), self.evolution_policy.minimum, self.evolution_policy.maximum))
+            setattr(
+                self,
+                trait,
+                _clamp(
+                    float(getattr(self, trait)),
+                    self.evolution_policy.minimum,
+                    self.evolution_policy.maximum,
+                ),
+            )
         if not self.last_coherent_traits:
             self.last_coherent_traits = self.trait_snapshot()
         else:
@@ -433,47 +447,101 @@ class Psyche:
         """
         now = datetime.now(timezone.utc).isoformat(timespec="seconds")
         independent = tuple(dict.fromkeys(str(item) for item in evidence if str(item)))
-        requested = {k: float(v) for k, v in deltas.items() if k in self._PLASTIC_TRAITS}
+        requested = {
+            k: float(v) for k, v in deltas.items() if k in self._PLASTIC_TRAITS
+        }
         if self.evolution_freeze_remaining > 0:
             self.evolution_freeze_remaining -= 1
-            self.trait_history.append({"ts": now, "status": "frozen", "cause": cause,
-                                       "evidence": list(independent), "requested": requested})
+            self.trait_history.append(
+                {
+                    "ts": now,
+                    "status": "frozen",
+                    "cause": cause,
+                    "evidence": list(independent),
+                    "requested": requested,
+                }
+            )
             return "frozen"
-        if any(abs(delta) >= self.evolution_policy.important_delta for delta in requested.values()) and len(independent) < self.evolution_policy.independent_evidence_required:
-            self.trait_history.append({"ts": now, "status": "review", "cause": cause,
-                                       "evidence": list(independent), "requested": requested,
-                                       "reason": "insufficient_independent_evidence"})
+        if (
+            any(
+                abs(delta) >= self.evolution_policy.important_delta
+                for delta in requested.values()
+            )
+            and len(independent) < self.evolution_policy.independent_evidence_required
+        ):
+            self.trait_history.append(
+                {
+                    "ts": now,
+                    "status": "review",
+                    "cause": cause,
+                    "evidence": list(independent),
+                    "requested": requested,
+                    "reason": "insufficient_independent_evidence",
+                }
+            )
             return "review"
 
         before = self.trait_snapshot()
         applied: dict[str, float] = {}
         for trait, delta in requested.items():
-            limited = max(-self.evolution_policy.max_delta, min(self.evolution_policy.max_delta, delta))
-            target = _clamp(before[trait] + limited, self.evolution_policy.minimum, self.evolution_policy.maximum)
+            limited = max(
+                -self.evolution_policy.max_delta,
+                min(self.evolution_policy.max_delta, delta),
+            )
+            target = _clamp(
+                before[trait] + limited,
+                self.evolution_policy.minimum,
+                self.evolution_policy.maximum,
+            )
             applied[trait] = target - before[trait]
 
-        recent = [row for row in self.trait_history[-self.evolution_policy.cumulative_window + 1:] if row.get("status") == "applied"]
+        recent = [
+            row
+            for row in self.trait_history[
+                -self.evolution_policy.cumulative_window + 1 :
+            ]
+            if row.get("status") == "applied"
+        ]
         structural_drops = []
         for trait in self._STRUCTURAL_TRAITS:
-            cumulative = -applied.get(trait, 0.0) + sum(max(0.0, -float(row.get("applied", {}).get(trait, 0.0))) for row in recent)
+            cumulative = -applied.get(trait, 0.0) + sum(
+                max(0.0, -float(row.get("applied", {}).get(trait, 0.0)))
+                for row in recent
+            )
             if cumulative >= self.evolution_policy.collapse_drop:
                 structural_drops.append(trait)
         if len(structural_drops) >= 2:
             for trait, value in self.last_coherent_traits.items():
                 setattr(self, trait, value)
-            review = {"ts": now, "status": "restored", "cause": cause,
-                      "traits": structural_drops, "snapshot": dict(self.last_coherent_traits)}
+            review = {
+                "ts": now,
+                "status": "restored",
+                "cause": cause,
+                "traits": structural_drops,
+                "snapshot": dict(self.last_coherent_traits),
+            }
             self.evolution_reviews.append(review)
-            self.trait_history.append({**review, "requested": requested, "evidence": list(independent)})
+            self.trait_history.append(
+                {**review, "requested": requested, "evidence": list(independent)}
+            )
             self.evolution_freeze_remaining = self.evolution_policy.freeze_events
             return "review"
 
         for trait, delta in applied.items():
             setattr(self, trait, before[trait] + delta)
         after = self.trait_snapshot()
-        self.trait_history.append({"ts": now, "status": "applied", "cause": cause,
-                                   "evidence": list(independent), "before": before,
-                                   "requested": requested, "applied": applied, "after": after})
+        self.trait_history.append(
+            {
+                "ts": now,
+                "status": "applied",
+                "cause": cause,
+                "evidence": list(independent),
+                "before": before,
+                "requested": requested,
+                "applied": applied,
+                "after": after,
+            }
+        )
         self.trait_history = self.trait_history[-512:]
         # A broadly negative structural movement remains provisional until the
         # configured cumulative window proves that it is not a collapse.
@@ -977,7 +1045,9 @@ class Psyche:
             ),
             trait_history=list(data.get("trait_history", []))[-512:],
             evolution_reviews=list(data.get("evolution_reviews", []))[-128:],
-            evolution_freeze_remaining=max(0, int(data.get("evolution_freeze_remaining", 0))),
+            evolution_freeze_remaining=max(
+                0, int(data.get("evolution_freeze_remaining", 0))
+            ),
             last_coherent_traits=dict(data.get("last_coherent_traits", {})),
         )
         mood_val = data.get("last_mood")

--- a/src/singular/resource_manager.py
+++ b/src/singular/resource_manager.py
@@ -49,7 +49,13 @@ class ResourceManager:
                 data = json.loads(self.path.read_text(encoding="utf-8"))
             except Exception:
                 return
-            for field in ("energy", "food", "warmth", "ecological_debt", "relational_debt"):
+            for field in (
+                "energy",
+                "food",
+                "warmth",
+                "ecological_debt",
+                "relational_debt",
+            ):
                 if field in data:
                     setattr(self, field, float(data[field]))
 
@@ -133,8 +139,12 @@ class ResourceManager:
         rel_norm = 0.0
         delayed_risk = 0.0
         if isinstance(dynamics, dict):
-            eco_norm = max(0.0, min(1.0, float(dynamics.get("ecological_debt", 0.0)) / 100.0))
-            rel_norm = max(0.0, min(1.0, float(dynamics.get("relational_debt", 0.0)) / 100.0))
+            eco_norm = max(
+                0.0, min(1.0, float(dynamics.get("ecological_debt", 0.0)) / 100.0)
+            )
+            rel_norm = max(
+                0.0, min(1.0, float(dynamics.get("relational_debt", 0.0)) / 100.0)
+            )
         if isinstance(signals, dict):
             delayed_risk = max(0.0, min(1.0, float(signals.get("delayed_risk", 0.0))))
 
@@ -173,11 +183,21 @@ class ResourceManager:
                 "trace_id": uuid4().hex,
                 "pipeline": "environment.resource_manager",
                 "input": {"kind": "world_event", "temperature_c": temp},
-                "decision": {"temperature_delta_from_neutral": round(diff, 3), "selected": decision},
-                "action": {"kind": decision, "warmth_before": round(before, 3), "warmth_after": round(after, 3)},
+                "decision": {
+                    "temperature_delta_from_neutral": round(diff, 3),
+                    "selected": decision,
+                },
+                "action": {
+                    "kind": decision,
+                    "warmth_before": round(before, 3),
+                    "warmth_after": round(after, 3),
+                },
                 "result": {
                     "gain_loss": delta,
-                    "objective_impact": {"objective": "homeostasis.warmth", "impact": delta},
+                    "objective_impact": {
+                        "objective": "homeostasis.warmth",
+                        "impact": delta,
+                    },
                 },
             }
         )
@@ -212,7 +232,10 @@ class ResourceManager:
             return CapabilityStatus.UNSTABLE
         if self.food < self.minimum_viable_food:
             return CapabilityStatus.STARVING
-        if self.energy < self.minimum_viable_energy or self.warmth < self.minimum_viable_warmth:
+        if (
+            self.energy < self.minimum_viable_energy
+            or self.warmth < self.minimum_viable_warmth
+        ):
             return CapabilityStatus.FATIGUED
         return CapabilityStatus.VIABLE
 
@@ -220,7 +243,9 @@ class ResourceManager:
         state = self.viability_state()
         if state in {CapabilityStatus.STARVING, CapabilityStatus.UNSTABLE}:
             return False, state
-        if capability == "mutation" and self.energy < (self.minimum_viable_energy + 4.0):
+        if capability == "mutation" and self.energy < (
+            self.minimum_viable_energy + 4.0
+        ):
             return False, CapabilityStatus.FATIGUED
         return True, state
 

--- a/src/singular/root_config.py
+++ b/src/singular/root_config.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path, PureWindowsPath
 from typing import Any
 
-
 _CONFIG_DIRNAME = ".singular"
 _CONFIG_FILENAME = "config.json"
 _REGISTRY_ROOT_KEY = "registry_root"

--- a/src/singular/routines.py
+++ b/src/singular/routines.py
@@ -11,7 +11,9 @@ from typing import Any, Mapping
 
 from singular.memory import _atomic_write_text
 
-DEFAULT_ROUTINES_PATH = Path(__file__).resolve().parents[2] / "configs" / "routines.yaml"
+DEFAULT_ROUTINES_PATH = (
+    Path(__file__).resolve().parents[2] / "configs" / "routines.yaml"
+)
 
 
 @dataclass(frozen=True)
@@ -101,7 +103,6 @@ class RoutinesOrchestrator:
             )
         return specs
 
-
     def _load_simple_routines_yaml(self, path: Path) -> dict[str, Any]:
         routines: list[dict[str, Any]] = []
         current: dict[str, Any] | None = None
@@ -153,10 +154,26 @@ class RoutinesOrchestrator:
             if not isinstance(key, str) or not isinstance(raw, dict):
                 continue
             state[key] = RoutineRunState(
-                last_run_at=raw.get("last_run_at") if isinstance(raw.get("last_run_at"), str) else None,
-                last_success=raw.get("last_success") if isinstance(raw.get("last_success"), bool) else None,
-                last_latency_ms=float(raw.get("last_latency_ms")) if isinstance(raw.get("last_latency_ms"), (int, float)) else None,
-                next_run_at=raw.get("next_run_at") if isinstance(raw.get("next_run_at"), str) else None,
+                last_run_at=(
+                    raw.get("last_run_at")
+                    if isinstance(raw.get("last_run_at"), str)
+                    else None
+                ),
+                last_success=(
+                    raw.get("last_success")
+                    if isinstance(raw.get("last_success"), bool)
+                    else None
+                ),
+                last_latency_ms=(
+                    float(raw.get("last_latency_ms"))
+                    if isinstance(raw.get("last_latency_ms"), (int, float))
+                    else None
+                ),
+                next_run_at=(
+                    raw.get("next_run_at")
+                    if isinstance(raw.get("next_run_at"), str)
+                    else None
+                ),
             )
         return state
 
@@ -165,7 +182,9 @@ class RoutinesOrchestrator:
             "routines": {name: asdict(item) for name, item in self.state.items()},
             "updated_at": self._now().isoformat(),
         }
-        _atomic_write_text(self.state_path, json.dumps(payload, ensure_ascii=False, indent=2))
+        _atomic_write_text(
+            self.state_path, json.dumps(payload, ensure_ascii=False, indent=2)
+        )
 
     def _parse_iso(self, value: str | None) -> datetime | None:
         if not value:
@@ -226,10 +245,14 @@ class RoutinesOrchestrator:
         adjusted.sort(key=lambda item: (-item.priority, item.deadline_at))
         return adjusted
 
-    def mark_executed(self, task: RoutineTask, *, success: bool, latency_ms: float) -> None:
+    def mark_executed(
+        self, task: RoutineTask, *, success: bool, latency_ms: float
+    ) -> None:
         executed_at = self._now()
         next_run = executed_at + timedelta(
-            minutes=next((spec.interval_minutes for spec in self.specs if spec.id == task.id), 60)
+            minutes=next(
+                (spec.interval_minutes for spec in self.specs if spec.id == task.id), 60
+            )
         )
         self.state[task.id] = RoutineRunState(
             last_run_at=executed_at.isoformat(),

--- a/src/singular/runs/explain.py
+++ b/src/singular/runs/explain.py
@@ -6,9 +6,15 @@ from __future__ import annotations
 def _score_impact(score_base: float, score_new: float) -> tuple[str, str]:
     delta = score_new - score_base
     if delta < 0:
-        return ("amélioration", f"score {score_base:.3f} → {score_new:.3f} ({delta:.3f})")
+        return (
+            "amélioration",
+            f"score {score_base:.3f} → {score_new:.3f} ({delta:.3f})",
+        )
     if delta > 0:
-        return ("régression", f"score {score_base:.3f} → {score_new:.3f} (+{delta:.3f})")
+        return (
+            "régression",
+            f"score {score_base:.3f} → {score_new:.3f} (+{delta:.3f})",
+        )
     return ("stable", f"score inchangé ({score_new:.3f})")
 
 
@@ -50,7 +56,9 @@ def summarize_mutation(
         else:
             reason = "rejetée (n'apporte pas de gain mesurable)"
 
-    changed_lines = max(0, sum(1 for line in diff.splitlines() if line.startswith(("+", "-"))) - 2)
+    changed_lines = max(
+        0, sum(1 for line in diff.splitlines() if line.startswith(("+", "-"))) - 2
+    )
 
     return (
         f"op={operator}; fichier={impacted_file}; {reason}; "

--- a/src/singular/runs/generations.py
+++ b/src/singular/runs/generations.py
@@ -125,13 +125,17 @@ def record_generation(
     return payload
 
 
-def rollback_generation(generation_id: int, *, base_dir: Path | None = None) -> dict[str, Any]:
+def rollback_generation(
+    generation_id: int, *, base_dir: Path | None = None
+) -> dict[str, Any]:
     """Atomically rollback the skill file to a stable generation snapshot."""
 
     root = Path(base_dir) if base_dir is not None else get_base_dir()
     generations_path = get_generations_path(root)
     items = _read_jsonl(generations_path)
-    generation = next((item for item in items if item.get("generation_id") == generation_id), None)
+    generation = next(
+        (item for item in items if item.get("generation_id") == generation_id), None
+    )
     if generation is None:
         raise ValueError(f"generation_not_found:{generation_id}")
     if not generation.get("stable"):
@@ -147,7 +151,9 @@ def rollback_generation(generation_id: int, *, base_dir: Path | None = None) -> 
 
     target.parent.mkdir(parents=True, exist_ok=True)
     content = snapshot.read_text(encoding="utf-8")
-    fd, tmp_name = tempfile.mkstemp(prefix=target.name, suffix=".tmp", dir=target.parent)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=target.name, suffix=".tmp", dir=target.parent
+    )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as tmp:
             tmp.write(content)

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -104,7 +104,11 @@ def log_provider_event(
         payload["context_metrics"] = dict(context_metrics)
     _provider_logger.info("provider_call", extra={"payload": payload})
     try:
-        root = Path(life_root) if life_root is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+        root = (
+            Path(life_root)
+            if life_root is not None
+            else Path(os.environ.get("SINGULAR_HOME", "."))
+        )
         ProviderEventsRepository(SQLiteStorage(StorageConfig(root=root))).add(payload)
     except Exception:
         _provider_logger.debug("provider_event_sqlite_persist_failed", exc_info=True)
@@ -163,7 +167,9 @@ class RunLogger:
             json.dumps(
                 {
                     "run_id": self.run_id,
-                    "started_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                    "started_at": datetime.now(timezone.utc).isoformat(
+                        timespec="seconds"
+                    ),
                 }
             ),
             encoding="utf-8",
@@ -320,7 +326,9 @@ class RunLogger:
 
     def _write_record(self, record: dict[str, Any]) -> None:
         record.setdefault("correlation_id", self.correlation_id)
-        record["life_id"] = canonical_life_id(record.get("life_id") or self.life_id or "default")
+        record["life_id"] = canonical_life_id(
+            record.get("life_id") or self.life_id or "default"
+        )
         self._file.write(json.dumps(record) + "\n")
         self._file.flush()
         os.fsync(self._file.fileno())
@@ -328,7 +336,9 @@ class RunLogger:
 
     def _write_event(self, event_type: str, payload: dict[str, Any], ts: str) -> None:
         payload.setdefault("correlation_id", self.correlation_id)
-        payload["life_id"] = canonical_life_id(payload.get("life_id") or self.life_id or "default")
+        payload["life_id"] = canonical_life_id(
+            payload.get("life_id") or self.life_id or "default"
+        )
         event = {
             "version": EVENT_SCHEMA_VERSION,
             "event_type": event_type,

--- a/src/singular/security/immune_response.py
+++ b/src/singular/security/immune_response.py
@@ -90,7 +90,9 @@ class AdaptiveImmunityEngine:
         )
 
         ttl = 600.0 if incident.recurred else 300.0
-        self._blacklist_until[incident.pattern] = incident.happened_at + timedelta(seconds=ttl)
+        self._blacklist_until[incident.pattern] = incident.happened_at + timedelta(
+            seconds=ttl
+        )
 
         return ImmuneResponsePlan(
             targeted_tests=tests,
@@ -113,7 +115,9 @@ class AdaptiveImmunityEngine:
                 updated_at=current,
             )
 
-    def is_temporarily_blacklisted(self, pattern: str, now: datetime | None = None) -> bool:
+    def is_temporarily_blacklisted(
+        self, pattern: str, now: datetime | None = None
+    ) -> bool:
         current = now or datetime.now(timezone.utc)
         expires_at = self._blacklist_until.get(pattern)
         if expires_at is None:
@@ -140,7 +144,9 @@ class AdaptiveImmunityEngine:
         if baseline_learning_velocity <= 0:
             learning_impact = 0.0
         else:
-            learning_impact = (baseline_learning_velocity - current_learning_velocity) / baseline_learning_velocity
+            learning_impact = (
+                baseline_learning_velocity - current_learning_velocity
+            ) / baseline_learning_velocity
 
         return ImmuneMetrics(
             recurrence_rate=max(0.0, recurrence_rate),
@@ -154,7 +160,9 @@ class AdaptiveImmunityEngine:
     def _reinforce(self, pattern: str, *, when: datetime) -> None:
         existing = self._memory.get(pattern)
         if existing is None:
-            self._memory[pattern] = ImmuneMemoryEntry(pattern=pattern, weight=1.0, updated_at=when)
+            self._memory[pattern] = ImmuneMemoryEntry(
+                pattern=pattern, weight=1.0, updated_at=when
+            )
             return
         self._memory[pattern] = ImmuneMemoryEntry(
             pattern=pattern,

--- a/src/singular/security/policy_engine.py
+++ b/src/singular/security/policy_engine.py
@@ -78,7 +78,9 @@ class ActionPolicyEngine:
         )
         if requires_confirmation:
             is_confirmed = bool(
-                self.confirmation_callback(request) if self.confirmation_callback else False
+                self.confirmation_callback(request)
+                if self.confirmation_callback
+                else False
             )
             if not is_confirmed:
                 decision = PolicyDecision(

--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -222,7 +222,9 @@ def timeline_path(path: Path | str | None = None) -> Path:
     return current.with_name(current.stem + TIMELINE_SUFFIX)
 
 
-def load_snapshots(path: Path | str | None = None, *, life_id: str | None = None) -> list[dict[str, Any]]:
+def load_snapshots(
+    path: Path | str | None = None, *, life_id: str | None = None
+) -> list[dict[str, Any]]:
     """Read valid snapshots without letting a damaged line hide later history."""
 
     records = _load_timeline_records(path)
@@ -263,7 +265,10 @@ def diagnose_timeline(path: Path | str | None = None) -> dict[str, Any]:
         "lives": attributable,
         "ambiguous_record_lines": ambiguous,
         "reconstruction_proposals": [
-            {"life_id": life, "command": f"rebuild_from_timeline(path, life_id={life!r})"}
+            {
+                "life_id": life,
+                "command": f"rebuild_from_timeline(path, life_id={life!r})",
+            }
             for life in sorted(attributable)
         ],
     }
@@ -317,9 +322,7 @@ def infer_trend(
     return (
         "up"
         if projected_delta >= minimum_delta
-        else "down"
-        if projected_delta <= -minimum_delta
-        else "stable"
+        else "down" if projected_delta <= -minimum_delta else "stable"
     )
 
 
@@ -491,13 +494,20 @@ def _migrate(payload: Mapping[str, Any]) -> SelfNarrative:
     return narrative
 
 
-def _quarantine_entries(path: Path, entries: Sequence[Mapping[str, Any]], reason: str) -> None:
+def _quarantine_entries(
+    path: Path, entries: Sequence[Mapping[str, Any]], reason: str
+) -> None:
     quarantine = path.with_name(path.stem + ".quarantine.jsonl")
     for entry in entries:
-        append_jsonl_line(quarantine, {"quarantined_at": _iso_now(), "reason": reason, "entry": dict(entry)})
+        append_jsonl_line(
+            quarantine,
+            {"quarantined_at": _iso_now(), "reason": reason, "entry": dict(entry)},
+        )
 
 
-def load(path: Path | str | None = None, *, life_id: str | None = None) -> SelfNarrative:
+def load(
+    path: Path | str | None = None, *, life_id: str | None = None
+) -> SelfNarrative:
     """Load narrative from disk with graceful fallback for missing/corrupt file."""
 
     file_path = _path_or_default(path)
@@ -529,7 +539,11 @@ def load(path: Path | str | None = None, *, life_id: str | None = None) -> SelfN
 
     expected = canonical_life_id(life_id) if life_id is not None else None
     raw_life = payload.get("life_id")
-    owner = canonical_life_id(raw_life) if isinstance(raw_life, str) and raw_life.strip() else expected
+    owner = (
+        canonical_life_id(raw_life)
+        if isinstance(raw_life, str) and raw_life.strip()
+        else expected
+    )
     # Explicit bootstrap migration: an untouched, entry-free default projection
     # may be claimed by the first concrete life that opens its own path.
     if expected is not None and owner == "default" and not payload.get("entries"):
@@ -541,16 +555,26 @@ def load(path: Path | str | None = None, *, life_id: str | None = None) -> SelfN
     clean_payload["life_id"] = owner
     accepted: list[Mapping[str, Any]] = []
     rejected: list[Mapping[str, Any]] = []
-    for item in payload.get("entries", []) if isinstance(payload.get("entries"), list) else []:
+    for item in (
+        payload.get("entries", []) if isinstance(payload.get("entries"), list) else []
+    ):
         if not isinstance(item, Mapping):
             continue
         raw_entry_life = item.get("life_id")
         # Explicit legacy rule: schema < 3 entries inherit an explicit projection owner.
-        if raw_entry_life is None and int(payload.get("schema_version", 0) or 0) < 3 and raw_life:
+        if (
+            raw_entry_life is None
+            and int(payload.get("schema_version", 0) or 0) < 3
+            and raw_life
+        ):
             migrated = dict(item)
             migrated["life_id"] = owner
             accepted.append(migrated)
-        elif isinstance(raw_entry_life, str) and raw_entry_life.strip() and canonical_life_id(raw_entry_life) == owner:
+        elif (
+            isinstance(raw_entry_life, str)
+            and raw_entry_life.strip()
+            and canonical_life_id(raw_entry_life) == owner
+        ):
             canonical = dict(item)
             canonical["life_id"] = owner
             accepted.append(canonical)
@@ -576,7 +600,11 @@ def save(
 
     file_path = _path_or_default(path)
     narrative.life_id = canonical_life_id(narrative.life_id)
-    foreign = [entry for entry in narrative.entries if canonical_life_id(entry.life_id) != narrative.life_id]
+    foreign = [
+        entry
+        for entry in narrative.entries
+        if canonical_life_id(entry.life_id) != narrative.life_id
+    ]
     if foreign:
         raise ValueError("cannot save narrative entries belonging to another life")
     for entry in narrative.entries:
@@ -694,7 +722,8 @@ def rebuild_from_timeline(
             candidate.entries = [
                 entry
                 for entry in candidate.entries
-                if entry.life_id and canonical_life_id(entry.life_id) == candidate.life_id
+                if entry.life_id
+                and canonical_life_id(entry.life_id) == candidate.life_id
             ]
             if wanted_life is None or candidate.life_id == wanted_life:
                 narrative = candidate
@@ -721,7 +750,8 @@ def rebuild_from_timeline(
             candidate.entries = [
                 entry
                 for entry in candidate.entries
-                if entry.life_id and canonical_life_id(entry.life_id) == candidate.life_id
+                if entry.life_id
+                and canonical_life_id(entry.life_id) == candidate.life_id
             ]
             if candidate.life_id == narrative.life_id:
                 narrative = candidate

--- a/src/singular/sensors/config.py
+++ b/src/singular/sensors/config.py
@@ -106,20 +106,28 @@ def _load_yaml_mapping(path: Path) -> Mapping[str, Any]:
     return payload
 
 
-def _coerce_percent(payload: Mapping[str, Any], key: str, *, min_v: float = 0.0, max_v: float = 100.0) -> float:
+def _coerce_percent(
+    payload: Mapping[str, Any], key: str, *, min_v: float = 0.0, max_v: float = 100.0
+) -> float:
     if key not in payload:
         raise HostSensorsConfigError(f"missing required key: {key}")
     raw = payload[key]
     try:
         value = float(raw)
     except (TypeError, ValueError) as exc:
-        raise HostSensorsConfigError(f"invalid numeric value for {key}: {raw!r}") from exc
+        raise HostSensorsConfigError(
+            f"invalid numeric value for {key}: {raw!r}"
+        ) from exc
     if value < min_v or value > max_v:
-        raise HostSensorsConfigError(f"value for {key} must be within [{min_v}, {max_v}]")
+        raise HostSensorsConfigError(
+            f"value for {key} must be within [{min_v}, {max_v}]"
+        )
     return value
 
 
-def _validate_threshold_order(low: float, high: float, *, low_name: str, high_name: str) -> None:
+def _validate_threshold_order(
+    low: float, high: float, *, low_name: str, high_name: str
+) -> None:
     if low >= high:
         raise HostSensorsConfigError(f"{low_name} must be < {high_name}")
 
@@ -161,8 +169,12 @@ def validate_host_sensors_payload(payload: Mapping[str, Any]) -> HostSensorThres
     cpu_critical = _coerce_percent(cpu, "critical_percent")
     ram_warning = _coerce_percent(ram, "warning_percent")
     ram_critical = _coerce_percent(ram, "critical_percent")
-    temperature_warning = _coerce_percent(temperature, "warning_c", min_v=-50.0, max_v=200.0)
-    temperature_critical = _coerce_percent(temperature, "critical_c", min_v=-50.0, max_v=200.0)
+    temperature_warning = _coerce_percent(
+        temperature, "warning_c", min_v=-50.0, max_v=200.0
+    )
+    temperature_critical = _coerce_percent(
+        temperature, "critical_c", min_v=-50.0, max_v=200.0
+    )
     disk_critical = _coerce_percent(disk, "critical_percent")
 
     _validate_threshold_order(
@@ -243,9 +255,13 @@ def load_host_sensor_thresholds(path: Path | None = None) -> HostSensorThreshold
         try:
             override_payload = json.loads(overrides_raw)
         except json.JSONDecodeError as exc:
-            raise HostSensorsConfigError(f"invalid JSON in {ENV_HOST_SENSORS_OVERRIDES}") from exc
+            raise HostSensorsConfigError(
+                f"invalid JSON in {ENV_HOST_SENSORS_OVERRIDES}"
+            ) from exc
         if not isinstance(override_payload, Mapping):
-            raise HostSensorsConfigError(f"{ENV_HOST_SENSORS_OVERRIDES} must contain a JSON mapping")
+            raise HostSensorsConfigError(
+                f"{ENV_HOST_SENSORS_OVERRIDES} must contain a JSON mapping"
+            )
         base_payload = _merge_nested(base_payload, dict(override_payload))
 
     return validate_host_sensors_payload(base_payload)

--- a/src/singular/sensors/host.py
+++ b/src/singular/sensors/host.py
@@ -125,7 +125,9 @@ def _collect_process_stdlib() -> tuple[float, float]:
 
     cpu_percent = 0.0
     try:
-        current = _ProcessSample(wall_time=time.monotonic(), cpu_time=time.process_time())
+        current = _ProcessSample(
+            wall_time=time.monotonic(), cpu_time=time.process_time()
+        )
         previous = _LAST_PROCESS_SAMPLE
         _LAST_PROCESS_SAMPLE = current
         if previous is not None:
@@ -198,12 +200,42 @@ def collect_host_metrics() -> dict[str, Any]:
     strategy = "minimal_fallback"
 
     metric_statuses: dict[str, dict[str, Any]] = {
-        "cpu_percent": _metric_payload(value=None, unit="percent", status=_STATUS_UNSUPPORTED, reason="cpu_probe_unavailable"),
-        "cpu_load_1m": _metric_payload(value=None, unit="load", status=_STATUS_UNSUPPORTED, reason="load_probe_unavailable"),
-        "ram_used_percent": _metric_payload(value=None, unit="percent", status=_STATUS_UNSUPPORTED, reason="memory_probe_unavailable"),
-        "ram_available_mb": _metric_payload(value=None, unit="MB", status=_STATUS_UNSUPPORTED, reason="memory_probe_unavailable"),
-        "disk_used_percent": _metric_payload(value=None, unit="percent", status=_STATUS_UNSUPPORTED, reason="disk_probe_unavailable"),
-        "disk_free_gb": _metric_payload(value=None, unit="GB", status=_STATUS_UNSUPPORTED, reason="disk_probe_unavailable"),
+        "cpu_percent": _metric_payload(
+            value=None,
+            unit="percent",
+            status=_STATUS_UNSUPPORTED,
+            reason="cpu_probe_unavailable",
+        ),
+        "cpu_load_1m": _metric_payload(
+            value=None,
+            unit="load",
+            status=_STATUS_UNSUPPORTED,
+            reason="load_probe_unavailable",
+        ),
+        "ram_used_percent": _metric_payload(
+            value=None,
+            unit="percent",
+            status=_STATUS_UNSUPPORTED,
+            reason="memory_probe_unavailable",
+        ),
+        "ram_available_mb": _metric_payload(
+            value=None,
+            unit="MB",
+            status=_STATUS_UNSUPPORTED,
+            reason="memory_probe_unavailable",
+        ),
+        "disk_used_percent": _metric_payload(
+            value=None,
+            unit="percent",
+            status=_STATUS_UNSUPPORTED,
+            reason="disk_probe_unavailable",
+        ),
+        "disk_free_gb": _metric_payload(
+            value=None,
+            unit="GB",
+            status=_STATUS_UNSUPPORTED,
+            reason="disk_probe_unavailable",
+        ),
         "host_temperature_c": _metric_payload(
             value=None,
             unit="C",
@@ -216,16 +248,31 @@ def collect_host_metrics() -> dict[str, Any]:
             status=_STATUS_UNSUPPORTED,
             reason="process_probe_unavailable",
         ),
-        "process_rss_mb": _metric_payload(value=None, unit="MB", status=_STATUS_UNSUPPORTED, reason="process_probe_unavailable"),
-        "host_uptime_s": _metric_payload(value=None, unit="s", status=_STATUS_UNSUPPORTED, reason="uptime_probe_unavailable"),
+        "process_rss_mb": _metric_payload(
+            value=None,
+            unit="MB",
+            status=_STATUS_UNSUPPORTED,
+            reason="process_probe_unavailable",
+        ),
+        "host_uptime_s": _metric_payload(
+            value=None,
+            unit="s",
+            status=_STATUS_UNSUPPORTED,
+            reason="uptime_probe_unavailable",
+        ),
     }
 
     if psutil is not None:
         strategy = "primary"
         try:
-            cpu_percent = max(0.0, min(_safe_float(psutil.cpu_percent(interval=None)), 100.0))
+            cpu_percent = max(
+                0.0, min(_safe_float(psutil.cpu_percent(interval=None)), 100.0)
+            )
             metric_statuses["cpu_percent"] = _metric_payload(
-                value=cpu_percent, unit="percent", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=cpu_percent,
+                unit="percent",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
         except Exception:
             cpu_percent = 0.0
@@ -234,7 +281,10 @@ def collect_host_metrics() -> dict[str, Any]:
             load = os.getloadavg()[0]
             cpu_load_1m = max(_safe_float(load), 0.0)
             metric_statuses["cpu_load_1m"] = _metric_payload(
-                value=cpu_load_1m, unit="load", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=cpu_load_1m,
+                unit="load",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
         except Exception:
             cpu_load_1m = None
@@ -247,46 +297,79 @@ def collect_host_metrics() -> dict[str, Any]:
 
         try:
             vm = psutil.virtual_memory()
-            ram_used_percent = max(0.0, min(_safe_float(getattr(vm, "percent", 0.0)), 100.0))
-            ram_available_mb = max(_safe_float(getattr(vm, "available", 0.0)) / _MB, 0.0)
+            ram_used_percent = max(
+                0.0, min(_safe_float(getattr(vm, "percent", 0.0)), 100.0)
+            )
+            ram_available_mb = max(
+                _safe_float(getattr(vm, "available", 0.0)) / _MB, 0.0
+            )
             metric_statuses["ram_used_percent"] = _metric_payload(
-                value=ram_used_percent, unit="percent", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=ram_used_percent,
+                unit="percent",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
             metric_statuses["ram_available_mb"] = _metric_payload(
-                value=ram_available_mb, unit="MB", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=ram_available_mb,
+                unit="MB",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
         except Exception:
             ram_used_percent, ram_available_mb = _collect_memory_stdlib()
             metric_statuses["ram_used_percent"] = _metric_payload(
-                value=ram_used_percent, unit="percent", status=_STATUS_PARTIAL, reason="psutil_virtual_memory_failed"
+                value=ram_used_percent,
+                unit="percent",
+                status=_STATUS_PARTIAL,
+                reason="psutil_virtual_memory_failed",
             )
             metric_statuses["ram_available_mb"] = _metric_payload(
-                value=ram_available_mb, unit="MB", status=_STATUS_PARTIAL, reason="psutil_virtual_memory_failed"
+                value=ram_available_mb,
+                unit="MB",
+                status=_STATUS_PARTIAL,
+                reason="psutil_virtual_memory_failed",
             )
 
         try:
             du = psutil.disk_usage(str(Path.cwd()))
-            disk_used_percent = max(0.0, min(_safe_float(getattr(du, "percent", 0.0)), 100.0))
+            disk_used_percent = max(
+                0.0, min(_safe_float(getattr(du, "percent", 0.0)), 100.0)
+            )
             disk_free_gb = max(_safe_float(getattr(du, "free", 0.0)) / _GB, 0.0)
             metric_statuses["disk_used_percent"] = _metric_payload(
-                value=disk_used_percent, unit="percent", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=disk_used_percent,
+                unit="percent",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
             metric_statuses["disk_free_gb"] = _metric_payload(
-                value=disk_free_gb, unit="GB", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=disk_free_gb,
+                unit="GB",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
         except Exception:
             disk_used_percent, disk_free_gb = _collect_disk_stdlib()
             metric_statuses["disk_used_percent"] = _metric_payload(
-                value=disk_used_percent, unit="percent", status=_STATUS_PARTIAL, reason="psutil_disk_usage_failed"
+                value=disk_used_percent,
+                unit="percent",
+                status=_STATUS_PARTIAL,
+                reason="psutil_disk_usage_failed",
             )
             metric_statuses["disk_free_gb"] = _metric_payload(
-                value=disk_free_gb, unit="GB", status=_STATUS_PARTIAL, reason="psutil_disk_usage_failed"
+                value=disk_free_gb,
+                unit="GB",
+                status=_STATUS_PARTIAL,
+                reason="psutil_disk_usage_failed",
             )
 
         host_temperature_c = _collect_temperatures_psutil()
         if host_temperature_c is not None:
             metric_statuses["host_temperature_c"] = _metric_payload(
-                value=host_temperature_c, unit="C", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=host_temperature_c,
+                unit="C",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
         else:
             metric_statuses["host_temperature_c"] = _metric_payload(
@@ -298,21 +381,35 @@ def collect_host_metrics() -> dict[str, Any]:
 
         try:
             process = psutil.Process(os.getpid())
-            process_cpu_percent = max(0.0, min(_safe_float(process.cpu_percent(interval=None)), 100.0))
+            process_cpu_percent = max(
+                0.0, min(_safe_float(process.cpu_percent(interval=None)), 100.0)
+            )
             process_rss_mb = max(_safe_float(process.memory_info().rss) / _MB, 0.0)
             metric_statuses["process_cpu_percent"] = _metric_payload(
-                value=process_cpu_percent, unit="percent", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=process_cpu_percent,
+                unit="percent",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
             metric_statuses["process_rss_mb"] = _metric_payload(
-                value=process_rss_mb, unit="MB", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+                value=process_rss_mb,
+                unit="MB",
+                status=_STATUS_AVAILABLE,
+                last_seen_at=collected_at,
             )
         except Exception:
             process_cpu_percent, process_rss_mb = _collect_process_stdlib()
             metric_statuses["process_cpu_percent"] = _metric_payload(
-                value=process_cpu_percent, unit="percent", status=_STATUS_PARTIAL, reason="psutil_process_probe_failed"
+                value=process_cpu_percent,
+                unit="percent",
+                status=_STATUS_PARTIAL,
+                reason="psutil_process_probe_failed",
             )
             metric_statuses["process_rss_mb"] = _metric_payload(
-                value=process_rss_mb, unit="MB", status=_STATUS_PARTIAL, reason="psutil_process_probe_failed"
+                value=process_rss_mb,
+                unit="MB",
+                status=_STATUS_PARTIAL,
+                reason="psutil_process_probe_failed",
             )
     else:
         strategy = "partial_fallback"
@@ -337,50 +434,90 @@ def collect_host_metrics() -> dict[str, Any]:
         try:
             cpu_load_1m = max(_safe_float(os.getloadavg()[0]), 0.0)
             metric_statuses["cpu_load_1m"] = _metric_payload(
-                value=cpu_load_1m, unit="load", status=_STATUS_PARTIAL, reason="loadavg_stdlib_fallback", last_seen_at=collected_at
+                value=cpu_load_1m,
+                unit="load",
+                status=_STATUS_PARTIAL,
+                reason="loadavg_stdlib_fallback",
+                last_seen_at=collected_at,
             )
         except Exception:
             cpu_load_1m = None
             metric_statuses["cpu_load_1m"] = _metric_payload(
-                value=None, unit="load", status=_STATUS_UNSUPPORTED, reason="loadavg_not_supported_on_platform"
+                value=None,
+                unit="load",
+                status=_STATUS_UNSUPPORTED,
+                reason="loadavg_not_supported_on_platform",
             )
 
         ram_used_percent, ram_available_mb = _collect_memory_stdlib()
         if ram_available_mb > 0.0:
             metric_statuses["ram_used_percent"] = _metric_payload(
-                value=ram_used_percent, unit="percent", status=_STATUS_PARTIAL, reason="memory_stdlib_fallback", last_seen_at=collected_at
+                value=ram_used_percent,
+                unit="percent",
+                status=_STATUS_PARTIAL,
+                reason="memory_stdlib_fallback",
+                last_seen_at=collected_at,
             )
             metric_statuses["ram_available_mb"] = _metric_payload(
-                value=ram_available_mb, unit="MB", status=_STATUS_PARTIAL, reason="memory_stdlib_fallback", last_seen_at=collected_at
+                value=ram_available_mb,
+                unit="MB",
+                status=_STATUS_PARTIAL,
+                reason="memory_stdlib_fallback",
+                last_seen_at=collected_at,
             )
         disk_used_percent, disk_free_gb = _collect_disk_stdlib()
         if disk_free_gb > 0.0 or disk_used_percent > 0.0:
             metric_statuses["disk_used_percent"] = _metric_payload(
-                value=disk_used_percent, unit="percent", status=_STATUS_PARTIAL, reason="disk_stdlib_fallback", last_seen_at=collected_at
+                value=disk_used_percent,
+                unit="percent",
+                status=_STATUS_PARTIAL,
+                reason="disk_stdlib_fallback",
+                last_seen_at=collected_at,
             )
             metric_statuses["disk_free_gb"] = _metric_payload(
-                value=disk_free_gb, unit="GB", status=_STATUS_PARTIAL, reason="disk_stdlib_fallback", last_seen_at=collected_at
+                value=disk_free_gb,
+                unit="GB",
+                status=_STATUS_PARTIAL,
+                reason="disk_stdlib_fallback",
+                last_seen_at=collected_at,
             )
         process_cpu_percent, process_rss_mb = _collect_process_stdlib()
         metric_statuses["process_cpu_percent"] = _metric_payload(
-            value=process_cpu_percent, unit="percent", status=_STATUS_PARTIAL, reason="process_stdlib_fallback", last_seen_at=collected_at
+            value=process_cpu_percent,
+            unit="percent",
+            status=_STATUS_PARTIAL,
+            reason="process_stdlib_fallback",
+            last_seen_at=collected_at,
         )
         metric_statuses["process_rss_mb"] = _metric_payload(
-            value=process_rss_mb, unit="MB", status=_STATUS_PARTIAL, reason="process_stdlib_fallback", last_seen_at=collected_at
+            value=process_rss_mb,
+            unit="MB",
+            status=_STATUS_PARTIAL,
+            reason="process_stdlib_fallback",
+            last_seen_at=collected_at,
         )
 
     host_uptime_s, uptime_reason = _collect_uptime_seconds()
     if host_uptime_s is not None:
         metric_statuses["host_uptime_s"] = _metric_payload(
-            value=host_uptime_s, unit="s", status=_STATUS_AVAILABLE, last_seen_at=collected_at
+            value=host_uptime_s,
+            unit="s",
+            status=_STATUS_AVAILABLE,
+            last_seen_at=collected_at,
         )
     else:
         metric_statuses["host_uptime_s"] = _metric_payload(
-            value=None, unit="s", status=_STATUS_UNSUPPORTED, reason=uptime_reason or "uptime_probe_unavailable"
+            value=None,
+            unit="s",
+            status=_STATUS_UNSUPPORTED,
+            reason=uptime_reason or "uptime_probe_unavailable",
         )
 
     if strategy != "primary":
-        has_minimal_signal = any(metric_statuses[name]["value"] is not None for name in ("host_uptime_s", "cpu_load_1m", "ram_available_mb"))
+        has_minimal_signal = any(
+            metric_statuses[name]["value"] is not None
+            for name in ("host_uptime_s", "cpu_load_1m", "ram_available_mb")
+        )
         cpu_or_disk_unavailable = (
             metric_statuses["cpu_percent"]["status"] == _STATUS_UNSUPPORTED
             and metric_statuses["disk_used_percent"]["status"] == _STATUS_UNSUPPORTED

--- a/src/singular/sensors/host_metrics_store.py
+++ b/src/singular/sensors/host_metrics_store.py
@@ -36,7 +36,9 @@ def host_metrics_file() -> Path:
 
 
 def _retention_samples() -> int:
-    raw = os.getenv("SINGULAR_HOST_METRICS_RETENTION_SAMPLES", str(_DEFAULT_RETENTION_SAMPLES))
+    raw = os.getenv(
+        "SINGULAR_HOST_METRICS_RETENTION_SAMPLES", str(_DEFAULT_RETENTION_SAMPLES)
+    )
     try:
         value = int(raw)
     except ValueError:
@@ -75,7 +77,9 @@ def _extract_metric_value(metrics: dict[str, Any], key: str) -> float | None:
     return _safe_float(raw)
 
 
-def _extract_metric_snapshot(metrics: dict[str, Any], key: str) -> dict[str, Any] | None:
+def _extract_metric_snapshot(
+    metrics: dict[str, Any], key: str
+) -> dict[str, Any] | None:
     candidate = metrics.get(key)
     if not isinstance(candidate, dict):
         return None
@@ -191,7 +195,9 @@ def compute_host_metrics_aggregates(
         mean_all = _mean(values)
         variances[key] = _variance(values, mean_all)
         rolling_means[key] = {
-            str(window): _mean(values[-window:]) for window in windows if len(values) >= 1
+            str(window): _mean(values[-window:])
+            for window in windows
+            if len(values) >= 1
         }
 
     return {
@@ -216,17 +222,41 @@ def summarize_environmental_impact(aggregates: dict[str, Any] | None) -> dict[st
         }
     rolling = aggregates.get("rolling_means", {})
     variance = aggregates.get("variance", {})
-    cpu_20 = _safe_float(((rolling.get("cpu_percent") or {}).get("20"))) if isinstance(rolling, dict) else None
-    ram_20 = _safe_float(((rolling.get("ram_used_percent") or {}).get("20"))) if isinstance(rolling, dict) else None
-    temp_20 = _safe_float(((rolling.get("host_temperature_c") or {}).get("20"))) if isinstance(rolling, dict) else None
+    cpu_20 = (
+        _safe_float(((rolling.get("cpu_percent") or {}).get("20")))
+        if isinstance(rolling, dict)
+        else None
+    )
+    ram_20 = (
+        _safe_float(((rolling.get("ram_used_percent") or {}).get("20")))
+        if isinstance(rolling, dict)
+        else None
+    )
+    temp_20 = (
+        _safe_float(((rolling.get("host_temperature_c") or {}).get("20")))
+        if isinstance(rolling, dict)
+        else None
+    )
     cpu_pressure = max(0.0, min((cpu_20 or 0.0) / 100.0, 1.0))
     ram_pressure = max(0.0, min((ram_20 or 0.0) / 100.0, 1.0))
     thermal_pressure = max(0.0, min((temp_20 or 0.0) / 95.0, 1.0))
-    pressure_score = (cpu_pressure * 0.45) + (ram_pressure * 0.35) + (thermal_pressure * 0.2)
+    pressure_score = (
+        (cpu_pressure * 0.45) + (ram_pressure * 0.35) + (thermal_pressure * 0.2)
+    )
 
-    cpu_var = _safe_float((variance or {}).get("cpu_percent")) if isinstance(variance, dict) else None
-    ram_var = _safe_float((variance or {}).get("ram_used_percent")) if isinstance(variance, dict) else None
-    variance_score = max(0.0, min((((cpu_var or 0.0) / 400.0) + ((ram_var or 0.0) / 400.0)) / 2.0, 1.0))
+    cpu_var = (
+        _safe_float((variance or {}).get("cpu_percent"))
+        if isinstance(variance, dict)
+        else None
+    )
+    ram_var = (
+        _safe_float((variance or {}).get("ram_used_percent"))
+        if isinstance(variance, dict)
+        else None
+    )
+    variance_score = max(
+        0.0, min((((cpu_var or 0.0) / 400.0) + ((ram_var or 0.0) / 400.0)) / 2.0, 1.0)
+    )
 
     if pressure_score >= 0.8:
         level = "critical"

--- a/src/singular/skills_daily.py
+++ b/src/singular/skills_daily.py
@@ -44,7 +44,9 @@ def _extract_task_label(record: dict[str, Any]) -> str | None:
 def build_daily_skills_snapshot(
     records: list[dict[str, Any]], *, now: datetime | None = None
 ) -> dict[str, Any]:
-    now_dt = now.astimezone(timezone.utc) if now is not None else datetime.now(timezone.utc)
+    now_dt = (
+        now.astimezone(timezone.utc) if now is not None else datetime.now(timezone.utc)
+    )
     since_24h = now_dt - timedelta(hours=24)
     since_7d = now_dt - timedelta(days=7)
     previous_24h = since_24h - timedelta(hours=24)
@@ -78,9 +80,15 @@ def build_daily_skills_snapshot(
         )
         skill_entry["total_uses"] += 1
         if timestamp is not None:
-            if skill_entry["first_seen_at"] is None or timestamp < skill_entry["first_seen_at"]:
+            if (
+                skill_entry["first_seen_at"] is None
+                or timestamp < skill_entry["first_seen_at"]
+            ):
                 skill_entry["first_seen_at"] = timestamp
-            if skill_entry["last_used_at"] is None or timestamp > skill_entry["last_used_at"]:
+            if (
+                skill_entry["last_used_at"] is None
+                or timestamp > skill_entry["last_used_at"]
+            ):
                 skill_entry["last_used_at"] = timestamp
             if timestamp >= since_24h:
                 skill_entry["uses_24h"] += 1
@@ -91,7 +99,11 @@ def build_daily_skills_snapshot(
             if previous_24h <= timestamp < since_24h:
                 skill_entry["uses_previous_24h"] += 1
         task_label = _extract_task_label(record)
-        if task_label and task_label not in skill_entry["associated_tasks"] and len(skill_entry["associated_tasks"]) < 4:
+        if (
+            task_label
+            and task_label not in skill_entry["associated_tasks"]
+            and len(skill_entry["associated_tasks"]) < 4
+        ):
             skill_entry["associated_tasks"].append(task_label)
         if isinstance(accepted, bool):
             skill_entry["attempts_with_result"] += 1
@@ -107,7 +119,9 @@ def build_daily_skills_snapshot(
     for item in per_skill.values():
         attempts = item["attempts_with_result"]
         success_rate = item["success_total"] / attempts if attempts else None
-        success_rate_24h = item["success_24h"] / item["uses_24h"] if item["uses_24h"] else None
+        success_rate_24h = (
+            item["success_24h"] / item["uses_24h"] if item["uses_24h"] else None
+        )
         if item["uses_24h"] > item["uses_previous_24h"]:
             trend = "hausse"
         elif item["uses_24h"] < item["uses_previous_24h"]:
@@ -119,7 +133,11 @@ def build_daily_skills_snapshot(
             learned += 1
         if item["uses_24h"] > 0:
             used += 1
-        if trend == "hausse" and success_rate_24h is not None and success_rate_24h >= 0.6:
+        if (
+            trend == "hausse"
+            and success_rate_24h is not None
+            and success_rate_24h >= 0.6
+        ):
             improved += 1
         top_skills.append(
             {
@@ -128,7 +146,9 @@ def build_daily_skills_snapshot(
                 "frequency": {"uses_24h": item["uses_24h"], "uses_7d": item["uses_7d"]},
                 "success_rate": success_rate,
                 "last_used_at": (
-                    item["last_used_at"].isoformat() if isinstance(item["last_used_at"], datetime) else None
+                    item["last_used_at"].isoformat()
+                    if isinstance(item["last_used_at"], datetime)
+                    else None
                 ),
                 "associated_tasks": item["associated_tasks"],
                 "trend": trend,

--- a/src/singular/social/graph.py
+++ b/src/singular/social/graph.py
@@ -40,7 +40,9 @@ class SocialGraph:
 
     def __init__(self, path: Path | None = None) -> None:
         self.path = path or (get_mem_dir() / "social_graph.json")
-        self.theory_of_mind = TheoryOfMindStore(self.path.with_name("theory_of_mind.json"))
+        self.theory_of_mind = TheoryOfMindStore(
+            self.path.with_name("theory_of_mind.json")
+        )
         self._relations: dict[str, PairRelation] = {}
         self._load()
 
@@ -115,7 +117,9 @@ class SocialGraph:
         self._save()
         return relation.to_dict()
 
-    def observe_mental_state(self, individual_id: str, event: str, **details: object) -> dict[str, object]:
+    def observe_mental_state(
+        self, individual_id: str, event: str, **details: object
+    ) -> dict[str, object]:
         """Update a peer hypothesis without changing the affective relation."""
 
         return self.theory_of_mind.observe(individual_id, event, **details)  # type: ignore[arg-type]

--- a/src/singular/social/theory_of_mind.py
+++ b/src/singular/social/theory_of_mind.py
@@ -18,8 +18,15 @@ from singular.memory import _atomic_write_text, get_mem_dir
 
 SCHEMA_VERSION = 2
 _EVIDENCE_LIMIT = 50
-EvidenceKind = Literal["direct_observation", "other_statement", "inference", "verified_outcome"]
-_EVIDENCE_KINDS = {"direct_observation", "other_statement", "inference", "verified_outcome"}
+EvidenceKind = Literal[
+    "direct_observation", "other_statement", "inference", "verified_outcome"
+]
+_EVIDENCE_KINDS = {
+    "direct_observation",
+    "other_statement",
+    "inference",
+    "verified_outcome",
+}
 
 
 def _utcnow() -> datetime:
@@ -88,7 +95,9 @@ class TheoryOfMindStore:
                     attributed_beliefs=_scores(value.get("attributed_beliefs")),
                     reliability=_clamp(value.get("reliability", 0.5)),
                     confidence=_clamp(value.get("confidence", 0.0)),
-                    reciprocity=max(-1.0, min(1.0, float(value.get("reciprocity", 0.0)))),
+                    reciprocity=max(
+                        -1.0, min(1.0, float(value.get("reciprocity", 0.0)))
+                    ),
                     evidence=_evidence(value.get("evidence")),
                     uncertainty=_clamp(value.get("uncertainty", 1.0)),
                     updated_at=str(value.get("updated_at", self.clock().isoformat())),
@@ -97,13 +106,25 @@ class TheoryOfMindStore:
                 continue
 
     def _save(self) -> None:
-        _atomic_write_text(self.path, json.dumps({
-            "schema_version": SCHEMA_VERSION,
-            "models": {key: model.to_dict() for key, model in sorted(self._models.items())},
-        }, ensure_ascii=False, indent=2))
+        _atomic_write_text(
+            self.path,
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "models": {
+                        key: model.to_dict()
+                        for key, model in sorted(self._models.items())
+                    },
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+        )
 
     def get(self, individual_id: str, *, decayed: bool = True) -> dict[str, object]:
-        model = self._models.get(str(individual_id), MentalStateModel(str(individual_id)))
+        model = self._models.get(
+            str(individual_id), MentalStateModel(str(individual_id))
+        )
         result = model.to_dict()
         if decayed and model.version:
             try:
@@ -143,8 +164,19 @@ class TheoryOfMindStore:
         key = str(individual_id)
         model = self._models.get(key, MentalStateModel(key))
         event_key = str(event).lower()
-        positive = event_key in {"conversation", "cooperation", "successful_cooperation", "promise_kept", "positive_outcome"}
-        negative = event_key in {"conflict", "cooperation_failure", "promise_broken", "negative_outcome"}
+        positive = event_key in {
+            "conversation",
+            "cooperation",
+            "successful_cooperation",
+            "promise_kept",
+            "positive_outcome",
+        }
+        negative = event_key in {
+            "conflict",
+            "cooperation_failure",
+            "promise_broken",
+            "negative_outcome",
+        }
         if outcome is not None:
             positive, negative = outcome, not outcome
 
@@ -152,10 +184,14 @@ class TheoryOfMindStore:
             model.supposed_goals.append(goal)
         if intention:
             previous = model.intentions.get(intention, 0.5)
-            model.intentions[intention] = _clamp(previous + (0.25 if positive else -0.4 if negative else 0.08))
+            model.intentions[intention] = _clamp(
+                previous + (0.25 if positive else -0.4 if negative else 0.08)
+            )
         if belief:
             previous = model.attributed_beliefs.get(belief, 0.5)
-            model.attributed_beliefs[belief] = _clamp(previous + (0.15 if not negative else -0.25))
+            model.attributed_beliefs[belief] = _clamp(
+                previous + (0.15 if not negative else -0.25)
+            )
         if positive:
             model.reliability = _clamp(model.reliability + 0.1)
             model.reciprocity = min(1.0, model.reciprocity + 0.15)
@@ -168,7 +204,9 @@ class TheoryOfMindStore:
             "other_statement": 0.45,
             "inference": 0.25,
         }[evidence_kind]
-        evidence_strength = (0.14 if outcome is not None or "promise" in event_key else 0.08)
+        evidence_strength = (
+            0.14 if outcome is not None or "promise" in event_key else 0.08
+        )
         evidence_strength *= kind_weight * _clamp(confidence)
         model.confidence = _clamp(model.confidence + evidence_strength)
         model.uncertainty = _clamp(1.0 - model.confidence)
@@ -181,7 +219,13 @@ class TheoryOfMindStore:
             "confidence": _clamp(confidence),
             "asserted_fact": evidence_kind == "verified_outcome",
         }
-        for name, value in (("intention", intention), ("goal", goal), ("belief", belief), ("outcome", outcome), ("note", note)):
+        for name, value in (
+            ("intention", intention),
+            ("goal", goal),
+            ("belief", belief),
+            ("outcome", outcome),
+            ("note", note),
+        ):
             if value is not None:
                 item[name] = value
         if source is not None:
@@ -193,7 +237,11 @@ class TheoryOfMindStore:
 
 
 def _strings(value: object) -> list[str]:
-    return [item for item in value if isinstance(item, str)] if isinstance(value, list) else []
+    return (
+        [item for item in value if isinstance(item, str)]
+        if isinstance(value, list)
+        else []
+    )
 
 
 def _scores(value: object) -> dict[str, float]:
@@ -210,4 +258,8 @@ def _scores(value: object) -> dict[str, float]:
 
 
 def _evidence(value: object) -> list[dict[str, object]]:
-    return [dict(item) for item in value if isinstance(item, dict)][-_EVIDENCE_LIMIT:] if isinstance(value, list) else []
+    return (
+        [dict(item) for item in value if isinstance(item, dict)][-_EVIDENCE_LIMIT:]
+        if isinstance(value, list)
+        else []
+    )

--- a/src/singular/storage_retention.py
+++ b/src/singular/storage_retention.py
@@ -204,7 +204,11 @@ def _safe_delete_path(target: Path) -> tuple[bool, str]:
 
 
 def persisted_retention_config_path(base_dir: Path | None = None) -> Path:
-    root = Path(base_dir) if base_dir is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    root = (
+        Path(base_dir)
+        if base_dir is not None
+        else Path(os.environ.get("SINGULAR_HOME", "."))
+    )
     return root / _DEFAULT_PERSISTED_CONFIG_RELATIVE_PATH
 
 
@@ -278,18 +282,33 @@ def build_runs_policy_report(
         if run_dir.is_dir():
             grouped.setdefault(run_dir.name, []).append(run_dir)
     for legacy_file in runs_dir.glob("*.jsonl"):
-        grouped.setdefault(_run_id_from_legacy_file(legacy_file), []).append(legacy_file)
+        grouped.setdefault(_run_id_from_legacy_file(legacy_file), []).append(
+            legacy_file
+        )
 
     candidates: list[tuple[str, Path, datetime, float, int, bool]] = []
     for run_id, artifacts in grouped.items():
-        mtimes = [mtime for artifact in artifacts if (mtime := _latest_mtime(artifact)) is not None]
+        mtimes = [
+            mtime
+            for artifact in artifacts
+            if (mtime := _latest_mtime(artifact)) is not None
+        ]
         if not mtimes:
             continue
         latest_mtime = max(mtimes)
         age_days = (ref_now - latest_mtime).total_seconds() / 86400
         size = sum(_walk_total_size(artifact) for artifact in artifacts)
         primary = runs_dir / run_id if (runs_dir / run_id).exists() else artifacts[0]
-        candidates.append((run_id, primary, latest_mtime, age_days, size, _is_active_run(runs_dir, run_id)))
+        candidates.append(
+            (
+                run_id,
+                primary,
+                latest_mtime,
+                age_days,
+                size,
+                _is_active_run(runs_dir, run_id),
+            )
+        )
 
     candidates.sort(key=lambda row: (row[2], row[0]), reverse=True)
 
@@ -297,7 +316,9 @@ def build_runs_policy_report(
     kept_count = 0
     kept_candidates: list[tuple[int, int]] = []
     running_size = 0
-    for index, (run_id, target, _mtime, age_days, size, active) in enumerate(candidates):
+    for index, (run_id, target, _mtime, age_days, size, active) in enumerate(
+        candidates
+    ):
         size_mb = size / _BYTES_PER_MB
         action = "keep"
         reason = "within_policy"
@@ -329,7 +350,9 @@ def build_runs_policy_report(
             kept_candidates.append((index, size))
 
     if running_size / _BYTES_PER_MB > config.max_total_runs_size_mb:
-        for index, size in sorted(kept_candidates, key=lambda row: row[0], reverse=True):
+        for index, size in sorted(
+            kept_candidates, key=lambda row: row[0], reverse=True
+        ):
             if running_size / _BYTES_PER_MB <= config.max_total_runs_size_mb:
                 break
             decision = decisions[index]
@@ -423,7 +446,11 @@ def run_retention_service(
     writing retention state.
     """
 
-    root = Path(base_dir) if base_dir is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    root = (
+        Path(base_dir)
+        if base_dir is not None
+        else Path(os.environ.get("SINGULAR_HOME", "."))
+    )
     target_runs_dir = Path(runs_dir) if runs_dir is not None else root / "runs"
     ref_now = now or _now_utc()
     config = load_retention_config(base_dir=root)
@@ -482,7 +509,9 @@ def run_retention_service(
             for decision in report.decisions
             if decision.action == "delete" and not decision.active
         ]
-        freed_mb = round(sum(decision.size_mb or 0.0 for decision in deleted_decisions), 4)
+        freed_mb = round(
+            sum(decision.size_mb or 0.0 for decision in deleted_decisions), 4
+        )
         counts = report.summary
         last_run_summary = {
             "scope": report.scope,
@@ -534,7 +563,11 @@ def retention_status_snapshot(
 ) -> Mapping[str, Any]:
     """Return a rich status payload used by CLI and dashboard monitoring."""
 
-    root = Path(base_dir) if base_dir is not None else Path(os.environ.get("SINGULAR_HOME", "."))
+    root = (
+        Path(base_dir)
+        if base_dir is not None
+        else Path(os.environ.get("SINGULAR_HOME", "."))
+    )
     target_runs_dir = Path(runs_dir) if runs_dir is not None else root / "runs"
     config = load_retention_config(base_dir=root)
     report = build_runs_policy_report(runs_dir=target_runs_dir, config=config, now=now)
@@ -546,11 +579,14 @@ def retention_status_snapshot(
 
     run_count = len(report.decisions)
     overdue_age = [
-        decision for decision in report.decisions if (decision.age_days or 0.0) > config.max_run_age_days
+        decision
+        for decision in report.decisions
+        if (decision.age_days or 0.0) > config.max_run_age_days
     ]
     exceeds = {
         "max_runs": run_count > config.max_runs,
-        "max_total_runs_size_mb": (runs_size_bytes / _BYTES_PER_MB) > config.max_total_runs_size_mb,
+        "max_total_runs_size_mb": (runs_size_bytes / _BYTES_PER_MB)
+        > config.max_total_runs_size_mb,
         "max_run_age_days": len(overdue_age) > 0,
     }
 

--- a/tests/fastapi_stub/__init__.py
+++ b/tests/fastapi_stub/__init__.py
@@ -71,7 +71,6 @@ class FastAPI:
 
         return decorator
 
-
     def post(
         self, path: str, **_kwargs: Any
     ) -> Callable[[Callable[[], Any]], Callable[[], Any]]:

--- a/tests/perception/test_audio_pipeline.py
+++ b/tests/perception/test_audio_pipeline.py
@@ -21,14 +21,23 @@ class StaticAudioProvider(AudioBlockProvider):
 
 
 class DummyTranscriber:
-    runtime = WhisperRuntime(device="cpu", model_size="tiny", backend="whisper", fallback_applied=True)
+    runtime = WhisperRuntime(
+        device="cpu", model_size="tiny", backend="whisper", fallback_applied=True
+    )
 
     def transcribe(self, blocks):
         start = blocks[0].started_at
         end = blocks[-1].started_at + blocks[-1].duration_s
         return {
             "text": "bonjour le monde",
-            "segments": [{"start": 0.0, "end": round(end - start, 3), "text": "bonjour le monde", "confidence": 0.86}],
+            "segments": [
+                {
+                    "start": 0.0,
+                    "end": round(end - start, 3),
+                    "text": "bonjour le monde",
+                    "confidence": 0.86,
+                }
+            ],
             "confidence": 0.86,
             "status": "ok",
             "runtime": self.runtime.__dict__,

--- a/tests/perception/test_os_pipeline.py
+++ b/tests/perception/test_os_pipeline.py
@@ -42,7 +42,9 @@ def test_os_pipeline_emits_raw_and_semantic_events() -> None:
     snapshot = OSSnapshot(
         observed_at="2026-04-15T00:00:00+00:00",
         active_window=ActiveWindowState(app="Zoom", title="Weekly Engineering Meeting"),
-        input_state=InputState(mouse_x=120, mouse_y=88, keyboard_active=True, idle_seconds=1.5),
+        input_state=InputState(
+            mouse_x=120, mouse_y=88, keyboard_active=True, idle_seconds=1.5
+        ),
         notifications=[
             NotificationRecord(
                 app="Calendar",
@@ -81,7 +83,9 @@ def test_os_pipeline_detects_coding_window() -> None:
     snapshot = OSSnapshot(
         observed_at="2026-04-15T00:00:00+00:00",
         active_window=ActiveWindowState(app="Code", title="repo - main.py"),
-        input_state=InputState(mouse_x=None, mouse_y=None, keyboard_active=False, idle_seconds=30.0),
+        input_state=InputState(
+            mouse_x=None, mouse_y=None, keyboard_active=False, idle_seconds=30.0
+        ),
         notifications=[],
         host_state=HostState(
             network_online=None,

--- a/tests/providers/test_llm_fallback_chain.py
+++ b/tests/providers/test_llm_fallback_chain.py
@@ -125,7 +125,9 @@ def test_context_budget_is_provider_aware_stable_and_safely_capped(monkeypatch):
     openai = providers.LLMProviderClient(name="openai", generate=lambda prompt: prompt)
     ollama = providers.LLMProviderClient(name="ollama", generate=lambda prompt: prompt)
     assert ContextBudget.for_client(openai) == ContextBudget.for_client(openai)
-    assert ContextBudget.for_client(ollama).total > ContextBudget.for_client(openai).total
+    assert (
+        ContextBudget.for_client(ollama).total > ContextBudget.for_client(openai).total
+    )
 
     monkeypatch.setenv("SINGULAR_TALK_CONTEXT_CHARS", "999999")
     assert ContextBudget.for_client(ollama).total == 2000

--- a/tests/providers/test_llm_openai.py
+++ b/tests/providers/test_llm_openai.py
@@ -202,7 +202,9 @@ def test_generate_reply_schema_error_non_string_content(monkeypatch):
     class FakeCompletions:
         def create(self, **_kwargs):
             return SimpleNamespace(
-                choices=[SimpleNamespace(message=SimpleNamespace(content=["not", "text"]))]
+                choices=[
+                    SimpleNamespace(message=SimpleNamespace(content=["not", "text"]))
+                ]
             )
 
     class FakeClient:

--- a/tests/providers/test_llm_provider_loader.py
+++ b/tests/providers/test_llm_provider_loader.py
@@ -3,14 +3,20 @@ import pytest
 from singular.providers import ProviderMisconfiguredError, _load_provider_contract
 
 
-def test_load_provider_contract_raises_explicit_error_when_dependency_is_missing(monkeypatch):
+def test_load_provider_contract_raises_explicit_error_when_dependency_is_missing(
+    monkeypatch,
+):
     module_name = "singular.providers.llm_broken"
 
     def fake_import_module(imported_name):
         assert imported_name == module_name
-        raise ModuleNotFoundError("No module named 'missing_dependency'", name="missing_dependency")
+        raise ModuleNotFoundError(
+            "No module named 'missing_dependency'", name="missing_dependency"
+        )
 
     monkeypatch.setattr("singular.providers.import_module", fake_import_module)
 
-    with pytest.raises(ProviderMisconfiguredError, match="missing dependency 'missing_dependency'"):
+    with pytest.raises(
+        ProviderMisconfiguredError, match="missing dependency 'missing_dependency'"
+    ):
         _load_provider_contract("broken")

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from singular.observability.audit_log import AuditLogStore, read_audit_events
 
 
-def test_audit_log_persists_correlated_records_and_redacts_sensitive_data(tmp_path: Path) -> None:
+def test_audit_log_persists_correlated_records_and_redacts_sensitive_data(
+    tmp_path: Path,
+) -> None:
     store = AuditLogStore(root=tmp_path)
 
     decision = store.log_decision(
@@ -40,4 +42,3 @@ def test_audit_log_persists_correlated_records_and_redacts_sensitive_data(tmp_pa
     assert len(events) == 3
     assert {event["category"] for event in events} == {"decision", "action", "result"}
     assert all(event["event_id"] == "evt-1" for event in events)
-

--- a/tests/test_benchmarks_runner.py
+++ b/tests/test_benchmarks_runner.py
@@ -30,7 +30,14 @@ def test_run_benchmarks_writes_artifacts_and_summary(tmp_path: Path) -> None:
     weights_path = benchmarks_dir / "weights.json"
 
     benchmarks_dir.mkdir()
-    for domain in ["raisonnement", "code", "planification", "memoire", "interaction", "adaptation"]:
+    for domain in [
+        "raisonnement",
+        "code",
+        "planification",
+        "memoire",
+        "interaction",
+        "adaptation",
+    ]:
         _write_domain(benchmarks_dir / f"{domain}.json", domain, "alpha beta")
 
     weights_path.write_text(
@@ -84,7 +91,14 @@ def test_run_benchmarks_fails_on_regression(tmp_path: Path) -> None:
     summary_path = tmp_path / "mem" / "benchmark_summary.json"
 
     benchmarks_dir.mkdir()
-    for domain in ["raisonnement", "code", "planification", "memoire", "interaction", "adaptation"]:
+    for domain in [
+        "raisonnement",
+        "code",
+        "planification",
+        "memoire",
+        "interaction",
+        "adaptation",
+    ]:
         _write_domain(benchmarks_dir / f"{domain}.json", domain, "alpha beta")
 
     run_benchmarks(
@@ -95,7 +109,14 @@ def test_run_benchmarks_fails_on_regression(tmp_path: Path) -> None:
         max_regression_drop=0.01,
     )
 
-    for domain in ["raisonnement", "code", "planification", "memoire", "interaction", "adaptation"]:
+    for domain in [
+        "raisonnement",
+        "code",
+        "planification",
+        "memoire",
+        "interaction",
+        "adaptation",
+    ]:
         _write_domain(benchmarks_dir / f"{domain}.json", domain, "alpha")
 
     with pytest.raises(BenchmarkRegressionError):

--- a/tests/test_cli_beliefs.py
+++ b/tests/test_cli_beliefs.py
@@ -33,5 +33,7 @@ def test_cli_beliefs_audit_and_reset(tmp_path, capsys) -> None:
     out = capsys.readouterr().out
     assert "supprimées" in out
 
-    payload = json.loads((life_dir / "mem" / "beliefs.json").read_text(encoding="utf-8"))
+    payload = json.loads(
+        (life_dir / "mem" / "beliefs.json").read_text(encoding="utf-8")
+    )
     assert payload == {}

--- a/tests/test_cli_diagnose_sandbox.py
+++ b/tests/test_cli_diagnose_sandbox.py
@@ -159,7 +159,13 @@ def test_diagnose_evolution_does_not_treat_candidate_incident_as_global_breaker(
     home = tmp_path / "life"
     _write_jsonl(
         home / "runs" / "run-1" / "events.jsonl",
-        [{"event": "sandbox_violation", "category": "invalid_mutation", "scope": "candidate"}],
+        [
+            {
+                "event": "sandbox_violation",
+                "category": "invalid_mutation",
+                "scope": "candidate",
+            }
+        ],
     )
 
     cli.main(["--home", str(home), "diagnose", "evolution"])

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -150,7 +150,9 @@ def test_status_supports_subcommand_format_and_verbose(
     assert captured["output_format"] == "table"
 
 
-def test_cli_loop_runs_startup_retention(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_cli_loop_runs_startup_retention(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     root = tmp_path / "loop-root"
     monkeypatch.delenv("SINGULAR_ROOT", raising=False)
     monkeypatch.delenv("SINGULAR_HOME", raising=False)
@@ -172,7 +174,9 @@ def test_cli_loop_runs_startup_retention(monkeypatch: pytest.MonkeyPatch, tmp_pa
     def fake_loop_run(**kwargs):
         called["loop"] = kwargs
 
-    monkeypatch.setattr("singular.storage_retention.run_retention_service", fake_run_retention_service)
+    monkeypatch.setattr(
+        "singular.storage_retention.run_retention_service", fake_run_retention_service
+    )
     monkeypatch.setattr("singular.runs.loop.loop", fake_loop_run)
 
     code = main(["--root", str(root), "loop", "--budget-seconds", "0.1"])
@@ -365,7 +369,18 @@ def test_lives_relations_commands_and_journal(
     main(["--root", str(root), "lives", "proximity", "alpha", "--score", "0.72"])
     assert "Score proximité mis à jour" in capsys.readouterr().out
 
-    main(["--root", str(root), "--format", "json", "lives", "relations", "--name", "alpha"])
+    main(
+        [
+            "--root",
+            str(root),
+            "--format",
+            "json",
+            "lives",
+            "relations",
+            "--name",
+            "alpha",
+        ]
+    )
     payload = json.loads(capsys.readouterr().out)
     assert payload["focus"]["slug"] == "alpha"
     assert payload["focus"]["proximity_score"] == 0.72

--- a/tests/test_cli_retention.py
+++ b/tests/test_cli_retention.py
@@ -1,4 +1,3 @@
-
 from singular.cli import main
 
 
@@ -26,7 +25,9 @@ def test_cli_retention_run_dry_run_dispatches(monkeypatch, tmp_path, capsys) -> 
         captured.update(kwargs)
         return _Outcome()
 
-    monkeypatch.setattr("singular.storage_retention.run_retention_service", fake_run_retention_service)
+    monkeypatch.setattr(
+        "singular.storage_retention.run_retention_service", fake_run_retention_service
+    )
 
     code = main(["--root", str(root), "retention", "run", "--dry-run"])
 
@@ -57,7 +58,9 @@ def test_cli_orchestrate_runs_startup_retention(monkeypatch, tmp_path) -> None:
         called["orchestrator"] = 1
         return 0
 
-    monkeypatch.setattr("singular.storage_retention.run_retention_service", fake_run_retention_service)
+    monkeypatch.setattr(
+        "singular.storage_retention.run_retention_service", fake_run_retention_service
+    )
     monkeypatch.setattr(
         "singular.orchestrator.run_orchestrator_daemon",
         fake_run_orchestrator_daemon,
@@ -77,16 +80,33 @@ def test_cli_retention_status_prints_usage(monkeypatch, tmp_path, capsys) -> Non
     def fake_retention_status_snapshot(**kwargs):
         return {
             "usage": {
-                "runs": {"size_mb": 1.5, "entries": [{"kind": "file", "name": "a.jsonl", "size_mb": 1.5}]},
+                "runs": {
+                    "size_mb": 1.5,
+                    "entries": [{"kind": "file", "name": "a.jsonl", "size_mb": 1.5}],
+                },
                 "mem": {"size_mb": 0.5, "entries": []},
                 "lives": {"size_mb": 2.0, "entries": []},
             },
-            "thresholds": {"max_runs": 20, "max_run_age_days": 30, "max_total_runs_size_mb": 512},
-            "active_thresholds": {"max_runs": False, "max_total_runs_size_mb": True, "max_run_age_days": False},
-            "last_purge": {"at": "2026-04-15T12:00:00+00:00", "summary": {"freed_mb": 3.5, "deleted": 7, "archived": 1}},
+            "thresholds": {
+                "max_runs": 20,
+                "max_run_age_days": 30,
+                "max_total_runs_size_mb": 512,
+            },
+            "active_thresholds": {
+                "max_runs": False,
+                "max_total_runs_size_mb": True,
+                "max_run_age_days": False,
+            },
+            "last_purge": {
+                "at": "2026-04-15T12:00:00+00:00",
+                "summary": {"freed_mb": 3.5, "deleted": 7, "archived": 1},
+            },
         }
 
-    monkeypatch.setattr("singular.storage_retention.retention_status_snapshot", fake_retention_status_snapshot)
+    monkeypatch.setattr(
+        "singular.storage_retention.retention_status_snapshot",
+        fake_retention_status_snapshot,
+    )
 
     code = main(["--root", str(root), "retention", "status"])
 
@@ -97,14 +117,25 @@ def test_cli_retention_status_prints_usage(monkeypatch, tmp_path, capsys) -> Non
     assert "max_total_runs_size_mb" in out
 
 
-def test_cli_retention_config_show_prints_active_thresholds(monkeypatch, tmp_path, capsys) -> None:
+def test_cli_retention_config_show_prints_active_thresholds(
+    monkeypatch, tmp_path, capsys
+) -> None:
     root = tmp_path / "root"
     main(["--root", str(root), "lives", "create", "--name", "Alpha"])
 
     def fake_retention_status_snapshot(**kwargs):
-        return {"thresholds": {"max_runs": 5, "max_run_age_days": 14, "max_total_runs_size_mb": 42}}
+        return {
+            "thresholds": {
+                "max_runs": 5,
+                "max_run_age_days": 14,
+                "max_total_runs_size_mb": 42,
+            }
+        }
 
-    monkeypatch.setattr("singular.storage_retention.retention_status_snapshot", fake_retention_status_snapshot)
+    monkeypatch.setattr(
+        "singular.storage_retention.retention_status_snapshot",
+        fake_retention_status_snapshot,
+    )
 
     code = main(["--root", str(root), "retention", "config", "show"])
 
@@ -114,7 +145,9 @@ def test_cli_retention_config_show_prints_active_thresholds(monkeypatch, tmp_pat
     assert '"max_run_age_days": 14' in out
 
 
-def test_cli_retention_run_dry_run_has_no_side_effects(monkeypatch, tmp_path, capsys) -> None:
+def test_cli_retention_run_dry_run_has_no_side_effects(
+    monkeypatch, tmp_path, capsys
+) -> None:
     root = tmp_path / "root"
     main(["--root", str(root), "lives", "create", "--name", "Alpha"])
 

--- a/tests/test_consolidation_coordinator.py
+++ b/tests/test_consolidation_coordinator.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from singular.identity.consolidation_coordinator import ConsolidationCoordinator, STAGES
 
 
-def test_stage_checkpoints_resume_and_retry_idempotently(tmp_path: Path, monkeypatch) -> None:
+def test_stage_checkpoints_resume_and_retry_idempotently(
+    tmp_path: Path, monkeypatch
+) -> None:
     coordinator = ConsolidationCoordinator(tmp_path)
     episodes = [{"id": "e1", "user_fact": "loves trees", "strategy": "reflect"}]
     original = coordinator._apply_stage
@@ -38,11 +40,18 @@ def test_stage_checkpoints_resume_and_retry_idempotently(tmp_path: Path, monkeyp
 
 def test_retention_contradictions_and_critical_provenance(tmp_path: Path) -> None:
     coordinator = ConsolidationCoordinator(tmp_path)
-    result = coordinator.run([
-        {"id": "critical", "user_fact": "is a parent", "importance": "critical", "obsolete": True},
-        {"id": "conflict", "user_fact": "not is a parent"},
-        {"id": "old", "preference": "tea", "obsolete": True},
-    ])
+    result = coordinator.run(
+        [
+            {
+                "id": "critical",
+                "user_fact": "is a parent",
+                "importance": "critical",
+                "obsolete": True,
+            },
+            {"id": "conflict", "user_fact": "not is a parent"},
+            {"id": "old", "preference": "tea", "obsolete": True},
+        ]
+    )
 
     assert result["items_rejected"] >= 1
     assert result["items_forgotten"] >= 1

--- a/tests/test_core_agent_runtime.py
+++ b/tests/test_core_agent_runtime.py
@@ -30,7 +30,9 @@ class _MindStub:
     def propose_intent(self, percept: PerceptEvent) -> Intent | None:
         return Intent(goal=f"inspect:{percept.event_type}", confidence=0.9)
 
-    def propose_action(self, intent: Intent, percept: PerceptEvent) -> ActionRequest | None:
+    def propose_action(
+        self, intent: Intent, percept: PerceptEvent
+    ) -> ActionRequest | None:
         return ActionRequest(
             action_type="os.notify",
             parameters={
@@ -52,7 +54,6 @@ class _ActionStub:
             message="done",
             audit={"intent_goal": request.intent_goal},
         )
-
 
 
 def test_agent_runtime_step_orchestrates_ports_and_events() -> None:
@@ -90,7 +91,6 @@ def test_agent_runtime_step_orchestrates_ports_and_events() -> None:
     assert results[0].audit["policy"]["allowed"] is True
 
 
-
 def test_agent_runtime_rejects_schema_version_mismatch() -> None:
     class _BadPerception:
         def collect(self) -> list[PerceptEvent]:
@@ -113,13 +113,16 @@ def test_agent_runtime_rejects_schema_version_mismatch() -> None:
         runtime.step()
 
 
-
 def test_agent_runtime_blocks_action_not_allowlisted() -> None:
     decisions: list[dict[str, object]] = []
     gate_topics: list[str] = []
     bus = RuntimeEventBus()
-    bus.subscribe("action.moral.decision", lambda event: gate_topics.append(event.topic))
-    bus.subscribe("action.policy.decision", lambda event: gate_topics.append(event.topic))
+    bus.subscribe(
+        "action.moral.decision", lambda event: gate_topics.append(event.topic)
+    )
+    bus.subscribe(
+        "action.policy.decision", lambda event: gate_topics.append(event.topic)
+    )
     runtime = AgentRuntime(
         perception=_PerceptionStub(),
         mind=_MindStub(),
@@ -150,7 +153,6 @@ def test_agent_runtime_blocks_action_not_allowlisted() -> None:
     assert gate_topics == ["action.moral.decision", "action.policy.decision"]
 
 
-
 def test_agent_runtime_simulates_dry_run_without_executing_action_port() -> None:
     class _ActionSpy(_ActionStub):
         def __init__(self) -> None:
@@ -176,10 +178,11 @@ def test_agent_runtime_simulates_dry_run_without_executing_action_port() -> None
     assert action_spy.called is False
 
 
-
 def test_agent_runtime_requires_human_confirmation_for_critical_actions() -> None:
     class _CriticalMind(_MindStub):
-        def propose_action(self, intent: Intent, percept: PerceptEvent) -> ActionRequest | None:
+        def propose_action(
+            self, intent: Intent, percept: PerceptEvent
+        ) -> ActionRequest | None:
             return ActionRequest(
                 action_type="os.notify",
                 parameters={
@@ -234,12 +237,13 @@ def test_agent_runtime_global_stop_hotkey_interrupts_step() -> None:
     assert seen == ["runtime.global_stop"]
 
 
-
 def test_agent_runtime_watchdog_stops_abnormal_action_loop() -> None:
     class _ManyPercepts:
         def collect(self) -> list[PerceptEvent]:
             return [
-                PerceptEvent(event_type=f"vision-{idx}", source="camera", payload={"idx": idx})
+                PerceptEvent(
+                    event_type=f"vision-{idx}", source="camera", payload={"idx": idx}
+                )
                 for idx in range(8)
             ]
 
@@ -259,12 +263,13 @@ def test_agent_runtime_watchdog_stops_abnormal_action_loop() -> None:
     assert len(results) == 3
 
 
-
 def test_agent_runtime_enforces_max_actions_per_minute() -> None:
     class _ManyPercepts:
         def collect(self) -> list[PerceptEvent]:
             return [
-                PerceptEvent(event_type=f"vision-{idx}", source="camera", payload={"idx": idx})
+                PerceptEvent(
+                    event_type=f"vision-{idx}", source="camera", payload={"idx": idx}
+                )
                 for idx in range(10)
             ]
 
@@ -278,7 +283,6 @@ def test_agent_runtime_enforces_max_actions_per_minute() -> None:
     results = runtime.step()
 
     assert len(results) == 2
-
 
 
 def test_agent_runtime_auto_disables_after_critical_errors() -> None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -19,15 +19,27 @@ def test_comparison_exposes_distinct_consulted_active_and_observed_lives(
     runs = tmp_path / "runs"
     runs.mkdir()
     (runs / "events.jsonl").write_text(
-        json.dumps({"ts": "2026-08-09T10:00:00Z", "life": "observed", "event": "interaction"}) + "\n",
+        json.dumps(
+            {"ts": "2026-08-09T10:00:00Z", "life": "observed", "event": "interaction"}
+        )
+        + "\n",
         encoding="utf-8",
     )
     registry_lives = {}
     for slug in ("consulted", "running", "observed"):
         path = tmp_path / slug
         path.mkdir()
-        registry_lives[slug] = {"slug": slug, "name": slug, "path": path, "status": "active"}
-    monkeypatch.setattr(dashboard_module, "load_registry", lambda: {"active": "running", "lives": registry_lives})
+        registry_lives[slug] = {
+            "slug": slug,
+            "name": slug,
+            "path": path,
+            "status": "active",
+        }
+    monkeypatch.setattr(
+        dashboard_module,
+        "load_registry",
+        lambda: {"active": "running", "lives": registry_lives},
+    )
     app = create_app(runs_dir=runs, psyche_file=tmp_path / "psyche.json")
     route = app._routes["/lives/comparison"]
     payload = route(life_id="consulted")
@@ -41,36 +53,70 @@ def test_comparison_exposes_distinct_consulted_active_and_observed_lives(
 def test_dashboard_exposes_viability_drift_diagnostics(tmp_path: Path) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
-    (runs_dir / "drift.jsonl").write_text(json.dumps({
-        "ts": "2026-08-09T10:00:00+00:00", "event": "interaction",
-        "interaction": "mutation_paused", "action": "paused",
-        "metrics": {"health": .35, "risk": .7, "fitness": .2},
-        "thresholds": {"drift_threshold": .12},
-        "windows": {"short": .35, "long": .62},
-    }) + "\n", encoding="utf-8")
-    payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get("/api/cockpit").json()
+    (runs_dir / "drift.jsonl").write_text(
+        json.dumps(
+            {
+                "ts": "2026-08-09T10:00:00+00:00",
+                "event": "interaction",
+                "interaction": "mutation_paused",
+                "action": "paused",
+                "metrics": {"health": 0.35, "risk": 0.7, "fitness": 0.2},
+                "thresholds": {"drift_threshold": 0.12},
+                "windows": {"short": 0.35, "long": 0.62},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    payload = (
+        TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+        .get("/api/cockpit")
+        .json()
+    )
     governance = payload["viability_governance"]
     assert governance["state"] == "paused"
     assert governance["mutations_enabled"] is False
-    assert governance["metrics"]["risk"] == .7
-    assert governance["thresholds"]["drift_threshold"] == .12
+    assert governance["metrics"]["risk"] == 0.7
+    assert governance["thresholds"]["drift_threshold"] == 0.12
 
 
 def test_trajectory_contract_joins_records_by_correlation_id(tmp_path: Path) -> None:
     records = [
-        {"ts": "2026-08-09T10:00:00+00:00", "event": "sandbox_violation", "correlation_id": "corr-1", "category": "forbidden_name", "life_id": "life-a"},
-        {"ts": "2026-08-09T10:00:01+00:00", "event": "mutation", "correlation_id": "corr-1", "op": "replace", "impacted_file": "skills/a.py", "accepted": False},
-        {"ts": "2026-08-09T10:00:02+00:00", "event": "governance.circuit_breaker_opened", "correlation_id": "corr-1", "corrective_action": "halt mutations"},
+        {
+            "ts": "2026-08-09T10:00:00+00:00",
+            "event": "sandbox_violation",
+            "correlation_id": "corr-1",
+            "category": "forbidden_name",
+            "life_id": "life-a",
+        },
+        {
+            "ts": "2026-08-09T10:00:01+00:00",
+            "event": "mutation",
+            "correlation_id": "corr-1",
+            "op": "replace",
+            "impacted_file": "skills/a.py",
+            "accepted": False,
+        },
+        {
+            "ts": "2026-08-09T10:00:02+00:00",
+            "event": "governance.circuit_breaker_opened",
+            "correlation_id": "corr-1",
+            "corrective_action": "halt mutations",
+        },
     ]
     payload = build_trajectory(records, tmp_path / "missing.json", lambda _: "run-a")
     assert [item["event"] for item in payload["correlations"]["corr-1"]] == [
-        "sandbox_violation", "mutation", "governance.circuit_breaker_opened"
+        "sandbox_violation",
+        "mutation",
+        "governance.circuit_breaker_opened",
     ]
     assert payload["correlations"]["corr-1"][1]["path"] == "skills/a.py"
     assert payload["causal_chronology"][2]["corrective_action"] == "halt mutations"
 
 
-def _receive_with_timeout(ws: TestClient._WSConnection, timeout: float = 2.0) -> dict[str, object]:
+def _receive_with_timeout(
+    ws: TestClient._WSConnection, timeout: float = 2.0
+) -> dict[str, object]:
     try:
         return ws.ws._queue.get(timeout=timeout)
     except Empty as exc:  # pragma: no cover - defensive for slow CI
@@ -109,7 +155,9 @@ def test_dashboard_endpoints(tmp_path: Path, monkeypatch) -> None:
     assert "last_purge" in retention
 
 
-def test_dashboard_brand_assets_are_referenced_and_served_as_svg(tmp_path: Path) -> None:
+def test_dashboard_brand_assets_are_referenced_and_served_as_svg(
+    tmp_path: Path,
+) -> None:
     app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
     client = TestClient(app)
 
@@ -187,7 +235,9 @@ def test_dashboard_context_normalizes_object_and_dict_life_metadata(
     ]
 
 
-def test_dashboard_starts_with_empty_registry_and_exposes_onboarding(tmp_path: Path, monkeypatch) -> None:
+def test_dashboard_starts_with_empty_registry_and_exposes_onboarding(
+    tmp_path: Path, monkeypatch
+) -> None:
     root = tmp_path / "empty-root"
     root.mkdir()
     monkeypatch.setenv("SINGULAR_ROOT", str(root))
@@ -272,10 +322,25 @@ def test_dashboard_quests_endpoint(tmp_path: Path, monkeypatch) -> None:
     mem_dir = tmp_path / "mem"
     mem_dir.mkdir()
     quests_state = {
-        "active": [{"name": "q1", "status": "active", "started_at": "2026-01-01T00:00:00+00:00"}],
-        "completed": [{"name": "q0", "status": "success", "started_at": "2026-01-01T00:00:00+00:00", "completed_at": "2026-01-01T00:01:00+00:00"}],
+        "active": [
+            {
+                "name": "q1",
+                "status": "active",
+                "started_at": "2026-01-01T00:00:00+00:00",
+            }
+        ],
+        "completed": [
+            {
+                "name": "q0",
+                "status": "success",
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "completed_at": "2026-01-01T00:01:00+00:00",
+            }
+        ],
     }
-    (mem_dir / "quests_state.json").write_text(json.dumps(quests_state), encoding="utf-8")
+    (mem_dir / "quests_state.json").write_text(
+        json.dumps(quests_state), encoding="utf-8"
+    )
 
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     app = create_app(runs_dir=runs_dir, psyche_file=psyche_file)
@@ -309,10 +374,14 @@ def test_dashboard_work_items_schema_contains_required_fields(
         ],
         "completed": [],
     }
-    (mem_dir / "quests_state.json").write_text(json.dumps(quests_state), encoding="utf-8")
+    (mem_dir / "quests_state.json").write_text(
+        json.dumps(quests_state), encoding="utf-8"
+    )
 
     run_file = runs_dir / "loop.jsonl"
-    run_file.write_text(json.dumps({"ts": "2026-01-01T00:00:00+00:00"}), encoding="utf-8")
+    run_file.write_text(
+        json.dumps({"ts": "2026-01-01T00:00:00+00:00"}), encoding="utf-8"
+    )
     consciousness_file = runs_dir / "loop.consciousness.jsonl"
     consciousness_file.write_text(
         json.dumps(
@@ -372,8 +441,6 @@ def test_dashboard_alerts_endpoint(tmp_path: Path) -> None:
         "sandbox_failures_rising",
         "prolonged_stagnation",
     }
-
-
 
 
 def test_dashboard_latest_run_summary_endpoint(tmp_path: Path) -> None:
@@ -642,9 +709,11 @@ def test_dashboard_vital_state_recovers_after_historical_failure_peak(
         encoding="utf-8",
     )
 
-    payload = TestClient(
-        create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
-    ).get("/api/cockpit").json()
+    payload = (
+        TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+        .get("/api/cockpit")
+        .json()
+    )
 
     assert payload["vital_timeline"]["state"] != "terminal"
     assert payload["vital_timeline"]["current_failure_streak"] == 0
@@ -705,9 +774,11 @@ def test_dashboard_cockpit_sandbox_governance_summary(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get(
-        "/api/cockpit"
-    ).json()
+    payload = (
+        TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+        .get("/api/cockpit")
+        .json()
+    )
 
     assert payload["governance_policy"]["circuit_breaker_threshold"] == 3
     assert payload["governance_policy"]["circuit_breaker_window_seconds"] == 180.0
@@ -720,7 +791,9 @@ def test_dashboard_cockpit_sandbox_governance_summary(tmp_path: Path) -> None:
     assert governance["recent_violations_count"] == 2
     assert governance["last_faulty_skill"] == "life-a:skills/bad.py"
     assert governance["cooldown_remaining_seconds"] > 0
-    assert governance["recommended_corrective_action"] == "halt mutations until cooldown"
+    assert (
+        governance["recommended_corrective_action"] == "halt mutations until cooldown"
+    )
     assert governance["empty_state"] is None
     assert {item["event"] for item in governance["events"]} >= {
         "sandbox_violation",
@@ -734,13 +807,16 @@ def test_dashboard_cockpit_sandbox_governance_empty_state(tmp_path: Path) -> Non
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
     (runs_dir / "empty-sandbox.jsonl").write_text(
-        json.dumps({"ts": "2026-05-11T08:00:00+00:00", "health": {"score": 99.0}}) + "\n",
+        json.dumps({"ts": "2026-05-11T08:00:00+00:00", "health": {"score": 99.0}})
+        + "\n",
         encoding="utf-8",
     )
 
-    payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get(
-        "/api/cockpit"
-    ).json()
+    payload = (
+        TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+        .get("/api/cockpit")
+        .json()
+    )
 
     governance = payload["sandbox_governance"]
     assert governance["recent_violations_count"] == 0
@@ -765,8 +841,12 @@ def test_dashboard_cockpit_life_status_defaults_without_memory_or_registry(
         encoding="utf-8",
     )
 
-    monkeypatch.setattr(dashboard_module, "load_registry", lambda: {"active": None, "lives": {}})
-    client = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+    monkeypatch.setattr(
+        dashboard_module, "load_registry", lambda: {"active": None, "lives": {}}
+    )
+    client = TestClient(
+        create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    )
 
     payload = client.get("/api/cockpit").json()
     assert payload["life_status"] == "not_alive_yet"
@@ -816,7 +896,9 @@ def test_dashboard_cockpit_life_status_defaults_when_active_life_has_no_memory(
             },
         },
     )
-    client = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+    client = TestClient(
+        create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    )
 
     payload = client.get("/api/cockpit").json()
     assert payload["life_status"] == "not_alive_yet"
@@ -861,7 +943,9 @@ def test_dashboard_cockpit_life_status_uses_extinct_registry_status(
             },
         },
     )
-    client = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+    client = TestClient(
+        create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
+    )
 
     payload = client.get("/api/cockpit").json()
     assert payload["life_status"] == "dead"
@@ -990,7 +1074,9 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "life-detail-panel" in body
     assert "<th><button data-sort='life'>Nom</button></th>" in body
     assert "<th><button data-sort='score'>Score / santé</button></th>" in body
-    assert "<th><button data-sort='last_activity'>Dernière activité</button></th>" in body
+    assert (
+        "<th><button data-sort='last_activity'>Dernière activité</button></th>" in body
+    )
     assert "<th><button data-sort='liveness'>Liveness</button></th>" in body
     assert "<th>Statut</th>" in body
     assert "<th>Risques</th>" in body
@@ -1001,7 +1087,9 @@ def test_dashboard_index_contains_cockpit_cards(tmp_path: Path) -> None:
     assert "data-essential-level='3'" in body
 
 
-def test_dashboard_essential_mode_critical_blocks_and_visibility_markers(tmp_path: Path) -> None:
+def test_dashboard_essential_mode_critical_blocks_and_visibility_markers(
+    tmp_path: Path,
+) -> None:
     app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
     body = TestClient(app).get("/").json()
 
@@ -1014,7 +1102,10 @@ def test_dashboard_essential_mode_critical_blocks_and_visibility_markers(tmp_pat
     ]:
         assert marker in body
 
-    assert "id='cockpit-detail' class='panel level-panel technical-only' data-essential-level='3'" in body
+    assert (
+        "id='cockpit-detail' class='panel level-panel technical-only' data-essential-level='3'"
+        in body
+    )
     assert "class='lives-grid' data-essential-level='2'" in body
     assert "class='lives-grid technical-only'" not in body
 
@@ -1023,12 +1114,12 @@ def test_dashboard_index_renders_main_sections(tmp_path: Path) -> None:
     app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
     body = TestClient(app).get("/").json()
 
-    assert "<section id=\"cockpit\">" in body
-    assert "<section id=\"timeline-section\">" in body
-    assert "<section id=\"reflections-section\">" in body
-    assert "<section id=\"vies\">" in body
-    assert "<section id=\"logs-live\">" in body
-    assert "<section id=\"parametres\">" in body
+    assert '<section id="cockpit">' in body
+    assert '<section id="timeline-section">' in body
+    assert '<section id="reflections-section">' in body
+    assert '<section id="vies">' in body
+    assert '<section id="logs-live">' in body
+    assert '<section id="parametres">' in body
 
 
 def test_dashboard_timeline_comparison_and_top_mutations(tmp_path: Path) -> None:
@@ -1167,7 +1258,9 @@ def test_dashboard_consciousness_endpoint_filters(tmp_path: Path) -> None:
     assert payload["items"][0]["objective"] == "coherence"
 
 
-def test_dashboard_lives_comparison_excludes_runs_without_explicit_life(tmp_path: Path) -> None:
+def test_dashboard_lives_comparison_excludes_runs_without_explicit_life(
+    tmp_path: Path,
+) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
     (runs_dir / "loop-1001.jsonl").write_text(
@@ -1266,17 +1359,25 @@ def test_dashboard_code_evolution_endpoint_and_comparison_link(tmp_path: Path) -
     client = TestClient(app)
 
     comparison_payload = client.get("/lives/comparison").json()
-    life_row = next(row for row in comparison_payload["table"] if row["life"] == "life-explicit")
-    assert life_row["code_evolution_endpoint"] == "/api/lives/life-explicit/code-evolution"
+    life_row = next(
+        row for row in comparison_payload["table"] if row["life"] == "life-explicit"
+    )
+    assert (
+        life_row["code_evolution_endpoint"] == "/api/lives/life-explicit/code-evolution"
+    )
     special_life_row = next(
-        row for row in comparison_payload["table"] if row["life"] == "life explicit/with spaces"
+        row
+        for row in comparison_payload["table"]
+        if row["life"] == "life explicit/with spaces"
     )
     assert (
         special_life_row["code_evolution_endpoint"]
         == "/api/lives/life%20explicit%2Fwith%20spaces/code-evolution"
     )
 
-    endpoint_payload = app._routes["/api/lives/{life}/code-evolution"](life="life-explicit")
+    endpoint_payload = app._routes["/api/lives/{life}/code-evolution"](
+        life="life-explicit"
+    )
     assert endpoint_payload["life"] == "life-explicit"
     assert endpoint_payload["count"] == 2
     assert endpoint_payload["summary"]["by_status"] == {"accepté": 1, "rejeté": 1}
@@ -1291,7 +1392,9 @@ def test_dashboard_code_evolution_endpoint_and_comparison_link(tmp_path: Path) -
     assert filtered_payload["items"][0]["status"] == "accepté"
 
 
-def test_run_timeline_endpoint_filters_pagination_and_event_coherence(tmp_path: Path) -> None:
+def test_run_timeline_endpoint_filters_pagination_and_event_coherence(
+    tmp_path: Path,
+) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
     run_file = runs_dir / "run-42.jsonl"
@@ -1379,7 +1482,12 @@ def test_run_timeline_endpoint_filters_pagination_and_event_coherence(tmp_path: 
     route = app._routes["/api/runs/{run_id}/timeline"]
 
     all_payload = route(run_id="run-42", page=1, page_size=2)
-    assert all_payload["pagination"] == {"page": 1, "page_size": 2, "total": 7, "total_pages": 4}
+    assert all_payload["pagination"] == {
+        "page": 1,
+        "page_size": 2,
+        "total": 7,
+        "total_pages": 4,
+    }
     assert [item["event"] for item in all_payload["items"]] == ["mutation", "delay"]
 
     page_two = route(run_id="run-42", page=2, page_size=2)
@@ -1413,7 +1521,8 @@ def test_run_timeline_endpoint_filters_pagination_and_event_coherence(tmp_path: 
         "governance.circuit_breaker_opened",
     }.issubset(event_types)
     breaker_item = next(
-        entry for entry in route(run_id="run-42")["items"]
+        entry
+        for entry in route(run_id="run-42")["items"]
         if entry["event"] == "governance.circuit_breaker_opened"
     )
     assert breaker_item["category"] == "sandbox_violation"
@@ -1424,7 +1533,9 @@ def test_run_timeline_endpoint_filters_pagination_and_event_coherence(tmp_path: 
     assert breaker_item["last_sandbox_diagnostics"] == {"sandbox_violation_streak": 3}
 
 
-def test_run_mutation_detail_endpoint_returns_diff_metrics_and_ast(tmp_path: Path) -> None:
+def test_run_mutation_detail_endpoint_returns_diff_metrics_and_ast(
+    tmp_path: Path,
+) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
     run_file = runs_dir / "run-mut.jsonl"
@@ -1695,7 +1806,9 @@ def test_lives_comparison_compare_lives_filter(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     app = create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
-    payload = app._routes["/lives/comparison"](compare_lives="life-a", time_window="all")
+    payload = app._routes["/lives/comparison"](
+        compare_lives="life-a", time_window="all"
+    )
     assert set(payload["lives"]) == {"life-a"}
     assert payload["filters"]["compare_lives"] == ["life-a"]
     assert payload["filters"]["time_window"] == "all"
@@ -1935,7 +2048,11 @@ def test_lives_genealogy_life_filter_limits_active_relations(
         lambda: {
             "active": "life-a",
             "lives": {
-                "life-a": {"slug": "life-a", "allies": ["life-b"], "rivals": ["life-c"]},
+                "life-a": {
+                    "slug": "life-a",
+                    "allies": ["life-b"],
+                    "rivals": ["life-c"],
+                },
                 "life-b": {"slug": "life-b", "allies": ["life-a"], "rivals": []},
                 "life-c": {"slug": "life-c", "allies": [], "rivals": ["life-a"]},
             },
@@ -1963,7 +2080,9 @@ def test_psyche_missing_returns_404(tmp_path: Path) -> None:
     assert response.status_code == 404
 
 
-def test_websocket_stream_incremental_events_and_growth_stability(tmp_path: Path) -> None:
+def test_websocket_stream_incremental_events_and_growth_stability(
+    tmp_path: Path,
+) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
     run_file = runs_dir / "run-live-20260511090000.jsonl.tmp"
@@ -1993,7 +2112,9 @@ def test_websocket_stream_incremental_events_and_growth_stability(tmp_path: Path
         }
 
         with run_file.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps({"ts": "2026-04-12T10:00:01", "event": "delay"}) + "\n")
+            handle.write(
+                json.dumps({"ts": "2026-04-12T10:00:01", "event": "delay"}) + "\n"
+            )
         update = _receive_with_timeout(ws)
         assert update == {
             "type": "run_event",
@@ -2003,7 +2124,9 @@ def test_websocket_stream_incremental_events_and_growth_stability(tmp_path: Path
         }
 
         with run_file.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps({"ts": "2026-04-12T10:00:02", "event": "refuse"}) + "\n")
+            handle.write(
+                json.dumps({"ts": "2026-04-12T10:00:02", "event": "refuse"}) + "\n"
+            )
             handle.write(
                 json.dumps(
                     {
@@ -2033,21 +2156,23 @@ def test_websocket_stream_incremental_events_and_growth_stability(tmp_path: Path
         ]
 
 
-def test_websocket_multiple_clients_receive_the_same_bounded_stream(tmp_path: Path) -> None:
+def test_websocket_multiple_clients_receive_the_same_bounded_stream(
+    tmp_path: Path,
+) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
     (runs_dir / "shared.jsonl").write_text(
-        json.dumps({"ts": "2026-04-12T10:00:00", "event": "interaction"})
-        + "\n",
+        json.dumps({"ts": "2026-04-12T10:00:00", "event": "interaction"}) + "\n",
         encoding="utf-8",
     )
     client = TestClient(
         create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")
     )
 
-    with client.websocket_connect("/ws") as first, client.websocket_connect(
-        "/ws"
-    ) as second:
+    with (
+        client.websocket_connect("/ws") as first,
+        client.websocket_connect("/ws") as second,
+    ):
         first_event = _receive_with_timeout(first)
         second_event = _receive_with_timeout(second)
 
@@ -2113,7 +2238,6 @@ def test_websocket_application_shutdown_closes_client_and_releases_slot(
     assert "CancelledError" not in capsys.readouterr().err
 
 
-
 def test_run_requires_uvicorn(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -2135,7 +2259,9 @@ def test_run_requires_uvicorn(
     assert "pip install uvicorn" in captured.err
 
 
-def test_dashboard_actions_endpoint_and_ui_panel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dashboard_actions_endpoint_and_ui_panel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("SINGULAR_DASHBOARD_ACTION_TOKEN", "secret")
     app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
     client = TestClient(app)
@@ -2222,7 +2348,9 @@ def test_dashboard_actions_require_token_unless_local_dev_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("SINGULAR_DASHBOARD_ACTION_TOKEN", raising=False)
-    monkeypatch.delenv("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS", raising=False)
+    monkeypatch.delenv(
+        "SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS", raising=False
+    )
     app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
     client = TestClient(app)
 
@@ -2230,7 +2358,10 @@ def test_dashboard_actions_require_token_unless_local_dev_override(
 
     assert missing_token.status_code == 403
     assert "SINGULAR_DASHBOARD_ACTION_TOKEN" in missing_token.json()["detail"]
-    assert "SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS=1" in missing_token.json()["detail"]
+    assert (
+        "SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS=1"
+        in missing_token.json()["detail"]
+    )
 
     monkeypatch.setenv("SINGULAR_DASHBOARD_ALLOW_UNAUTHENTICATED_ACTIONS", "1")
     allowed = client.post("/api/actions/lives_list", json={}).json()
@@ -2257,9 +2388,11 @@ def test_dashboard_emergency_stop_action_writes_active_life_stop_signal(
     with pytest.raises(Exception):
         route("emergency_stop", payload=json.dumps({"scope": "active_life"}))
 
-    result = TestClient(app).post(
-        "/api/actions/emergency_stop", json={"scope": "active_life"}
-    ).json()
+    result = (
+        TestClient(app)
+        .post("/api/actions/emergency_stop", json={"scope": "active_life"})
+        .json()
+    )
 
     assert result["ok"] is True
     assert result["action"] == "emergency_stop"
@@ -2270,6 +2403,7 @@ def test_dashboard_emergency_stop_action_writes_active_life_stop_signal(
     assert payload["reason"] == "dashboard_emergency_stop"
     assert payload["requested_by"] == "dashboard"
     assert payload["life"] == meta.slug
+
 
 def test_dashboard_actions_validation_robustness(tmp_path: Path) -> None:
     app = create_app(runs_dir=tmp_path / "runs", psyche_file=tmp_path / "psyche.json")
@@ -2460,15 +2594,22 @@ def test_lives_comparison_get_does_not_reconcile_registry_silently(
     assert first_payload["lives"]["alpha"]["life_status"] == "dead"
     assert first_payload["lives"]["alpha"]["extinction_seen_in_runs"] is True
     assert first_payload["lives"]["alpha"]["registry_run_status_inconsistency"] is True
-    assert first_payload["lives"]["alpha"]["status_reconciliation_suggestion"] == "mark_extinct"
-    assert first_payload["status_reconciliation"] == second_payload["status_reconciliation"] == [
-        {
-            "life": "alpha",
-            "registry_status": "active",
-            "extinction_seen_in_runs": True,
-            "suggestion": "mark_extinct",
-        }
-    ]
+    assert (
+        first_payload["lives"]["alpha"]["status_reconciliation_suggestion"]
+        == "mark_extinct"
+    )
+    assert (
+        first_payload["status_reconciliation"]
+        == second_payload["status_reconciliation"]
+        == [
+            {
+                "life": "alpha",
+                "registry_status": "active",
+                "extinction_seen_in_runs": True,
+                "suggestion": "mark_extinct",
+            }
+        ]
+    )
 
 
 def test_lives_status_reconciliation_action_marks_suggested_extinctions(
@@ -2528,7 +2669,12 @@ def test_lives_status_reconciliation_action_marks_suggested_extinctions(
             "suggestion": "mark_extinct",
         }
     ]
-    assert json.loads(registry_file.read_text(encoding="utf-8"))["lives"]["alpha"]["status"] == "extinct"
+    assert (
+        json.loads(registry_file.read_text(encoding="utf-8"))["lives"]["alpha"][
+            "status"
+        ]
+        == "extinct"
+    )
 
 
 def test_chat_get_reports_status_without_running_chat(
@@ -2561,7 +2707,10 @@ def test_chat_get_reports_status_without_running_chat(
     assert response["available"] is True
     assert response["registry_status"] == "active"
     assert response["status"] == "ready"
-    assert response["message"] == "Utilisez POST avec un corps JSON pour envoyer un message."
+    assert (
+        response["message"]
+        == "Utilisez POST avec un corps JSON pour envoyer un message."
+    )
 
 
 def test_chat_post_remains_the_message_execution_path(
@@ -2592,10 +2741,14 @@ def test_chat_post_remains_the_message_execution_path(
 
     assert response.status_code == 200
     assert response.json()["status"] == "message_missing"
-    assert response.json()["response"] == "Message vide: saisissez un contenu à envoyer."
+    assert (
+        response.json()["response"] == "Message vide: saisissez un contenu à envoyer."
+    )
 
 
-def test_dashboard_cockpit_exposes_used_memories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dashboard_cockpit_exposes_used_memories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     runs_dir = tmp_path / "runs"
     runs_dir.mkdir()
     mem_dir = tmp_path / "mem"
@@ -2615,13 +2768,17 @@ def test_dashboard_cockpit_exposes_used_memories(tmp_path: Path, monkeypatch: py
     )
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
 
-    payload = TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json")).get(
-        "/api/cockpit"
-    ).json()
+    payload = (
+        TestClient(create_app(runs_dir=runs_dir, psyche_file=tmp_path / "psyche.json"))
+        .get("/api/cockpit")
+        .json()
+    )
 
     assert payload["memory_metrics"]["has_memory_signal"] is True
-    assert payload["memory_metrics"]["used_memories"][0]["summary"] == "bug prioritaire rappelé"
-
+    assert (
+        payload["memory_metrics"]["used_memories"][0]["summary"]
+        == "bug prioritaire rappelé"
+    )
 
 
 def test_dashboard_context_exposes_degraded_dummy_diagnostic(tmp_path, monkeypatch):
@@ -2629,15 +2786,19 @@ def test_dashboard_context_exposes_degraded_dummy_diagnostic(tmp_path, monkeypat
         "state": "degraded_dummy",
         "llm_real": False,
         "deterministic_fake": True,
-        "providers": [{
-            "provider": "openai",
-            "state": "unavailable",
-            "cause": "missing OPENAI_API_KEY",
-            "configuration_command": "singular config openai",
-        }],
+        "providers": [
+            {
+                "provider": "openai",
+                "state": "unavailable",
+                "cause": "missing OPENAI_API_KEY",
+                "configuration_command": "singular config openai",
+            }
+        ],
     }
     monkeypatch.setattr(dashboard_module, "provider_diagnostics", lambda: diagnostic)
 
-    context = create_app(psyche_file=tmp_path / "psyche.json")._routes["/dashboard/context"]()
+    context = create_app(psyche_file=tmp_path / "psyche.json")._routes[
+        "/dashboard/context"
+    ]()
 
     assert context["llm_providers"] == diagnostic

--- a/tests/test_dashboard_services.py
+++ b/tests/test_dashboard_services.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from singular.dashboard.services.lives_comparison import aggregate_lives, build_life_timeseries
+from singular.dashboard.services.lives_comparison import (
+    aggregate_lives,
+    build_life_timeseries,
+)
 from singular.dashboard.services.metrics_contract import normalize_life_metrics
 from singular.dashboard.services.code_evolution import aggregate_code_evolution
 from singular.dashboard.services.trajectory import build_trajectory
@@ -11,9 +14,21 @@ from singular.dashboard.services.trajectory import build_trajectory
 def test_life_metrics_contract_keeps_selected_active_and_latest_distinct() -> None:
     lives, identities = normalize_life_metrics(
         {
-            "consulted": {"registry_status": "active", "life_status": "alive", "last_activity": None},
-            "running": {"registry_status": "active", "life_status": "alive", "last_activity": "2026-08-08T00:00:00Z"},
-            "observed": {"registry_status": "archived", "life_status": "fragile", "last_activity": "2026-08-09T00:00:00Z"},
+            "consulted": {
+                "registry_status": "active",
+                "life_status": "alive",
+                "last_activity": None,
+            },
+            "running": {
+                "registry_status": "active",
+                "life_status": "alive",
+                "last_activity": "2026-08-08T00:00:00Z",
+            },
+            "observed": {
+                "registry_status": "archived",
+                "life_status": "fragile",
+                "last_activity": "2026-08-09T00:00:00Z",
+            },
         },
         selected_life_id="consulted",
         registry_active_life_id="running",
@@ -27,7 +42,9 @@ def test_life_metrics_contract_keeps_selected_active_and_latest_distinct() -> No
 
 def test_trajectory_service_builds_priority_changes_and_links(tmp_path: Path) -> None:
     quests = tmp_path / "quests_state.json"
-    quests.write_text('{"active":[{"name":"obj-a"}],"completed":[{"name":"obj-b"}]}' , encoding="utf-8")
+    quests.write_text(
+        '{"active":[{"name":"obj-a"}],"completed":[{"name":"obj-b"}]}', encoding="utf-8"
+    )
     records = [
         {"ts": "2026-01-01T00:00:00Z", "objective_priorities": {"obj-a": 0.2}},
         {
@@ -39,7 +56,9 @@ def test_trajectory_service_builds_priority_changes_and_links(tmp_path: Path) ->
         },
     ]
 
-    payload = build_trajectory(records, quests, lambda rec: str(rec.get("run_id", "unknown")))
+    payload = build_trajectory(
+        records, quests, lambda rec: str(rec.get("run_id", "unknown"))
+    )
 
     assert payload["objectives"]["counts"]["in_progress"] == 1
     assert payload["objectives"]["counts"]["completed"] == 1
@@ -77,7 +96,9 @@ def test_lives_comparison_service_aggregates_metrics() -> None:
         record_life=lambda rec: str(rec.get("life", "unknown")),
         record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
         is_mutation_record=lambda rec: "score_base" in rec,
-        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        as_float=lambda value: (
+            float(value) if isinstance(value, (int, float)) else None
+        ),
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
@@ -92,17 +113,38 @@ def test_lives_comparison_service_aggregates_metrics() -> None:
 
 def test_life_timeseries_buckets_metrics_and_keeps_evidence() -> None:
     records = [
-        {"ts": "2026-01-01T00:10:00Z", "health": {"score": 60}, "energy": 40,
-         "event": "mutation", "accepted": True, "run_id": "run 1"},
-        {"ts": "2026-01-01T00:50:00Z", "health": {"score": 80}, "mood": 75,
-         "event": "interaction", "run_id": "run 1"},
-        {"ts": "2026-01-01T02:00:00Z", "event": "skill_acquired", "skill": "alpha:vision",
-         "accepted": False, "run_id": "run-2"},
+        {
+            "ts": "2026-01-01T00:10:00Z",
+            "health": {"score": 60},
+            "energy": 40,
+            "event": "mutation",
+            "accepted": True,
+            "run_id": "run 1",
+        },
+        {
+            "ts": "2026-01-01T00:50:00Z",
+            "health": {"score": 80},
+            "mood": 75,
+            "event": "interaction",
+            "run_id": "run 1",
+        },
+        {
+            "ts": "2026-01-01T02:00:00Z",
+            "event": "skill_acquired",
+            "skill": "alpha:vision",
+            "accepted": False,
+            "run_id": "run-2",
+        },
     ]
 
     payload = build_life_timeseries(
-        records, life="alpha", time_window="all", resolution="hour", limit=10,
-        mutation_index=0, record_run_id=lambda rec: str(rec["run_id"]),
+        records,
+        life="alpha",
+        time_window="all",
+        resolution="hour",
+        limit=10,
+        mutation_index=0,
+        record_run_id=lambda rec: str(rec["run_id"]),
     )
 
     assert payload["count"] == 2
@@ -144,7 +186,9 @@ def test_lives_comparison_includes_registry_life_without_records_in_table() -> N
         record_life=lambda rec: str(rec.get("life", "unknown")),
         record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
         is_mutation_record=lambda rec: "score_base" in rec,
-        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        as_float=lambda value: (
+            float(value) if isinstance(value, (int, float)) else None
+        ),
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
@@ -173,7 +217,9 @@ def test_lives_comparison_marks_selected_active_life_without_records() -> None:
         record_life=lambda rec: str(rec.get("life", "unknown")),
         record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
         is_mutation_record=lambda rec: "score_base" in rec,
-        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        as_float=lambda value: (
+            float(value) if isinstance(value, (int, float)) else None
+        ),
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
@@ -198,7 +244,9 @@ def test_lives_comparison_default_rows_follow_active_and_dead_filters() -> None:
         record_life=lambda rec: str(rec.get("life", "unknown")),
         record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
         is_mutation_record=lambda rec: "score_base" in rec,
-        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        as_float=lambda value: (
+            float(value) if isinstance(value, (int, float)) else None
+        ),
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
@@ -233,9 +281,13 @@ def test_lives_comparison_normalizes_registry_life_statuses() -> None:
         record_life=lambda rec: str(rec.get("life", "unknown")),
         record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
         is_mutation_record=lambda rec: "score_base" in rec,
-        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        as_float=lambda value: (
+            float(value) if isinstance(value, (int, float)) else None
+        ),
         alerts_from_records=lambda _: [],
-        compute_vital_timeline=lambda **kwargs: {"registry_status": kwargs["registry_status"]},
+        compute_vital_timeline=lambda **kwargs: {
+            "registry_status": kwargs["registry_status"]
+        },
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
     )
 
@@ -251,6 +303,7 @@ def test_lives_comparison_normalizes_registry_life_statuses() -> None:
     assert comparison["delta"]["run_terminated"] is True
     assert comparison["epsilon"]["life_status"] == "unknown"
     assert comparison["zeta"]["life_status"] == "unknown"
+
 
 def test_code_evolution_service_aggregates_by_life_and_metrics() -> None:
     payload = aggregate_code_evolution(
@@ -295,14 +348,22 @@ def test_code_evolution_service_aggregates_by_life_and_metrics() -> None:
         life="alpha",
         record_life=lambda rec: str(rec.get("life", "unknown")),
         record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
-        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        as_float=lambda value: (
+            float(value) if isinstance(value, (int, float)) else None
+        ),
     )
 
     assert payload["life"] == "alpha"
     assert payload["count"] == 2
     assert payload["items"][0]["timestamp"] == "2026-03-02T00:00:00Z"
-    assert payload["items"][1]["metrics"]["latency_ms"] == {"before": 100.0, "after": 75.0}
+    assert payload["items"][1]["metrics"]["latency_ms"] == {
+        "before": 100.0,
+        "after": 75.0,
+    }
     assert payload["items"][1]["metrics"]["stability"] == {"before": 0.7, "after": 0.9}
     assert payload["summary"]["by_status"] == {"accepté": 1, "rejeté": 1}
     assert payload["summary"]["by_change_type"] == {"perf_fix": 1, "cleanup": 1}
-    assert payload["summary"]["by_target"] == {"skills/a.py": 1, "singular.life.loop": 1}
+    assert payload["summary"]["by_target"] == {
+        "skills/a.py": 1,
+        "singular.life.loop": 1,
+    }

--- a/tests/test_dashboard_static_smoke.py
+++ b/tests/test_dashboard_static_smoke.py
@@ -31,12 +31,17 @@ def test_life_identity_renderers_do_not_conflate_three_distinct_lives() -> None:
 
 def test_timeline_static_exposes_correlation_navigation() -> None:
     timeline = (DASHBOARD_STATIC / "render-timeline.js").read_text(encoding="utf-8")
-    conversations = (DASHBOARD_STATIC / "render-conversations.js").read_text(encoding="utf-8")
+    conversations = (DASHBOARD_STATIC / "render-conversations.js").read_text(
+        encoding="utf-8"
+    )
     template = DASHBOARD_TEMPLATE.read_text(encoding="utf-8")
     assert "correlation_id" in timeline
     assert "Mutation déclenchante" in timeline
     assert "timeline-path" in timeline
-    assert all(label in conversations for label in ("données absentes", "sain", "mode dégradé", "bloqué"))
+    assert all(
+        label in conversations
+        for label in ("données absentes", "sain", "mode dégradé", "bloqué")
+    )
     assert "cause, décision, conséquence, vie, action corrective" in template
 
 
@@ -78,7 +83,10 @@ def test_dashboard_bootstrap_literal_ids_exist_or_are_created() -> None:
     unprotected_missing = {
         element_id
         for element_id in missing
-        if re.search(rf"document\.getElementById\([\"']{re.escape(element_id)}[\"']\)\.", bootstrap)
+        if re.search(
+            rf"document\.getElementById\([\"']{re.escape(element_id)}[\"']\)\.",
+            bootstrap,
+        )
     }
     assert not unprotected_missing, (
         "Bootstrap references missing dashboard IDs without a guard: "
@@ -91,18 +99,22 @@ def test_dashboard_js_uses_guards_for_direct_get_element_access() -> None:
     offenders: list[str] = []
     direct_access = re.compile(r"document\.getElementById\([^\n]+?\)\.(?!\?)")
     for path in AUDITED_JS:
-      text = path.read_text(encoding="utf-8")
-      for match in direct_access.finditer(text):
-          line = text.count("\n", 0, match.start()) + 1
-          offenders.append(f"{path}:{line}: {match.group(0)}")
+        text = path.read_text(encoding="utf-8")
+        for match in direct_access.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            offenders.append(f"{path}:{line}: {match.group(0)}")
 
-    assert not offenders, "Unprotected direct DOM access remains:\n" + "\n".join(offenders)
+    assert not offenders, "Unprotected direct DOM access remains:\n" + "\n".join(
+        offenders
+    )
 
 
 def test_dashboard_quests_websocket_targets_existing_raw_panel() -> None:
     bootstrap = (DASHBOARD_STATIC / "bootstrap.js").read_text(encoding="utf-8")
     assert "getElementById('quests')" not in bootstrap
-    assert "getElementById('quests-json-raw')" in bootstrap or "loadQuests()" in bootstrap
+    assert (
+        "getElementById('quests-json-raw')" in bootstrap or "loadQuests()" in bootstrap
+    )
 
 
 def test_dashboard_tab_navigation_supports_legacy_hashes() -> None:
@@ -129,7 +141,13 @@ def test_dashboard_tab_navigation_supports_legacy_hashes() -> None:
         "#tab-technique",
     ]:
         assert current_tab in template
-    for legacy_href in ["#cockpit", "#timeline-section", "#vies", "#logs-live", "#parametres"]:
+    for legacy_href in [
+        "#cockpit",
+        "#timeline-section",
+        "#vies",
+        "#logs-live",
+        "#parametres",
+    ]:
         assert f"href='{legacy_href}'" not in template
 
 
@@ -361,7 +379,9 @@ if (!optionsHtml.includes('Vie &lt;script&gt;alert(1)&lt;/script&gt;')) {{
     subprocess.run(["node", str(script)], check=True)
 
 
-def test_cockpit_loader_keeps_available_data_when_cockpit_endpoint_fails(tmp_path: Path) -> None:
+def test_cockpit_loader_keeps_available_data_when_cockpit_endpoint_fails(
+    tmp_path: Path,
+) -> None:
     """Exercise the cockpit loader against a failed /api/cockpit response."""
     script = tmp_path / "cockpit_partial_failure_check.mjs"
     module_path = (Path.cwd() / DASHBOARD_STATIC / "render-cockpit.js").as_uri()
@@ -481,7 +501,9 @@ if (!raw.includes('"global_status": "warning"')) {{ throw new Error(`fallback co
     subprocess.run(["node", str(script)], check=True)
 
 
-def test_dashboard_bootstrap_keeps_local_handlers_when_websocket_fails(tmp_path: Path) -> None:
+def test_dashboard_bootstrap_keeps_local_handlers_when_websocket_fails(
+    tmp_path: Path,
+) -> None:
     """A WebSocket construction error must not disable local dashboard controls."""
     script = tmp_path / "dashboard_websocket_failure_check.mjs"
     module_path = (Path.cwd() / DASHBOARD_STATIC / "bootstrap.js").as_uri()
@@ -662,7 +684,9 @@ if (!result.textContent.includes('Saisissez le nom exact')) {{ throw new Error(`
     subprocess.run(["node", str(script)], check=True)
 
 
-def test_dashboard_websocket_url_supports_http_https_and_proxy_prefix(tmp_path: Path) -> None:
+def test_dashboard_websocket_url_supports_http_https_and_proxy_prefix(
+    tmp_path: Path,
+) -> None:
     """The browser protocol and optional reverse-proxy prefix determine the WebSocket URL."""
     script = tmp_path / "dashboard_websocket_url_check.mjs"
     module_path = (Path.cwd() / DASHBOARD_STATIC / "bootstrap.js").as_uri()
@@ -797,7 +821,9 @@ if (birth.disabled || !archive.disabled || !talk.disabled || !emergency.disabled
     subprocess.run(["node", str(script)], check=True)
 
 
-def test_archived_dead_or_stopped_lives_disable_operator_actions(tmp_path: Path) -> None:
+def test_archived_dead_or_stopped_lives_disable_operator_actions(
+    tmp_path: Path,
+) -> None:
     """Operator talk/archive/emergency stop are blocked for non-runnable life statuses."""
     script = tmp_path / "blocked_life_action_check.mjs"
     module_path = (Path.cwd() / DASHBOARD_STATIC / "actions.js").as_uri()

--- a/tests/test_death.py
+++ b/tests/test_death.py
@@ -255,7 +255,9 @@ def test_death_by_traits(tmp_path: Path, monkeypatch):
     assert any(entry.get("event") == "death" for entry in log)
 
 
-def test_extinction_generates_terminal_artifacts_and_status(tmp_path: Path, monkeypatch):
+def test_extinction_generates_terminal_artifacts_and_status(
+    tmp_path: Path, monkeypatch
+):
     skills_dir, ckpt = _setup(tmp_path)
     _patch_logger(monkeypatch, tmp_path)
     _patch_memory(monkeypatch, tmp_path)
@@ -287,7 +289,9 @@ def test_extinction_generates_terminal_artifacts_and_status(tmp_path: Path, monk
 
     bus = EventBus()
     terminal_events: list[dict[str, object]] = []
-    bus.subscribe("life.terminated", lambda event: terminal_events.append(event.payload))
+    bus.subscribe(
+        "life.terminated", lambda event: terminal_events.append(event.payload)
+    )
 
     monitor = DeathMonitor(max_age=1, max_failures=99, min_trait=0.0)
     run(
@@ -301,20 +305,28 @@ def test_extinction_generates_terminal_artifacts_and_status(tmp_path: Path, monk
         event_bus=bus,
     )
 
-    autopsy = json.loads((life_home / "mem" / "autopsy.json").read_text(encoding="utf-8"))
+    autopsy = json.loads(
+        (life_home / "mem" / "autopsy.json").read_text(encoding="utf-8")
+    )
     assert autopsy["technical_causes"]
     assert autopsy["behavioral_causes"]
 
-    biography = json.loads((life_home / "mem" / "biography.final.json").read_text(encoding="utf-8"))
+    biography = json.loads(
+        (life_home / "mem" / "biography.final.json").read_text(encoding="utf-8")
+    )
     assert biography["periods"]
     assert biography["turning_points"]
     assert biography["regrets_and_pride"]["regrets"]
     assert biography["regrets_and_pride"]["pride"]
 
-    stop_signal = json.loads((life_home / "mem" / "orchestrator.stop.json").read_text(encoding="utf-8"))
+    stop_signal = json.loads(
+        (life_home / "mem" / "orchestrator.stop.json").read_text(encoding="utf-8")
+    )
     assert stop_signal["stop"] is True
 
-    updated_registry = json.loads((registry_dir / "registry.json").read_text(encoding="utf-8"))
+    updated_registry = json.loads(
+        (registry_dir / "registry.json").read_text(encoding="utf-8")
+    )
     assert updated_registry["lives"]["life-a"]["status"] == "extinct"
 
     assert terminal_events

--- a/tests/test_developmental_stages.py
+++ b/tests/test_developmental_stages.py
@@ -2,27 +2,52 @@ import json
 
 from singular.learning.developmental import DevelopmentalModel, MaturityEvidence
 
-
 CONFIG = "configs/developmental_curriculum.json"
 
 
 def evidence(**changes):
-    values = dict(calibration=.85, stability=.85, retention=.85, skill_mastery=.8,
-                  constraint_adherence=1, recovery=.8, samples=40)
+    values = dict(
+        calibration=0.85,
+        stability=0.85,
+        retention=0.85,
+        skill_mastery=0.8,
+        constraint_adherence=1,
+        recovery=0.8,
+        samples=40,
+    )
     values.update(changes)
     return MaturityEvidence(**values)
 
 
 def test_progression_stagnation_and_persistence(tmp_path):
     model = DevelopmentalModel.from_config(tmp_path, CONFIG)
-    assert model.observe(evidence(stability=.1), justification="unstable trial").id == "observation"
-    assert model.observe(evidence(), justification="validated window one").id == "observation"
-    assert model.observe(evidence(), justification="validated window two").id == "observation"
-    assert model.observe(evidence(), justification="validated window three").id == "guided_practice"
+    assert (
+        model.observe(evidence(stability=0.1), justification="unstable trial").id
+        == "observation"
+    )
+    assert (
+        model.observe(evidence(), justification="validated window one").id
+        == "observation"
+    )
+    assert (
+        model.observe(evidence(), justification="validated window two").id
+        == "observation"
+    )
+    assert (
+        model.observe(evidence(), justification="validated window three").id
+        == "guided_practice"
+    )
     restarted = DevelopmentalModel.from_config(tmp_path, CONFIG)
     assert restarted.current.id == "guided_practice"
-    transitions = [json.loads(line) for line in restarted.transitions_path.read_text().splitlines()]
-    assert [item["reason"] for item in transitions] == ["stagnation", "prerequisites_met", "prerequisites_met", "prerequisites_met"]
+    transitions = [
+        json.loads(line) for line in restarted.transitions_path.read_text().splitlines()
+    ]
+    assert [item["reason"] for item in transitions] == [
+        "stagnation",
+        "prerequisites_met",
+        "prerequisites_met",
+        "prerequisites_met",
+    ]
     assert all(item["justification"] for item in transitions)
 
 
@@ -31,7 +56,10 @@ def test_incident_regresses_immediately(tmp_path):
     model.observe(evidence(), justification="one")
     model.observe(evidence(), justification="two")
     model.observe(evidence(), justification="three")
-    assert model.observe(evidence(incidents=1), justification="constraint incident").id == "observation"
+    assert (
+        model.observe(evidence(incidents=1), justification="constraint incident").id
+        == "observation"
+    )
     last = json.loads(model.transitions_path.read_text().splitlines()[-1])
     assert last["kind"] == "regression"
 
@@ -41,7 +69,7 @@ def test_sensitive_action_cannot_be_accessed_prematurely_or_bypass_safety(tmp_pa
     early = model.gate(action="delete_data", sensitive=True, human_approved=True)
     assert not early.allowed and early.reason == "action_not_available_at_stage"
     assert not model.gate(action="observe", governance_allowed=False).allowed
-    assert model.exploration_budget(10) == .05
+    assert model.exploration_budget(10) == 0.05
     assert model.filter_skills(["observe", "network"]) == ["observe"]
 
 
@@ -50,9 +78,14 @@ def test_human_approval_remains_required_at_advanced_stage(tmp_path):
     model.observe(evidence(), justification="guided 1")
     model.observe(evidence(), justification="guided 2")
     model.observe(evidence(), justification="guided 3")
-    advanced = evidence(calibration=1, stability=1, retention=1, skill_mastery=1, recovery=1)
+    advanced = evidence(
+        calibration=1, stability=1, retention=1, skill_mastery=1, recovery=1
+    )
     for number in range(4):
-        assert model.observe(advanced, justification=f"advanced {number}").id == "guided_practice"
+        assert (
+            model.observe(advanced, justification=f"advanced {number}").id
+            == "guided_practice"
+        )
     assert model.observe(advanced, justification="advanced 4").id == "bounded_autonomy"
     denied = model.gate(action="delete_data", sensitive=True)
     assert not denied.allowed and denied.requires_human_approval

--- a/tests/test_generations_registry.py
+++ b/tests/test_generations_registry.py
@@ -13,7 +13,11 @@ from singular.runs.generations import get_generations_path, record_generation
 
 
 def _read_jsonl(path: Path) -> list[dict]:
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
 
 
 def test_generation_timestamp_is_timezone_aware_without_deprecation_warning(
@@ -43,7 +47,9 @@ def test_generation_timestamp_is_timezone_aware_without_deprecation_warning(
     assert timestamp.utcoffset() == timezone.utc.utcoffset(timestamp)
 
 
-def test_generation_registry_stays_coherent_with_run_events(tmp_path: Path, monkeypatch) -> None:
+def test_generation_registry_stays_coherent_with_run_events(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir(parents=True, exist_ok=True)
@@ -75,7 +81,9 @@ def test_generation_registry_stays_coherent_with_run_events(tmp_path: Path, monk
     assert candidate_paths
     events_path = max(candidate_paths, key=lambda p: p.stat().st_mtime)
     events = _read_jsonl(events_path)
-    mutation_events = [entry for entry in events if entry.get("event_type") == "mutation"]
+    mutation_events = [
+        entry for entry in events if entry.get("event_type") == "mutation"
+    ]
     assert mutation_events
     mutation_payload = mutation_events[-1]["payload"]
 
@@ -84,7 +92,9 @@ def test_generation_registry_stays_coherent_with_run_events(tmp_path: Path, monk
     assert generation["score"]["new"] == mutation_payload["score_new"]
 
 
-def test_cli_rollback_generation_restores_stable_snapshot(tmp_path: Path, monkeypatch) -> None:
+def test_cli_rollback_generation_restores_stable_snapshot(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.setenv("SINGULAR_ROOT", str(tmp_path))
     metadata = bootstrap_life("Rollback Life")
     monkeypatch.setenv("SINGULAR_HOME", str(metadata.path))
@@ -112,15 +122,17 @@ def test_cli_rollback_generation_restores_stable_snapshot(tmp_path: Path, monkey
 
     skill_path.write_text("def f():\n    return 999\n", encoding="utf-8")
 
-    exit_code = cli.main([
-        "--root",
-        str(tmp_path),
-        "--life",
-        metadata.slug,
-        "rollback",
-        "--generation",
-        str(generation["generation_id"]),
-    ])
+    exit_code = cli.main(
+        [
+            "--root",
+            str(tmp_path),
+            "--life",
+            metadata.slug,
+            "rollback",
+            "--generation",
+            str(generation["generation_id"]),
+        ]
+    )
 
     assert exit_code == 0
     assert "return 2" in skill_path.read_text(encoding="utf-8")

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from singular.life.health import HealthTracker, ViabilityDriftDetector, detect_health_state
+from singular.life.health import (
+    HealthTracker,
+    ViabilityDriftDetector,
+    detect_health_state,
+)
 from singular.life.loop import _retain_health_history
 from singular.runs import report as report_mod
 
@@ -35,7 +39,9 @@ def test_health_tracker_progression() -> None:
         scores.append(snap.score)
 
     assert scores[-1] > 70.0
-    assert detect_health_state(scores, short_window=10, long_window=50) == "amélioration"
+    assert (
+        detect_health_state(scores, short_window=10, long_window=50) == "amélioration"
+    )
 
 
 def test_health_tracker_regression() -> None:
@@ -72,14 +78,21 @@ def test_health_tracker_regression() -> None:
 
 def test_viability_drift_state_round_trips_with_metrics_and_thresholds() -> None:
     detector = ViabilityDriftDetector()
-    metrics = {"health": .8, "risk": .1, "resources": .7, "failure_rate": .1,
-               "traits": .9, "useful_skills": .8, "fitness": .75}
+    metrics = {
+        "health": 0.8,
+        "risk": 0.1,
+        "resources": 0.7,
+        "failure_rate": 0.1,
+        "traits": 0.9,
+        "useful_skills": 0.8,
+        "fitness": 0.75,
+    }
     for _ in range(7):
         detector.observe(metrics)
     diagnostics = ViabilityDriftDetector.from_state(detector.to_state()).diagnostics()
-    assert diagnostics["metrics"]["useful_skills"] == .8
+    assert diagnostics["metrics"]["useful_skills"] == 0.8
     assert diagnostics["thresholds"]["stable_cycles"] == 4
-    assert diagnostics["windows"]["short"] > .7
+    assert diagnostics["windows"]["short"] > 0.7
 
 
 def test_report_prints_health_state(tmp_path: Path, capsys) -> None:
@@ -121,6 +134,9 @@ def test_detect_health_state_with_retained_history_keeps_trend() -> None:
     retained = _retain_health_history(history, fine_window=500, aggregate_every=10)
 
     assert len(retained) == 610
-    assert detect_health_state(
-        [point["score"] for point in retained], short_window=20, long_window=100
-    ) == "amélioration"
+    assert (
+        detect_health_state(
+            [point["score"] for point in retained], short_window=20, long_window=100
+        )
+        == "amélioration"
+    )

--- a/tests/test_host_metrics_store.py
+++ b/tests/test_host_metrics_store.py
@@ -51,7 +51,9 @@ def test_host_metrics_aggregates_and_impact(tmp_path, monkeypatch) -> None:
     assert impact["decision_bias"] == "robustesse"
 
 
-def test_host_metrics_store_accepts_metric_status_payload(tmp_path, monkeypatch) -> None:
+def test_host_metrics_store_accepts_metric_status_payload(
+    tmp_path, monkeypatch
+) -> None:
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     append_host_metrics_sample(
         {

--- a/tests/test_host_sensor.py
+++ b/tests/test_host_sensor.py
@@ -27,10 +27,14 @@ def test_collect_host_metrics_returns_normalized_payload() -> None:
     assert isinstance(metrics["disk_free_gb"], float)
     assert isinstance(metrics["process_cpu_percent"], float)
     assert isinstance(metrics["process_rss_mb"], float)
-    assert metrics["host_uptime_s"] is None or isinstance(metrics["host_uptime_s"], float)
+    assert metrics["host_uptime_s"] is None or isinstance(
+        metrics["host_uptime_s"], float
+    )
     assert isinstance(metrics["metric_status"], dict)
     assert metrics["cpu_load_1m"] is None or isinstance(metrics["cpu_load_1m"], float)
-    assert metrics["host_temperature_c"] is None or isinstance(metrics["host_temperature_c"], float)
+    assert metrics["host_temperature_c"] is None or isinstance(
+        metrics["host_temperature_c"], float
+    )
 
 
 def test_collect_host_metrics_without_psutil(monkeypatch) -> None:

--- a/tests/test_host_sensors_config.py
+++ b/tests/test_host_sensors_config.py
@@ -45,7 +45,14 @@ host_sensors:
 
     monkeypatch.setenv(
         "SINGULAR_HOST_SENSORS_OVERRIDES",
-        json.dumps({"host_sensors": {"cpu": {"critical_percent": 91}, "disk": {"critical_percent": 96}}}),
+        json.dumps(
+            {
+                "host_sensors": {
+                    "cpu": {"critical_percent": 91},
+                    "disk": {"critical_percent": 96},
+                }
+            }
+        ),
     )
 
     thresholds = load_host_sensor_thresholds(config)

--- a/tests/test_identity_coherence.py
+++ b/tests/test_identity_coherence.py
@@ -10,20 +10,36 @@ from singular.identity import (
 )
 
 
-def test_identity_change_categories_require_evidence_and_protect_safety(tmp_path: Path) -> None:
+def test_identity_change_categories_require_evidence_and_protect_safety(
+    tmp_path: Path,
+) -> None:
     guard = IdentityCoherenceGuard(
-        invariants=IdentityInvariants("Singular", (), ()), root=tmp_path,
+        invariants=IdentityInvariants("Singular", (), ()),
+        root=tmp_path,
         change_policy=IdentityChangePolicy(max_delta=0.05),
     )
-    normal = guard.evaluate_identity_change(category="plastic_trait", current=0.5,
-                                            proposed=0.9, cause="reviews",
-                                            evidence=["run-a", "run-b"])
+    normal = guard.evaluate_identity_change(
+        category="plastic_trait",
+        current=0.5,
+        proposed=0.9,
+        cause="reviews",
+        evidence=["run-a", "run-b"],
+    )
     assert normal.accepted and normal.value == pytest.approx(0.55)
-    unsupported = guard.evaluate_identity_change(category="identity_commitment", current="care",
-                                                 proposed="speed", cause="one message",
-                                                 evidence=["message"])
-    unsafe = guard.evaluate_identity_change(category="safety_limit", current=True,
-                                            proposed=False, cause="request", evidence=["a", "b"])
+    unsupported = guard.evaluate_identity_change(
+        category="identity_commitment",
+        current="care",
+        proposed="speed",
+        cause="one message",
+        evidence=["message"],
+    )
+    unsafe = guard.evaluate_identity_change(
+        category="safety_limit",
+        current=True,
+        proposed=False,
+        cause="request",
+        evidence=["a", "b"],
+    )
     assert not unsupported.accepted
     assert not unsafe.accepted
 

--- a/tests/test_identity_consolidation_pipeline.py
+++ b/tests/test_identity_consolidation_pipeline.py
@@ -47,12 +47,18 @@ def test_pipeline_compaction_preserves_identity_invariants(tmp_path: Path) -> No
     assert "identity.created" in lines[0]
 
 
-def test_pipeline_detects_cumulative_simultaneous_trait_collapse(tmp_path: Path) -> None:
+def test_pipeline_detects_cumulative_simultaneous_trait_collapse(
+    tmp_path: Path,
+) -> None:
     mem = tmp_path / "mem"
     Psyche().save_state(mem / "psyche.json")
     episodes = [
-        {"event": "stress", "cause": f"stress-{index}", "evidence": ["sensor", "report"],
-         "trait_changes": {"patience": -0.1, "optimism": -0.1, "resilience": -0.1}}
+        {
+            "event": "stress",
+            "cause": f"stress-{index}",
+            "evidence": ["sensor", "report"],
+            "trait_changes": {"patience": -0.1, "optimism": -0.1, "resilience": -0.1},
+        }
         for index in range(2)
     ]
     result = ConsolidationPipeline(

--- a/tests/test_identity_core.py
+++ b/tests/test_identity_core.py
@@ -8,34 +8,70 @@ from singular.identity.self_model import SCHEMA_VERSION, SelfModelStore
 from singular.psyche import Psyche
 
 
-def test_legacy_migration_separates_facts_and_preserves_evidence(tmp_path: Path) -> None:
+def test_legacy_migration_separates_facts_and_preserves_evidence(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "self_model.json"
-    path.write_text(json.dumps({"traits": {"patient": .8}, "preferences": {},
-                                "constraints": {}, "updated_at": "2020-01-01T00:00:00+00:00"}))
+    path.write_text(
+        json.dumps(
+            {
+                "traits": {"patient": 0.8},
+                "preferences": {},
+                "constraints": {},
+                "updated_at": "2020-01-01T00:00:00+00:00",
+            }
+        )
+    )
     store = SelfModelStore(path)
-    migrated = store.apply_facts([{"kind": "user_fact", "value": "born in Paris",
-                                   "source": "conversation:42", "confidence": .9,
-                                   "observed_at": "2024-01-01T00:00:00+00:00"}])
+    migrated = store.apply_facts(
+        [
+            {
+                "kind": "user_fact",
+                "value": "born in Paris",
+                "source": "conversation:42",
+                "confidence": 0.9,
+                "observed_at": "2024-01-01T00:00:00+00:00",
+            }
+        ]
+    )
 
     assert migrated["schema_version"] == SCHEMA_VERSION
     assert migrated["stable_id"]
     assert "born in Paris" not in migrated["traits"]
     fact = migrated["autobiographical_facts"]["born in Paris"]
-    assert (fact["source"], fact["confidence"], fact["observed_at"], fact["last_confirmed_at"]) == (
-        "conversation:42", .9, "2024-01-01T00:00:00+00:00", "2024-01-01T00:00:00+00:00")
+    assert (
+        fact["source"],
+        fact["confidence"],
+        fact["observed_at"],
+        fact["last_confirmed_at"],
+    ) == (
+        "conversation:42",
+        0.9,
+        "2024-01-01T00:00:00+00:00",
+        "2024-01-01T00:00:00+00:00",
+    )
     assert SelfModelStore(path).read()["stable_id"] == migrated["stable_id"]
 
 
 def test_restart_and_consolidation_keep_durable_identity(tmp_path: Path) -> None:
     mem = tmp_path / "life" / "mem"
     mem.mkdir(parents=True)
-    (mem / "biography.json").write_text(json.dumps({
-        "identity": {"id": "stable-1", "name": "Ariane"},
-        "birth_certificate": {"event_type": "birth_certificate", "issued_at": "2024-01-01"},
-        "self_summaries": [{"text": "Née pour apprendre."}],
-    }))
-    psyche = Psyche(identity_commitments={"values": ["truth"], "red_lines": ["harm"]},
-                    identity_wounds=.7)
+    (mem / "biography.json").write_text(
+        json.dumps(
+            {
+                "identity": {"id": "stable-1", "name": "Ariane"},
+                "birth_certificate": {
+                    "event_type": "birth_certificate",
+                    "issued_at": "2024-01-01",
+                },
+                "self_summaries": [{"text": "Née pour apprendre."}],
+            }
+        )
+    )
+    psyche = Psyche(
+        identity_commitments={"values": ["truth"], "red_lines": ["harm"]},
+        identity_wounds=0.7,
+    )
     service = IdentityCoreService(tmp_path / "life")
     first = service.synchronize(psyche)
     first["commitments"] = ["keep promises"]
@@ -50,5 +86,7 @@ def test_restart_and_consolidation_keep_durable_identity(tmp_path: Path) -> None
     assert current["name"] == "Ariane"
     assert current["biographical_summary"] == "Née pour apprendre."
     assert current["commitments"] == ["keep promises"]
-    assert current["identity_wounds"] == [{"kind": "legacy_psyche_wound", "severity": .7}]
+    assert current["identity_wounds"] == [
+        {"kind": "legacy_psyche_wound", "severity": 0.7}
+    ]
     assert restarted.coherence_invariants().long_term_commitments == ("keep promises",)

--- a/tests/test_import_packages.py
+++ b/tests/test_import_packages.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 PUBLIC_MODULES = (
     "graine",
     "singular",

--- a/tests/test_learning_orchestrator.py
+++ b/tests/test_learning_orchestrator.py
@@ -4,33 +4,48 @@ import json
 
 from singular.learning import FeedbackEvent, LearningOrchestrator, LearningPolicy
 
-
 POLICY = LearningPolicy(minimum_evidence=2, minimum_distinct_sources=2)
 
 
-def event(source: str, reward: float, *, event_id: str, life_id: str = "one") -> FeedbackEvent:
-    return FeedbackEvent(source, "route", reward, {"domain": "test"}, event_id=event_id, life_id=life_id)
+def event(
+    source: str, reward: float, *, event_id: str, life_id: str = "one"
+) -> FeedbackEvent:
+    return FeedbackEvent(
+        source, "route", reward, {"domain": "test"}, event_id=event_id, life_id=life_id
+    )
 
 
 def ready(tmp_path, *, evaluator=None) -> LearningOrchestrator:
-    learner = LearningOrchestrator(tmp_path, life_id="one", policy=POLICY, evaluator=evaluator)
+    learner = LearningOrchestrator(
+        tmp_path, life_id="one", policy=POLICY, evaluator=evaluator
+    )
     learner.add_regression_case("known", {"prompt": "1+1"}, 2)
     return learner
 
 
 def test_incremental_feedback_stays_candidate_until_evidence_threshold(tmp_path):
     learner = ready(tmp_path)
-    candidate = learner.ingest(event("run", 0.3, event_id="a"), kind="strategy", proposed_value="careful")
+    candidate = learner.ingest(
+        event("run", 0.3, event_id="a"), kind="strategy", proposed_value="careful"
+    )
     assert not learner.evaluate_and_promote(candidate).activated
-    learner.ingest(event("conversation", 0.4, event_id="b"), kind="strategy", proposed_value="careful")
+    learner.ingest(
+        event("conversation", 0.4, event_id="b"),
+        kind="strategy",
+        proposed_value="careful",
+    )
     assert learner.evaluate_and_promote(candidate).activated
     assert learner.metrics()["retention_30d_pct"] == 100.0
 
 
 def test_contradictory_feedback_blocks_activation(tmp_path):
     learner = ready(tmp_path)
-    candidate = learner.ingest(event("run", 0.8, event_id="a"), kind="strategy", proposed_value="fast")
-    learner.ingest(event("action", 0.8, event_id="b"), kind="strategy", proposed_value="slow")
+    candidate = learner.ingest(
+        event("run", 0.8, event_id="a"), kind="strategy", proposed_value="fast"
+    )
+    learner.ingest(
+        event("action", 0.8, event_id="b"), kind="strategy", proposed_value="slow"
+    )
     decision = learner.evaluate_and_promote(candidate)
     assert not decision.activated
     assert "contradictory_feedback" in decision.reason
@@ -38,8 +53,12 @@ def test_contradictory_feedback_blocks_activation(tmp_path):
 
 def test_rollback_restores_previous_active_version(tmp_path):
     learner = ready(tmp_path)
-    candidate = learner.ingest(event("run", 0.2, event_id="a"), kind="strategy", proposed_value="v1")
-    learner.ingest(event("action", 0.2, event_id="b"), kind="strategy", proposed_value="v1")
+    candidate = learner.ingest(
+        event("run", 0.2, event_id="a"), kind="strategy", proposed_value="v1"
+    )
+    learner.ingest(
+        event("action", 0.2, event_id="b"), kind="strategy", proposed_value="v1"
+    )
     assert learner.evaluate_and_promote(candidate).activated
     assert learner.rollback(key="strategy:route")
     state = json.loads(learner.state_path.read_text())
@@ -47,9 +66,20 @@ def test_rollback_restores_previous_active_version(tmp_path):
 
 
 def test_drift_and_forgetting_protection_reject_candidate(tmp_path):
-    learner = ready(tmp_path, evaluator=lambda *_: {"gain": .2, "retention": .4, "regression": .2})
-    candidate = learner.ingest(event("run", -0.4, event_id="a"), kind="skill", proposed_value={"reliability": .8})
-    learner.ingest(event("social", 0.8, event_id="b"), kind="skill", proposed_value={"reliability": .8})
+    learner = ready(
+        tmp_path,
+        evaluator=lambda *_: {"gain": 0.2, "retention": 0.4, "regression": 0.2},
+    )
+    candidate = learner.ingest(
+        event("run", -0.4, event_id="a"),
+        kind="skill",
+        proposed_value={"reliability": 0.8},
+    )
+    learner.ingest(
+        event("social", 0.8, event_id="b"),
+        kind="skill",
+        proposed_value={"reliability": 0.8},
+    )
     decision = learner.evaluate_and_promote(candidate)
     assert not decision.activated
     assert "drift_detected" in decision.reason
@@ -59,10 +89,19 @@ def test_drift_and_forgetting_protection_reject_candidate(tmp_path):
 def test_lives_are_isolated(tmp_path):
     first = ready(tmp_path)
     second = LearningOrchestrator(tmp_path, life_id="two", policy=POLICY)
-    first.ingest(event("run", .1, event_id="shared"), kind="belief", proposed_value=True)
-    second.ingest(event("run", .1, event_id="shared", life_id="two"), kind="belief", proposed_value=True)
+    first.ingest(
+        event("run", 0.1, event_id="shared"), kind="belief", proposed_value=True
+    )
+    second.ingest(
+        event("run", 0.1, event_id="shared", life_id="two"),
+        kind="belief",
+        proposed_value=True,
+    )
     assert first.state_path != second.state_path
-    assert json.loads(first.state_path.read_text())["events"].keys() == json.loads(second.state_path.read_text())["events"].keys()
+    assert (
+        json.loads(first.state_path.read_text())["events"].keys()
+        == json.loads(second.state_path.read_text())["events"].keys()
+    )
 
 
 def test_interrupted_transaction_is_recovered(tmp_path):

--- a/tests/test_life_loop_targeted.py
+++ b/tests/test_life_loop_targeted.py
@@ -10,10 +10,18 @@ import pytest
 
 from singular.cognition.reflect import ActionHypothesis, reflect_action
 from singular.life import loop
-from singular.life.coevolution_flow import CoevolutionConfig, CoevolutionFlow, LivingTestPool, TestCandidate
+from singular.life.coevolution_flow import (
+    CoevolutionConfig,
+    CoevolutionFlow,
+    LivingTestPool,
+    TestCandidate,
+)
 from singular.life.loop import EcosystemRules, Organism, WorldState, run_tick
 from singular.life.mutation_flow import select_operator
-from singular.life.reproduction_flow import ReproductionDecisionPolicy, decide_reproduction
+from singular.life.reproduction_flow import (
+    ReproductionDecisionPolicy,
+    decide_reproduction,
+)
 from singular.life.sandbox_scoring import score_code_with_error
 from singular.resource_manager import CapabilityStatus, ResourceManager
 
@@ -39,8 +47,12 @@ def _inc_operator(tree: ast.AST, rng=None) -> ast.AST:
 def test_reflection_prefers_long_term_low_risk_action() -> None:
     decision = reflect_action(
         [
-            ActionHypothesis("risky", long_term=0.9, sandbox_risk=0.9, resource_cost=0.7),
-            ActionHypothesis("steady", long_term=0.75, sandbox_risk=0.05, resource_cost=0.05),
+            ActionHypothesis(
+                "risky", long_term=0.9, sandbox_risk=0.9, resource_cost=0.7
+            ),
+            ActionHypothesis(
+                "steady", long_term=0.75, sandbox_risk=0.05, resource_cost=0.05
+            ),
         ]
     )
 
@@ -51,7 +63,10 @@ def test_reflection_prefers_long_term_low_risk_action() -> None:
 
 def test_operator_selection_uses_analyze_and_objective_bias() -> None:
     operators = {"low_count": _dec_operator, "rewarded": _inc_operator}
-    stats = {"low_count": {"count": 0, "reward": 0.0}, "rewarded": {"count": 3, "reward": 1.0}}
+    stats = {
+        "low_count": {"count": 0, "reward": 0.0},
+        "rewarded": {"count": 3, "reward": 1.0},
+    }
 
     assert select_operator(operators, stats, "analyze", random.Random(0)) == "low_count"
 
@@ -103,7 +118,9 @@ def test_run_tick_manages_resources_and_mutates_skill(temp_life) -> None:
     )
 
     assert state.iteration == 1
-    assert (temp_life["skills_dir"] / "skill.py").read_text(encoding="utf-8").strip() == "result = 1"
+    assert (temp_life["skills_dir"] / "skill.py").read_text(
+        encoding="utf-8"
+    ).strip() == "result = 1"
     assert resources.energy != before_energy
 
 
@@ -168,7 +185,9 @@ class _SleepyPsyche:
         return None
 
 
-def test_run_tick_sleeps_without_mutating_when_energy_is_low(temp_life, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_tick_sleeps_without_mutating_when_energy_is_low(
+    temp_life, monkeypatch: pytest.MonkeyPatch
+) -> None:
     sleepy = _SleepyPsyche()
     monkeypatch.setattr(loop.Psyche, "load_state", staticmethod(lambda: sleepy))
 
@@ -183,7 +202,9 @@ def test_run_tick_sleeps_without_mutating_when_energy_is_low(temp_life, monkeypa
     assert state.iteration == 1
     assert sleepy.sleeping is True
     assert sleepy.sleep_ticks == 1
-    assert (temp_life["skills_dir"] / "skill.py").read_text(encoding="utf-8") == "result = 2\n"
+    assert (temp_life["skills_dir"] / "skill.py").read_text(
+        encoding="utf-8"
+    ) == "result = 2\n"
     checkpoint = json.loads(temp_life["checkpoint_path"].read_text(encoding="utf-8"))
     assert checkpoint["iteration"] == 1
 
@@ -204,7 +225,9 @@ def test_reproduction_decision_accepts_healthy_governed_parents(temp_life) -> No
         parent_a_health=1.0,
         parent_b_health=1.0,
         governance_allowed=True,
-        policy=ReproductionDecisionPolicy(min_parent_health=0.1, compatibility_threshold=0.1),
+        policy=ReproductionDecisionPolicy(
+            min_parent_health=0.1, compatibility_threshold=0.1
+        ),
     )
 
     assert decision.accepted is True
@@ -234,7 +257,9 @@ def test_coevolution_rejects_regression_detected_by_living_test(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     flow = CoevolutionFlow(
-        pool=LivingTestPool(tests=[TestCandidate("result == 1")], ttl={"result == 1": 3}),
+        pool=LivingTestPool(
+            tests=[TestCandidate("result == 1")], ttl={"result == 1": 3}
+        ),
         config=CoevolutionConfig(enabled=True, robustness_weight=robustness_weight),
     )
     monkeypatch.setattr(flow.pool, "evaluate", lambda code: [code == "result = 1"])
@@ -257,17 +282,25 @@ def test_coevolution_rejects_regression_detected_by_living_test(
     assert decision.score_combined_new == expected_combined
 
 
-def test_cycle_complet_creation_tick_mutation_learning_reproduction_and_stop(temp_life) -> None:
+def test_cycle_complet_creation_tick_mutation_learning_reproduction_and_stop(
+    temp_life,
+) -> None:
     world = WorldState(
         organisms={
             "alpha": Organism(temp_life["skills_dir"], energy=5.0, resources=5.0),
-            "beta": Organism(temp_life["root"] / "beta" / "skills", energy=5.0, resources=5.0),
+            "beta": Organism(
+                temp_life["root"] / "beta" / "skills", energy=5.0, resources=5.0
+            ),
         }
     )
-    (temp_life["skills_dir"] / "skill.py").write_text("result = 2\ndef solve():\n    return 2\n", encoding="utf-8")
+    (temp_life["skills_dir"] / "skill.py").write_text(
+        "result = 2\ndef solve():\n    return 2\n", encoding="utf-8"
+    )
     beta_skill = world.organisms["beta"].skills_dir
     beta_skill.mkdir(parents=True)
-    (beta_skill / "skill.py").write_text("result = 3\ndef solve():\n    return 3\n", encoding="utf-8")
+    (beta_skill / "skill.py").write_text(
+        "result = 3\ndef solve():\n    return 3\n", encoding="utf-8"
+    )
 
     state = run_tick(
         {name: org.skills_dir for name, org in world.organisms.items()},
@@ -277,7 +310,9 @@ def test_cycle_complet_creation_tick_mutation_learning_reproduction_and_stop(tem
         world=world,
         ecosystem_rules=EcosystemRules(
             crossover_interval=1,
-            reproduction_policy=ReproductionDecisionPolicy(min_parent_health=0.1, compatibility_threshold=0.1, cooldown_ticks=1),
+            reproduction_policy=ReproductionDecisionPolicy(
+                min_parent_health=0.1, compatibility_threshold=0.1, cooldown_ticks=1
+            ),
         ),
         tick_budget_seconds=0.05,
     )
@@ -285,7 +320,10 @@ def test_cycle_complet_creation_tick_mutation_learning_reproduction_and_stop(tem
     assert state.iteration == 1
     assert state.stats["dec"]["count"] == 1
     assert list(Path("runs").glob("**/*.jsonl"))
-    assert any(path.name.startswith("child_") for path in temp_life["root"].iterdir()) or world.reproduction_cooldowns
+    assert (
+        any(path.name.startswith("child_") for path in temp_life["root"].iterdir())
+        or world.reproduction_cooldowns
+    )
 
     stopped = loop.run(
         temp_life["skills_dir"],
@@ -298,7 +336,9 @@ def test_cycle_complet_creation_tick_mutation_learning_reproduction_and_stop(tem
     assert stopped.iteration == state.iteration
 
 
-def test_contextual_operator_is_preferred_for_stable_life_but_refused_terminal() -> None:
+def test_contextual_operator_is_preferred_for_stable_life_but_refused_terminal() -> (
+    None
+):
     from singular.beliefs.meta_learning import StrategyRecommendation
 
     operators = {"proven": _dec_operator, "fallback": _inc_operator}
@@ -307,16 +347,29 @@ def test_contextual_operator_is_preferred_for_stable_life_but_refused_terminal()
         "fallback": {"count": 5, "reward": 5.0},
     }
     evidence = StrategyRecommendation(
-        operator="proven", confidence=0.75, context_key="stable",
-        sample_count=8, regression_risk=0.2, uncertainty=0.1, recency=1.0,
+        operator="proven",
+        confidence=0.75,
+        context_key="stable",
+        sample_count=8,
+        regression_risk=0.2,
+        uncertainty=0.1,
+        recency=1.0,
     )
     stable = select_operator(
-        operators, stats, "exploit", random.Random(0),
-        contextual_recommendation=evidence, vital_risk=0.1,
+        operators,
+        stats,
+        "exploit",
+        random.Random(0),
+        contextual_recommendation=evidence,
+        vital_risk=0.1,
     )
     terminal = select_operator(
-        operators, stats, "exploit", random.Random(0),
-        contextual_recommendation=evidence, vital_risk=0.95,
+        operators,
+        stats,
+        "exploit",
+        random.Random(0),
+        contextual_recommendation=evidence,
+        vital_risk=0.95,
     )
     assert stable == "proven"
     assert terminal == "fallback"

--- a/tests/test_life_status.py
+++ b/tests/test_life_status.py
@@ -687,7 +687,9 @@ def test_compute_life_status_budget_exhaustion_is_not_death(life_home_factory) -
 
     life_home, mem = life_home_factory()
     _write_json(mem / "world_state.json", {"global_health": {"score": 90}})
-    _write_json(mem / "self_narrative.json", {"identity": {"name": "Alpha", "slug": "alpha"}})
+    _write_json(
+        mem / "self_narrative.json", {"identity": {"name": "Alpha", "slug": "alpha"}}
+    )
     _write_json(mem / "quests_state.json", {})
 
     result = compute_life_status(

--- a/tests/test_liveness_index.py
+++ b/tests/test_liveness_index.py
@@ -2,15 +2,21 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from singular.dashboard.services.lives_comparison import aggregate_lives, compute_liveness_index
-
+from singular.dashboard.services.lives_comparison import (
+    aggregate_lives,
+    compute_liveness_index,
+)
 
 NOW = datetime(2026, 4, 15, 12, 0, 0, tzinfo=timezone.utc)
 
 
 def test_liveness_index_reaches_high_score_when_all_signals_present() -> None:
     records = [
-        {"ts": "2026-04-15T10:00:00+00:00", "event": "perception", "perception_summary": "host stable"},
+        {
+            "ts": "2026-04-15T10:00:00+00:00",
+            "event": "perception",
+            "perception_summary": "host stable",
+        },
         {
             "ts": "2026-04-15T10:02:00+00:00",
             "event": "consciousness",
@@ -19,7 +25,11 @@ def test_liveness_index_reaches_high_score_when_all_signals_present() -> None:
             "status": "in_progress",
             "progress": 0.3,
         },
-        {"ts": "2026-04-15T10:03:00+00:00", "event": "interaction", "interaction": {"with": "human"}},
+        {
+            "ts": "2026-04-15T10:03:00+00:00",
+            "event": "interaction",
+            "interaction": {"with": "human"},
+        },
         {
             "ts": "2026-04-15T10:05:00+00:00",
             "event": "mutation",
@@ -62,13 +72,26 @@ def test_liveness_index_avoids_false_positive_on_sparse_noise() -> None:
     assert payload["components"]["interactions"]["score"] == 0.0
     assert payload["components"]["validated_internal_modifications"]["score"] == 0.0
     assert "interactions" in payload["indices"]["liveness"]["missing_data"]
-    assert any("aucune interaction observée depuis 7 jours" in item for item in payload["recommendations"])
+    assert any(
+        "aucune interaction observée depuis 7 jours" in item
+        for item in payload["recommendations"]
+    )
 
 
 def test_liveness_index_partial_interaction_threshold() -> None:
     records = [
-        {"ts": "2026-04-15T10:00:00+00:00", "event": "interaction", "interaction": {"with": "human"}},
-        {"ts": "2026-04-15T10:02:00+00:00", "event": "mutation", "accepted": False, "score_base": 5, "score_new": 7},
+        {
+            "ts": "2026-04-15T10:00:00+00:00",
+            "event": "interaction",
+            "interaction": {"with": "human"},
+        },
+        {
+            "ts": "2026-04-15T10:02:00+00:00",
+            "event": "mutation",
+            "accepted": False,
+            "score_base": 5,
+            "score_new": 7,
+        },
     ]
 
     payload = compute_liveness_index(records, now=NOW)
@@ -113,7 +136,9 @@ def test_lives_comparison_exposes_liveness_fields() -> None:
         record_life=lambda rec: str(rec.get("life", "unknown")),
         record_run_id=lambda rec: str(rec.get("run_id", "unknown")),
         is_mutation_record=lambda rec: "score_base" in rec,
-        as_float=lambda value: float(value) if isinstance(value, (int, float)) else None,
+        as_float=lambda value: (
+            float(value) if isinstance(value, (int, float)) else None
+        ),
         alerts_from_records=lambda _: [],
         compute_vital_timeline=lambda **_: {"ok": True},
         registry_life_meta=lambda life_name, lives: (life_name, lives.get(life_name)),
@@ -124,7 +149,10 @@ def test_lives_comparison_exposes_liveness_fields() -> None:
     assert "recent_activity" in alpha["life_liveness_components"]
     assert isinstance(alpha["life_liveness_proofs"], list)
     assert len(alpha["life_liveness_proofs"]) <= 5
-    assert alpha["score_diagnostics"]["health"]["formula_version"] == "health-observation-v1.0"
+    assert (
+        alpha["score_diagnostics"]["health"]["formula_version"]
+        == "health-observation-v1.0"
+    )
     assert alpha["score_diagnostics"]["liveness"]["components"]
 
 
@@ -132,7 +160,11 @@ def test_autonomy_index_ignores_voluntary_budget_records() -> None:
     payload = compute_liveness_index(
         [
             {"ts": "2026-04-15T10:00:00+00:00", "event": "perception"},
-            {"ts": "2026-04-15T10:01:00+00:00", "event": "loop.budget_exhausted", "voluntary_budget": True},
+            {
+                "ts": "2026-04-15T10:01:00+00:00",
+                "event": "loop.budget_exhausted",
+                "voluntary_budget": True,
+            },
         ],
         now=NOW,
     )
@@ -144,7 +176,15 @@ def test_autonomy_index_ignores_voluntary_budget_records() -> None:
 
 def test_liveness_index_reports_mutation_viability_separately() -> None:
     payload = compute_liveness_index(
-        [{"ts": "2026-04-15T10:00:00+00:00", "event": "mutation", "accepted": True, "score_base": 5, "score_new": 4}],
+        [
+            {
+                "ts": "2026-04-15T10:00:00+00:00",
+                "event": "mutation",
+                "accepted": True,
+                "score_base": 5,
+                "score_new": 4,
+            }
+        ],
         now=NOW,
     )
 
@@ -153,12 +193,27 @@ def test_liveness_index_reports_mutation_viability_separately() -> None:
 
 
 def test_mutation_viability_distinguishes_durable_candidate() -> None:
-    payload = compute_liveness_index([
-        {"event": "mutation", "accepted": False, "useful": True,
-         "durably_viable": False, "score_base": 10, "score_new": 5},
-        {"event": "mutation", "accepted": True, "useful": True,
-         "durably_viable": True, "score_base": 10, "score_new": 8},
-    ], now=NOW)
+    payload = compute_liveness_index(
+        [
+            {
+                "event": "mutation",
+                "accepted": False,
+                "useful": True,
+                "durably_viable": False,
+                "score_base": 10,
+                "score_new": 5,
+            },
+            {
+                "event": "mutation",
+                "accepted": True,
+                "useful": True,
+                "durably_viable": True,
+                "score_base": 10,
+                "score_new": 8,
+            },
+        ],
+        now=NOW,
+    )
     assert payload["mutation_viability"]["accepted_count"] == 1
     assert payload["mutation_viability"]["accepted_useful_changes"] == 1
     assert payload["mutation_viability"]["durably_viable_count"] == 1

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -279,8 +279,12 @@ def test_clone_life_applies_inheritance_policy_and_logs_transfers(
     source_mem = source.path / "mem"
     source_skills = source.path / "skills"
     source_skills.mkdir(parents=True, exist_ok=True)
-    (source_skills / "kept.py").write_text("def run(context=None):\n    return {'ok': True}\n", encoding="utf-8")
-    (source_skills / "dropped.py").write_text("def run(context=None):\n    return {'ok': True}\n", encoding="utf-8")
+    (source_skills / "kept.py").write_text(
+        "def run(context=None):\n    return {'ok': True}\n", encoding="utf-8"
+    )
+    (source_skills / "dropped.py").write_text(
+        "def run(context=None):\n    return {'ok': True}\n", encoding="utf-8"
+    )
 
     (source_mem / "skills.json").write_text(
         json.dumps(
@@ -306,26 +310,38 @@ def test_clone_life_applies_inheritance_policy_and_logs_transfers(
     clone_mem = clone.path / "mem"
     clone_skills = clone.path / "skills"
 
-    inherited_skills = json.loads((clone_mem / "skills.json").read_text(encoding="utf-8"))
+    inherited_skills = json.loads(
+        (clone_mem / "skills.json").read_text(encoding="utf-8")
+    )
     assert list(inherited_skills) == ["kept"]
     assert (clone_skills / "kept.py").exists()
     assert not (clone_skills / "dropped.py").exists()
 
-    memory_summary = json.loads((clone_mem / "legacy_memory_summary.json").read_text(encoding="utf-8"))
+    memory_summary = json.loads(
+        (clone_mem / "legacy_memory_summary.json").read_text(encoding="utf-8")
+    )
     assert len(memory_summary) == 1
     assert memory_summary[0]["event"] == "quest"
 
-    lessons = json.loads((clone_mem / "legacy_lessons.json").read_text(encoding="utf-8"))
+    lessons = json.loads(
+        (clone_mem / "legacy_lessons.json").read_text(encoding="utf-8")
+    )
     assert lessons["success_count"] == 1
     assert lessons["failure_count"] == 0
 
-    inheritance = json.loads((clone_mem / "inheritance_policy.json").read_text(encoding="utf-8"))
+    inheritance = json.loads(
+        (clone_mem / "inheritance_policy.json").read_text(encoding="utf-8")
+    )
     assert "inheritance_policy" in inheritance
     assert inheritance["inherited_from"] == source.slug
 
     journal_path = tmp_path / "mem" / "legacy_transfers.jsonl"
     assert journal_path.exists()
-    journal_lines = [json.loads(line) for line in journal_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    journal_lines = [
+        json.loads(line)
+        for line in journal_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
     assert len(journal_lines) == 3
     assert all(item["source"] == source.slug for item in journal_lines)
     assert all(item["target"] == clone.slug for item in journal_lines)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -67,16 +67,28 @@ def test_birth_initializes_identity_profile_and_psyche(tmp_path: Path) -> None:
     assert psyche_data["schema_version"] >= 1
 
 
-def test_birth_writes_auditable_snapshot_certificate_and_summary(tmp_path: Path) -> None:
+def test_birth_writes_auditable_snapshot_certificate_and_summary(
+    tmp_path: Path,
+) -> None:
     birth(seed=7, home=tmp_path)
     mem_dir = tmp_path / "mem"
 
-    snapshot = json.loads((mem_dir / "initial_snapshot.json").read_text(encoding="utf-8"))
+    snapshot = json.loads(
+        (mem_dir / "initial_snapshot.json").read_text(encoding="utf-8")
+    )
     assert snapshot["schema_version"] == 1
     assert snapshot["initial_state_checksum"]
-    assert set(snapshot["initial_state"]) == {"identity", "psyche", "values", "goals", "world"}
+    assert set(snapshot["initial_state"]) == {
+        "identity",
+        "psyche",
+        "values",
+        "goals",
+        "world",
+    }
 
-    life_events = (mem_dir / "life_events.jsonl").read_text(encoding="utf-8").splitlines()
+    life_events = (
+        (mem_dir / "life_events.jsonl").read_text(encoding="utf-8").splitlines()
+    )
     assert life_events
     birth_event = json.loads(life_events[-1])
     assert birth_event["schema_version"] == 1
@@ -173,7 +185,9 @@ def test_birth_initializes_default_skills(tmp_path: Path) -> None:
     )
     assert skills_data == {name: {"score": 0.0} for name in expected_skill_names}
 
-    catalog = json.loads((tmp_path / "mem" / "skill_catalog.json").read_text(encoding="utf-8"))
+    catalog = json.loads(
+        (tmp_path / "mem" / "skill_catalog.json").read_text(encoding="utf-8")
+    )
     assert set(catalog) >= set(expected_skill_names)
 
 
@@ -233,7 +247,9 @@ def test_skill_maintenance_archive_and_restore_is_lossless(tmp_path: Path) -> No
     skills_path.parent.mkdir(parents=True, exist_ok=True)
     skills_path.write_text(json.dumps(data), encoding="utf-8")
 
-    apply_skill_maintenance(dormant_after_days=5, archive_after_days=30, path=skills_path)
+    apply_skill_maintenance(
+        dormant_after_days=5, archive_after_days=30, path=skills_path
+    )
     archived = json.loads(skills_path.read_text(encoding="utf-8"))
     assert archived["beta"]["lifecycle"]["state"] == "archived"
     assert archived["beta"]["metrics"]["usage_count"] == 1
@@ -250,7 +266,9 @@ def test_skill_temporary_disable_and_controlled_delete(tmp_path: Path) -> None:
     skills_path = tmp_path / "mem" / "skills.json"
     update_score("gamma", 0.2, path=skills_path)
 
-    temporarily_disable_skill("gamma", duration_hours=2, reason="cooldown", path=skills_path)
+    temporarily_disable_skill(
+        "gamma", duration_hours=2, reason="cooldown", path=skills_path
+    )
     disabled = json.loads(skills_path.read_text(encoding="utf-8"))
     assert disabled["gamma"]["lifecycle"]["state"] == "temporarily_disabled"
     assert disabled["gamma"]["lifecycle"]["disabled_until"] is not None

--- a/tests/test_memory_compaction.py
+++ b/tests/test_memory_compaction.py
@@ -10,7 +10,11 @@ from singular.memory_compaction import compact_episodic_jsonl, compact_generatio
 def _read_jsonl(path: Path) -> list[dict]:
     if not path.exists():
         return []
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
 
 
 def test_compact_episodic_keeps_recent_and_writes_snapshot_refs(tmp_path: Path) -> None:
@@ -20,10 +24,16 @@ def test_compact_episodic_keeps_recent_and_writes_snapshot_refs(tmp_path: Path) 
 
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
     rows = [
-        {"ts": (base + timedelta(minutes=i)).isoformat(), "event": "tick", "text": f"evt-{i}"}
+        {
+            "ts": (base + timedelta(minutes=i)).isoformat(),
+            "event": "tick",
+            "text": f"evt-{i}",
+        }
         for i in range(8)
     ]
-    episodic.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    episodic.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
 
     result = compact_episodic_jsonl(
         mem_dir=mem_dir,
@@ -39,7 +49,9 @@ def test_compact_episodic_keeps_recent_and_writes_snapshot_refs(tmp_path: Path) 
     assert result["snapshot_count"] == 3
 
     compacted = _read_jsonl(episodic)
-    refs = [row for row in compacted if row.get("event") == "episodic.compaction.reference"]
+    refs = [
+        row for row in compacted if row.get("event") == "episodic.compaction.reference"
+    ]
     assert len(refs) == 3
     assert compacted[-3:] == rows[-3:]
 
@@ -109,7 +121,9 @@ def test_compact_generations_keeps_recent_and_minimal_audit(tmp_path: Path) -> N
             "stable": True,
         },
     ]
-    generations.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    generations.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
 
     result = compact_generations_jsonl(
         mem_dir=mem_dir,
@@ -121,14 +135,19 @@ def test_compact_generations_keeps_recent_and_minimal_audit(tmp_path: Path) -> N
     assert result["compacted"] is True
     compacted = _read_jsonl(generations)
 
-    assert any(row.get("generation_id") == 3 and row.get("verdict") == "accepted" for row in compacted)
+    assert any(
+        row.get("generation_id") == 3 and row.get("verdict") == "accepted"
+        for row in compacted
+    )
 
     old_audit = [row for row in compacted if row.get("generation_id") == 1]
     assert old_audit
     assert old_audit[0]["event"] == "generations.audit.minimal"
     assert "mutation" not in old_audit[0]
 
-    assert any(row.get("event") == "generations.rejected.aggregate" for row in compacted)
+    assert any(
+        row.get("event") == "generations.rejected.aggregate" for row in compacted
+    )
     assert any(row.get("event") == "generations.compaction.meta" for row in compacted)
 
 
@@ -137,14 +156,24 @@ def test_compact_episodic_emits_memory_consolidated(tmp_path):
     mem_dir.mkdir()
     episodic = mem_dir / "episodic.jsonl"
     rows = [
-        {"event": "user", "text": f"souvenir bug {idx}", "ts": f"2026-01-01T00:00:0{idx}+00:00"}
+        {
+            "event": "user",
+            "text": f"souvenir bug {idx}",
+            "ts": f"2026-01-01T00:00:0{idx}+00:00",
+        }
         for idx in range(4)
     ]
-    episodic.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    episodic.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
 
-    result = compact_episodic_jsonl(mem_dir=mem_dir, keep_last_events=1, snapshot_chunk_size=2)
+    result = compact_episodic_jsonl(
+        mem_dir=mem_dir, keep_last_events=1, snapshot_chunk_size=2
+    )
 
     assert result["compacted"] is True
-    compacted = [json.loads(line) for line in episodic.read_text(encoding="utf-8").splitlines()]
+    compacted = [
+        json.loads(line) for line in episodic.read_text(encoding="utf-8").splitlines()
+    ]
     assert compacted[0]["event"] == "memory.consolidated"
     assert "Consolidated 3 historical episodic events" in compacted[0]["summary"]

--- a/tests/test_memory_layers.py
+++ b/tests/test_memory_layers.py
@@ -31,10 +31,14 @@ def test_service_retention_and_consolidation(tmp_path):
     short_path = tmp_path / "layers" / "short_term.jsonl"
     long_path = tmp_path / "layers" / "long_term.jsonl"
 
-    short_lines = [line for line in short_path.read_text(encoding="utf-8").splitlines() if line]
+    short_lines = [
+        line for line in short_path.read_text(encoding="utf-8").splitlines() if line
+    ]
     assert len(short_lines) == 2
 
-    long_lines = [line for line in long_path.read_text(encoding="utf-8").splitlines() if line]
+    long_lines = [
+        line for line in long_path.read_text(encoding="utf-8").splitlines() if line
+    ]
     assert len(long_lines) >= 2
 
 
@@ -52,7 +56,10 @@ def test_add_episode_enriches_semantic_memory(tmp_path, monkeypatch):
     )
 
     semantic_path = get_memory_layers_dir() / "semantic.jsonl"
-    lines = [json.loads(line) for line in semantic_path.read_text(encoding="utf-8").splitlines()]
+    lines = [
+        json.loads(line)
+        for line in semantic_path.read_text(encoding="utf-8").splitlines()
+    ]
     texts = [entry["text"] for entry in lines]
     assert "lives in paris" in texts
     assert "coffee" in texts

--- a/tests/test_memory_layers_service_targeted.py
+++ b/tests/test_memory_layers_service_targeted.py
@@ -12,10 +12,16 @@ from singular.memory_layers.service import MemoryLayerService
 def _read_jsonl(path):
     if not path.exists():
         return []
-    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
 
 
-def test_memory_backend_put_is_atomic_and_recovers_after_replace_error(isolated_memory, monkeypatch) -> None:
+def test_memory_backend_put_is_atomic_and_recovers_after_replace_error(
+    isolated_memory, monkeypatch
+) -> None:
     _service, backend, memory_dir = isolated_memory
     backend.put("short_term", MemoryRecord(id="existing", text="old"))
     before = (memory_dir / "short_term.jsonl").read_text(encoding="utf-8")
@@ -67,7 +73,9 @@ def test_backend_deduplicates_records_by_id(isolated_memory) -> None:
     assert rows[0]["metadata"]["v"] == 2
 
 
-def test_service_recovers_after_backend_error_on_next_ingest(tmp_path, monkeypatch) -> None:
+def test_service_recovers_after_backend_error_on_next_ingest(
+    tmp_path, monkeypatch
+) -> None:
     backend = LocalJsonMemoryBackend(tmp_path)
     service = MemoryLayerService(backend, short_term_window=5, consolidate_every=10)
     calls = {"count": 0}
@@ -90,7 +98,9 @@ def test_service_recovers_after_backend_error_on_next_ingest(tmp_path, monkeypat
     assert rows[0]["text"] == "recovered"
 
 
-def test_service_extracts_semantic_facts_and_enforces_short_term_window(isolated_memory) -> None:
+def test_service_extracts_semantic_facts_and_enforces_short_term_window(
+    isolated_memory,
+) -> None:
     service, _backend, memory_dir = isolated_memory
     service.short_term_window = 2
 

--- a/tests/test_memory_retrieval.py
+++ b/tests/test_memory_retrieval.py
@@ -6,7 +6,11 @@ from singular.memory_layers import (
     MemoryRecord,
     MemoryRetrievalService,
 )
-from singular.organisms.talk import ContextBudget, ContextItem, _build_structured_context
+from singular.organisms.talk import (
+    ContextBudget,
+    ContextItem,
+    _build_structured_context,
+)
 
 
 def _write(path: Path, value: object) -> None:
@@ -90,8 +94,23 @@ def test_ranking_deduplication_and_life_isolation(tmp_path: Path) -> None:
 def test_prompt_memory_selection_exposes_provenance_and_prefers_active_life() -> None:
     result = _build_structured_context(
         [
-            ContextItem("recalled_memories", "Ada active", "episode:ada", relevance=.8, recency=.9, confidence=.9),
-            ContextItem("recalled_memories", "Eve inactive", "episode:eve", relevance=.8, recency=.9, confidence=.9, active_life=False),
+            ContextItem(
+                "recalled_memories",
+                "Ada active",
+                "episode:ada",
+                relevance=0.8,
+                recency=0.9,
+                confidence=0.9,
+            ),
+            ContextItem(
+                "recalled_memories",
+                "Eve inactive",
+                "episode:eve",
+                relevance=0.8,
+                recency=0.9,
+                confidence=0.9,
+                active_life=False,
+            ),
         ],
         ContextBudget(total=140, recalled_memories=70, safety=0),
     )

--- a/tests/test_meta_learning.py
+++ b/tests/test_meta_learning.py
@@ -182,16 +182,30 @@ def test_contextual_evidence_is_stable_but_not_transferable_to_terminal_life(
         )
 
     stable = recommend_strategy(
-        store, failure_type="anticipated", environment_signal="stable",
-        mood="calm", outcome_hint="success", candidates=["const_tune"],
-        skill_family="python", vital_state="stable", objective="robustesse",
-        governance_mode="enabled", candidate_characteristics={"complexity": "low"},
+        store,
+        failure_type="anticipated",
+        environment_signal="stable",
+        mood="calm",
+        outcome_hint="success",
+        candidates=["const_tune"],
+        skill_family="python",
+        vital_state="stable",
+        objective="robustesse",
+        governance_mode="enabled",
+        candidate_characteristics={"complexity": "low"},
     )
     terminal = recommend_strategy(
-        store, failure_type="anticipated", environment_signal="stable",
-        mood="calm", outcome_hint="success", candidates=["const_tune"],
-        skill_family="python", vital_state="terminal", objective="robustesse",
-        governance_mode="enabled", candidate_characteristics={"complexity": "low"},
+        store,
+        failure_type="anticipated",
+        environment_signal="stable",
+        mood="calm",
+        outcome_hint="success",
+        candidates=["const_tune"],
+        skill_family="python",
+        vital_state="terminal",
+        objective="robustesse",
+        governance_mode="enabled",
+        candidate_characteristics={"complexity": "low"},
     )
 
     assert stable is not None
@@ -207,13 +221,21 @@ def test_contextual_evidence_is_stable_but_not_transferable_to_terminal_life(
 def test_one_success_does_not_create_high_confidence(tmp_path: Path) -> None:
     store = BeliefStore(path=tmp_path / "beliefs.json")
     features = extract_run_features(
-        operator="lucky", accepted=True, base_score=1.0, mutated_score=0.5,
-        temperature=20.0, mood="calm",
+        operator="lucky",
+        accepted=True,
+        base_score=1.0,
+        mutated_score=0.5,
+        temperature=20.0,
+        mood="calm",
     )
     register_run_result(store, features, reward_delta=0.5)
     recommendation = recommend_strategy(
-        store, failure_type="anticipated", environment_signal="stable",
-        mood="calm", outcome_hint="success", candidates=["lucky"],
+        store,
+        failure_type="anticipated",
+        environment_signal="stable",
+        mood="calm",
+        outcome_hint="success",
+        candidates=["lucky"],
     )
     assert recommendation is not None
     assert recommendation.sample_count == 1

--- a/tests/test_moral_context.py
+++ b/tests/test_moral_context.py
@@ -24,7 +24,9 @@ def test_sensitive_action_without_context_cannot_bypass_veto(tmp_path):
     assert decision.acceptable_alternative_conditions
 
 
-def test_persistent_red_line_survives_restart_and_action_context_cannot_erase_it(tmp_path):
+def test_persistent_red_line_survives_restart_and_action_context_cannot_erase_it(
+    tmp_path,
+):
     service = IdentityCoreService(tmp_path)
     model = service.synchronize()
     model["red_lines"] = ["human_dignity"]
@@ -35,21 +37,31 @@ def test_persistent_red_line_survives_restart_and_action_context_cannot_erase_it
         "identity_commitments": [
             {"value": "human_dignity", "absolute": False, "weight": 0.0}
         ],
-        "consequences": [{
-            "description": "humiliation",
-            "affected_party": "person",
-            "harm": 0.5,
-            "values": ["human_dignity"],
-        }],
+        "consequences": [
+            {
+                "description": "humiliation",
+                "affected_party": "person",
+                "harm": 0.5,
+                "values": ["human_dignity"],
+            }
+        ],
         "affected_parties": [{"identifier": "person"}],
     }
-    context = MoralContextBuilder(restarted).build(MoralAction("message.send"), supplied)
+    context = MoralContextBuilder(restarted).build(
+        MoralAction("message.send"), supplied
+    )
     decision = MoralDecisionEngine().evaluate(
-        MoralAction("message.send"), context.consequences,
-        context.affected_parties, context.identity_commitments, context.uncertainty
+        MoralAction("message.send"),
+        context.consequences,
+        context.affected_parties,
+        context.identity_commitments,
+        context.uncertainty,
     )
 
-    assert any(item["absolute"] and item["value"] == "human_dignity" for item in context.identity_commitments)
+    assert any(
+        item["absolute"] and item["value"] == "human_dignity"
+        for item in context.identity_commitments
+    )
     assert decision.veto_reason == "engagement identitaire absolu menacé: human_dignity"
 
 
@@ -60,6 +72,9 @@ def test_context_journal_records_provenance_and_alternative_conditions(tmp_path)
     context = builder.build(MoralAction("network.publish"))
 
     assert context.permissions == ("external_effect",)
-    assert {entry["kind"] for entry in context.provenance} >= {"consequence", "affected_party"}
+    assert {entry["kind"] for entry in context.provenance} >= {
+        "consequence",
+        "affected_party",
+    }
     assert events[0]["event"] == "moral.context.constructed"
     assert events[0]["acceptable_alternative_conditions"]

--- a/tests/test_moral_decision.py
+++ b/tests/test_moral_decision.py
@@ -4,7 +4,14 @@ from singular.morals import MoralDecisionEngine
 def test_absolute_veto_for_rights_violation() -> None:
     decision = MoralDecisionEngine().evaluate(
         "publish_private_data",
-        [{"description": "privacy breach", "harm": 0.7, "violates_rights": True, "values": ("privacy",)}],
+        [
+            {
+                "description": "privacy breach",
+                "harm": 0.7,
+                "violates_rights": True,
+                "values": ("privacy",),
+            }
+        ],
         [{"identifier": "user", "vulnerability": 0.5}],
         [{"value": "privacy", "absolute": True}],
         0.1,
@@ -18,7 +25,11 @@ def test_conflict_between_two_values_is_made_explicit() -> None:
     decision = MoralDecisionEngine().evaluate(
         "tell_difficult_truth",
         [
-            {"description": "supports autonomy", "benefit": 0.8, "values": ("autonomy",)},
+            {
+                "description": "supports autonomy",
+                "benefit": 0.8,
+                "values": ("autonomy",),
+            },
             {"description": "causes distress", "harm": 0.3, "values": ("autonomy",)},
         ],
         identity_commitments=[{"value": "autonomy"}],
@@ -34,14 +45,22 @@ def test_high_uncertainty_reduces_score_and_requires_more_information() -> None:
     high = engine.evaluate("act", uncertainty=0.9)
 
     assert high.scores["overall"] < low.scores["overall"]
-    assert any("informations" in item for item in high.acceptable_alternative_conditions)
+    assert any(
+        "informations" in item for item in high.acceptable_alternative_conditions
+    )
 
 
 def test_selects_less_harmful_acceptable_alternative() -> None:
     selected, considered = MoralDecisionEngine().select_least_harmful(
         [
-            {"action": "force", "consequences": [{"description": "injury", "harm": 0.8}]},
-            {"action": "negotiate", "consequences": [{"description": "delay", "harm": 0.1, "benefit": 0.3}]},
+            {
+                "action": "force",
+                "consequences": [{"description": "injury", "harm": 0.8}],
+            },
+            {
+                "action": "negotiate",
+                "consequences": [{"description": "delay", "harm": 0.1, "benefit": 0.3}],
+            },
         ]
     )
 

--- a/tests/test_multi_life_help_integration.py
+++ b/tests/test_multi_life_help_integration.py
@@ -9,7 +9,9 @@ from singular.multiagent import (
 )
 
 
-def test_multi_life_help_improves_success_without_policy_violation(tmp_path: Path) -> None:
+def test_multi_life_help_improves_success_without_policy_violation(
+    tmp_path: Path,
+) -> None:
     requester_root = tmp_path / "life-a"
     helper_root = tmp_path / "life-b"
     requester_skills = requester_root / "skills"

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -79,9 +79,12 @@ def test_run_logger_canonicalizes_three_life_identifiers(tmp_path: Path) -> None
     for raw, expected in (("Ada", "ada"), ("BOB", "bob"), ("Eve Smith", "eve-smith")):
         with RunLogger(raw, root=tmp_path / raw / "runs", life_id=raw) as logger:
             logger.log_event("contradictory", summary=raw)
-        record = json.loads((tmp_path / raw / "runs" / raw / "events.jsonl").read_text().splitlines()[0])
+        record = json.loads(
+            (tmp_path / raw / "runs" / raw / "events.jsonl").read_text().splitlines()[0]
+        )
         assert record["life_id"] == expected
         assert record["payload"]["life_id"] == expected
+
 
 def test_multi_organism_events_and_dashboard(tmp_path: Path, monkeypatch) -> None:
     org1 = tmp_path / "org1" / "skills"
@@ -109,7 +112,9 @@ def test_multi_organism_events_and_dashboard(tmp_path: Path, monkeypatch) -> Non
     )
 
     log_file = next(runs_dir.glob("loop-*.jsonl"))
-    rows = [json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()]
+    rows = [
+        json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()
+    ]
     interactions = [row for row in rows if row.get("event") == "interaction"]
     assert any(
         row.get("interaction") == life_loop.INTERACTION_RESOURCE_COMPETITION

--- a/tests/test_multiagent_life_loop.py
+++ b/tests/test_multiagent_life_loop.py
@@ -32,7 +32,9 @@ def _governance_policy() -> MutationGovernancePolicy:
     )
 
 
-def test_runtime_requests_help_offers_skill_and_resolves_offer_conflict(tmp_path: Path) -> None:
+def test_runtime_requests_help_offers_skill_and_resolves_offer_conflict(
+    tmp_path: Path,
+) -> None:
     transport = InMemoryQueueTransport()
     runtime = MultiAgentRuntime(
         transport=transport,
@@ -60,7 +62,10 @@ def test_runtime_requests_help_offers_skill_and_resolves_offer_conflict(tmp_path
             peers=("alpha",),
         )
     )
-    assert [message.intent for message in beta_decision.emitted] == ["help.requested", "help.offered"]
+    assert [message.intent for message in beta_decision.emitted] == [
+        "help.requested",
+        "help.offered",
+    ]
 
     runtime.emit(
         TaskOffer(
@@ -91,11 +96,18 @@ def test_runtime_requests_help_offers_skill_and_resolves_offer_conflict(tmp_path
     assert "accepted_best_offer" in alpha_decision.reasons
 
 
-def test_runtime_records_conversation_and_versions_used_for_arbitration(tmp_path: Path) -> None:
+def test_runtime_records_conversation_and_versions_used_for_arbitration(
+    tmp_path: Path,
+) -> None:
     graph = SocialGraph(tmp_path / "social.json")
     graph.record_interaction(
-        "alpha", "beta", "promise", evidence_kind="other_statement",
-        intention="help", confidence=0.9, source="beta",
+        "alpha",
+        "beta",
+        "promise",
+        evidence_kind="other_statement",
+        intention="help",
+        confidence=0.9,
+        source="beta",
     )
     transport = InMemoryQueueTransport()
     runtime = MultiAgentRuntime(transport=transport, social_graph=graph)
@@ -103,23 +115,40 @@ def test_runtime_records_conversation_and_versions_used_for_arbitration(tmp_path
     skills.mkdir(parents=True)
     skill = skills / "solver.py"
     skill.write_text("result = 1\n", encoding="utf-8")
-    runtime.emit(TaskOffer(
-        helper_id="beta", receiver_id="alpha", task="task", skill="solver.py",
-        confidence=0.9, priority=3,
-    ).to_message())
+    runtime.emit(
+        TaskOffer(
+            helper_id="beta",
+            receiver_id="alpha",
+            task="task",
+            skill="solver.py",
+            confidence=0.9,
+            priority=3,
+        ).to_message()
+    )
 
-    decision = runtime.begin_tick(LifeTickContext(
-        life_id="alpha", task="task", skill_path=skill, skills_dir=skills,
-        score=1.0, confidence=0.1, governance_allowed=True,
-    ))
+    decision = runtime.begin_tick(
+        LifeTickContext(
+            life_id="alpha",
+            task="task",
+            skill_path=skill,
+            skills_dir=skills,
+            score=1.0,
+            confidence=0.1,
+            governance_allowed=True,
+        )
+    )
 
     assert decision.mental_models_used["beta"]["version"] == 1
-    evidence = SocialGraph(tmp_path / "social.json").get_mental_state("beta")["evidence"]
+    evidence = SocialGraph(tmp_path / "social.json").get_mental_state("beta")[
+        "evidence"
+    ]
     assert evidence[-1]["evidence_kind"] == "other_statement"
     assert evidence[-1]["event"] == "promise"
 
 
-def test_runtime_refuses_and_gates_when_governance_or_rivalry_is_high(tmp_path: Path) -> None:
+def test_runtime_refuses_and_gates_when_governance_or_rivalry_is_high(
+    tmp_path: Path,
+) -> None:
     transport = InMemoryQueueTransport()
     runtime = MultiAgentRuntime(transport=transport)
     skills_dir = tmp_path / "alpha" / "skills"
@@ -146,7 +175,9 @@ def test_runtime_refuses_and_gates_when_governance_or_rivalry_is_high(tmp_path: 
     assert [message.intent for message in decision.emitted] == ["help.refused"]
 
 
-def test_life_loop_consults_multiagent_runtime_during_tick(tmp_path: Path, monkeypatch) -> None:
+def test_life_loop_consults_multiagent_runtime_during_tick(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
     alpha_skills = tmp_path / "alpha" / "skills"
     beta_skills = tmp_path / "beta" / "skills"
@@ -158,7 +189,9 @@ def test_life_loop_consults_multiagent_runtime_during_tick(tmp_path: Path, monke
     transport = InMemoryQueueTransport()
     runtime = MultiAgentRuntime(
         transport=transport,
-        policy=MultiAgentPolicy(low_score_threshold=1.0, high_confidence_threshold=0.99),
+        policy=MultiAgentPolicy(
+            low_score_threshold=1.0, high_confidence_threshold=0.99
+        ),
         governance_policy=_governance_policy(),
     )
     world = WorldState()

--- a/tests/test_multiagent_protocol.py
+++ b/tests/test_multiagent_protocol.py
@@ -33,7 +33,9 @@ def _send_messages_worker(path: str, start: int, count: int) -> None:
         )
 
 
-def _append_collective_worker(root: str, namespace: str, start: int, count: int) -> None:
+def _append_collective_worker(
+    root: str, namespace: str, start: int, count: int
+) -> None:
     memory = CollectiveMemory(Path(root), namespace)
     for idx in range(start, start + count):
         memory.append({"kind": "mp", "id": idx})
@@ -334,7 +336,9 @@ def test_atomic_write_text_flushes_and_fsyncs_and_creates_parent(
         unlink_calls.append(path)
         raise FileNotFoundError
 
-    monkeypatch.setattr(protocol_module.tempfile, "NamedTemporaryFile", _fake_named_tempfile)
+    monkeypatch.setattr(
+        protocol_module.tempfile, "NamedTemporaryFile", _fake_named_tempfile
+    )
     monkeypatch.setattr(protocol_module.os, "fsync", fsync_mock)
     monkeypatch.setattr(protocol_module.os, "replace", replace_mock)
     monkeypatch.setattr(protocol_module.os, "unlink", _fake_unlink)

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -59,7 +59,9 @@ def test_intrinsic_goals_boost_robustesse_when_tech_debt_rises(tmp_path) -> None
     assert with_debt_rise.robustesse > without_debt_rise.robustesse
 
 
-def test_intrinsic_goals_adjust_coherence_and_efficacite_from_user_friction(tmp_path) -> None:
+def test_intrinsic_goals_adjust_coherence_and_efficacite_from_user_friction(
+    tmp_path,
+) -> None:
     goals = IntrinsicGoals(path=tmp_path / "goals.json")
     psyche = Psyche()
 
@@ -100,7 +102,11 @@ def test_intrinsic_goals_uses_skill_reputation_telemetry(tmp_path) -> None:
         resources={"energy": 80.0, "food": 80.0, "warmth": 80.0},
         perception_signals={
             "skill_reputation": {
-                "skill_a": {"mean_cost": 180.0, "mean_quality": 0.25, "recent_failures": 4},
+                "skill_a": {
+                    "mean_cost": 180.0,
+                    "mean_quality": 0.25,
+                    "recent_failures": 4,
+                },
             }
         },
     )
@@ -150,7 +156,9 @@ def test_intrinsic_goals_account_for_host_environment_pressure(tmp_path) -> None
     assert high_pressure.efficacite < low_pressure.efficacite
 
 
-def test_intrinsic_goals_strategy_turns_cautious_on_repeated_negative_feedback(tmp_path) -> None:
+def test_intrinsic_goals_strategy_turns_cautious_on_repeated_negative_feedback(
+    tmp_path,
+) -> None:
     goals = IntrinsicGoals(path=tmp_path / "goals.json")
     strategy = goals.derive_execution_strategy(
         {
@@ -177,7 +185,12 @@ def test_intrinsic_goals_adjust_routine_priorities_from_urgency(tmp_path) -> Non
         ],
         perception_signals={
             "episode_memory": {
-                "structured_feedback": {"frustration": 0.2, "satisfaction": 0.2, "urgency": 0.8, "theme": "support"}
+                "structured_feedback": {
+                    "frustration": 0.2,
+                    "satisfaction": 0.2,
+                    "urgency": 0.8,
+                    "theme": "support",
+                }
             }
         },
     )
@@ -215,7 +228,10 @@ def test_intrinsic_goals_modulates_weights_from_narrative_and_history(tmp_path) 
 
     assert modulated.robustesse > baseline.robustesse
     assert modulated.exploration < baseline.exploration
-    assert goals.history()[-1]["signals"]["intrinsic_modulation_version"] == "intrinsic-mod-v2"
+    assert (
+        goals.history()[-1]["signals"]["intrinsic_modulation_version"]
+        == "intrinsic-mod-v2"
+    )
 
 
 def test_intrinsic_goals_strategy_applies_repeated_failure_penalty(tmp_path) -> None:
@@ -223,7 +239,12 @@ def test_intrinsic_goals_strategy_applies_repeated_failure_penalty(tmp_path) -> 
     strategy = goals.derive_execution_strategy(
         {
             "episode_memory": {
-                "structured_feedback": {"frustration": 0.2, "satisfaction": 0.8, "urgency": 0.4, "theme": "general"}
+                "structured_feedback": {
+                    "frustration": 0.2,
+                    "satisfaction": 0.8,
+                    "urgency": 0.4,
+                    "theme": "general",
+                }
             },
             "narrative_indicators": {"risk_aversion_by_action_family": {"exec": 0.2}},
             "execution_history": {"repeated_failure_pressure": 0.8},
@@ -243,14 +264,26 @@ def test_intrinsic_goals_raise_robustesse_under_eco_relational_debt(tmp_path) ->
         tick=1,
         psyche=psyche,
         health_score=82.0,
-        resources={"energy": 82.0, "food": 82.0, "warmth": 82.0, "ecological_debt": 0.0, "relational_debt": 0.0},
+        resources={
+            "energy": 82.0,
+            "food": 82.0,
+            "warmth": 82.0,
+            "ecological_debt": 0.0,
+            "relational_debt": 0.0,
+        },
         perception_signals={},
     )
     pressured = goals.update_tick(
         tick=2,
         psyche=psyche,
         health_score=82.0,
-        resources={"energy": 82.0, "food": 82.0, "warmth": 82.0, "ecological_debt": 70.0, "relational_debt": 65.0},
+        resources={
+            "energy": 82.0,
+            "food": 82.0,
+            "warmth": 82.0,
+            "ecological_debt": 70.0,
+            "relational_debt": 65.0,
+        },
         perception_signals={
             "world_events": [
                 {"type": "world.delayed.crisis", "data": {"risk": 0.7}},

--- a/tests/test_orchestrator_service_targeted.py
+++ b/tests/test_orchestrator_service_targeted.py
@@ -6,14 +6,24 @@ from datetime import datetime, timezone
 
 from singular.events import EventBus, HELP_REQUESTED
 from singular.orchestrator import service as orchestrator_service
-from singular.orchestrator.service import LifecyclePhase, OrchestratorConfig, OrchestratorService, SchedulerConfig
+from singular.orchestrator.service import (
+    LifecyclePhase,
+    OrchestratorConfig,
+    OrchestratorService,
+    SchedulerConfig,
+)
 from singular.skills.runtime import SkillExecutionResult
 
 
 def _service(root, *, bus=None, dry_run=True, **config_kwargs) -> OrchestratorService:
     return OrchestratorService(
         config=OrchestratorConfig(
-            scheduler=SchedulerConfig(veille_seconds=0.01, action_seconds=0.01, introspection_seconds=0.01, sommeil_seconds=0.01),
+            scheduler=SchedulerConfig(
+                veille_seconds=0.01,
+                action_seconds=0.01,
+                introspection_seconds=0.01,
+                sommeil_seconds=0.01,
+            ),
             poll_interval_seconds=0.01,
             tick_budget_seconds=0.05,
             mutation_window_seconds=0.05,
@@ -46,11 +56,15 @@ def test_runtime_adaptation_prudent_mode_and_skip_action(temp_life) -> None:
 def test_startup_stop_signal_is_honored_without_tick(temp_life, monkeypatch) -> None:
     service = _service(temp_life["root"])
     service.stop_signal_path.write_text(
-        json.dumps({"reason": "test", "requested_at": datetime.now(timezone.utc).isoformat()}),
+        json.dumps(
+            {"reason": "test", "requested_at": datetime.now(timezone.utc).isoformat()}
+        ),
         encoding="utf-8",
     )
     called = {"tick": 0}
-    monkeypatch.setattr(service, "tick", lambda: called.__setitem__("tick", called["tick"] + 1))
+    monkeypatch.setattr(
+        service, "tick", lambda: called.__setitem__("tick", called["tick"] + 1)
+    )
 
     service.run_forever()
 
@@ -59,7 +73,11 @@ def test_startup_stop_signal_is_honored_without_tick(temp_life, monkeypatch) -> 
 
 
 def test_transient_tick_errors_backoff_then_continue(temp_life, monkeypatch) -> None:
-    service = _service(temp_life["root"], max_consecutive_tick_failures=3, tick_failure_backoff_seconds=0.01)
+    service = _service(
+        temp_life["root"],
+        max_consecutive_tick_failures=3,
+        tick_failure_backoff_seconds=0.01,
+    )
     calls = {"tick": 0, "sleep": 0}
 
     def flaky_tick():
@@ -70,7 +88,11 @@ def test_transient_tick_errors_backoff_then_continue(temp_life, monkeypatch) -> 
         return LifecyclePhase.ACTION
 
     monkeypatch.setattr(service, "tick", flaky_tick)
-    monkeypatch.setattr(orchestrator_service.time, "sleep", lambda _seconds: calls.__setitem__("sleep", calls["sleep"] + 1))
+    monkeypatch.setattr(
+        orchestrator_service.time,
+        "sleep",
+        lambda _seconds: calls.__setitem__("sleep", calls["sleep"] + 1),
+    )
 
     service.run_forever()
 
@@ -80,7 +102,9 @@ def test_transient_tick_errors_backoff_then_continue(temp_life, monkeypatch) -> 
 
 def test_veille_phase_triggers_quests(temp_life, monkeypatch) -> None:
     service = _service(temp_life["root"])
-    monkeypatch.setattr(orchestrator_service, "capture_signals", lambda bus=None: {"novelty": 1.0})
+    monkeypatch.setattr(
+        orchestrator_service, "capture_signals", lambda bus=None: {"novelty": 1.0}
+    )
     triggered: list[dict[str, object]] = []
 
     def fake_evaluate(signals):
@@ -92,7 +116,10 @@ def test_veille_phase_triggers_quests(temp_life, monkeypatch) -> None:
     service._run_phase(LifecyclePhase.VEILLE)
 
     assert triggered == [{"novelty": 1.0}]
-    assert service.state.last_events[-1]["details"]["quests_triggered"][0]["quest_id"] == "q1"
+    assert (
+        service.state.last_events[-1]["details"]["quests_triggered"][0]["quest_id"]
+        == "q1"
+    )
 
 
 @dataclass
@@ -102,17 +129,35 @@ class _RoutineSpec:
     priority: int
 
 
-def test_action_phase_orchestrates_skill_routines_and_life_tick(temp_life, monkeypatch) -> None:
+def test_action_phase_orchestrates_skill_routines_and_life_tick(
+    temp_life, monkeypatch
+) -> None:
     service = _service(temp_life["root"], dry_run=False)
-    service._latest_signals = {"host_metrics": {"cpu_percent": 10.0, "ram_used_percent": 10.0, "host_temperature_c": 20.0}}
+    service._latest_signals = {
+        "host_metrics": {
+            "cpu_percent": 10.0,
+            "ram_used_percent": 10.0,
+            "host_temperature_c": 20.0,
+        }
+    }
     service.routines.specs = [_RoutineSpec("routine", "do", 1)]
     service.goals.derive_execution_strategy = lambda signals: {"mode": "explore"}
     service.goals.adjust_routine_priorities = lambda specs, perception_signals: specs
-    service.skill_runtime.execute_best_skill = lambda task, context: SkillExecutionResult("skill", "succeeded", score=1.0)
-    service.routines.execute_with_runtime = lambda skill_runtime, base_context, priority_overrides: [{"id": "routine", "status": "done"}]
-    service.quest_runtime.settle_active = lambda **kwargs: [{"quest_id": "q1", "status": "settled"}]
+    service.skill_runtime.execute_best_skill = (
+        lambda task, context: SkillExecutionResult("skill", "succeeded", score=1.0)
+    )
+    service.routines.execute_with_runtime = (
+        lambda skill_runtime, base_context, priority_overrides: [
+            {"id": "routine", "status": "done"}
+        ]
+    )
+    service.quest_runtime.settle_active = lambda **kwargs: [
+        {"quest_id": "q1", "status": "settled"}
+    ]
     calls: list[dict[str, object]] = []
-    monkeypatch.setattr(orchestrator_service, "run_tick", lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr(
+        orchestrator_service, "run_tick", lambda **kwargs: calls.append(kwargs)
+    )
 
     service._run_phase(LifecyclePhase.ACTION)
 
@@ -129,10 +174,16 @@ def test_repeated_action_failures_publish_help_request(temp_life) -> None:
     events = []
     bus.subscribe(HELP_REQUESTED, lambda event: events.append(event))
     service = _service(temp_life["root"], bus=bus, help_request_failure_threshold=2)
-    failed = SkillExecutionResult(skill="missing", status="failed", reason="no_compatible_skill")
+    failed = SkillExecutionResult(
+        skill="missing", status="failed", reason="no_compatible_skill"
+    )
 
-    service._track_action_failure_and_request_help(task_name="orchestrator.action", skill_execution=failed)
-    service._track_action_failure_and_request_help(task_name="orchestrator.action", skill_execution=failed)
+    service._track_action_failure_and_request_help(
+        task_name="orchestrator.action", skill_execution=failed
+    )
+    service._track_action_failure_and_request_help(
+        task_name="orchestrator.action", skill_execution=failed
+    )
 
     assert len(events) == 1
     assert events[0].payload["task"] == "orchestrator.action"

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 import pytest
 
-from singular.psyche import Psyche, Mood, TraitEvolutionPolicy, choose_action_from_psyche
+from singular.psyche import (
+    Psyche,
+    Mood,
+    TraitEvolutionPolicy,
+    choose_action_from_psyche,
+)
 from singular.resource_manager import ResourceManager
 from singular.motivation import GoalPolicy, Objective
 
@@ -77,7 +82,12 @@ def test_state_persistence(tmp_path: Path) -> None:
 
 def test_trait_evolution_is_bounded_rate_limited_and_explained() -> None:
     psyche = Psyche(evolution_policy=TraitEvolutionPolicy(max_delta=0.05))
-    assert psyche.evolve_traits({"curiosity": 0.4}, cause="observations", evidence=["a", "b"]) == "applied"
+    assert (
+        psyche.evolve_traits(
+            {"curiosity": 0.4}, cause="observations", evidence=["a", "b"]
+        )
+        == "applied"
+    )
     assert psyche.curiosity == pytest.approx(0.55)
     assert psyche.trait_history[-1]["cause"] == "observations"
     assert psyche.trait_history[-1]["before"]["curiosity"] == 0.5
@@ -89,12 +99,15 @@ def test_cumulative_correlated_structural_collapse_restores_and_freezes() -> Non
     for index in range(2):
         status = psyche.evolve_traits(
             {"patience": -0.1, "optimism": -0.1, "resilience": -0.1},
-            cause=f"stress-{index}", evidence=["sensor-a", "sensor-b"],
+            cause=f"stress-{index}",
+            evidence=["sensor-a", "sensor-b"],
         )
     assert status == "review"
     assert psyche.trait_snapshot() == initial
     assert psyche.evolution_reviews[-1]["status"] == "restored"
-    assert psyche.evolve_traits({"curiosity": 0.05}, cause="next", evidence=[]) == "frozen"
+    assert (
+        psyche.evolve_traits({"curiosity": 0.05}, cause="next", evidence=[]) == "frozen"
+    )
 
 
 def test_resource_manager_influences_mood(tmp_path: Path) -> None:
@@ -125,7 +138,9 @@ def test_objective_policy_persistence_and_schema(tmp_path: Path) -> None:
                 weight=0.7,
                 parent=None,
                 horizon_ticks=4,
-                policy=GoalPolicy(besoin=0.9, priorite=0.8, urgence=1.0, alignement_valeurs=0.7),
+                policy=GoalPolicy(
+                    besoin=0.9, priorite=0.8, urgence=1.0, alignement_valeurs=0.7
+                ),
             )
         }
     )
@@ -145,14 +160,18 @@ def test_weighted_axes_and_operator_bias() -> None:
             "root": Objective(
                 "root",
                 weight=1.0,
-                policy=GoalPolicy(besoin=0.6, priorite=0.9, urgence=0.2, alignement_valeurs=0.9),
+                policy=GoalPolicy(
+                    besoin=0.6, priorite=0.9, urgence=0.2, alignement_valeurs=0.9
+                ),
             ),
             "urgent": Objective(
                 "urgent",
                 weight=0.5,
                 parent="root",
                 horizon_ticks=3,
-                policy=GoalPolicy(besoin=0.9, priorite=0.5, urgence=1.0, alignement_valeurs=0.4),
+                policy=GoalPolicy(
+                    besoin=0.9, priorite=0.5, urgence=1.0, alignement_valeurs=0.4
+                ),
             ),
         }
     )
@@ -208,7 +227,14 @@ def test_social_state_bounds_are_stable() -> None:
 @pytest.mark.parametrize(
     ("mood", "energy", "signals", "social_states", "expected_action", "reason_text"),
     [
-        (Mood.FATIGUE, 12.0, {"resource_energy": 12.0}, {}, "rest", "fatigue_or_low_energy"),
+        (
+            Mood.FATIGUE,
+            12.0,
+            {"resource_energy": 12.0},
+            {},
+            "rest",
+            "fatigue_or_low_energy",
+        ),
         (Mood.CURIOUS, 80.0, {"opportunity": 0.9}, {}, "move", "curiosity"),
         (Mood.ANGER, 70.0, {"competition_pressure": 0.8}, {}, "compete", "anger"),
         (

--- a/tests/test_quests_runtime.py
+++ b/tests/test_quests_runtime.py
@@ -41,7 +41,9 @@ def _write_quest(path: Path, *, name: str = "q-arb") -> None:
     )
 
 
-def test_objective_arbitration_pauses_then_resumes_and_tracks_history(tmp_path: Path) -> None:
+def test_objective_arbitration_pauses_then_resumes_and_tracks_history(
+    tmp_path: Path,
+) -> None:
     quests_dir = tmp_path / "quests"
     mem_dir = tmp_path / "mem"
     quests_dir.mkdir()
@@ -54,7 +56,9 @@ def test_objective_arbitration_pauses_then_resumes_and_tracks_history(tmp_path: 
     assert len(runtime.state.active) == 1
 
     psyche = DummyPsyche()
-    resources = ResourceManager(path=tmp_path / "resources.json", energy=10, food=10, warmth=10)
+    resources = ResourceManager(
+        path=tmp_path / "resources.json", energy=10, food=10, warmth=10
+    )
     outcome = runtime.settle_active(
         psyche=psyche,
         resource_manager=resources,
@@ -83,7 +87,9 @@ def test_objective_arbitration_pauses_then_resumes_and_tracks_history(tmp_path: 
     assert "active" in transitions
 
 
-def test_objective_arbitration_can_abandon_after_repeated_pressure(tmp_path: Path) -> None:
+def test_objective_arbitration_can_abandon_after_repeated_pressure(
+    tmp_path: Path,
+) -> None:
     quests_dir = tmp_path / "quests"
     mem_dir = tmp_path / "mem"
     quests_dir.mkdir()
@@ -93,16 +99,43 @@ def test_objective_arbitration_can_abandon_after_repeated_pressure(tmp_path: Pat
     runtime = QuestRuntime(base_dir=tmp_path, mem_dir=mem_dir)
     runtime.evaluate_triggers({"external_pressure": 0.8})
     psyche = DummyPsyche()
-    resources = ResourceManager(path=tmp_path / "resources.json", energy=12, food=12, warmth=12)
+    resources = ResourceManager(
+        path=tmp_path / "resources.json", energy=12, food=12, warmth=12
+    )
 
     record = runtime.state.active[0]
     record.history.extend(
         [
-            {"at": "2026-01-01T00:00:00+00:00", "from": "active", "to": "paused", "reason": "prior_pressure"},
-            {"at": "2026-01-01T00:01:00+00:00", "from": "paused", "to": "active", "reason": "prior_recovery"},
-            {"at": "2026-01-01T00:02:00+00:00", "from": "active", "to": "paused", "reason": "prior_pressure"},
-            {"at": "2026-01-01T00:03:00+00:00", "from": "paused", "to": "active", "reason": "prior_recovery"},
-            {"at": "2026-01-01T00:04:00+00:00", "from": "active", "to": "paused", "reason": "prior_pressure"},
+            {
+                "at": "2026-01-01T00:00:00+00:00",
+                "from": "active",
+                "to": "paused",
+                "reason": "prior_pressure",
+            },
+            {
+                "at": "2026-01-01T00:01:00+00:00",
+                "from": "paused",
+                "to": "active",
+                "reason": "prior_recovery",
+            },
+            {
+                "at": "2026-01-01T00:02:00+00:00",
+                "from": "active",
+                "to": "paused",
+                "reason": "prior_pressure",
+            },
+            {
+                "at": "2026-01-01T00:03:00+00:00",
+                "from": "paused",
+                "to": "active",
+                "reason": "prior_recovery",
+            },
+            {
+                "at": "2026-01-01T00:04:00+00:00",
+                "from": "active",
+                "to": "paused",
+                "reason": "prior_pressure",
+            },
         ]
     )
 
@@ -114,6 +147,11 @@ def test_objective_arbitration_can_abandon_after_repeated_pressure(tmp_path: Pat
     )
     assert outcome["abandoned"] == ["q-arb"]
     assert any(item.status == "abandoned" for item in runtime.state.completed)
-    abandoned = next(item for item in runtime.state.completed if item.status == "abandoned")
+    abandoned = next(
+        item for item in runtime.state.completed if item.status == "abandoned"
+    )
     assert abandoned.history[-1]["to"] == "abandoned"
-    assert abandoned.history[-1]["reason"] == "objective_arbitration_high_emotional_cost_or_risk"
+    assert (
+        abandoned.history[-1]["reason"]
+        == "objective_arbitration_high_emotional_cost_or_risk"
+    )

--- a/tests/test_replay_session.py
+++ b/tests/test_replay_session.py
@@ -13,7 +13,9 @@ def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
             file.write(json.dumps(row) + "\n")
 
 
-def test_replay_session_returns_zero_when_lineage_is_consistent(tmp_path: Path, capsys) -> None:
+def test_replay_session_returns_zero_when_lineage_is_consistent(
+    tmp_path: Path, capsys
+) -> None:
     log_path = tmp_path / "audit.jsonl"
     _write_jsonl(
         log_path,
@@ -83,4 +85,3 @@ def test_replay_session_detects_missing_result(tmp_path: Path) -> None:
 
     code = main([str(log_path), "--session-id", "s1"])
     assert code == 3
-

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -476,7 +476,9 @@ def test_report_supports_subcommand_format_option(monkeypatch, tmp_path, capsys)
     assert payload["context"]["run_id"] == "run-json"
 
 
-def test_report_json_payload_contains_stabilized_life_verdict(monkeypatch, tmp_path, capsys):
+def test_report_json_payload_contains_stabilized_life_verdict(
+    monkeypatch, tmp_path, capsys
+):
     monkeypatch.chdir(tmp_path)
     _patch_life_status(
         monkeypatch,
@@ -512,7 +514,9 @@ def test_report_json_payload_contains_stabilized_life_verdict(monkeypatch, tmp_p
     }
 
 
-def test_report_markdown_contains_stabilized_life_verdict(monkeypatch, tmp_path, capsys):
+def test_report_markdown_contains_stabilized_life_verdict(
+    monkeypatch, tmp_path, capsys
+):
     monkeypatch.chdir(tmp_path)
     _patch_life_status(
         monkeypatch,

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -68,7 +68,9 @@ def _create_runs_fixture(root: Path, now: datetime) -> dict[str, Path]:
         }
         for index in range(120)
     ]
-    episodic.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    episodic.write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
 
     return {
         "runs": runs,
@@ -98,7 +100,9 @@ def test_retention_purge_by_quantity(tmp_path: Path) -> None:
     assert fixture["old"].exists()
     assert not fixture["ancient"].exists()
     assert fixture["active_old"].exists()
-    assert any(d.run_id == "run-ancient" and d.reason == "max_runs" for d in report.decisions)
+    assert any(
+        d.run_id == "run-ancient" and d.reason == "max_runs" for d in report.decisions
+    )
 
 
 def test_retention_purge_by_age(tmp_path: Path) -> None:
@@ -118,7 +122,10 @@ def test_retention_purge_by_age(tmp_path: Path) -> None:
     assert fixture["old"].exists()
     assert not fixture["ancient"].exists()
     assert fixture["active_old"].exists()
-    assert any(d.run_id == "run-ancient" and d.reason == "max_run_age_days" for d in report.decisions)
+    assert any(
+        d.run_id == "run-ancient" and d.reason == "max_run_age_days"
+        for d in report.decisions
+    )
 
 
 def test_retention_purge_by_size_budget(tmp_path: Path) -> None:
@@ -221,7 +228,9 @@ def test_retention_is_idempotent_across_two_runs(tmp_path: Path, monkeypatch) ->
 def test_retention_dry_run_has_no_side_effects(tmp_path: Path, monkeypatch) -> None:
     now = datetime(2026, 4, 15, tzinfo=timezone.utc)
     fixture = _create_runs_fixture(tmp_path, now)
-    before_listing = sorted(str(path.relative_to(tmp_path)) for path in tmp_path.rglob("*"))
+    before_listing = sorted(
+        str(path.relative_to(tmp_path)) for path in tmp_path.rglob("*")
+    )
     before_runs_size = _tree_size_bytes(fixture["runs"])
 
     monkeypatch.setenv("SINGULAR_RETENTION_MAX_RUNS", "1")
@@ -233,7 +242,9 @@ def test_retention_dry_run_has_no_side_effects(tmp_path: Path, monkeypatch) -> N
         enforce_minimum_interval=False,
     )
 
-    after_listing = sorted(str(path.relative_to(tmp_path)) for path in tmp_path.rglob("*"))
+    after_listing = sorted(
+        str(path.relative_to(tmp_path)) for path in tmp_path.rglob("*")
+    )
     after_runs_size = _tree_size_bytes(fixture["runs"])
 
     assert outcome.executed is True

--- a/tests/test_run_logger_double.py
+++ b/tests/test_run_logger_double.py
@@ -21,7 +21,9 @@ def test_recording_run_logger_implements_life_loop_contract():
     }
 
     assert logger.run_id == "contract-run"
-    assert all(callable(getattr(logger, method, None)) for method in methods_used_by_life_loop)
+    assert all(
+        callable(getattr(logger, method, None)) for method in methods_used_by_life_loop
+    )
     assert logger.__enter__() is logger
     assert logger.__exit__(None, None, None) is False
 

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -20,9 +20,7 @@ def test_default_root_uses_singular_home_at_construction_time(
     assert (home / "runs" / "late-home").is_dir()
 
 
-def test_default_root_follows_two_successive_lives(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_default_root_follows_two_successive_lives(tmp_path: Path, monkeypatch) -> None:
     homes = [tmp_path / "life-a", tmp_path / "life-b"]
 
     for index, home in enumerate(homes):

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -248,21 +248,19 @@ def test_refuses_missing_container_runtime(monkeypatch):
     monkeypatch.setattr(sandbox.shutil, "which", lambda _name: None)
     with pytest.raises(SandboxError, match="podman or docker"):
         run("result = 1")
+
+
 def test_path_resolution_distinguishes_broken_link_and_internal_denial(tmp_path):
     allowed = tmp_path / "skills"
     allowed.mkdir()
     broken = allowed / "broken.py"
     broken.symlink_to(tmp_path / "absent-target.py")
 
-    unresolved = classify_source_sandbox_path(
-        broken, (allowed,), sandbox_root=tmp_path
-    )
+    unresolved = classify_source_sandbox_path(broken, (allowed,), sandbox_root=tmp_path)
     internal = tmp_path / "private" / "artifact.py"
     internal.parent.mkdir()
     internal.write_text("result = 1\n")
-    denied = classify_source_sandbox_path(
-        internal, (allowed,), sandbox_root=tmp_path
-    )
+    denied = classify_source_sandbox_path(internal, (allowed,), sandbox_root=tmp_path)
 
     assert unresolved.category == "unresolved_path"
     assert denied.category == "unauthorized_internal_path"

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -14,11 +14,20 @@ pytestmark = pytest.mark.usefixtures("local_sandbox")
 
 
 def test_technical_gain_is_rejected_when_it_destroys_health():
-    weights = {name: 0.0 for name in (
-        "functional_gain", "health", "vital_risk", "resources",
-        "sandbox_stability", "cost", "quest_progress", "identity_continuity",
-        "useful_skills_retention",
-    )}
+    weights = {
+        name: 0.0
+        for name in (
+            "functional_gain",
+            "health",
+            "vital_risk",
+            "resources",
+            "sandbox_stability",
+            "cost",
+            "quest_progress",
+            "identity_continuity",
+            "useful_skills_retention",
+        )
+    }
     weights.update(functional_gain=0.3, health=0.18, vital_risk=-0.18)
     config = LifecycleFitnessConfig(weights, 2, 0.0, 0.15)
     decision = evaluate_mutation_fitness(

--- a/tests/test_self_narrative.py
+++ b/tests/test_self_narrative.py
@@ -30,18 +30,31 @@ def test_load_creates_default_file_when_missing(tmp_path: Path) -> None:
     }
 
 
-def test_contaminated_timeline_rebuilds_ada_bob_and_eve_separately(tmp_path: Path) -> None:
+def test_contaminated_timeline_rebuilds_ada_bob_and_eve_separately(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "shared.json"
     for life, claim in (("Ada", "succès"), ("Bob", "échec"), ("Eve", "incident")):
         own = tmp_path / f"{life}.json"
-        project_event({"event_type": "incident", "event_id": life, "summary": claim}, own, life_id=life)
-        with path.with_name("shared.timeline.jsonl").open("a", encoding="utf-8") as target:
-            target.write(own.with_name(f"{life}.timeline.jsonl").read_text(encoding="utf-8"))
+        project_event(
+            {"event_type": "incident", "event_id": life, "summary": claim},
+            own,
+            life_id=life,
+        )
+        with path.with_name("shared.timeline.jsonl").open(
+            "a", encoding="utf-8"
+        ) as target:
+            target.write(
+                own.with_name(f"{life}.timeline.jsonl").read_text(encoding="utf-8")
+            )
 
     report = diagnose_timeline(path)
     assert report["contaminated"] is True
     assert set(report["lives"]) == {"ada", "bob", "eve"}
-    rebuilt = {life: rebuild_from_timeline(path, life_id=life, persist=False) for life in report["lives"]}
+    rebuilt = {
+        life: rebuild_from_timeline(path, life_id=life, persist=False)
+        for life in report["lives"]
+    }
     assert {entry.summary for entry in rebuilt["ada"].entries} == {"succès"}
     assert {entry.summary for entry in rebuilt["bob"].entries} == {"échec"}
     assert {entry.summary for entry in rebuilt["eve"].entries} == {"incident"}

--- a/tests/test_skill_quarantine.py
+++ b/tests/test_skill_quarantine.py
@@ -104,7 +104,11 @@ def test_valid_skill_is_not_quarantined_after_sandbox_timeouts(
     )
 
     skills_file = tmp_path / "mem" / "skills.json"
-    skills = json.loads(skills_file.read_text(encoding="utf-8")) if skills_file.exists() else {}
+    skills = (
+        json.loads(skills_file.read_text(encoding="utf-8"))
+        if skills_file.exists()
+        else {}
+    )
     lifecycle = skills.get("valid", {}).get("lifecycle", {})
     assert lifecycle.get("state") != "temporarily_disabled"
 
@@ -122,7 +126,8 @@ def test_valid_skill_is_not_quarantined_after_sandbox_timeouts(
         event
         for event in events
         if event.get("event_type") == "interaction"
-        and event.get("payload", {}).get("interaction") == "sandbox_infrastructure_failure"
+        and event.get("payload", {}).get("interaction")
+        == "sandbox_infrastructure_failure"
     ]
     assert len(infrastructure_events) >= 3
     assert all(

--- a/tests/test_state_model.py
+++ b/tests/test_state_model.py
@@ -4,7 +4,9 @@ from singular.mind.state_model import PerceivedEvent, StateModel, UserFeedback
 def test_state_model_event_updates_are_bounded() -> None:
     state = StateModel(humeur=0.5, energie=0.5, confiance=0.5, charge_cognitive=0.2)
 
-    event = PerceivedEvent(valence=1.0, intensity=1.0, cognitive_load=0.9, energy_delta=-0.8)
+    event = PerceivedEvent(
+        valence=1.0, intensity=1.0, cognitive_load=0.9, energy_delta=-0.8
+    )
     state.update_from_event(event)
 
     snap = state.snapshot()
@@ -15,7 +17,9 @@ def test_state_model_event_updates_are_bounded() -> None:
 def test_user_feedback_lowers_cognitive_load_when_clear() -> None:
     state = StateModel(charge_cognitive=0.7)
 
-    state.update_from_user_feedback(UserFeedback(sentiment=0.2, clarity=1.0, trust_signal=0.1))
+    state.update_from_user_feedback(
+        UserFeedback(sentiment=0.2, clarity=1.0, trust_signal=0.1)
+    )
 
     assert state.charge_cognitive < 0.7
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -129,7 +129,12 @@ def test_status_filters_non_mutation_records_for_success_rate(
     assert payload["mutation_success_rate"] == 50.0
     assert payload["success_rate"] == 50.0
     assert payload["vital_timeline"]["age"] == 3
-    assert payload["vital_timeline"]["state"] in {"mature", "declining", "terminal", "extinct"}
+    assert payload["vital_timeline"]["state"] in {
+        "mature",
+        "declining",
+        "terminal",
+        "extinct",
+    }
     assert payload["life_status"]["status"] == "fragile"
     assert payload["life_status"]["score"] == 0.42
     assert set(payload["life_status"]) == {
@@ -195,9 +200,28 @@ def test_status_exposes_quest_counts(tmp_path, monkeypatch, capsys) -> None:
     (mem_dir / "quests_state.json").write_text(
         json.dumps(
             {
-                "active": [{"name": "q1", "status": "active", "started_at": "2026-01-01T00:00:00+00:00"}],
-                "paused": [{"name": "q2", "status": "paused", "started_at": "2026-01-01T00:00:00+00:00"}],
-                "completed": [{"name": "q0", "status": "success", "started_at": "2026-01-01T00:00:00+00:00", "completed_at": "2026-01-01T00:01:00+00:00"}],
+                "active": [
+                    {
+                        "name": "q1",
+                        "status": "active",
+                        "started_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+                "paused": [
+                    {
+                        "name": "q2",
+                        "status": "paused",
+                        "started_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ],
+                "completed": [
+                    {
+                        "name": "q0",
+                        "status": "success",
+                        "started_at": "2026-01-01T00:00:00+00:00",
+                        "completed_at": "2026-01-01T00:01:00+00:00",
+                    }
+                ],
             }
         ),
         encoding="utf-8",
@@ -273,7 +297,10 @@ def test_status_exposes_trajectory_priority_and_narrative_links(
     assert payload["trajectory"]["priority_changes"]
     assert payload["trajectory"]["priority_changes"][0]["objective"] == "coherence"
     assert payload["trajectory"]["objective_narrative_links"]
-    assert payload["trajectory"]["objective_narrative_links"][0]["objective"] == "coherence"
+    assert (
+        payload["trajectory"]["objective_narrative_links"][0]["objective"]
+        == "coherence"
+    )
 
 
 def test_status_exposes_skill_lifecycle_counts(tmp_path, monkeypatch, capsys) -> None:

--- a/tests/test_values_schema.py
+++ b/tests/test_values_schema.py
@@ -125,7 +125,9 @@ def test_internal_policy_denials_do_not_open_global_breaker(tmp_path: Path) -> N
     assert decision.allowed is True
 
 
-def test_incident_scopes_only_allow_global_escape_to_open_breaker(tmp_path: Path) -> None:
+def test_incident_scopes_only_allow_global_escape_to_open_breaker(
+    tmp_path: Path,
+) -> None:
     policy = MutationGovernancePolicy(
         circuit_breaker_category_thresholds={"confirmed_root_escape": 1},
         circuit_state_file=tmp_path / "mem" / "governance_circuit.json",

--- a/tests/test_vital_transitions.py
+++ b/tests/test_vital_transitions.py
@@ -6,18 +6,34 @@ from singular.life.health import ViabilityDriftDetector
 
 def test_viability_drift_escalates_and_recovers_with_hysteresis() -> None:
     detector = ViabilityDriftDetector()
-    healthy = {"health": .9, "risk": .05, "resources": .9, "failure_rate": .05,
-               "traits": .9, "useful_skills": .9, "fitness": .9}
-    degraded = {"health": .1, "risk": .9, "resources": .1, "failure_rate": .9,
-                "traits": .2, "useful_skills": .2, "fitness": .1}
+    healthy = {
+        "health": 0.9,
+        "risk": 0.05,
+        "resources": 0.9,
+        "failure_rate": 0.05,
+        "traits": 0.9,
+        "useful_skills": 0.9,
+        "fitness": 0.9,
+    }
+    degraded = {
+        "health": 0.1,
+        "risk": 0.9,
+        "resources": 0.1,
+        "failure_rate": 0.9,
+        "traits": 0.2,
+        "useful_skills": 0.2,
+        "fitness": 0.1,
+    }
     transitions = []
     for metrics in [healthy] * 12 + [degraded] * 14 + [healthy] * 30:
         action, transition = detector.observe(metrics)
         if transition:
             transitions.append((action, transition))
     assert transitions == [
-        ("throttled", "drift"), ("paused", "drift"),
-        ("restored", "drift"), ("operator", "drift"),
+        ("throttled", "drift"),
+        ("paused", "drift"),
+        ("restored", "drift"),
+        ("operator", "drift"),
         ("normal", "recovered"),
     ]
 
@@ -53,7 +69,9 @@ def test_vital_transition_to_extinct_preempts_other_states() -> None:
         current_health=99.0,
         failure_rate=0.0,
         failure_streak=0,
-        extinction_seen=True, registry_status="extinct", extinction_duration=3,
+        extinction_seen=True,
+        registry_status="extinct",
+        extinction_duration=3,
     )
     assert payload["state"] == "extinct"
     assert payload["risk_level"] == "high"
@@ -63,13 +81,27 @@ def test_vital_transition_to_extinct_preempts_other_states() -> None:
 @pytest.mark.parametrize("name", ["Ada", "Bob", "Eve"])
 def test_named_lives_follow_deterministic_audited_trajectory(name: str) -> None:
     life = VitalStateMachine()
-    assert life.transition(VitalState.AT_RISK, cause=f"{name}:resource_loss") == VitalState.AT_RISK
-    assert life.transition(VitalState.CRITICAL, cause="sustained_failure") == VitalState.CRITICAL
+    assert (
+        life.transition(VitalState.AT_RISK, cause=f"{name}:resource_loss")
+        == VitalState.AT_RISK
+    )
+    assert (
+        life.transition(VitalState.CRITICAL, cause="sustained_failure")
+        == VitalState.CRITICAL
+    )
     life.record_rescue("recovery_quest")
     life.record_rescue("healthy_checkpoint_search")
-    assert life.transition(VitalState.TERMINAL, cause="rescue_exhausted") == VitalState.TERMINAL
-    assert life.transition(VitalState.DEAD, cause="resources_exhausted") == VitalState.DEAD
-    assert life.transition(VitalState.EXTINCT, cause="concordant_evidence") == VitalState.EXTINCT
+    assert (
+        life.transition(VitalState.TERMINAL, cause="rescue_exhausted")
+        == VitalState.TERMINAL
+    )
+    assert (
+        life.transition(VitalState.DEAD, cause="resources_exhausted") == VitalState.DEAD
+    )
+    assert (
+        life.transition(VitalState.EXTINCT, cause="concordant_evidence")
+        == VitalState.EXTINCT
+    )
     assert life.audit() == {
         "root_cause": f"{name}:resource_loss",
         "rescue_attempts": ["recovery_quest", "healthy_checkpoint_search"],
@@ -78,8 +110,14 @@ def test_named_lives_follow_deterministic_audited_trajectory(name: str) -> None:
 
 
 def test_single_extinction_signal_is_not_irreversible() -> None:
-    payload = compute_vital_timeline(age=1, current_health=99, failure_rate=0,
-        failure_streak=0, extinction_seen=True, extinction_duration=99)
+    payload = compute_vital_timeline(
+        age=1,
+        current_health=99,
+        failure_rate=0,
+        failure_streak=0,
+        extinction_seen=True,
+        extinction_duration=99,
+    )
     assert payload["state"] == "stable"
     assert payload["extinction_evidence"]["confirmed"] is False
 
@@ -111,17 +149,24 @@ def test_vital_reproduction_window_boundary_conditions() -> None:
     assert too_old["reproduction_eligible"] is False
 
 
-
 def test_vital_budget_exhaustion_is_not_extinction_marker(tmp_path) -> None:
     from singular.life.life_status import LifeStatus, compute_life_status
 
     mem = tmp_path / "mem"
     mem.mkdir()
-    (mem / "world_state.json").write_text('{"global_health":{"score":80}}', encoding="utf-8")
-    (mem / "self_narrative.json").write_text('{"identity":{"name":"Alpha","slug":"alpha"}}', encoding="utf-8")
-    (mem / "quests_state.json").write_text('{}', encoding="utf-8")
+    (mem / "world_state.json").write_text(
+        '{"global_health":{"score":80}}', encoding="utf-8"
+    )
+    (mem / "self_narrative.json").write_text(
+        '{"identity":{"name":"Alpha","slug":"alpha"}}', encoding="utf-8"
+    )
+    (mem / "quests_state.json").write_text("{}", encoding="utf-8")
 
-    result = compute_life_status(tmp_path, registry_entry={"status": "active"}, runs=[{"event": "loop.budget_exhausted", "voluntary_budget": True}])
+    result = compute_life_status(
+        tmp_path,
+        registry_entry={"status": "active"},
+        runs=[{"event": "loop.budget_exhausted", "voluntary_budget": True}],
+    )
 
     assert result.status == LifeStatus.BUDGET_EXHAUSTED
     assert result.evidence["vital_timeline"]["state"] != "extinct"

--- a/tests/test_wheel_distribution.py
+++ b/tests/test_wheel_distribution.py
@@ -33,11 +33,13 @@ def test_installed_wheel_contains_all_runtime_resources(tmp_path: Path) -> None:
         check=True,
     )
     python = venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
-    subprocess.run([python, "-m", "pip", "install", "--no-deps", str(wheel)], check=True)
+    subprocess.run(
+        [python, "-m", "pip", "install", "--no-deps", str(wheel)], check=True
+    )
 
     execution_dir = tmp_path / "installed-runtime"
     execution_dir.mkdir()
-    script = r'''
+    script = r"""
 from importlib.resources import as_file, files
 from pathlib import Path
 
@@ -79,7 +81,7 @@ assert dashboard.joinpath("templates", "mutation_detail.html").is_file()
 assert dashboard.joinpath("static", "dashboard.css").is_file()
 app = create_app()
 assert any(getattr(route, "name", None) == "dashboard-static" for route in app.routes)
-'''
+"""
     env = os.environ.copy()
     env.pop("PYTHONPATH", None)
     subprocess.run([python, "-c", script], cwd=execution_dir, env=env, check=True)

--- a/tools/replay_session.py
+++ b/tools/replay_session.py
@@ -43,7 +43,9 @@ def _lineage_report(events: list[dict[str, Any]]) -> list[str]:
     for (event_id, action_id), rows in by_action.items():
         categories = {str(item.get("category")) for item in rows}
         if "action" not in categories:
-            issues.append(f"event_id={event_id}, action_id={action_id}: result without action")
+            issues.append(
+                f"event_id={event_id}, action_id={action_id}: result without action"
+            )
 
     return sorted(set(issues))
 
@@ -55,7 +57,9 @@ def _print_timeline(events: list[dict[str, Any]], verbose: bool) -> None:
         event_id = row.get("event_id", "-")
         intent_id = row.get("intent_id", "-")
         action_id = row.get("action_id", "-")
-        print(f"[{index:04d}] {ts} | {category:<8} | event={event_id} intent={intent_id} action={action_id}")
+        print(
+            f"[{index:04d}] {ts} | {category:<8} | event={event_id} intent={intent_id} action={action_id}"
+        )
         if verbose:
             print(json.dumps(row.get("data", {}), ensure_ascii=False, indent=2))
 


### PR DESCRIPTION
### Motivation
- Uniformiser le style des sources Python avec la configuration `black` du dépôt et développer les signatures/compréhensions/dictionnaires afin d'éviter des corrections ponctuelles non uniformes.
- Normaliser les blocs d'import dans le module `identity` pour améliorer la lisibilité et la cohérence.

### Description
- Développement et réécriture des signatures, compréhensions et dictionnaires dans `src/singular/learning/developmental.py` pour `DevelopmentalStage.from_dict` et plusieurs méthodes de `DevelopmentalModel` (`__init__`, `from_config`, `_write`, `observe`, `gate`, `filter_quests`, `dashboard_projection`) conformément au format Black et aux annotations de type existantes.
- Normalisation du bloc d'import dans `src/singular/identity/__init__.py` (imports multi-lignes et tuple/énumération d'`__all__`).
- Application de `black` sur l’ensemble du dépôt selon la configuration `[tool.black]` de `pyproject.toml`, reformattant les fichiers signalés par la vérification CI (formatage étendu à ~173 fichiers détectés par la passe CI).

### Testing
- `ruff check .` — réussi (pas d'erreurs signalées après les modifications).
- `black --check --target-version py310 --fast .` — réussi (vérification `black` passée après reformattage).
- `python scripts/check_deployment_manifests.py` — réussi.
- Tests ciblés : `pytest -q tests/test_developmental_stages.py tests/test_identity.py` — 6 tests réussis.
- Exécution complète de la suite tests (`pytest -m "not integration"`) a été lancée et montre un état existant de la base (908 passed, 70 failed, 4 skipped) impliquant des échecs liés à l’environnement (absence de Docker/Podman pour certains sandbox tests, échanges de dépendances réseau, etc.), qui sont préexistants et indépendants du formatage.
- `mypy src` a été exécuté et signale des erreurs de typage préexistantes (305 erreurs dans 51 fichiers) qui ne sont pas liées aux changements de formatage de ce PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78f7568008832aa575308ccabd348c)