### PR TITLE
Séparer la construction des distributions et ajouter un job de résumé CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,15 +166,38 @@ jobs:
         run: pytest -q -m sandbox_oci
 
   build:
-    name: build
+    name: Build distributions
     runs-on: ubuntu-latest
     needs: [lint, typecheck, tests, optional-integrations, sandbox-oci]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+      - name: Build source and wheel distributions
+        run: python -m build
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: distributions
+          path: dist/
+
+  ci-summary:
+    name: CI summary
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, tests, optional-integrations, sandbox-oci, build]
     if: ${{ always() }}
     steps:
-      - name: Fail when dependencies failed
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      - name: Write job results
+        env:
+          NEEDS_RESULTS: ${{ toJSON(needs) }}
         run: |
-          echo "Upstream CI job failed or was cancelled."
-          exit 1
-      - name: CI summary
-        run: echo "lint/typecheck/tests/optional-integrations/sandbox-oci completed successfully."
+          {
+            echo "## CI job results"
+            echo
+            echo '```json'
+            echo "$NEEDS_RESULTS"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation

- Remplacer l’ancien job agrégateur `build` par une vraie construction de distribution qui s’exécute uniquement après la réussite des contrôles requis.
- Produire les distributions source et wheel et les rendre disponibles comme artefact pour des usages ultérieurs.
- Fournir un job de synthèse `CI summary` qui s’exécute toujours (`if: always()`), affiche les résultats agrégés de `needs` dans `$GITHUB_STEP_SUMMARY` et n’échoue pas artificiellement.

### Description

- Le job `build` a été renommé en `Build distributions` et reçoit des étapes explicites pour `actions/checkout@v4`, `actions/setup-python@v5`, l’installation de l’outil de build via `python -m pip install --upgrade build`, la génération des distributions via `python -m build` et l’upload du répertoire `dist/` avec `actions/upload-artifact@v4`.
- Le comportement qui faisait échouer le job lorsque des dépendances en amont échouaient a été retiré de ce job afin que la construction s’exécute uniquement si les `needs` sont satisfaits (par la dépendance explicite).
- Un nouveau job `ci-summary` (nommage explicite) a été ajouté avec `if: ${{ always() }}` et `needs` incluant tous les contrôles plus `build`, et il écrit la structure JSON de `needs` dans `$GITHUB_STEP_SUMMARY` pour fournir un résumé lisible sans rendre le pipeline bloquant.
- Le résumé est produit comme bloc JSON encerclé par une balise de code dans `$GITHUB_STEP_SUMMARY` pour éviter de le présenter comme un échec de compilation.

### Testing

- Exécuté `git diff --check` et la vérification a réussi sans erreurs.
- Parsé le fichier `./.github/workflows/ci.yml` avec Ruby YAML et vérifié que les jobs `build` et `ci-summary` existent, et cette vérification a réussi.
- Tentative d’exécution d’`actionlint` indiquée mais `actionlint` n’est pas installée dans l’environnement, donc le linting Actions n’a pas été exécuté.
- Tentative automatisée d’enregistrer les métadonnées de PR via le serveur MCP a échoué en raison d’un problème d’environnement (`mcp.server.fastmcp` manquant et erreurs liées au proxy), donc cette intégration n’a pas pu être complétée automatiquement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78fca32ba8832a977fb491c7acc22d)