### PR TITLE
Constrain httpx in dashboard extra and verify TestClient compatibility in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,20 +104,37 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install ".[test,${{ matrix.extra }}]"
-      - name: Verify dashboard uses the installed FastAPI dependency
+      - name: Verify installed dashboard metadata and TestClient dependencies
         if: matrix.integration == 'dashboard'
         env:
           SINGULAR_TEST_FASTAPI: ${{ matrix.fastapi-mode }}
         run: |
           python - <<'PY'
+          from importlib.metadata import requires
           from pathlib import Path
+
           import fastapi
+          import httpx
+          from fastapi import FastAPI
+          from fastapi.testclient import TestClient
+
+          dashboard_requirements = [
+              requirement
+              for requirement in requires("singular") or []
+              if 'extra == "dashboard"' in requirement
+          ]
+          if not any(requirement.lower().startswith("httpx") for requirement in dashboard_requirements):
+              raise SystemExit("installed dashboard extra metadata does not declare httpx")
 
           module_path = Path(fastapi.__file__).resolve()
           stub_path = (Path.cwd() / "tests" / "fastapi_stub").resolve()
           print(f"fastapi loaded from: {module_path}")
+          print(f"httpx loaded from: {Path(httpx.__file__).resolve()}")
           if module_path == stub_path or stub_path in module_path.parents:
               raise SystemExit("dashboard integration loaded tests/fastapi_stub")
+
+          client = TestClient(FastAPI())
+          client.close()
           PY
       - name: Run optional integration contract
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ test = [
 yaml = ["pyyaml>=6.0,<7"]
 dashboard = [
     "fastapi>=0.110,<1",
+    # Starlette 0.36.x (allowed by FastAPI 0.110) is incompatible with httpx
+    # 0.28+, while newer allowed Starlette releases support httpx 0.27.
+    "httpx>=0.27,<0.28",
     "uvicorn>=0.29,<1",
     "websockets>=12,<16",
 ]

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_dashboard_extra_declares_testclient_compatible_httpx_range() -> None:
+    """Keep TestClient's transport dependency in the dashboard extra.
+
+    FastAPI 0.110 permits Starlette 0.36.x, whose TestClient still passes the
+    removed ``app=`` argument to httpx and therefore needs httpx below 0.28.
+    The 0.27 lower bound also covers newer Starlette releases permitted by the
+    project's intentionally broad FastAPI range.
+    """
+
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    metadata = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    dashboard = metadata["project"]["optional-dependencies"]["dashboard"]
+
+    assert "fastapi>=0.110,<1" in dashboard
+    assert "httpx>=0.27,<0.28" in dashboard


### PR DESCRIPTION
### Motivation

- Ensure that the `dashboard` extra includes an `httpx` range compatible with FastAPI 0.110 and the Starlette versions it permits so `fastapi.testclient.TestClient` continues to work.
- Keep `httpx` explicitly in the `dashboard` extra because CI installs `.[test,dashboard]` and tests rely on that extra providing TestClient's transport dependency.

### Description

- Add `"httpx>=0.27,<0.28"` to the `dashboard` optional dependency in `pyproject.toml` to avoid `httpx` 0.28+ incompatibility with older Starlette versions allowed by `fastapi>=0.110,<1`.
- Strengthen the `optional-integrations` dashboard CI step in `.github/workflows/ci.yml` to assert the installed package metadata declares `httpx`, print resolved `httpx` path, and instantiate `fastapi.testclient.TestClient` to verify the extra is sufficient.
- Add `tests/test_project_metadata.py` which checks the `dashboard` extra in `pyproject.toml` contains both the `fastapi` and the `httpx` constraints.

### Testing

- Ran `pytest -q tests/test_project_metadata.py`, which passed (1 passed). 
- Ran `ruff check tests/test_project_metadata.py` and `black --check --target-version py310 tests/test_project_metadata.py`, both of which passed.
- Ran `git diff --check` which reported no issues.
- Attempted an isolated installation into a temporary venv with `pip install '.[dashboard]'`, but the package-download step failed in this environment due to a proxy error preventing `setuptools` download; the equivalent verification will run in CI where network access is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79005f9630832a947274fb057238df)