### PR TITLE
Add progressive mypy baseline for Python 3.10 and fix typing issues in status/diagnostics/dashboard/cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,13 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          # Mypy validates the declared minimum; runtime compatibility remains
+          # covered by the test and lint matrices.
+          python-version: "3.10"
       - name: Install typecheck dependencies
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,16 @@ select = ["E4", "E7", "E9", "F", "I"]
 "src/singular/storage/__init__.py" = ["I001"]
 "src/singular/watch/__init__.py" = ["I001"]
 "tests/fastapi_stub/__init__.py" = ["I001"]
+
+[tool.mypy]
+python_version = "3.10"
+# The type-checking baseline is intentionally progressive.  Keep this list
+# explicit so newly-clean modules can be added without globally suppressing
+# concrete errors in the rest of the historical codebase.
+files = [
+    "src/singular/cli.py",
+    "src/singular/dashboard/actions.py",
+    "src/singular/diagnostics/autonomous.py",
+    "src/singular/organisms/status.py",
+]
+follow_imports = "skip"

--- a/src/singular/cli.py
+++ b/src/singular/cli.py
@@ -2567,19 +2567,19 @@ def main(argv: list[str] | None = None) -> int:
         if args.autonomous:
             from .diagnostics.autonomous import autonomous_diagnostics
 
-            report = autonomous_diagnostics(run_generation=args.generate)
+            diagnostic_report = autonomous_diagnostics(run_generation=args.generate)
             if args.output_format == "json":
-                print(json.dumps(report, ensure_ascii=False, indent=2))
+                print(json.dumps(diagnostic_report, ensure_ascii=False, indent=2))
             else:
-                print(f"Diagnostic autonomie: {report['status']}")
+                print(f"Diagnostic autonomie: {diagnostic_report['status']}")
                 print("check_id | sévérité | état | preuve | correction")
-                for check in report["checks"]:
+                for check in diagnostic_report["checks"]:
                     print(
                         f"{check['check_id']} | {check['severity']} | {check['state']} | "
                         f"{json.dumps(check['evidence'], ensure_ascii=False, sort_keys=True)} | "
                         f"{check['remediation_command'] or '-'}"
                     )
-            return int(report["exit_code"])
+            return diagnostic_report["exit_code"]
         _doctor(fix=args.fix)
         _doctor_providers()
 
@@ -2845,7 +2845,10 @@ def main(argv: list[str] | None = None) -> int:
             except (ValueError, TypeError) as exc:
                 print(f"Valeur invalide pour {args.key}: {exc}", file=sys.stderr)
                 return 1
-            policy = replace(policy, **{field_name: value})
+            # ``field_name`` is selected from the closed mapping above and the
+            # parser validates its corresponding runtime type before replace.
+            policy_update: dict[str, Any] = {field_name: value}
+            policy = replace(policy, **policy_update)
             try:
                 save_runtime_policy(policy)
             except PolicySchemaError as exc:

--- a/src/singular/dashboard/actions.py
+++ b/src/singular/dashboard/actions.py
@@ -244,9 +244,10 @@ class DashboardActionService:
                     "temperature": host_metrics.get("host_temperature_c"),
                     "disk": host_metrics.get("disk_used_percent"),
                 }
+                raw_metric_status_map = host_metrics.get("metric_status")
                 metric_status_map = (
-                    host_metrics.get("metric_status")
-                    if isinstance(host_metrics.get("metric_status"), dict)
+                    raw_metric_status_map
+                    if isinstance(raw_metric_status_map, dict)
                     else {}
                 )
                 metric_status_aliases = {
@@ -263,14 +264,14 @@ class DashboardActionService:
                         latest_statuses[metric_name] = status_payload
                         raw_value = status_payload.get("value", raw_value)
                     if isinstance(raw_value, (int, float)):
-                        value = float(raw_value)
-                        latest_values[metric_name] = value
+                        observed_value = float(raw_value)
+                        latest_values[metric_name] = observed_value
                         history_map[metric_name].append(
                             {
                                 "ts": ts if isinstance(ts, str) else None,
-                                "value": value,
+                                "value": observed_value,
                                 "risk": self._host_metric_risk(
-                                    metric_name, value, thresholds
+                                    metric_name, observed_value, thresholds
                                 ),
                             }
                         )
@@ -298,10 +299,9 @@ class DashboardActionService:
         global_status = "ok"
         for metric_name in ("cpu", "ram", "temperature", "disk"):
             value = latest_values[metric_name]
+            raw_status_payload = latest_statuses.get(metric_name)
             status_payload = (
-                latest_statuses.get(metric_name)
-                if isinstance(latest_statuses.get(metric_name), dict)
-                else {}
+                raw_status_payload if isinstance(raw_status_payload, dict) else {}
             )
             status = str(
                 (status_payload or {}).get("status")
@@ -636,7 +636,8 @@ class DashboardActionService:
             raise ValueError("no active life")
         registry = load_registry()
         active = registry.get("active")
-        lives = registry.get("lives") if isinstance(registry.get("lives"), dict) else {}
+        raw_lives = registry.get("lives")
+        lives = raw_lives if isinstance(raw_lives, dict) else {}
         metadata = lives.get(active) if isinstance(active, str) else None
         mem_dir = Path(life) / "mem"
         stop_path = mem_dir / "orchestrator.stop.json"

--- a/src/singular/diagnostics/autonomous.py
+++ b/src/singular/diagnostics/autonomous.py
@@ -7,12 +7,27 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 READY = 0
 DEGRADED = 1
 BLOCKED = 2
 SCHEMA_VERSION = 1
+
+
+class DiagnosticCheck(TypedDict):
+    check_id: str
+    severity: str
+    state: str
+    evidence: dict[str, Any]
+    remediation_command: str | None
+
+
+class AutonomousDiagnosticReport(TypedDict):
+    schema_version: int
+    status: str
+    exit_code: int
+    checks: list[DiagnosticCheck]
 
 
 def _check(
@@ -21,7 +36,7 @@ def _check(
     state: str,
     evidence: dict[str, Any],
     remediation: str | None,
-) -> dict[str, Any]:
+) -> DiagnosticCheck:
     return {
         "check_id": check_id,
         "severity": severity,
@@ -65,7 +80,7 @@ def _mutation_evidence(home: Path) -> dict[str, Any] | None:
     return newest[1] if newest else None
 
 
-def _systemd_check(root: Path, home: Path) -> dict[str, Any]:
+def _systemd_check(root: Path, home: Path) -> DiagnosticCheck:
     if not shutil.which("systemctl"):
         return _check(
             "systemd_consistency",
@@ -106,7 +121,9 @@ def _systemd_check(root: Path, home: Path) -> dict[str, Any]:
     )
 
 
-def autonomous_diagnostics(*, run_generation: bool = False) -> dict[str, Any]:
+def autonomous_diagnostics(
+    *, run_generation: bool = False
+) -> AutonomousDiagnosticReport:
     """Run ordered autonomous-readiness checks and return a stable payload."""
 
     from singular.governance.policy import load_circuit_state
@@ -114,7 +131,7 @@ def autonomous_diagnostics(*, run_generation: bool = False) -> dict[str, Any]:
     from singular.providers import doctor_providers
     from singular.root_config import diagnose_registry_root
 
-    checks: list[dict[str, Any]] = []
+    checks: list[DiagnosticCheck] = []
     root_info = diagnose_registry_root()
     root = root_info["root"]
     root_ok = root.is_dir()

--- a/src/singular/organisms/status.py
+++ b/src/singular/organisms/status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, TypedDict
 
 from ..life.health import detect_health_state
 from ..life.life_status import compute_life_status
@@ -45,7 +46,35 @@ def _fmt_number(value: object, unit: str = "") -> str:
     return "-"
 
 
-def _read_quest_status() -> dict[str, object]:
+class QuestStatus(TypedDict):
+    active: list[Any]
+    paused: list[Any]
+    completed: list[Any]
+
+
+class StatusPayload(TypedDict):
+    latest_run: str | None
+    last_execution_ms: float | None
+    success_rate: float | None
+    mutation_success_rate: float | None
+    mutation_count: int
+    invalid_lines: int
+    health: dict[str, Any] | None
+    life_status: dict[str, Any]
+    alerts: list[dict[str, Any]]
+    mood: str | None
+    traits: dict[str, float]
+    autonomy_metrics: dict[str, Any]
+    quests: QuestStatus
+    trajectory: dict[str, Any]
+    skills_lifecycle: dict[str, int]
+    daily_skills: dict[str, Any]
+    vital_timeline: dict[str, Any]
+    host_environment: dict[str, Any]
+    relationships: dict[str, Any]
+
+
+def _read_quest_status() -> QuestStatus:
     path = get_mem_dir() / "quests_state.json"
     if not path.exists():
         return {"active": [], "paused": [], "completed": []}
@@ -55,11 +84,12 @@ def _read_quest_status() -> dict[str, object]:
         return {"active": [], "paused": [], "completed": []}
     if not isinstance(payload, dict):
         return {"active": [], "paused": [], "completed": []}
-    active = payload.get("active") if isinstance(payload.get("active"), list) else []
-    paused = payload.get("paused") if isinstance(payload.get("paused"), list) else []
-    completed = (
-        payload.get("completed") if isinstance(payload.get("completed"), list) else []
-    )
+    raw_active = payload.get("active")
+    raw_paused = payload.get("paused")
+    raw_completed = payload.get("completed")
+    active = raw_active if isinstance(raw_active, list) else []
+    paused = raw_paused if isinstance(raw_paused, list) else []
+    completed = raw_completed if isinstance(raw_completed, list) else []
     return {"active": active, "paused": paused, "completed": completed[-20:]}
 
 
@@ -90,13 +120,11 @@ def _extract_objective_priorities(record: dict[str, object]) -> dict[str, float]
 def _build_trajectory_payload(
     *,
     records: list[dict[str, object]],
-    quests: dict[str, object],
+    quests: QuestStatus,
 ) -> dict[str, object]:
-    active = quests.get("active") if isinstance(quests.get("active"), list) else []
-    paused = quests.get("paused") if isinstance(quests.get("paused"), list) else []
-    completed = (
-        quests.get("completed") if isinstance(quests.get("completed"), list) else []
-    )
+    active = quests["active"]
+    paused = quests["paused"]
+    completed = quests["completed"]
 
     objective_status: dict[str, str] = {}
     for item in active:
@@ -162,12 +190,12 @@ def _build_trajectory_payload(
             record.get("self_narrative_event"), str
         ):
             continue
-        objective = record.get("objective")
-        if not isinstance(objective, str):
+        record_objective = record.get("objective")
+        if not isinstance(record_objective, str):
             continue
         narrative_links.append(
             {
-                "objective": objective,
+                "objective": record_objective,
                 "event": record.get("self_narrative_event", event),
                 "at": record.get("ts") if isinstance(record.get("ts"), str) else None,
                 "run": (
@@ -202,9 +230,9 @@ def _build_trajectory_payload(
     }
 
 
-def _read_skill_lifecycle_status() -> dict[str, object]:
+def _read_skill_lifecycle_status() -> dict[str, int]:
     skills = read_skills()
-    summary = {
+    summary: dict[str, int] = {
         "active": 0,
         "dormant": 0,
         "archived": 0,
@@ -229,7 +257,7 @@ def _read_skill_lifecycle_status() -> dict[str, object]:
 def status(*, verbose: bool = False, output_format: str = "plain") -> None:
     """Display basic metrics and current psyche state."""
 
-    payload: dict[str, object] = {
+    payload: StatusPayload = {
         "latest_run": None,
         "last_execution_ms": None,
         "success_rate": None,
@@ -374,15 +402,13 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             if verbose:
                 alerts = alerts_from_records(records)
                 payload["alerts"] = alerts
-    payload.setdefault("alerts", [])
-
     psyche = Psyche.load_state()
     mood = psyche.last_mood.value if psyche.last_mood else "neutral"
     payload["mood"] = mood
     payload["quests"] = _read_quest_status()
     payload["trajectory"] = _build_trajectory_payload(
         records=all_records if "all_records" in locals() else [],
-        quests=payload["quests"] if isinstance(payload["quests"], dict) else {},
+        quests=payload["quests"],
     )
     payload["skills_lifecycle"] = _read_skill_lifecycle_status()
     payload["life_status"] = {
@@ -412,15 +438,15 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         return
 
     if output_format == "table":
+        health = payload["health"]
         autonomy = (
             payload.get("autonomy_metrics")
             if isinstance(payload.get("autonomy_metrics"), dict)
             else {}
         )
+        raw_decision_quality = autonomy.get("decision_quality")
         decision_quality = (
-            autonomy.get("decision_quality")
-            if isinstance(autonomy.get("decision_quality"), dict)
-            else {}
+            raw_decision_quality if isinstance(raw_decision_quality, dict) else {}
         )
         run_rows = [
             ["Latest run", str(payload.get("latest_run") or "-")],
@@ -452,8 +478,8 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             [
                 "Health score",
                 (
-                    f"{payload['health']['score']}/100 ({payload['health']['trend']}, fenêtres {payload['health']['window']})"
-                    if isinstance(payload.get("health"), dict)
+                    f"{health['score']}/100 ({health['trend']}, fenêtres {health['window']})"
+                    if health is not None
                     else "-"
                 ),
             ],
@@ -644,10 +670,9 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             if isinstance(payload.get("autonomy_metrics"), dict)
             else {}
         )
+        raw_decision_quality = autonomy.get("decision_quality")
         decision_quality = (
-            autonomy.get("decision_quality")
-            if isinstance(autonomy.get("decision_quality"), dict)
-            else {}
+            raw_decision_quality if isinstance(raw_decision_quality, dict) else {}
         )
         print(f"Autonomy index: {_fmt_number(autonomy.get('autonomy_index'))}")
         print(f"Mutation viability: {_fmt_number(autonomy.get('mutation_viability'))}")
@@ -683,11 +708,8 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
             if isinstance(payload.get("host_environment"), dict)
             else {}
         )
-        host_impact = (
-            host_environment.get("impact")
-            if isinstance(host_environment.get("impact"), dict)
-            else {}
-        )
+        raw_host_impact = host_environment.get("impact")
+        host_impact = raw_host_impact if isinstance(raw_host_impact, dict) else {}
         print(f"Impact environnement hôte: {host_impact.get('impact_level', 'low')}")
         print(f"Biais décisionnel hôte: {host_impact.get('decision_bias', 'balanced')}")
         causes = vital.get("causes")
@@ -732,23 +754,17 @@ def status(*, verbose: bool = False, output_format: str = "plain") -> None:
         if isinstance(payload.get("relationships"), dict)
         else {}
     )
-    family = (
-        relationships.get("family")
-        if isinstance(relationships.get("family"), dict)
-        else {}
-    )
-    social = (
-        relationships.get("social")
-        if isinstance(relationships.get("social"), dict)
-        else {}
-    )
+    raw_family = relationships.get("family")
+    family = raw_family if isinstance(raw_family, dict) else {}
+    raw_social = relationships.get("social")
+    social = raw_social if isinstance(raw_social, dict) else {}
     print(f"Arbre familial: {len(family.get('nodes', []))} nœuds")
     print(f"Réseau social: {len(social.get('edges', []))} relations")
     print(f"Conflits actifs: {len(relationships.get('active_conflicts', []))}")
     quests = (
         payload.get("quests")
         if isinstance(payload.get("quests"), dict)
-        else {"active": [], "completed": []}
+        else {"active": [], "paused": [], "completed": []}
     )
     print(f"Quêtes actives: {len(quests.get('active', []))}")
     print(f"Quêtes terminées: {len(quests.get('completed', []))}")


### PR DESCRIPTION
### Motivation

- Establish a progressive, explicit mypy baseline targeting the declared minimum Python version (`3.10`) so type-checking can be incrementally widened instead of globally suppressed.
- Fix concrete type-use errors (overly broad `object` unions, unchecked `.get()` / indexing, and undefined names) reported by CI in the status/diagnostics/dashboard/cli areas so selected modules become mypy-clean.

### Description

- Add a `[tool.mypy]` section to `pyproject.toml` with `python_version = "3.10"`, an explicit `files` list for the initial baseline, and `follow_imports = "skip"` so typechecking is progressive and focused.  (mod: `pyproject.toml`)
- Simplify the CI `typecheck` job to run `mypy` once on the minimum supported interpreter (`3.10`) while keeping test/lint matrices for runtime coverage. (mod: `.github/workflows/ci.yml`)
- Introduce `TypedDict` types (`DiagnosticCheck`, `AutonomousDiagnosticReport`, `QuestStatus`, `StatusPayload`) and use them to tighten JSON payload handling and return shapes in `src/singular/diagnostics/autonomous.py` and `src/singular/organisms/status.py`.
- Narrow union uses and validate raw values before attribute/index access in `src/singular/dashboard/actions.py` and `src/singular/organisms/status.py` (e.g. `raw_*` temporaries, explicit dict checks), fix variable name collisions and undefined references in `src/singular/cli.py`, and make `replace(policy, ...)` use an explicit typed `dict` after parsing.

### Testing

- Ran `mypy` against the declared baseline modules and the modified files reported no issues for the selected list.
- Ran `ruff check` on the modified files and `black` (with formatting applied where needed) and the checks passed after formatting.
- Executed targeted pytest runs: non-sandbox dashboard/doctor tests passed; sandbox-related `diagnose sandbox` tests failed in this environment when Podman/Docker is absent (expected external dependency), and a final targeted run of the doctor/dashboard subset reported `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a790924a9a8832a8b7e1546783f903f)