### PR TITLE
Separate mandatory-test collection in CI; ensure FastAPI stub is used during collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install '.[test]'
+      - name: Collect mandatory tests
+        run: pytest --collect-only -m "not integration"
       # pytest.ini promotes DeprecationWarning to errors (with only narrowly
-      # scoped compatibility exclusions), so this is also the CI deprecation pass.
-      - name: Pytest with deprecation and global coverage guardrails
-        run: pytest -m "not integration" --cov=src/singular --cov-fail-under=85 --cov-report=term-missing --cov-report=xml:coverage.xml
+      # scoped compatibility exclusions). Keep this pass separate so collection,
+      # deprecations, and coverage failures have distinct log annotations.
+      - name: Pytest with deprecations as errors
+        run: pytest -m "not integration"
+      - name: Pytest with global coverage guardrails
+        run: pytest -m "not integration" -W default::DeprecationWarning --cov=src/singular --cov-fail-under=85 --cov-report=term-missing --cov-report=xml:coverage.xml
       - name: Validate critical modules coverage >= 90%
         run: |
           python scripts/check_coverage_thresholds.py \

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 markers =
-    integration: integration tests that may execute an injected deployment command
+    integration: optional tests requiring external commands or real integration dependencies
     sandbox_oci: tests requiring Linux, Docker or Podman, seccomp, and SINGULAR_SANDBOX_IMAGE
 testpaths = tests
 pythonpath = .

--- a/tests/fastapi_stub/testclient.py
+++ b/tests/fastapi_stub/testclient.py
@@ -35,6 +35,8 @@ class Response:
 class TestClient:
     """Very small subset of the real TestClient API used in tests."""
 
+    __test__ = False
+
     def __init__(self, app: Any) -> None:
         self.app = app
 

--- a/tests/test_dashboard_smoke_e2e.py
+++ b/tests/test_dashboard_smoke_e2e.py
@@ -68,6 +68,7 @@ def dashboard_browser_url(tmp_path: Path) -> str:
         thread.join(timeout=5)
 
 
+@pytest.mark.integration
 def test_dashboard_browser_remains_responsive_when_backends_fail(
     dashboard_browser_url: str,
 ) -> None:

--- a/tests/test_multi_organisms.py
+++ b/tests/test_multi_organisms.py
@@ -3,7 +3,7 @@ import json
 import random
 from pathlib import Path
 
-from fastapi_stub import TestClient
+from fastapi.testclient import TestClient
 
 import singular.life.loop as life_loop
 from singular.dashboard import create_app

--- a/tests/test_offline_multi_life_evaluation.py
+++ b/tests/test_offline_multi_life_evaluation.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
-from fastapi_stub import TestClient
+from fastapi.testclient import TestClient
 
 from singular.dashboard import create_app
 from singular.evaluation import run_multi_life_evaluation

--- a/tests/test_targeted_lifecycle_narrative_trajectory.py
+++ b/tests/test_targeted_lifecycle_narrative_trajectory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from fastapi_stub import TestClient
+from fastapi.testclient import TestClient
 
 from singular.dashboard import create_app
 from singular.environment import sim_world


### PR DESCRIPTION
### Motivation
- Make import and collection errors for the mandatory test slice visible quickly and separately from coverage failures. 
- Ensure tests that must use the lightweight FastAPI stub actually see the stub during collection so collection/import errors do not pull a real FastAPI. 
- Keep `DeprecationWarning` promoted to errors, but separate that check from the coverage pass so the first failing category is obvious in GH Actions logs.

### Description
- Add a dedicated CI step that runs `pytest --collect-only -m "not integration"` before any test execution or coverage reporting in `.github/workflows/ci.yml`. 
- Split the mandatory pytest invocation into two steps: one that enforces deprecations as errors (`pytest -m "not integration"`) and a separate coverage run that passes `-W default::DeprecationWarning` and produces the coverage reports. 
- Update `pytest.ini` to clarify the `integration` marker as "optional tests requiring external commands or real integration dependencies". 
- Normalize dashboard-related tests to import the real TestClient symbol (`from fastapi.testclient import TestClient`) so the `tests/conftest.py` stub redirection takes effect, and mark the heavy Playwright-driven browser smoke test as `@pytest.mark.integration`. 
- Prevent pytest from collecting the test stub `TestClient` by setting `__test__ = False` on the stubbed `TestClient` in `tests/fastapi_stub/testclient.py`. 
- Apply code formatting fixes where required (Black/Ruff) to keep the tree consistent after the changes.

### Testing
- Ran `pytest --collect-only -m "not integration"` which succeeded and collected `982` mandatory tests with `3` integration tests deselected. 
- Ran linters/formatters: `ruff check .` and `black --check --target-version py310 --fast .` (Black required a small reformat which was applied). 
- Ran `pytest -m "not integration"` (deprecation pass) and then `pytest -m "not integration"` with coverage; the collection separation exposed many unrelated runtime failures in the full suite (the run was interrupted after execution and reported ~61 failing tests, ~482 passing, 1 skipped), primarily caused by environmental/test-runtime constraints (notably the secure sandbox requiring Docker/Podman and other functional state assumptions). 
- Ran a targeted subset `pytest tests/test_multi_organisms.py tests/test_offline_multi_life_evaluation.py tests/test_targeted_lifecycle_narrative_trajectory.py -m 'not integration'` which showed the imports/stub fixes worked but surfaced three functional failures in multi-organisms tests unrelated to the import/collection changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a790f82b708832a8b541e89db711380)