### PR TITLE
ci: run static checks on Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,13 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          # Run tooling on the minimum supported Python version declared by
+          # requires-python; runtime compatibility is covered by the test matrix.
+          python-version: "3.10"
       - name: Install lint dependencies
         run: |
           python -m pip install --upgrade pip
@@ -39,7 +37,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           # Mypy validates the declared minimum; runtime compatibility remains
-          # covered by the test and lint matrices.
+          # covered by the test matrix.
           python-version: "3.10"
       - name: Install typecheck dependencies
         run: |


### PR DESCRIPTION
### Motivation

- Réduire la duplication de l’exécution des outils statiques et exécuter Ruff, Black et la validation des manifests une seule fois sur la version minimale supportée de Python.
- Documenter explicitement Python 3.10 comme runtime pour les vérifications statiques conformément à `requires-python = ">=3.10"`.
- Conserver la matrice multi-version pour le job `tests` afin de vérifier les différences d’exécution pertinentes entre Python 3.10, 3.11 et 3.12.

### Description

- Supprime la matrice `python-version` du job `lint` et fixe `actions/setup-python` à `python-version: "3.10"` pour ce job.
- Clarifie le commentaire de `typecheck` pour indiquer que la compatibilité d’exécution est couverte par la matrice de tests et conserve `python-version: "3.10"` pour Mypy.
- Ne modifie pas la matrice du job `tests`, ni les identifiants de jobs référencés par `needs`, pour éviter de changer l’ordre/dependances de `build`.

### Testing

- Validé que le fichier YAML est correctement parsable avec `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml", aliases: true)'` et que la charge utile est un YAML valide.
- Exécuté une assertion automatique via Ruby pour vérifier l’absence de la `strategy` de `lint`, que `lint` et `typecheck` utilisent `python-version: "3.10"`, et que la matrice `tests` reste `["3.10", "3.11", "3.12"]`, et cette vérification a réussi.
- Lancé `git diff --check` pour s’assurer qu’il n’y a pas de problèmes de formatage ou d’espaces superflus et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79117a19b8832a8464363be8460c2b)