### PR TITLE
Configure Ruff, apply safe fixes, normalize imports and narrow matplotlib exception handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,42 @@ extend-exclude = '''
 | ^/tests/test_mutation_absurde\.py
 )
 '''
+
+[tool.ruff]
+target-version = "py310"
+extend-exclude = [
+    # Generated/fixture sources whose deliberately unusual formatting is part
+    # of the mutation and reducer test data rather than production Python.
+    "src/graine/target/tests/test_evaluate.py",
+    "src/graine/target/tests/test_reduce_sum.py",
+    "src/singular/__main__.py",
+    "src/singular/life/reproduction.py",
+    "tests/test_mutation_absurde.py",
+]
+
+[tool.ruff.lint]
+# Keep correctness/parse errors from pycodestyle and Pyflakes, plus a stable
+# import order. Formatting remains Black's responsibility.
+select = ["E4", "E7", "E9", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+# Package initializers intentionally order imports to preserve initialization
+# dependencies and their public re-export order; alphabetizing can create
+# circular imports or change optional-dependency fallbacks.
+"src/graine/kernel/__init__.py" = ["I001"]
+"src/graine/meta/__init__.py" = ["I001"]
+"src/singular/dashboard/__init__.py" = ["I001"]
+"src/singular/embodiment/__init__.py" = ["I001"]
+"src/singular/events/__init__.py" = ["I001"]
+"src/singular/governance/__init__.py" = ["I001"]
+"src/singular/learning/__init__.py" = ["I001"]
+"src/singular/memory_layers/__init__.py" = ["I001"]
+"src/singular/morals/__init__.py" = ["I001"]
+"src/singular/multiagent/__init__.py" = ["I001"]
+"src/singular/orchestrator/__init__.py" = ["I001"]
+"src/singular/providers/__init__.py" = ["I001"]
+"src/singular/sensors/__init__.py" = ["I001"]
+"src/singular/skills/__init__.py" = ["I001"]
+"src/singular/storage/__init__.py" = ["I001"]
+"src/singular/watch/__init__.py" = ["I001"]
+"tests/fastapi_stub/__init__.py" = ["I001"]

--- a/scripts/run_offline_multi_life_eval.py
+++ b/scripts/run_offline_multi_life_eval.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
+
 import argparse
 import json
 import sys

--- a/src/graine/evolver/generate.py
+++ b/src/graine/evolver/generate.py
@@ -12,10 +12,10 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from .dsl import (
-    Patch,
     CYCLOMATIC_LIMIT,
     THETA_DIFF_LIMIT,
     DSLValidationError,
+    Patch,
 )
 
 

--- a/src/graine/evolver/main.py
+++ b/src/graine/evolver/main.py
@@ -8,13 +8,13 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import List
 
-from .generate import propose_mutations
-from .select import Candidate, select
-from .dsl import Patch
 from ..kernel.logger import JsonlLogger
-from ..meta.dsl import MetaSpec, ALLOWED_MUTABLE_SURFACES
+from ..meta.dsl import ALLOWED_MUTABLE_SURFACES, MetaSpec
 from ..meta.evolve import propose_mutation as mutate_meta
 from ..meta.phantom import replay_snapshots
+from .dsl import Patch
+from .generate import propose_mutations
+from .select import Candidate, select
 
 META_MUTATION_LOG = Path("life/meta_mutation_log")
 

--- a/src/graine/evolver/select.py
+++ b/src/graine/evolver/select.py
@@ -10,9 +10,9 @@ rejected before the multi-objective selection is performed.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Dict, List
-import logging
 
 from .dsl import Patch
 

--- a/src/graine/kernel/interpreter.py
+++ b/src/graine/kernel/interpreter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import signal
 import time
-from typing import Any, Dict, Callable, Optional, Set
+from typing import Any, Callable, Dict, Optional, Set
 
 try:  # pragma: no cover - psutil is optional
     import psutil  # type: ignore[import-untyped]

--- a/src/graine/meta/dsl.py
+++ b/src/graine/meta/dsl.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Any, cast
+from typing import Any, Dict, List, cast
 
 from graine.evolver.dsl import OPERATOR_NAMES
 from graine.kernel.verifier import DIFF_LIMIT

--- a/src/graine/meta/evolve.py
+++ b/src/graine/meta/evolve.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from random import Random
 from typing import Dict
 
-from .dsl import MetaSpec, MAX_POPULATION_CAP, SELECTION_STRATEGIES
+from .dsl import MAX_POPULATION_CAP, SELECTION_STRATEGIES, MetaSpec
 
 
 def _renormalize(dist: Dict[str, float]) -> None:

--- a/src/graine/meta/phantom.py
+++ b/src/graine/meta/phantom.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Iterable, Dict, List, Any
+from typing import Any, Dict, Iterable, List
+
+from graine.runs.replay import SNAPSHOT_DIR
 
 from .dsl import MetaSpec
-from graine.runs.replay import SNAPSHOT_DIR
 
 
 def replay(history: Iterable[Dict[str, object]]) -> bool:

--- a/src/graine/runs/report.py
+++ b/src/graine/runs/report.py
@@ -7,9 +7,9 @@ import json
 import statistics
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterable, Dict, List, Any, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
-from .replay import SNAPSHOT_DIR, REPORT_DIR
+from .replay import REPORT_DIR, SNAPSHOT_DIR
 
 
 def _pareto_front(points: List[Dict[str, float]]) -> List[Dict[str, float]]:

--- a/src/graine/tests/test_dsl.py
+++ b/src/graine/tests/test_dsl.py
@@ -1,13 +1,13 @@
 import pytest
 
 from graine.evolver.dsl import (
-    Patch,
-    DSLValidationError,
     CYCLOMATIC_LIMIT,
     OPERATOR_NAMES,
     THETA_DIFF_LIMIT,
+    DSLValidationError,
+    Patch,
 )
-from graine.evolver.generate import propose_mutations, load_zones
+from graine.evolver.generate import load_zones, propose_mutations
 
 
 def build_patch(**overrides):

--- a/src/graine/tests/test_kernel.py
+++ b/src/graine/tests/test_kernel.py
@@ -1,7 +1,6 @@
 import pytest
 
-from graine.kernel import run_variant, VerificationError
-from graine.kernel import verifier
+from graine.kernel import VerificationError, run_variant, verifier
 
 
 def test_load_objectives_parses_config():

--- a/src/graine/tests/test_meta.py
+++ b/src/graine/tests/test_meta.py
@@ -1,13 +1,18 @@
 import json
-import pytest
 import random
 from pathlib import Path
 
-from graine.meta.dsl import MetaSpec, MetaValidationError, MAX_POPULATION_CAP
-from graine.meta.dsl import ALLOWED_MUTABLE_SURFACES
+import pytest
+
+from graine.kernel.verifier import DIFF_LIMIT
+from graine.meta.dsl import (
+    ALLOWED_MUTABLE_SURFACES,
+    MAX_POPULATION_CAP,
+    MetaSpec,
+    MetaValidationError,
+)
 from graine.meta.evolve import propose_mutation
 from graine.meta.phantom import replay_snapshots
-from graine.kernel.verifier import DIFF_LIMIT
 
 
 def build_spec(**overrides):

--- a/src/graine/tests/test_runs.py
+++ b/src/graine/tests/test_runs.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 from graine.runs import capture_run, replay

--- a/src/graine/tests/test_selection.py
+++ b/src/graine/tests/test_selection.py
@@ -1,4 +1,5 @@
 import logging
+
 from graine.evolver.dsl import Patch
 from graine.evolver.select import Candidate, select
 

--- a/src/singular/action/sandbox_runner.py
+++ b/src/singular/action/sandbox_runner.py
@@ -7,7 +7,8 @@ small typed catalog of actions.
 from __future__ import annotations
 
 from collections import deque
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeout
 from dataclasses import dataclass, field
 from threading import Event
 from time import monotonic

--- a/src/singular/agents/agent.py
+++ b/src/singular/agents/agent.py
@@ -8,10 +8,9 @@ from typing import Dict, Optional
 
 from singular.cognition.reflect import ActionHypothesis, reflect_action
 from singular.memory import add_episode
-from singular.morals.moral_rules import score_action
-from singular.morals import MoralAction, MoralDecisionEngine
-
 from singular.models.agents.motivation import Motivation
+from singular.morals import MoralAction, MoralDecisionEngine
+from singular.morals.moral_rules import score_action
 
 
 @dataclass

--- a/src/singular/beliefs/meta_learning.py
+++ b/src/singular/beliefs/meta_learning.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-import math
 from typing import Iterable, Mapping
 
 from .store import BeliefStore, _parse_datetime

--- a/src/singular/beliefs/store.py
+++ b/src/singular/beliefs/store.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 import json
 import math
 import os
-from pathlib import Path
 import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Iterable
 
 

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -649,6 +649,7 @@ def _circuit_corrective_action(state: dict[str, Any]) -> str:
 def _recover_governance(*, operator: str, justification: str, emergency: bool) -> int:
     """Move open -> half_open -> closed only through an audited safe mutation probe."""
     from datetime import datetime, timezone
+
     from .governance.policy import (
         audit_circuit_transition,
         load_circuit_state,
@@ -2804,6 +2805,7 @@ def main(argv: list[str] | None = None) -> int:
 
     elif args.command == "policy":
         from dataclasses import replace
+
         from .governance.policy import (
             PolicySchemaError,
             load_runtime_policy,

--- a/src/singular/core/agent_runtime.py
+++ b/src/singular/core/agent_runtime.py
@@ -6,16 +6,15 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Callable, Protocol
-
-from singular.security.policy_engine import ActionPolicyEngine
 from uuid import uuid4
-from singular.memory import add_causal_trace, add_episode, get_mem_dir
+
 from singular.cognition.self_observation import SelfObservationService
 from singular.embodiment import Acknowledgement, Command, EmergencyStop, Observation
-from singular.morals import MoralAction, MoralDecisionEngine
-from singular.morals import MoralContextBuilder
 from singular.identity.core import IdentityCoreService
+from singular.memory import add_causal_trace, add_episode, get_mem_dir
 from singular.memory_layers.embodiment_pipeline import EmbodimentOutcomePipeline
+from singular.morals import MoralAction, MoralContextBuilder, MoralDecisionEngine
+from singular.security.policy_engine import ActionPolicyEngine
 
 DEFAULT_SCHEMA_VERSION = "1.0"
 

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -17,13 +17,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
-from singular.lives import get_registry_root, load_registry
-from singular.sensors import load_host_sensor_thresholds
-from singular.skills_daily import build_daily_skills_snapshot
 from singular.dashboard.repositories.run_records import (
     RunRecordsRepository,
     resolve_current_life_home,
 )
+from singular.lives import get_registry_root, load_registry
+from singular.sensors import load_host_sensor_thresholds
+from singular.skills_daily import build_daily_skills_snapshot
 
 
 @dataclass(slots=True)

--- a/src/singular/embodiment/adapters.py
+++ b/src/singular/embodiment/adapters.py
@@ -6,8 +6,8 @@ not imply that a ROS installation (or robot) is present.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, fields, is_dataclass
 import time
+from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Any, Callable, Mapping
 
 from .contracts import (

--- a/src/singular/embodiment/bridge.py
+++ b/src/singular/embodiment/bridge.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import importlib
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 

--- a/src/singular/environment/artifacts.py
+++ b/src/singular/environment/artifacts.py
@@ -6,8 +6,8 @@ Metadata dates use ISO 8601 at second precision with the explicit UTC offset
 
 from __future__ import annotations
 
-import os
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable

--- a/src/singular/evaluation/multi_life.py
+++ b/src/singular/evaluation/multi_life.py
@@ -6,12 +6,12 @@ simulated state is evidence of subjective experience.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import hashlib
 import json
 import os
-from pathlib import Path
 import random
+from dataclasses import dataclass
+from pathlib import Path
 from statistics import median, pstdev
 from typing import Any
 

--- a/src/singular/events/bus.py
+++ b/src/singular/events/bus.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-from dataclasses import dataclass
-from datetime import datetime, timezone
 import atexit
 import logging
 import os
-from queue import Empty, Queue
 import threading
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from queue import Empty, Queue
 from typing import Any, Callable
 
 EventHandler = Callable[["Event"], None]

--- a/src/singular/goals/intrinsic.py
+++ b/src/singular/goals/intrinsic.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
-import json
 
+from singular.goals.perception_rules import apply_perception_rules
 from singular.governance.values import ValueWeights
 from singular.memory import _atomic_write_text, get_mem_dir
-from singular.goals.perception_rules import apply_perception_rules
 
 OBJECTIVE_CATALOGUE = ("coherence", "robustesse", "efficacite", "exploration")
 INTRINSIC_MODULATION_VERSION = "intrinsic-mod-v2"

--- a/src/singular/goals/quest_generation.py
+++ b/src/singular/goals/quest_generation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
-from typing import Any, Mapping, Literal, Protocol
+from typing import Any, Literal, Mapping, Protocol
 
 Origin = Literal["intrinsic", "external"]
 

--- a/src/singular/governance/policy.py
+++ b/src/singular/governance/policy.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
-from collections import deque
 import json
 import logging
 import os
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping
 from uuid import uuid4

--- a/src/singular/identity/consolidation.py
+++ b/src/singular/identity/consolidation.py
@@ -7,10 +7,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .episodic_store import EpisodicStore
 from .core import IdentityCoreService
-from .semantic_memory import SemanticMemoryStore
+from .episodic_store import EpisodicStore
 from .self_model import SelfModelStore
+from .semantic_memory import SemanticMemoryStore
 
 
 @dataclass(frozen=True)

--- a/src/singular/identity/consolidation_coordinator.py
+++ b/src/singular/identity/consolidation_coordinator.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import hashlib
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 

--- a/src/singular/identity/episodic_store.py
+++ b/src/singular/identity/episodic_store.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 

--- a/src/singular/identity/self_model.py
+++ b/src/singular/identity/self_model.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
 from uuid import uuid4

--- a/src/singular/identity/semantic_memory.py
+++ b/src/singular/identity/semantic_memory.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import hashlib
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 

--- a/src/singular/identity/synchronization.py
+++ b/src/singular/identity/synchronization.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import json
 from pathlib import Path
 from typing import Any, Mapping
 from uuid import uuid4

--- a/src/singular/interaction/tts_engine.py
+++ b/src/singular/interaction/tts_engine.py
@@ -9,10 +9,10 @@ Le module fournit:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from enum import Enum
 import math
 import struct
+from dataclasses import dataclass
+from enum import Enum
 from typing import Iterable, Iterator
 
 

--- a/src/singular/io_utils.py
+++ b/src/singular/io_utils.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager, nullcontext
-from pathlib import Path
-from typing import Any, Iterator
 import json
 import os
 import tempfile
 import time
+from contextlib import contextmanager, nullcontext
+from pathlib import Path
+from typing import Any, Iterator
 
 if os.name == "nt":
     import msvcrt

--- a/src/singular/learning/developmental.py
+++ b/src/singular/learning/developmental.py
@@ -7,9 +7,9 @@ but can never grant an action rejected by governance or human approval policy.
 
 from __future__ import annotations
 
+import json
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
-import json
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
 

--- a/src/singular/learning/imitation.py
+++ b/src/singular/learning/imitation.py
@@ -11,8 +11,10 @@ from pathlib import Path
 from typing import Any, Mapping, Protocol, Sequence
 
 from singular.io_utils import append_jsonl_line, atomic_write_text
-from singular.life.sandbox import SandboxError, run as sandbox_run
+from singular.life.sandbox import SandboxError
+from singular.life.sandbox import run as sandbox_run
 from singular.life.skill_catalog import refresh_skill_catalog
+
 from .demonstration import DemonstrationEvent
 
 

--- a/src/singular/learning/orchestrator.py
+++ b/src/singular/learning/orchestrator.py
@@ -7,14 +7,14 @@ independent evidence and a successful persistent regression-suite evaluation.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
 import hashlib
 import json
 import math
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping
-import uuid
 
 from singular.beliefs.store import BeliefStore
 from singular.io_utils import atomic_write_text, file_lock

--- a/src/singular/life/coevolution_flow.py
+++ b/src/singular/life/coevolution_flow.py
@@ -10,8 +10,8 @@ decision object that callers can log.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import random
+from dataclasses import dataclass, field
 from typing import Iterable
 
 from .map_elites import MapElites

--- a/src/singular/life/death.py
+++ b/src/singular/life/death.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from collections import deque
+from dataclasses import dataclass
 from typing import Tuple
 
 from singular.psyche import Psyche

--- a/src/singular/life/lineage.py
+++ b/src/singular/life/lineage.py
@@ -8,8 +8,8 @@ generation, mutation provenance, and score using the same compact schema.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
 import json
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Mapping
 

--- a/src/singular/life/loop.py
+++ b/src/singular/life/loop.py
@@ -3,131 +3,130 @@ from __future__ import annotations
 import argparse
 import ast
 import difflib
-from importlib.resources import as_file
+import hashlib
+import heapq
 import json
 import logging
 import math
+import os
 import random
 import time
-import heapq
-import hashlib
-import os
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from importlib.resources import as_file
 from pathlib import Path
 from typing import Callable, Dict, Iterable, Mapping
 
+# Graine is the external proposal generator for the life loop: it does not
+# write files directly here, but supplies validated patch/operator intentions.
+from graine.evolver.generate import propose_mutations
+from singular import self_narrative
+from singular.beliefs.meta_learning import (
+    extract_run_features,
+    recommend_strategy,
+    register_run_result,
+)
+from singular.beliefs.store import BeliefStore
 from singular.cognition.reflect import (
     ActionHypothesis,
     ReflectionDecision,
     reflect_action,
 )
 from singular.cognition.self_observation import SelfObservationService
-from singular.beliefs.store import BeliefStore
-from singular.beliefs.meta_learning import (
-    extract_run_features,
-    recommend_strategy,
-    register_run_result,
-)
-from singular.events import EventBus, get_global_event_bus
-from singular.memory import (
-    add_causal_trace,
-    read_skills,
-    register_memory_event_handlers,
-    temporarily_disable_skill,
-    update_score,
-    add_episode,
-    get_mem_dir,
-    format_recalled_memories,
-    recall_relevant_episodes,
-)
-from singular.psyche import Psyche, Mood, choose_action_from_psyche
-from singular.resources import config_resource
-from singular.runs.logger import RunLogger
-from singular.runs.explain import summarize_mutation
-from singular.runs.generations import record_generation
-from singular.organisms.spawn import mutation_absurde
-from singular.perception import capture_signals, get_temperature
-
-# Graine is the external proposal generator for the life loop: it does not
-# write files directly here, but supplies validated patch/operator intentions.
-from graine.evolver.generate import propose_mutations
 from singular.environment import artifacts as env_artifacts
 from singular.environment import files as env_files
 from singular.environment import notifications as env_notifications
 from singular.environment import sim_world
 from singular.environment.reputation import ReputationSystem
 from singular.environment.world_resources import CompetitorIntent, WorldResourcePool
+from singular.events import EventBus, get_global_event_bus
 from singular.goals import IntrinsicGoals
-from singular import self_narrative
-from singular.resource_manager import ResourceManager
-from singular.resource_manager import CapabilityStatus
-from singular.life.metabolism.rewards import RewardContribution, apply_rewards
-from singular.lives import load_registry, set_life_status
-from singular.life.effectors import perform_action
-from singular.life.world_state import PersistentWorldState
-from singular.social.graph import SocialGraph
-from singular.multiagent.runtime import LifeTickContext, MultiAgentRuntime
-from singular.life.ecosystem import (
-    ARCHETYPES,
-    EcosystemRulesConfig,
-    compute_population_metrics,
-    draw_global_event,
-)
-
-from .death import DeathMonitor
-from .health import HealthTracker, ViabilityDriftDetector
 from singular.governance.policy import (
     MutationGovernancePolicy,
     classify_governance_incident,
     classify_sandbox_error_type,
 )
 from singular.governance.values import load_value_weights
+from singular.identity.core import IdentityCoreService
+from singular.learning.imitation import ImitationEngine
+from singular.life.ecosystem import (
+    ARCHETYPES,
+    EcosystemRulesConfig,
+    compute_population_metrics,
+    draw_global_event,
+)
+from singular.life.effectors import perform_action
+from singular.life.metabolism.rewards import RewardContribution, apply_rewards
+from singular.life.world_state import PersistentWorldState
+from singular.lives import load_registry, set_life_status
+from singular.memory import (
+    add_causal_trace,
+    add_episode,
+    format_recalled_memories,
+    get_mem_dir,
+    read_skills,
+    recall_relevant_episodes,
+    register_memory_event_handlers,
+    temporarily_disable_skill,
+    update_score,
+)
 from singular.morals import (
     MoralAction,
     MoralContextBuilder,
     MoralDecision,
     MoralDecisionEngine,
 )
-from singular.identity.core import IdentityCoreService
+from singular.multiagent.runtime import LifeTickContext, MultiAgentRuntime
+from singular.organisms.spawn import mutation_absurde
+from singular.perception import capture_signals, get_temperature
+from singular.psyche import Mood, Psyche, choose_action_from_psyche
+from singular.resource_manager import CapabilityStatus, ResourceManager
+from singular.resources import config_resource
+from singular.runs.explain import summarize_mutation
+from singular.runs.generations import record_generation
+from singular.runs.logger import RunLogger
+from singular.social.graph import SocialGraph
 
 from .checkpointing import (
     CHECKPOINT_VERSION as CHECKPOINT_VERSION,
+)
+from .checkpointing import (
     Checkpoint,
     load_checkpoint,
     save_checkpoint,
 )
-from .sandbox_scoring import (
-    SandboxScore,
-    classify_source_sandbox_path,
-    score_code_with_error,
-    score_code,
-    _sandbox_failure_category,
+from .coevolution_flow import (
+    CoevolutionConfig,
+    CoevolutionFlow,
+    LivingTestPool,
+    MapElites,
 )
-from .mutation_flow import apply_mutation, select_operator, _load_default_operators
+from .death import DeathMonitor
 from .fitness import (
     FitnessDecision,
     evaluate_mutation_fitness,
     load_lifecycle_fitness_config,
 )
-from .resource_flow import manage_resources
+from .health import HealthTracker, ViabilityDriftDetector
+from .mutation_flow import _load_default_operators, apply_mutation, select_operator
+from .profiling import LifeLoopProfiler
 from .reproduction_flow import (
     ReproductionDecisionPolicy,
+    _pick_crossover_parents,
     authorize_reproduction_write,
     crossover,
     decide_reproduction,
-    _pick_crossover_parents,
 )
-from .coevolution_flow import (
-    CoevolutionConfig,
-    CoevolutionFlow,
-    MapElites,
-    LivingTestPool,
+from .resource_flow import manage_resources
+from .sandbox_scoring import (
+    SandboxScore,
+    _sandbox_failure_category,
+    classify_source_sandbox_path,
+    score_code,
+    score_code_with_error,
 )
 from .skill_genesis import create_skill
 from .social_decision import decide_social_actions
-from .profiling import LifeLoopProfiler
-from singular.learning.imitation import ImitationEngine
 
 # mypy: ignore-errors
 

--- a/src/singular/life/map_elites.py
+++ b/src/singular/life/map_elites.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import random
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Tuple
-import random
 
 Descriptor = Tuple[int, int]
 DescriptorFunc = Callable[[str, float], Tuple[int, int]]

--- a/src/singular/life/mutation_flow.py
+++ b/src/singular/life/mutation_flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 import importlib
 import random
-from typing import Callable, Dict, Mapping, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Dict, Mapping
 
 if TYPE_CHECKING:
     from singular.beliefs.meta_learning import StrategyRecommendation

--- a/src/singular/life/quest.py
+++ b/src/singular/life/quest.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List
-import json
 
 
 class QuestSpecError(ValueError):

--- a/src/singular/life/sandbox.py
+++ b/src/singular/life/sandbox.py
@@ -7,13 +7,13 @@ treated as a security boundary; that boundary is an OCI container runtime.
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
 import json
 import math
 import os
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
 from typing import Any
 
 try:

--- a/src/singular/life/sandbox_scoring.py
+++ b/src/singular/life/sandbox_scoring.py
@@ -5,8 +5,7 @@ import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
-from typing import ClassVar
+from typing import ClassVar, Iterable
 
 from . import sandbox
 

--- a/src/singular/life/synthesis.py
+++ b/src/singular/life/synthesis.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import ast
 import os
+from pathlib import Path
 
 # mypy: ignore-errors
-
 from . import quest
 from .skill_validation import validate_generated_skill
 

--- a/src/singular/life/test_coevolution.py
+++ b/src/singular/life/test_coevolution.py
@@ -7,8 +7,8 @@ deterministic when driven with a seeded ``random.Random`` instance.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import random
+from dataclasses import dataclass, field
 from typing import Iterable
 
 from . import sandbox

--- a/src/singular/life/world_state.py
+++ b/src/singular/life/world_state.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import json
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/src/singular/lives.py
+++ b/src/singular/lives.py
@@ -13,8 +13,8 @@ from pathlib import Path
 from typing import Any, Dict
 
 from .governance.policy import MutationGovernancePolicy
-from .root_config import default_registry_root, load_configured_registry_root
 from .memory import append_jsonl_line_safe
+from .root_config import default_registry_root, load_configured_registry_root
 
 _REGISTRY_DIRNAME = "lives"
 _REGISTRY_FILENAME = "registry.json"

--- a/src/singular/memory.py
+++ b/src/singular/memory.py
@@ -6,11 +6,11 @@ when the optional :mod:`PyYAML <yaml>` package is available.
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping
 import json
 import os
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
 
 from .events import Event, EventBus
 from .io_utils import append_jsonl_line, atomic_write_text

--- a/src/singular/memory_compaction.py
+++ b/src/singular/memory_compaction.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-from datetime import datetime, timedelta, timezone
 import hashlib
 import json
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from random import Random
 from typing import Any

--- a/src/singular/memory_layers/local_json.py
+++ b/src/singular/memory_layers/local_json.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from collections import Counter
-from pathlib import Path
 import json
 import math
 import os
 import re
 import tempfile
+from collections import Counter
+from pathlib import Path
 from typing import Callable
 
 from .base import MemoryBackend, MemoryRecord

--- a/src/singular/memory_layers/retrieval.py
+++ b/src/singular/memory_layers/retrieval.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
-from datetime import datetime, timezone
 import hashlib
 import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 

--- a/src/singular/memory_layers/service.py
+++ b/src/singular/memory_layers/service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import hashlib
 import json
+from datetime import datetime, timezone
 from typing import Any
 
 from .base import MemoryBackend, MemoryRecord

--- a/src/singular/memory_layers/vector_adapter.py
+++ b/src/singular/memory_layers/vector_adapter.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
 import logging
 import os
+from pathlib import Path
 
 from .base import MemoryBackend
 from .local_json import LocalJsonMemoryBackend

--- a/src/singular/mind/llm_adapter.py
+++ b/src/singular/mind/llm_adapter.py
@@ -10,9 +10,9 @@ ou API compatible) avec :
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
 import time
+from dataclasses import dataclass
 from typing import Any
 from urllib import error, request
 

--- a/src/singular/motivation.py
+++ b/src/singular/motivation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 

--- a/src/singular/multiagent/protocol.py
+++ b/src/singular/multiagent/protocol.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any, Iterable, Literal, Protocol
 import json
 import os
 import tempfile
 import time
 from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Literal, Protocol
 
 from singular.events import (
     HELP_ACCEPTED,

--- a/src/singular/multiagent/runtime.py
+++ b/src/singular/multiagent/runtime.py
@@ -10,6 +10,7 @@ from singular.governance.policy import (
     AUTH_REVIEW_REQUIRED,
     MutationGovernancePolicy,
 )
+from singular.learning.imitation import ImitationEngine
 from singular.multiagent.protocol import (
     AgentMessage,
     CollectiveMemory,
@@ -19,7 +20,6 @@ from singular.multiagent.protocol import (
     resolve_conflicts,
 )
 from singular.social.graph import SocialGraph
-from singular.learning.imitation import ImitationEngine
 
 
 @dataclass(slots=True)

--- a/src/singular/observability/audit_log.py
+++ b/src/singular/observability/audit_log.py
@@ -7,15 +7,15 @@ offline for diagnostics.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Iterable, Mapping
 import hashlib
 import json
 import os
 import re
 import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
 
 _SENSITIVE_KEY_PATTERN = re.compile(
     r"(pass(word)?|secret|token|api[_-]?key|authorization|cookie|session|private[_-]?key|"

--- a/src/singular/orchestrator/service.py
+++ b/src/singular/orchestrator/service.py
@@ -2,31 +2,31 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
-from enum import Enum
 import hashlib
 import json
 import logging
 import signal
 import time
-from uuid import uuid4
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable
+from uuid import uuid4
 
+from singular.cognition.self_observation import SelfObservationService
 from singular.events import (
+    HELP_REQUESTED,
     Event,
     EventBus,
-    HELP_REQUESTED,
     build_help_event_payload,
     get_global_event_bus,
 )
 from singular.goals import IntrinsicGoals
 from singular.goals.quest_generation import generate_quests
-from singular.cognition.self_observation import SelfObservationService
+from singular.governance.policy import MutationGovernancePolicy
 from singular.identity import ConsolidationCoordinator, ConsolidationPipeline
 from singular.identity.synchronization import IdentitySynchronizationService
-from singular.governance.policy import MutationGovernancePolicy
 from singular.life.coevolution_flow import LivingTestPool
 from singular.life.loop import WorldState, run_tick
 from singular.lives import canonical_life_id, resolve_life
@@ -37,12 +37,20 @@ from singular.memory import (
     read_episodes,
     read_psyche,
 )
+from singular.metrics import (
+    compute_behavioral_regulation_metrics,
+    compute_regulation_inputs,
+)
 from singular.orchestrator.lifecycle_clock import (
     LifecycleClockConfig,
     load_lifecycle_clock_config,
 )
 from singular.perception import capture_signals
 from singular.psyche import Psyche
+from singular.quests import QuestRuntime
+from singular.resource_manager import ResourceManager
+from singular.routines import RoutinesOrchestrator
+from singular.runs.logger import RunLogger
 from singular.self_narrative import (
     infer_trend,
     load_snapshots,
@@ -50,16 +58,8 @@ from singular.self_narrative import (
     summarize_short,
     update_from_signals,
 )
-from singular.resource_manager import ResourceManager
-from singular.quests import QuestRuntime
 from singular.sensors import load_host_sensor_thresholds
 from singular.skills.runtime import SkillRuntime
-from singular.routines import RoutinesOrchestrator
-from singular.runs.logger import RunLogger
-from singular.metrics import (
-    compute_behavioral_regulation_metrics,
-    compute_regulation_inputs,
-)
 
 log = logging.getLogger(__name__)
 

--- a/src/singular/organisms/birth.py
+++ b/src/singular/organisms/birth.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import random
 import string
-import json
-import hashlib
 from datetime import datetime, timezone
 from math import isfinite
 from pathlib import Path
@@ -16,9 +16,9 @@ from ..environment.sim_world import default_world_state, save_world_state
 from ..goals.intrinsic import GoalState
 from ..governance.values import ValueWeights
 from ..identity import create_identity
+from ..life.skill_catalog import refresh_skill_catalog
 from ..memory import ensure_memory_structure, update_score, write_profile
 from ..psyche import Psyche
-from ..life.skill_catalog import refresh_skill_catalog
 from ..resources import config_resource
 
 _PSYCHE_TRAITS = ("curiosity", "patience", "playfulness", "optimism", "resilience")

--- a/src/singular/organisms/quest.py
+++ b/src/singular/organisms/quest.py
@@ -9,7 +9,7 @@ from singular.life.quest import SpecValidationError, load
 from singular.life.synthesis import synthesise
 
 from ..memory import add_episode, ensure_memory_structure, update_score
-from ..psyche import Psyche, Mood
+from ..psyche import Mood, Psyche
 
 
 def quest(spec: Path) -> None:

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ..lives import list_relations
 from ..life.health import detect_health_state
 from ..life.life_status import compute_life_status
 from ..life.vital import compute_vital_timeline
+from ..lives import list_relations
+from ..memory import get_mem_dir, read_skills
 from ..metrics.autonomy import compute_autonomy_metrics
 from ..psyche import Psyche
-from ..memory import get_mem_dir
-from ..memory import read_skills
 from ..runs.logger import RUNS_DIR
 from ..schedulers.reevaluation import alerts_from_records
 from ..sensors import compute_host_metrics_aggregates, summarize_environmental_impact

--- a/src/singular/organisms/talk.py
+++ b/src/singular/organisms/talk.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import os
 import random
 import time
-import json
 from dataclasses import dataclass, field
-from typing import Mapping, Any, Iterable
-from pathlib import Path
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
 from uuid import uuid4
 
+from ..identity.synchronization import IdentitySynchronizationService
+from ..learning.imitation import ImitationEngine
+from ..lives import canonical_life_id
 from ..memory import (
     add_causal_trace,
     add_episode,
@@ -22,11 +25,8 @@ from ..memory import (
 from ..memory_layers import MemoryRetrievalService, build_backend
 from ..perception import capture_signals
 from ..perception.interaction import apply_psyche_deltas, extract_structured_signals
-from ..psyche import Mood, Psyche
-from ..identity.synchronization import IdentitySynchronizationService
-from ..self_narrative import load as load_self_narrative, summarize_short
-from ..lives import canonical_life_id
 from ..providers import (
+    PROVIDER_CONFIGURATION_COMMANDS,
     FallbackLLMClient,
     LLMProviderError,
     ProviderMisconfiguredError,
@@ -34,13 +34,14 @@ from ..providers import (
     ProviderRetryExhaustedError,
     ProviderTimeoutError,
     ProviderUnavailableError,
-    PROVIDER_CONFIGURATION_COMMANDS,
     describe_client,
     load_llm_client,
     provider_is_real,
 )
+from ..psyche import Mood, Psyche
 from ..runs.logger import log_provider_event
-from ..learning.imitation import ImitationEngine
+from ..self_narrative import load as load_self_narrative
+from ..self_narrative import summarize_short
 
 _UNKNOWN_GUARD = 'Garde anti-hallucination: si une information demandée est inconnue, réponds explicitement "inconnu".'
 

--- a/src/singular/providers/llm_local.py
+++ b/src/singular/providers/llm_local.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
 
 from . import (

--- a/src/singular/providers/llm_ollama.py
+++ b/src/singular/providers/llm_ollama.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import ipaddress
 import json
 import os
-import socket
 import shutil
+import socket
 import subprocess
 import time
 from typing import Any
-from urllib.parse import urlparse
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
 from . import (

--- a/src/singular/providers/llm_openai.py
+++ b/src/singular/providers/llm_openai.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import Any
 
 from . import (

--- a/src/singular/psyche.py
+++ b/src/singular/psyche.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Dict, Any, ClassVar, Mapping, Sequence
-from datetime import datetime, timezone
-from pathlib import Path
 import random
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
+from typing import Any, ClassVar, Dict, Mapping, Sequence
 
 from .memory import read_psyche, write_psyche
 from .motivation import GoalPolicy, Objective

--- a/src/singular/quests.py
+++ b/src/singular/quests.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timedelta, timezone
 import hashlib
 import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 from singular.goals.quest_generation import GeneratedQuest
-
-from singular.life.quest import Spec, load as load_spec
+from singular.life.quest import Spec
+from singular.life.quest import load as load_spec
 from singular.memory import _atomic_write_text, add_episode, get_mem_dir
 from singular.psyche import Mood, Psyche
 from singular.resource_manager import ResourceManager

--- a/src/singular/resource_manager.py
+++ b/src/singular/resource_manager.py
@@ -9,8 +9,7 @@ from pathlib import Path
 from typing import List
 from uuid import uuid4
 
-from .memory import add_causal_trace
-from .memory import _atomic_write_text
+from .memory import _atomic_write_text, add_causal_trace
 
 
 class CapabilityStatus(str, Enum):

--- a/src/singular/routines.py
+++ b/src/singular/routines.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
-import json
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Mapping

--- a/src/singular/runs/generations.py
+++ b/src/singular/runs/generations.py
@@ -6,11 +6,11 @@ offset ``+00:00``.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import hashlib
 import json
 import os
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 

--- a/src/singular/runs/logger.py
+++ b/src/singular/runs/logger.py
@@ -7,28 +7,26 @@ offset (``+00:00``). Compact timestamps used in filenames remain UTC
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from pathlib import Path
 import json
 import logging
 import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Mapping
 from uuid import uuid4
-from typing import Any, Mapping
 
-from ..storage_retention import run_retention_service
 from ..lives import canonical_life_id
+from ..memory import add_episode, add_procedural_memory
+from ..psyche import Psyche
 from ..storage import (
     ProviderEventsRepository,
     RunsRepository,
-    SQLiteStorage,
     SkillScoresRepository,
+    SQLiteStorage,
     StorageConfig,
 )
-
-from ..psyche import Psyche
-from ..memory import add_episode, add_procedural_memory
-from typing import Callable, Dict
+from ..storage_retention import run_retention_service
 
 # Base directory for persistent files
 _BASE_DIR = Path(os.environ.get("SINGULAR_HOME", "."))

--- a/src/singular/runs/report.py
+++ b/src/singular/runs/report.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from collections import Counter
 from pathlib import Path
-import json
 from typing import Any
 
-from .logger import RUNS_DIR
 from ..governance.policy import load_runtime_policy
 from ..life.health import detect_health_state
 from ..life.life_status import compute_life_status
-from ..memory import read_skills, get_skills_file
-from ..storage import RunsRepository, SQLiteStorage, StorageConfig
+from ..memory import get_skills_file, read_skills
 from ..sensors import compute_host_metrics_aggregates, summarize_environmental_impact
+from ..storage import RunsRepository, SQLiteStorage, StorageConfig
+from .logger import RUNS_DIR
 
 
 def load_run_records(

--- a/src/singular/runs/run.py
+++ b/src/singular/runs/run.py
@@ -6,13 +6,13 @@ import ast
 import difflib
 import random
 
+from graine.evolver.generate import propose_mutations
 from singular.beliefs.store import BeliefStore
 from singular.life.operators import const_tune, deadcode_elim, eq_rewrite_reduce_sum
 from singular.life.score import score
-from graine.evolver.generate import propose_mutations
 
-from ..psyche import Psyche
 from ..memory import add_episode
+from ..psyche import Psyche
 
 
 def run(seed: int | None = None) -> str:

--- a/src/singular/self_narrative.py
+++ b/src/singular/self_narrative.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
-import json
-import hashlib
 
 from singular.identity.coherence import detect_contradictions
 from singular.io_utils import append_jsonl_line, atomic_write_text

--- a/src/singular/sensors/config.py
+++ b/src/singular/sensors/config.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
 import json
 import os
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping
 

--- a/src/singular/sensors/host_metrics_store.py
+++ b/src/singular/sensors/host_metrics_store.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-import json
-import os
 
 from singular.memory import append_jsonl_line_safe, get_mem_dir
 

--- a/src/singular/skills/runtime.py
+++ b/src/singular/skills/runtime.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
 import hashlib
 import json
 import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 

--- a/src/singular/social/graph.py
+++ b/src/singular/social/graph.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-import json
 
 from singular.memory import _atomic_write_text, get_mem_dir
 from singular.social.theory_of_mind import TheoryOfMindStore

--- a/src/singular/social/theory_of_mind.py
+++ b/src/singular/social/theory_of_mind.py
@@ -7,10 +7,10 @@ is not evidence that we know what they believe or intend to do.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from datetime import datetime, timezone
 import json
 import math
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Literal, Mapping
 

--- a/src/singular/storage/importer.py
+++ b/src/singular/storage/importer.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import json
+from pathlib import Path
 from typing import Any
 
 from .sqlite import (

--- a/src/singular/storage/sqlite.py
+++ b/src/singular/storage/sqlite.py
@@ -7,10 +7,10 @@ mirrored by callers to their existing files.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
 import json
 import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Mapping
 
 SCHEMA_VERSION = 1

--- a/src/singular/storage_retention.py
+++ b/src/singular/storage_retention.py
@@ -9,13 +9,13 @@ Configuration is resolved with the following precedence:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
 import json
 import os
 import shutil
 import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Mapping
 
 from .io_utils import append_jsonl_line

--- a/src/singular/watch/daemon.py
+++ b/src/singular/watch/daemon.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime, timezone
 import json
 import os
-from pathlib import Path
 import signal
 import tempfile
 import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from ..memory import get_mem_dir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,8 @@ if fastapi_mode == "stub":
 
 import pytest  # noqa: E402
 
-from singular.life.checkpointing import Checkpoint, save_checkpoint  # noqa: E402
 from singular.life import sandbox as life_sandbox  # noqa: E402
+from singular.life.checkpointing import Checkpoint, save_checkpoint  # noqa: E402
 from singular.memory_layers.local_json import LocalJsonMemoryBackend  # noqa: E402
 from singular.memory_layers.service import MemoryLayerService  # noqa: E402
 

--- a/tests/fastapi_stub/testclient.py
+++ b/tests/fastapi_stub/testclient.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
-from urllib.parse import parse_qs, urlsplit
-import mimetypes
-
 import asyncio
 import inspect
+import mimetypes
 import threading
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
 from . import HTTPException, WebSocket, WebSocketDisconnect
 

--- a/tests/perception/test_os_pipeline.py
+++ b/tests/perception/test_os_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import singular.perception as perception
 from singular.perception.os.capture import (
     ActiveWindowState,
     HostState,
@@ -11,7 +12,6 @@ from singular.perception.os.capture import (
     OSSnapshotProvider,
 )
 from singular.perception.os.pipeline import OSPerceptionPipeline
-import singular.perception as perception
 
 
 @dataclass

--- a/tests/providers/test_llm_local.py
+++ b/tests/providers/test_llm_local.py
@@ -3,10 +3,10 @@ import pytest
 from singular.providers import (
     ProviderRetryExhaustedError,
     ProviderTimeoutError,
+    llm_local,
     load_llm_client,
     load_llm_provider,
 )
-from singular.providers import llm_local
 
 
 def test_load_llm_provider_local():

--- a/tests/providers/test_llm_ollama.py
+++ b/tests/providers/test_llm_ollama.py
@@ -11,8 +11,8 @@ from singular.providers import (
     ProviderMisconfiguredError,
     ProviderTimeoutError,
     ProviderUnavailableError,
+    llm_ollama,
 )
-from singular.providers import llm_ollama
 
 
 class FakeHTTPResponse:

--- a/tests/providers/test_llm_openai.py
+++ b/tests/providers/test_llm_openai.py
@@ -9,8 +9,8 @@ from singular.providers import (
     ProviderQuotaExceededError,
     ProviderRetryExhaustedError,
     ProviderTimeoutError,
+    llm_openai,
 )
-from singular.providers import llm_openai
 
 
 def test_generate_reply_without_key(monkeypatch):

--- a/tests/test_agent_motivation.py
+++ b/tests/test_agent_motivation.py
@@ -1,5 +1,5 @@
-from singular.models.agents import Motivation
 from singular.agents import Agent
+from singular.models.agents import Motivation
 
 
 def test_update_and_choose_goal():

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -4,8 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from singular import memory
-from singular import io_utils
+from singular import io_utils, memory
 from singular.resource_manager import ResourceManager
 
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,8 +1,8 @@
-import json
-from pathlib import Path
-import types
 import grp
+import json
 import pwd
+import types
+from pathlib import Path
 
 import singular.cli as cli
 

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import types
+from pathlib import Path
 
 import singular.cli as cli
 from singular.lives import load_registry

--- a/tests/test_cli_lives.py
+++ b/tests/test_cli_lives.py
@@ -1,6 +1,6 @@
-from pathlib import Path
 import json
 import logging
+from pathlib import Path
 
 import pytest
 

--- a/tests/test_consolidation_coordinator.py
+++ b/tests/test_consolidation_coordinator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from singular.identity.consolidation_coordinator import ConsolidationCoordinator, STAGES
+from singular.identity.consolidation_coordinator import STAGES, ConsolidationCoordinator
 
 
 def test_stage_checkpoints_resume_and_retry_idempotently(

--- a/tests/test_core_agent_runtime.py
+++ b/tests/test_core_agent_runtime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-from singular.security.policy_engine import ActionPolicyEngine, PolicyRule
 from singular.core.agent_runtime import (
     ActionRequest,
     ActionResult,
@@ -13,6 +12,7 @@ from singular.core.agent_runtime import (
     RuntimeEventBus,
     RuntimeSafetyConfig,
 )
+from singular.security.policy_engine import ActionPolicyEngine, PolicyRule
 
 
 class _PerceptionStub:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,9 +1,9 @@
 import asyncio
 import inspect
 import json
+import threading
 from pathlib import Path
 from queue import Empty
-import threading
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_dashboard_run_records_repository.py
+++ b/tests/test_dashboard_run_records_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import json
+from pathlib import Path
 
 from singular.dashboard.repositories.run_records import RunRecordsRepository
 

--- a/tests/test_dashboard_services.py
+++ b/tests/test_dashboard_services.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from singular.dashboard.services.code_evolution import aggregate_code_evolution
 from singular.dashboard.services.lives_comparison import (
     aggregate_lives,
     build_life_timeseries,
 )
 from singular.dashboard.services.metrics_contract import normalize_life_metrics
-from singular.dashboard.services.code_evolution import aggregate_code_evolution
 from singular.dashboard.services.trajectory import build_trajectory
 
 

--- a/tests/test_dashboard_smoke_e2e.py
+++ b/tests/test_dashboard_smoke_e2e.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import json
 import inspect
+import json
 import os
-from pathlib import Path
 import socket
 import threading
 import time
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/test_death.py
+++ b/tests/test_death.py
@@ -1,13 +1,13 @@
 import ast
 import functools
-import random
 import json
+import random
 from pathlib import Path
 
 import singular.life.loop as life_loop
-from singular.life.loop import run
-from singular.life.death import DeathMonitor
 from singular.events import EventBus
+from singular.life.death import DeathMonitor
+from singular.life.loop import run
 
 
 class _StablePsyche:
@@ -51,8 +51,9 @@ def _patch_logger(monkeypatch, tmp_path: Path):
 
 
 def _patch_memory(monkeypatch, tmp_path: Path):
-    import singular.runs.logger as logger_mod
     import json
+
+    import singular.runs.logger as logger_mod
 
     episodic = tmp_path / "mem" / "episodic.jsonl"
 

--- a/tests/test_embodiment_runtime.py
+++ b/tests/test_embodiment_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 
 from singular import cli
+from singular.core.agent_runtime import AgentRuntime, Intent
 from singular.embodiment import (
     ActuatorSimulator,
     Command,
@@ -10,7 +11,6 @@ from singular.embodiment import (
     ErrorCode,
     ScriptedSensor,
 )
-from singular.core.agent_runtime import AgentRuntime, Intent
 from singular.identity.consolidation_coordinator import ConsolidationCoordinator
 from singular.memory_layers import (
     EmbodimentOutcomePipeline,

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,7 +1,7 @@
-from singular.resource_manager import ResourceManager
 from singular.environment.notifications import auto_post, notify
 from singular.memory import read_causal_timeline
 from singular.perception import PerceptionNoiseFilter
+from singular.resource_manager import ResourceManager
 
 
 def test_update_from_environment_increases_warmth(tmp_path, monkeypatch):

--- a/tests/test_events_bus.py
+++ b/tests/test_events_bus.py
@@ -7,9 +7,9 @@ from singular.events.bus import (
     HELP_COMPLETED,
     HELP_OFFERED,
     HELP_REQUESTED,
-    EventBus,
-    Event,
     STANDARD_HELP_EVENTS,
+    Event,
+    EventBus,
     build_help_event_payload,
     get_bus_strict_from_env,
 )

--- a/tests/test_generations_registry.py
+++ b/tests/test_generations_registry.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import ast
 import json
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
-import warnings
 
 import singular.cli as cli
 from singular.life import loop as life_loop

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,6 +1,6 @@
-from pathlib import Path
-from datetime import datetime
 import hashlib
+from datetime import datetime
+from pathlib import Path
 
 from singular.identity import create_identity, read_identity
 

--- a/tests/test_identity_coherence.py
+++ b/tests/test_identity_coherence.py
@@ -1,11 +1,12 @@
 import json
-import pytest
 from pathlib import Path
 
+import pytest
+
 from singular.identity import (
+    IdentityChangePolicy,
     IdentityCoherenceGuard,
     IdentityInvariants,
-    IdentityChangePolicy,
     detect_contradictions,
 )
 

--- a/tests/test_immune_response.py
+++ b/tests/test_immune_response.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-from singular.security.immune_response import AdaptiveImmunityEngine, IncidentRecord
 from singular.governance.policy import MutationGovernancePolicy
+from singular.security.immune_response import AdaptiveImmunityEngine, IncidentRecord
 
 
 def test_trigger_response_builds_targeted_actions_and_blacklist() -> None:

--- a/tests/test_install_restart_acceptance.py
+++ b/tests/test_install_restart_acceptance.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import grp
 import json
 import os
 import pwd
-import grp
 import shlex
 from pathlib import Path
 

--- a/tests/test_lives.py
+++ b/tests/test_lives.py
@@ -17,11 +17,11 @@ from singular.lives import (
     reconcile_lives,
     resolve_life,
     rival_lives,
-    set_proximity,
     set_life_status,
+    set_proximity,
 )
-from singular.root_config import set_configured_registry_root
 from singular.organisms.birth import birth
+from singular.root_config import set_configured_registry_root
 
 
 def test_birth_uses_isolated_homes(tmp_path: Path) -> None:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,15 +1,14 @@
+import ast
 import builtins
-import json
-import random
 import functools
+import json
+import logging
+import random
 import sys
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 
-import ast
-
-import logging
 import pytest
 
 pytestmark = pytest.mark.usefixtures("local_sandbox")
@@ -20,15 +19,15 @@ sys.path.append(str(root_dir / "src"))
 
 import singular.life.loop as life_loop  # noqa: E402
 import singular.life.sandbox as life_sandbox  # noqa: E402
-from singular.life.loop import EcosystemRules, run  # noqa: E402
+from singular.events import EventBus  # noqa: E402
+from singular.governance.policy import MutationGovernancePolicy  # noqa: E402
 from singular.life.checkpointing import load_checkpoint  # noqa: E402
 from singular.life.health import detect_health_state  # noqa: E402
-from singular.life.test_coevolution import LivingTestPool, TestCandidate  # noqa: E402
-from singular.resource_manager import ResourceManager  # noqa: E402
-from singular.psyche import Psyche, Mood  # noqa: E402
-from singular.governance.policy import MutationGovernancePolicy  # noqa: E402
+from singular.life.loop import EcosystemRules, run  # noqa: E402
 from singular.life.reproduction import ReproductionDecisionPolicy  # noqa: E402
-from singular.events import EventBus  # noqa: E402
+from singular.life.test_coevolution import LivingTestPool, TestCandidate  # noqa: E402
+from singular.psyche import Mood, Psyche  # noqa: E402
+from singular.resource_manager import ResourceManager  # noqa: E402
 
 
 def test_repository_addition_skill_satisfies_sandbox_scoring_contract(local_sandbox):
@@ -1323,15 +1322,16 @@ def test_artifact_creation_persistence(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("SINGULAR_HOME", str(tmp_path))
 
     import importlib
+
     from singular.environment import artifacts as env_artifacts
 
     importlib.reload(env_artifacts)
 
     from singular.environment.artifacts import (
-        create_text_art,
+        ARTIFACTS_DIR,
         create_ascii_drawing,
         create_simple_melody,
-        ARTIFACTS_DIR,
+        create_text_art,
     )
 
     mood = "neutre"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,23 +1,23 @@
-from pathlib import Path
 import json
 import multiprocessing as mp
 from concurrent.futures import ThreadPoolExecutor
-
-import pytest
+from pathlib import Path
 from typing import Any
 
+import pytest
+
+import singular.memory as memory
 from singular.memory import (
     add_episode,
     apply_skill_maintenance,
     controlled_delete_skill,
+    record_skill_metric,
     restore_skill,
     temporarily_disable_skill,
     update_note,
     update_score,
     update_trait,
-    record_skill_metric,
 )
-import singular.memory as memory
 from singular.organisms.birth import birth
 
 

--- a/tests/test_module_entrypoint.py
+++ b/tests/test_module_entrypoint.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import ast
 import runpy
 import sys
-import tomllib
 from pathlib import Path
 
 import pytest
+import tomllib
 
 
 def _read_project_script_target() -> str:

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -1,13 +1,13 @@
-from pathlib import Path
-
 import ast
 import json
 import random
+from pathlib import Path
+
+from fastapi_stub import TestClient
 
 import singular.life.loop as life_loop
-from singular.life.loop import EcosystemRules, WorldState
 from singular.dashboard import create_app
-from fastapi_stub import TestClient
+from singular.life.loop import EcosystemRules, WorldState
 
 
 def _dec_operator(tree: ast.AST, rng=None) -> ast.AST:

--- a/tests/test_multiagent_protocol.py
+++ b/tests/test_multiagent_protocol.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
 import json
 import multiprocessing as mp
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import Mock
 
+from singular.governance.policy import MutationGovernancePolicy
 from singular.multiagent import (
     AgentMessage,
     CollectiveMemory,
@@ -17,7 +18,6 @@ from singular.multiagent import (
     validate_message_schema,
 )
 from singular.multiagent import protocol as protocol_module
-from singular.governance.policy import MutationGovernancePolicy
 
 
 def _send_messages_worker(path: str, start: int, count: int) -> None:

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,6 +1,6 @@
-from singular.psyche import Psyche, Mood
-from singular.motivation import GoalPolicy, Objective, HierarchicalObjectivesManager
 from singular.goals.intrinsic import IntrinsicGoals
+from singular.motivation import GoalPolicy, HierarchicalObjectivesManager, Objective
+from singular.psyche import Mood, Psyche
 
 
 def test_curiosity_increases():

--- a/tests/test_orchestrator_service.py
+++ b/tests/test_orchestrator_service.py
@@ -1,8 +1,8 @@
-from pathlib import Path
-from datetime import datetime, timedelta, timezone
 import json
 import logging
 import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 

--- a/tests/test_orchestrator_service_targeted.py
+++ b/tests/test_orchestrator_service_targeted.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from singular.events import EventBus, HELP_REQUESTED
+from singular.events import HELP_REQUESTED, EventBus
 from singular.orchestrator import service as orchestrator_service
 from singular.orchestrator.service import (
     LifecyclePhase,

--- a/tests/test_perception.py
+++ b/tests/test_perception.py
@@ -1,13 +1,13 @@
+import json
 import os
 import sys
 import types
 from dataclasses import replace
-import json
 
 from singular.events import EventBus
 from singular.governance.policy import load_runtime_policy, save_runtime_policy
-from singular.perception import capture_signals, reset_perception_state
 from singular.memory import add_episode, read_episodes
+from singular.perception import capture_signals, reset_perception_state
 from singular.perception.interaction import (
     CONTRACT_VERSION,
     apply_psyche_deltas,

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
+
+import tomllib
 
 
 def test_dashboard_extra_declares_testclient_compatible_httpx_range() -> None:

--- a/tests/test_psyche.py
+++ b/tests/test_psyche.py
@@ -2,14 +2,14 @@ from pathlib import Path
 
 import pytest
 
+from singular.motivation import GoalPolicy, Objective
 from singular.psyche import (
-    Psyche,
     Mood,
+    Psyche,
     TraitEvolutionPolicy,
     choose_action_from_psyche,
 )
 from singular.resource_manager import ResourceManager
-from singular.motivation import GoalPolicy, Objective
 
 
 def test_feel_updates_traits_and_last_mood() -> None:

--- a/tests/test_quest.py
+++ b/tests/test_quest.py
@@ -1,4 +1,5 @@
 import json
+
 import pytest
 
 from singular.life import quest

--- a/tests/test_replay_session.py
+++ b/tests/test_replay_session.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from pathlib import Path
 import json
+from pathlib import Path
 
 from tools.replay_session import main
 

--- a/tests/test_reproduction.py
+++ b/tests/test_reproduction.py
@@ -1,19 +1,19 @@
-from pathlib import Path
-
 import ast
 import json
+from pathlib import Path
+
 import pytest
 
-from singular.organisms.spawn import spawn
 from singular.governance.policy import MutationGovernancePolicy
 from singular.life.reproduction import (
     InheritanceRules,
     ReproductionDecisionPolicy,
     ReproductionVariationPolicy,
     authorize_reproduction_write,
-    decide_reproduction,
     crossover,
+    decide_reproduction,
 )
+from singular.organisms.spawn import spawn
 from singular.social.graph import SocialGraph
 
 

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import json
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from singular.memory_compaction import compact_episodic_jsonl

--- a/tests/test_runs_logger.py
+++ b/tests/test_runs_logger.py
@@ -1,7 +1,7 @@
 import json
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
-import warnings
 
 from singular.runs import RunLogger
 from singular.runs.explain import summarize_mutation
@@ -264,9 +264,9 @@ def test_run_logger_persists_run_and_skill_reputation_to_sqlite(tmp_path: Path) 
 
     from singular.storage import (
         RunsRepository,
+        SkillScoresRepository,
         SQLiteStorage,
         StorageConfig,
-        SkillScoresRepository,
     )
 
     storage = SQLiteStorage(StorageConfig(root=tmp_path))

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,14 +1,14 @@
 import pytest
 
-from singular.life.fitness import LifecycleFitnessConfig, evaluate_mutation_fitness
 from singular.life import sandbox
-from singular.life.score import score
+from singular.life.fitness import LifecycleFitnessConfig, evaluate_mutation_fitness
 from singular.life.sandbox_scoring import (
     SandboxScore,
-    classify_source_sandbox_path,
     _sandbox_failure_category,
+    classify_source_sandbox_path,
     score_code_with_error,
 )
+from singular.life.score import score
 
 pytestmark = pytest.mark.usefixtures("local_sandbox")
 

--- a/tests/test_self_narrative.py
+++ b/tests/test_self_narrative.py
@@ -3,13 +3,13 @@ from pathlib import Path
 
 from singular.self_narrative import (
     SCHEMA_VERSION,
+    diagnose_timeline,
     load,
+    project_event,
+    rebuild_from_timeline,
     summarize_long,
     summarize_short,
     update_from_signals,
-    diagnose_timeline,
-    project_event,
-    rebuild_from_timeline,
 )
 
 

--- a/tests/test_skill_catalog.py
+++ b/tests/test_skill_catalog.py
@@ -1,6 +1,6 @@
-from pathlib import Path
 import hashlib
 import json
+from pathlib import Path
 
 from singular.life.skill_catalog import read_skill_catalog, refresh_skill_catalog
 

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import json
+from pathlib import Path
 
 from singular.events import EventBus
 from singular.skills.runtime import SkillRuntime

--- a/tests/test_storage_repositories.py
+++ b/tests/test_storage_repositories.py
@@ -1,14 +1,14 @@
-from pathlib import Path
 import json
 import sqlite3
+from pathlib import Path
 
 from singular.storage import (
     EpisodesRepository,
     RunsRepository,
+    SkillScoresRepository,
     SQLiteStorage,
     StorageConfig,
     WorldStateRepository,
-    SkillScoresRepository,
     import_legacy_storage,
 )
 

--- a/tests/test_storage_retention.py
+++ b/tests/test_storage_retention.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import json
+from datetime import datetime, timedelta, timezone
 
 from singular.storage_retention import (
     apply_runs_retention,

--- a/tests/test_talk.py
+++ b/tests/test_talk.py
@@ -1,5 +1,5 @@
-import random
 import os
+import random
 
 import pytest
 
@@ -14,11 +14,11 @@ from singular.organisms.talk import (
     talk,
 )
 from singular.providers import (
-    LLMProviderContract,
     LLMProviderClient,
-    ProviderUnavailableError,
+    LLMProviderContract,
     ProviderQuotaExceededError,
     ProviderTimeoutError,
+    ProviderUnavailableError,
 )
 
 

--- a/tests/test_targeted_lifecycle_narrative_trajectory.py
+++ b/tests/test_targeted_lifecycle_narrative_trajectory.py
@@ -7,18 +7,18 @@ from fastapi_stub import TestClient
 
 from singular.dashboard import create_app
 from singular.environment import sim_world
-from singular.goals.quest_generation import generate_quests
-from singular.life.death import DeathMonitor
-from singular.life import loop as life_loop
-from singular.life.loop import load_checkpoint
-from singular.organisms.birth import birth
-from singular.organisms.status import status
 from singular.events import EventBus
+from singular.goals.quest_generation import generate_quests
+from singular.life import loop as life_loop
+from singular.life.death import DeathMonitor
+from singular.life.loop import load_checkpoint
 from singular.orchestrator.service import (
     LifecyclePhase,
     OrchestratorConfig,
     OrchestratorService,
 )
+from singular.organisms.birth import birth
+from singular.organisms.status import status
 from singular.self_narrative import SCHEMA_VERSION, load, update_from_signals
 
 

--- a/tests/test_values_schema.py
+++ b/tests/test_values_schema.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timedelta, timezone
 import json
 import logging
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -13,8 +13,8 @@ from singular.governance.policy import (
     load_circuit_state,
 )
 from singular.governance.values import (
-    ValueWeights,
     ValuesSchemaError,
+    ValueWeights,
     load_value_weights,
     validate_values_payload,
 )

--- a/tests/test_victor_lifecycle_acceptance.py
+++ b/tests/test_victor_lifecycle_acceptance.py
@@ -7,8 +7,8 @@ moral decisions, skill safety, restart recovery, and end-of-life auditability.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from singular.cognition.reflect import ReflectionDecision

--- a/tests/test_vital_transitions.py
+++ b/tests/test_vital_transitions.py
@@ -1,7 +1,7 @@
 import pytest
 
-from singular.life.vital import VitalState, VitalStateMachine, compute_vital_timeline
 from singular.life.health import ViabilityDriftDetector
+from singular.life.vital import VitalState, VitalStateMachine, compute_vital_timeline
 
 
 def test_viability_drift_escalates_and_recovers_with_hysteresis() -> None:

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,4 +1,5 @@
 import json
+
 import viz
 
 

--- a/tests/test_wheel_distribution.py
+++ b/tests/test_wheel_distribution.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 
 
 def test_installed_wheel_contains_all_runtime_resources(tmp_path: Path) -> None:

--- a/tools/replay_session.py
+++ b/tools/replay_session.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-from pathlib import Path
-from typing import Any
 import argparse
 import json
 import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
 
 from singular.observability.audit_log import filter_session, read_audit_events
 

--- a/viz.py
+++ b/viz.py
@@ -57,7 +57,7 @@ def main(argv: list[str] | None = None) -> int:
             output = args.output or Path(f"{args.id}.png")
             _png_charts(scores, ops, output)
             print(f"Saved plot to {output}")
-        except Exception:
+        except (ImportError, OSError, RuntimeError, ValueError):
             print("matplotlib is required for PNG output; use --ascii if unavailable")
             return 1
     return 0


### PR DESCRIPTION
### Motivation
- Formaliser une configuration `ruff` dans `pyproject.toml` pour cibler Python 3.10, documenter les fichiers exclus et activer les familles de règles de correction/parse/import réellement voulues.
- Appliquer les corrections automatiques sûres et normaliser l’ordre des imports pour réduire le bruit des diagnostics sans masquer globalement les 838 messages.
- Corriger une gestion d'exception trop large dans `viz.py` et éviter des réordonnancements d'import qui créent des cycles.

### Description
- Ajout de la section `[tool.ruff]` et `[tool.ruff.lint]` à `pyproject.toml` avec `target-version = "py310"`, `extend-exclude` et `select = ["E4", "E7", "E9", "F", "I"]`.
- Ajout de `per-file-ignores` (justifiées) pour une liste restreinte d’initiaux de paquets dont l’ordre d’import est intentionnellement significatif pour éviter des cycles d’import.
- Application de `ruff --fix` (fixs sûrs) sur les fichiers suivis et normalisation de nombreux blocs d’imports (ex. `tools/replay_session.py` et multiples modules modifiés pour l’ordre/cohérence des imports).
- Remplacement de `except Exception:` par `except (ImportError, OSError, RuntimeError, ValueError):` dans `viz.py:60` pour ne capter que les erreurs attendues lors de l’import ou du rendu matplotlib.
- Commit final annoté comme «Configure Ruff and normalize tracked Python imports». Aucun diagnostic global n’a été désactivé ; les exceptions indispensables reçoivent des `per-file-ignores` documentés.

### Testing
- Linter: `ruff check .` et `black --check --target-version py310 --fast .` ont été exécutés et sont passés après application des correctifs automatiques.
- Correctifs automatiques: `ruff --fix` appliqué et 171 erreurs fixées automatiquement dans le jeu de fichiers suivis.
- Tests ciblés: `pytest -q tests/test_viz.py tests/test_replay_session.py` ont réussi (`3 passed`).
- Import smoke: `pytest -q tests/test_import_packages.py tests/test_viz.py tests/test_replay_session.py` exposait un cycle d’import préexistant entre `singular.memory` / `memory_layers` / `self_narrative` et a été adressé en réordonnant les imports et en ajoutant un `per-file-ignores` pour l’init concerné; les vérifications ciblées ont ensuite réussi.
- Suite non-integration: un run plus large (`pytest -q -m "not integration and not sandbox_oci"`) montre des échecs existants (75 failures) liés à l’état de référence et aux limitations d’environnement (absence de runtime OCI et contraintes réseau lors de builds isolés) et ne sont pas causés par cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7904533a70832aa9c6694fd1e30a70)